### PR TITLE
[AGTMETRICS-433] serializer/v3: encode unit field

### DIFF
--- a/pkg/serializer/internal/metrics/iterable_series_v3.go
+++ b/pkg/serializer/internal/metrics/iterable_series_v3.go
@@ -69,6 +69,8 @@ const (
 	columnSketchBinCnts
 	columnSourceTypeNameRef
 	columnOriginRef
+	columnDictUnitStr
+	columnUnitRef
 	numberOfColumns
 )
 
@@ -98,6 +100,8 @@ var columnNames = []string{
 	"SketchBinCounts",
 	"SourceTypeName",
 	"OriginInfo",
+	"DictUnitStr",
+	"UnitRef",
 }
 
 // Constants for type column
@@ -113,6 +117,7 @@ const (
 	valueFloat64 int64 = 0x30
 
 	flagNoIndex = 0x100
+	flagHasUnit = 0x200
 )
 
 const (
@@ -131,6 +136,7 @@ type payloadsBuilderV3 struct {
 	deltaTimestamp         deltaEncoder
 	deltaSourceTypeNameRef deltaEncoder
 	deltaOriginRef         deltaEncoder
+	deltaUnitRef           deltaEncoder
 
 	pointsThisPayload   int
 	maxPointsPerPayload int
@@ -306,6 +312,7 @@ func (pb *payloadsBuilderV3) reset() {
 	pb.deltaTimestamp.reset()
 	pb.deltaSourceTypeNameRef.reset()
 	pb.deltaOriginRef.reset()
+	pb.deltaUnitRef.reset()
 	pb.compressor.Reset()
 	pb.stats = v3stats{}
 }
@@ -456,8 +463,16 @@ func (pb *payloadsBuilderV3) writeSerieToTxn(serie *metrics.Serie) {
 	if serie.NoIndex {
 		typeValue |= flagNoIndex
 	}
+	if serie.Unit != "" {
+		typeValue |= flagHasUnit
+	}
 
 	pb.txn.Int64(columnType, typeValue)
+
+	if serie.Unit != "" {
+		pb.txn.Sint64(columnUnitRef,
+			pb.deltaUnitRef.encode(pb.dict.internUnit(serie.Unit)))
+	}
 
 	for _, pnt := range serie.Points {
 		pb.writePointCommon(int64(pnt.Ts))
@@ -664,6 +679,7 @@ type dictionaryBuilder struct {
 	tagsInterner           interner[istr]
 	resourceInterner       interner[istr]
 	sourceTypeNameInterner interner[istr]
+	unitInterner           interner[istr]
 
 	originInfoInterner interner[originInfo]
 
@@ -693,6 +709,7 @@ func newDictionaryBuilder(txn *stream.ColumnTransaction) *dictionaryBuilder {
 		resourceInterner: newInterner[istr](txn, columnDictResourceStr),
 
 		sourceTypeNameInterner: newInterner[istr](txn, columnDictSourceTypeName),
+		unitInterner:           newInterner[istr](txn, columnDictUnitStr),
 
 		originInfoInterner: newInterner[originInfo](txn, columnDictOrigin),
 
@@ -706,6 +723,7 @@ func (db *dictionaryBuilder) reset() {
 	db.tagsInterner.reset()
 	db.resourceInterner.reset()
 	db.sourceTypeNameInterner.reset()
+	db.unitInterner.reset()
 	db.originInfoInterner.reset()
 	db.tagsLastID = 0
 	db.tagsIndex = map[tagsKey]int64{}
@@ -819,6 +837,13 @@ func (db *dictionaryBuilder) internSourceTypeName(stn string) int64 {
 		return 0
 	}
 	return db.sourceTypeNameInterner.intern(istr(stn))
+}
+
+func (db *dictionaryBuilder) internUnit(unit string) int64 {
+	if unit == "" {
+		return 0
+	}
+	return db.unitInterner.intern(istr(unit))
 }
 
 // pointType represents the kind (integer or floating point, range) of a time series point value.

--- a/pkg/serializer/internal/metrics/iterable_series_v3_test.go
+++ b/pkg/serializer/internal/metrics/iterable_series_v3_test.go
@@ -143,6 +143,99 @@ func TestPayloadsBuilderV3(t *testing.T) {
 	}, ps[0].GetContent())
 }
 
+func TestPayloadsBuilderV3_Unit(t *testing.T) {
+	r := assert.New(t)
+	const ts = 1756737057.1
+	series := metrics.Series{
+		&metrics.Serie{
+			Name:     "lat",
+			Unit:     "millisecond",
+			Points:   []metrics.Point{{Ts: ts, Value: 1}},
+			Interval: 10,
+		},
+		&metrics.Serie{
+			Name:     "count",
+			Points:   []metrics.Point{{Ts: ts, Value: 2}},
+			Interval: 10,
+		},
+		&metrics.Serie{
+			Name:     "lat2",
+			Unit:     "millisecond",
+			Points:   []metrics.Point{{Ts: ts, Value: 3}},
+			Interval: 10,
+		},
+	}
+
+	pipelineConfig := PipelineConfig{
+		Filter: AllowAllFilter{},
+		V3:     true,
+	}
+	pipelineContext := &PipelineContext{}
+
+	pb, err := newPayloadsBuilderV3(1000, 10000, 1000_0000, noopimpl.New(), pipelineConfig, pipelineContext)
+	require.NoError(t, err)
+
+	for _, s := range series {
+		r.NoError(pb.writeSerie(s))
+	}
+	r.NoError(pb.finishPayload())
+
+	ps := pipelineContext.payloads
+	r.Len(ps, 1)
+
+	r.Equal([]byte{
+		// metricData
+		3<<3 | 2, 0x66,
+
+		// dictNameStr
+		1<<3 | 2, 15,
+		/* 1 */ 3, 0x6c, 0x61, 0x74, // "lat"
+		/* 2 */ 5, 0x63, 0x6f, 0x75, 0x6e, 0x74, // "count"
+		/* 3 */ 4, 0x6c, 0x61, 0x74, 0x32, // "lat2"
+
+		// dictOrigin (single (product=10, 0, 0) interned -- product=10 is the default agent product
+		// returned by metricSourceToOriginProduct for an unset Source)
+		9<<3 | 2, 3, 10, 0, 0,
+
+		// type: gauge|sint64|flagHasUnit, gauge|sint64, gauge|sint64|flagHasUnit
+		10<<3 | 2, 5, 0x93, 0x04, 0x13, 0x93, 0x04,
+
+		// nameRef (delta-encoded sint64, sequence 1,2,3 -> deltas 1,1,1 -> zigzag 2,2,2)
+		11<<3 | 2, 3, 2, 2, 2,
+
+		// tagsRef (all zero, no tags)
+		12<<3 | 2, 3, 0, 0, 0,
+
+		// resourcesRef (all zero, no resources)
+		13<<3 | 2, 3, 0, 0, 0,
+
+		// interval (int64 varint, all 10)
+		14<<3 | 2, 3, 10, 10, 10,
+
+		// numPoints (int64 varint, all 1)
+		15<<3 | 2, 3, 1, 1, 1,
+
+		// timestamp (delta-encoded sint64; first ts = 1756737057, then deltas of 0)
+		16<<3 | 2, 1, 7, 0xc2, 0xb8, 0xad, 0x8b, 0xd, 0, 0,
+
+		// valueSint64 (1,2,3 -> zigzag 2,4,6)
+		17<<3 | 2, 1, 3, 2, 4, 6,
+
+		// sourceTypeNameRef (all 0)
+		23<<3 | 2, 1, 3, 0, 0, 0,
+
+		// originRef (interned id 1 for all, deltas 1,0,0 -> zigzag 2,0,0)
+		24<<3 | 2, 1, 3, 2, 0, 0,
+
+		// dictUnitStr (single entry "millisecond" interned)
+		25<<3 | 2, 1, 12, 11,
+		0x6d, 0x69, 0x6c, 0x6c, 0x69, 0x73, 0x65, 0x63, 0x6f, 0x6e, 0x64,
+
+		// unitRef (sparse: entries for series 1 and 3 only; both unit id 1, deltas 1,0 -> zigzag 2,0)
+		26<<3 | 2, 1, 2, 2, 0,
+	}, ps[0].GetContent())
+}
+
 func BenchmarkPayloadsBuilderV3(b *testing.B) {
 	const ts = 1756737057.1
 	serie := &metrics.Serie{
@@ -212,7 +305,7 @@ func TestPayloadBuildersV3_Split(t *testing.T) {
 		V3:     true,
 	}
 	pipelineContext := &PipelineContext{}
-	pb, err := newPayloadsBuilderV3(180, 10000, 1000_0000, noopimpl.New(), pipelineConfig, pipelineContext)
+	pb, err := newPayloadsBuilderV3(188, 10000, 1000_0000, noopimpl.New(), pipelineConfig, pipelineContext)
 	require.NoError(t, err)
 
 	r.NoError(pb.writeSerie(series[0]))
@@ -224,7 +317,7 @@ func TestPayloadBuildersV3_Split(t *testing.T) {
 	r.Len(payloads, 3)
 
 	r.Equal(2, payloads[0].GetPointCount())
-	r.Less(len(payloads[1].GetContent()), 180)
+	r.Less(len(payloads[1].GetContent()), 188)
 	r.Equal(1, payloads[1].GetPointCount())
 	r.Equal(1, payloads[2].GetPointCount())
 	r.NotContains("foo", payloads[1].GetContent())


### PR DESCRIPTION
### What does this PR do?

Extend the V3 metric serializer to encode the per-series `Unit` field that PR has #50017 added.

### Motivation

PR #50017 wired `Serie.Unit` through the V2 encoder, but the V3 columnar encoder was left out. This leads to a gap between V2 and V3 payloads which mush match.

### Describe how you validated your changes

- Added a unit test which does byte-level assertion of the unit field's presence.

### Additional Notes
