### PR TITLE
Avoid api endpoints ambiguity

### DIFF
--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -200,7 +200,7 @@ func componentStatus(cliParams *cliParams, component string, client ipc.HTTPClie
 
 	v := setIpcURL(cliParams)
 
-	endpoint, err := client.NewIPCEndpoint("/agent/status/" + component)
+	endpoint, err := client.NewIPCEndpoint("/agent/status/section/" + component)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -200,7 +200,7 @@ func componentStatus(cliParams *cliParams, component string, client ipc.HTTPClie
 
 	v := setIpcURL(cliParams)
 
-	endpoint, err := client.NewIPCEndpoint(fmt.Sprintf("/agent/%s/status", component))
+	endpoint, err := client.NewIPCEndpoint("/agent/status/" + component)
 	if err != nil {
 		return err
 	}

--- a/comp/api/api/apiimpl/internal/agent/agent.go
+++ b/comp/api/api/apiimpl/internal/agent/agent.go
@@ -37,34 +37,12 @@ func SetupHandlers(
 
 	// TODO: move these to a component that is registerable
 	r.HandleFunc("/status/health", getHealth).Methods("GET")
-	r.HandleFunc("/{component}/status", componentStatusHandler).Methods("POST")
-	r.HandleFunc("/{component}/configs", componentConfigHandler).Methods("GET")
+	r.HandleFunc("/jmx/status", setJMXStatus).Methods("POST")
+	r.HandleFunc("/jmx/configs", getJMXConfigs).Methods("GET")
 	r.HandleFunc("/install-info", installinfo.HandleGetInstallInfo).Methods("GET")
 	r.HandleFunc("/install-info", installinfo.HandleSetInstallInfo).Methods("POST", "PUT")
 	coverage.SetupCoverageHandler(r)
 	return r
-}
-
-func componentConfigHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	component := vars["component"]
-	switch component {
-	case "jmx":
-		getJMXConfigs(w, r)
-	default:
-		http.Error(w, log.Errorf("bad url or resource does not exist").Error(), 404)
-	}
-}
-
-func componentStatusHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	component := vars["component"]
-	switch component {
-	case "jmx":
-		setJMXStatus(w, r)
-	default:
-		http.Error(w, log.Errorf("bad url or resource does not exist").Error(), 404)
-	}
 }
 
 func getHealth(w http.ResponseWriter, _ *http.Request) {

--- a/comp/api/api/apiimpl/observability/telemetry.go
+++ b/comp/api/api/apiimpl/observability/telemetry.go
@@ -48,7 +48,7 @@ func (th *telemetryMiddlewareFactory) Middleware(serverName string) func(http.Ha
 
 			// Plant a route capture in the context so that WrapWithRouteTemplate (called at
 			// handler registration) can fill it with the matched route template. This avoids
-			// high-cardinality metric tags from path variables such as /{component}/status.
+			// high-cardinality metric tags from path variables such as /status/section/{component}.
 			r, capture := withRouteCapture(r)
 			next.ServeHTTP(w, r)
 

--- a/comp/api/api/apiimpl/observability/utils_test.go
+++ b/comp/api/api/apiimpl/observability/utils_test.go
@@ -50,7 +50,7 @@ func TestWrapWithRouteTemplate(t *testing.T) {
 		{"", "/test", "/test"},
 		{"", "/test/", "/test/"},
 		{"", "/test/{id}", "/test/{id}"},
-		{"/agent", "/{component}/status", "/agent/{component}/status"},
+		{"/agent", "/status/section/{component}", "/agent/status/section/{component}"},
 	}
 
 	for _, tc := range testCases {

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -143,7 +143,7 @@ func newStatus(deps dependencies) provides {
 		),
 		APIGetSection: api.NewAgentEndpointProvider(
 			c.getSection,
-			"/status/{component}",
+			"/status/section/{component}",
 			"GET",
 		),
 		APIGetSectionList: api.NewAgentEndpointProvider(

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -143,7 +143,7 @@ func newStatus(deps dependencies) provides {
 		),
 		APIGetSection: api.NewAgentEndpointProvider(
 			c.getSection,
-			"/{component}/status",
+			"/status/{component}",
 			"GET",
 		),
 		APIGetSectionList: api.NewAgentEndpointProvider(

--- a/comp/core/status/statusimpl/status_api_endpoints_test.go
+++ b/comp/core/status/statusimpl/status_api_endpoints_test.go
@@ -167,8 +167,8 @@ func TestStatusAPIEndpoints(t *testing.T) {
 		{
 			testDesc:    "with header section",
 			method:      "GET",
-			routerPath:  "/{component}/status",
-			testedPath:  "/header/status",
+			routerPath:  "/status/section/{component}",
+			testedPath:  "/status/section/header",
 			httpHandler: provider.APIGetSection.Provider.HandlerFunc(),
 			expectedBody: func() []byte {
 				status, err := provider.Comp.GetStatusBySections([]string{"header"}, "text", false)
@@ -180,8 +180,8 @@ func TestStatusAPIEndpoints(t *testing.T) {
 		{
 			testDesc:    "with unknown section text format",
 			method:      "GET",
-			routerPath:  "/{component}/status",
-			testedPath:  "/unknown/status",
+			routerPath:  "/status/section/{component}",
+			testedPath:  "/status/section/unknown",
 			httpHandler: provider.APIGetSection.Provider.HandlerFunc(),
 			expectedBody: func() []byte {
 				_, err := provider.Comp.GetStatusBySections([]string{"unknown"}, "text", false)
@@ -194,8 +194,8 @@ func TestStatusAPIEndpoints(t *testing.T) {
 		{
 			testDesc:    "with unknown section json format",
 			method:      "GET",
-			routerPath:  "/{component}/status",
-			testedPath:  "/unknown/status?format=json",
+			routerPath:  "/status/section/{component}",
+			testedPath:  "/status/section/unknown?format=json",
 			httpHandler: provider.APIGetSection.Provider.HandlerFunc(),
 			expectedBody: func() []byte {
 				_, err := provider.Comp.GetStatusBySections([]string{"unknown"}, "json", false)


### PR DESCRIPTION
### What does this PR do?
Update the per-component status endpoint to `/status/section/{component}` rather than `/{component}/status` (GET requests).

Also update `/{component}/status` and `/{component}/configs` to only accept `jmx` (POST requests, the handler only works for `jmx`).

### Motivation
Avoid a route conflict depending on ordering, where `GET /{component}/status` and `GET /config/{setting}` could both match the same request for example.
This is a footgun in general, and prevents some simplification I want to make in follow-up PRs.

### Describe how you validated your changes
CI, manual testing for status component specifically.

### Additional Notes
