### PR TITLE
Bump requested CI runner memory for Bazel jobs

### DIFF
--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -68,8 +68,8 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   variables:
     KUBERNETES_CPU_REQUEST: 4
-    KUBERNETES_MEMORY_REQUEST: "12Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
+    KUBERNETES_MEMORY_REQUEST: "32Gi"
+    KUBERNETES_MEMORY_LIMIT: "32Gi"
 
 .bazel:runner:linux-arm64:
   #extends: .bazel:defs:cache:persistent
@@ -79,8 +79,8 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   variables:
     KUBERNETES_CPU_REQUEST: 4
-    KUBERNETES_MEMORY_REQUEST: "12Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
+    KUBERNETES_MEMORY_REQUEST: "32Gi"
+    KUBERNETES_MEMORY_LIMIT: "32Gi"
 
 .bazel:runner:macos-amd64:
   extends: .bazel:defs:cache:macos


### PR DESCRIPTION
### What does this PR do?

Bumps the [memory requested ](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/2411528655/Onboarding+To+Gitlab+CI#Resources-requests-and-limits-on-Kubernetes-Job--%3Akubernetes%3A)for CI bazel jobs to 32 GiB, matching the requests for omnibus build jobs.

### Motivation

We are seeing OOM's in jobs (like [this](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1672925647)) where a lot needs to be rebuilt (in the example, it's a bump to the Go SDK which requires rebuilding all Go packages and deps that have been ported).

### Describe how you validated your changes

### Additional Notes

This unblocks current work; we may look into alternative solutions in the future.
