### PR TITLE
[AGENTRUN-1300] fix(jetson): correctly execute the tegrastats command without `sh -c`

### DIFF
--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -143,6 +143,18 @@ func (c *JetsonCheck) processTegraStatsOutput(tegraStatsOuptut string) error {
 	return nil
 }
 
+// runCommand executes the tegrastats command, optionally with sudo.
+func runCommand(ctx context.Context, cmdStr string, useSudo bool) ([]byte, error) {
+	var cmd *exec.Cmd
+	if useSudo {
+		// -n, non-interactive mode, no prompts are used
+		cmd = exec.CommandContext(ctx, "sudo", "-n", "sh", "-c", cmdStr)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	}
+	return cmd.Output()
+}
+
 // Run executes the check
 func (c *JetsonCheck) Run() error {
 	tegraStatsCmd := fmt.Sprintf("%s %s", c.tegraStatsPath, strings.Join(c.commandOpts, " "))
@@ -151,15 +163,8 @@ func (c *JetsonCheck) Run() error {
 	defer cancel()
 
 	cmdStr := fmt.Sprintf("(%s) & pid=$!; (sleep %d && kill -9 $pid)", tegraStatsCmd, int((2 * tegraStatsInterval).Seconds()))
-	var cmd *exec.Cmd
-	if c.useSudo {
-		// -n, non-interactive mode, no prompts are used
-		cmd = exec.CommandContext(ctx, "sudo", "-n", cmdStr)
-	} else {
-		cmd = exec.CommandContext(ctx, cmdStr)
-	}
 
-	tegrastatsOutput, err := cmd.Output()
+	tegrastatsOutput, err := runCommand(ctx, cmdStr, c.useSudo)
 	if err != nil {
 		switch err := err.(type) {
 		case *exec.ExitError:

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -148,7 +148,7 @@ func runCommand(ctx context.Context, binary string, args []string, useSudo bool)
 	var cmd *exec.Cmd
 	if useSudo {
 		// -n, non-interactive mode, no prompts are used
-		cmd = exec.CommandContext(ctx, "sudo", binary, args...)
+		cmd = exec.CommandContext(ctx, "sudo", append([]string{binary}, args...)...)
 	} else {
 		cmd = exec.CommandContext(ctx, binary, args...)
 	}

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -159,12 +159,11 @@ func runCommand(ctx context.Context, cmdStr string, useSudo bool) ([]byte, error
 func (c *JetsonCheck) Run() error {
 	tegraStatsCmd := fmt.Sprintf("%s %s", c.tegraStatsPath, strings.Join(c.commandOpts, " "))
 
+	// Kill tegrastats if it runs for twice as long as the interval we specified, to avoid blocking
+	// the check forever
 	ctx, cancel := context.WithTimeout(context.Background(), 2*tegraStatsInterval)
 	defer cancel()
-
-	cmdStr := fmt.Sprintf("(%s) & pid=$!; (sleep %d && kill -9 $pid)", tegraStatsCmd, int((2 * tegraStatsInterval).Seconds()))
-
-	tegrastatsOutput, err := runCommand(ctx, cmdStr, c.useSudo)
+	tegrastatsOutput, err := runCommand(ctx, tegraStatsCmd, c.useSudo)
 	if err != nil {
 		switch err := err.(type) {
 		case *exec.ExitError:

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -148,7 +148,7 @@ func runCommand(ctx context.Context, binary string, args []string, useSudo bool)
 	var cmd *exec.Cmd
 	if useSudo {
 		// -n, non-interactive mode, no prompts are used
-		cmd = exec.CommandContext(ctx, "sudo", binary, sudoArgs...)
+		cmd = exec.CommandContext(ctx, "sudo", binary, args...)
 	} else {
 		cmd = exec.CommandContext(ctx, binary, args...)
 	}

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -144,26 +144,24 @@ func (c *JetsonCheck) processTegraStatsOutput(tegraStatsOuptut string) error {
 }
 
 // runCommand executes the tegrastats command, optionally with sudo.
-func runCommand(ctx context.Context, cmdStr string, useSudo bool) ([]byte, error) {
+func runCommand(ctx context.Context, binary string, args []string, useSudo bool) ([]byte, error) {
 	var cmd *exec.Cmd
 	if useSudo {
 		// -n, non-interactive mode, no prompts are used
-		cmd = exec.CommandContext(ctx, "sudo", "-n", "sh", "-c", cmdStr)
+		cmd = exec.CommandContext(ctx, "sudo", binary, sudoArgs...)
 	} else {
-		cmd = exec.CommandContext(ctx, "sh", "-c", cmdStr)
+		cmd = exec.CommandContext(ctx, binary, args...)
 	}
 	return cmd.Output()
 }
 
 // Run executes the check
 func (c *JetsonCheck) Run() error {
-	tegraStatsCmd := fmt.Sprintf("%s %s", c.tegraStatsPath, strings.Join(c.commandOpts, " "))
-
 	// Kill tegrastats if it runs for twice as long as the interval we specified, to avoid blocking
 	// the check forever
 	ctx, cancel := context.WithTimeout(context.Background(), 2*tegraStatsInterval)
 	defer cancel()
-	tegrastatsOutput, err := runCommand(ctx, tegraStatsCmd, c.useSudo)
+	tegrastatsOutput, err := runCommand(ctx, c.tegraStatsPath, c.commandOpts, c.useSudo)
 	if err != nil {
 		switch err := err.(type) {
 		case *exec.ExitError:

--- a/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
@@ -621,7 +621,19 @@ use_sudo: true
 }
 
 func TestRunCommand(t *testing.T) {
-	out, err := runCommand(context.Background(), "echo hello", false)
-	require.NoError(t, err)
-	assert.Equal(t, "hello\n", string(out))
+	tests := []struct {
+		cmd            string
+		expectedOutput string
+	}{
+		{cmd: "echo hello", expectedOutput: "hello\n"},
+		{cmd: "printf '%s' hello", expectedOutput: "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			out, err := runCommand(context.Background(), tt.cmd, false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedOutput, string(out))
+		})
+	}
 }

--- a/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
@@ -8,10 +8,12 @@
 package nvidia
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -616,4 +618,10 @@ use_sudo: true
 			}
 		})
 	}
+}
+
+func TestRunCommand(t *testing.T) {
+	out, err := runCommand(context.Background(), "echo hello", false)
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", string(out))
 }

--- a/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
@@ -622,16 +622,17 @@ use_sudo: true
 
 func TestRunCommand(t *testing.T) {
 	tests := []struct {
-		cmd            string
+		binary         string
+		args           []string
 		expectedOutput string
 	}{
-		{cmd: "echo hello", expectedOutput: "hello\n"},
-		{cmd: "printf '%s' hello", expectedOutput: "hello"},
+		{binary: "echo", args: []string{"hello"}, expectedOutput: "hello\n"},
+		{binary: "printf", args: []string{"%s", "hello"}, expectedOutput: "hello"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.cmd, func(t *testing.T) {
-			out, err := runCommand(context.Background(), tt.cmd, false)
+		t.Run(tt.binary, func(t *testing.T) {
+			out, err := runCommand(context.Background(), tt.binary, tt.args, false)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedOutput, string(out))
 		})


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug introduced in https://github.com/DataDog/datadog-agent/pull/45057, it made the tegrastats command fail because `sh -c` was removed.

This PR splits the binary string and the arguments string to be able to run the tegrastats command without `sh -c`, making the check less prone to injection.

In parallel, the PR cleans up the check execution by simplifying the timeout handling of the command. 

### Motivation

Fix bug introduced in a previous PR and solve the issue https://github.com/DataDog/datadog-agent/issues/50654.

### Describe how you validated your changes

Unit test to make sure that we can run basic commands

### Additional Notes
