### PR TITLE
test(e2e/discovery): add k8s test using Helm charts

### DIFF
--- a/test/e2e-framework/components/datadog/agent/ecsFargate.go
+++ b/test/e2e-framework/components/datadog/agent/ecsFargate.go
@@ -40,7 +40,7 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 		Cpu:                    pulumi.IntPtr(0),
 		Name:                   pulumi.String("datadog-agent"),
 		Image:                  pulumi.String(image),
-		Essential:              pulumi.BoolPtr(false),
+		Essential:              pulumi.BoolPtr(true),
 		ReadonlyRootFilesystem: pulumi.BoolPtr(true),
 		DependsOn: ecs.TaskDefinitionContainerDependencyArray{
 			ecs.TaskDefinitionContainerDependencyArgs{

--- a/test/e2e-framework/components/datadog/agent/ecsFargate.go
+++ b/test/e2e-framework/components/datadog/agent/ecsFargate.go
@@ -40,7 +40,7 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 		Cpu:                    pulumi.IntPtr(0),
 		Name:                   pulumi.String("datadog-agent"),
 		Image:                  pulumi.String(image),
-		Essential:              pulumi.BoolPtr(true),
+		Essential:              pulumi.BoolPtr(false),
 		ReadonlyRootFilesystem: pulumi.BoolPtr(true),
 		DependsOn: ecs.TaskDefinitionContainerDependencyArray{
 			ecs.TaskDefinitionContainerDependencyArgs{

--- a/test/new-e2e/tests/discovery/config/helm-values.tmpl
+++ b/test/new-e2e/tests/discovery/config/helm-values.tmpl
@@ -1,0 +1,16 @@
+datadog:
+  processAgent:
+    processCollection: true
+  logs:
+    enabled: false
+  envDict:
+    DD_LANGUAGE_DETECTION_ENABLED: "true"
+
+agents:
+  containers:
+    systemProbe:
+      env:
+        - name: DD_DISCOVERY_ENABLED
+          value: "true"
+        - name: DD_DISCOVERY_USE_SYSTEM_PROBE_LITE
+          value: "{{.UseSystemProbeLite}}"

--- a/test/new-e2e/tests/discovery/config/helm-values.tmpl
+++ b/test/new-e2e/tests/discovery/config/helm-values.tmpl
@@ -16,9 +16,6 @@ datadog:
     DD_LANGUAGE_DETECTION_ENABLED: "true"
 
 agents:
-  image:
-    tag: "7.78.0"
-    doNotCheckTag: true
   # The discovery-e2e-mode annotation is purely a no-op marker
   # whose only purpose is to change the DaemonSet pod template
   # hash between sub-tests, forcing a pod rollout. Without it,

--- a/test/new-e2e/tests/discovery/config/helm-values.tmpl
+++ b/test/new-e2e/tests/discovery/config/helm-values.tmpl
@@ -1,8 +1,4 @@
 datadog:
-  processAgent:
-    processCollection: true
-  logs:
-    enabled: false
   discovery:
     enabled: true
 {{- if eq .Mode "sp" }}
@@ -12,8 +8,6 @@ datadog:
   systemProbe:
     enableOOMKill: true
 {{- end }}
-  envDict:
-    DD_LANGUAGE_DETECTION_ENABLED: "true"
 
 agents:
   # The discovery-e2e-mode annotation is purely a no-op marker

--- a/test/new-e2e/tests/discovery/config/helm-values.tmpl
+++ b/test/new-e2e/tests/discovery/config/helm-values.tmpl
@@ -5,7 +5,10 @@ datadog:
     enabled: false
   discovery:
     enabled: true
-{{- if .EnableOOMKill }}
+{{- if eq .Mode "sp" }}
+  # Add a non-discovery system-probe feature so the agent's
+  # shouldExecSPLite logic keeps the full binary running instead
+  # of exec'ing into system-probe-lite.
   systemProbe:
     enableOOMKill: true
 {{- end }}
@@ -16,3 +19,12 @@ agents:
   image:
     tag: "7.78.0"
     doNotCheckTag: true
+  # The discovery-e2e-mode annotation is purely a no-op marker
+  # whose only purpose is to change the DaemonSet pod template
+  # hash between sub-tests, forcing a pod rollout. Without it,
+  # toggling datadog.systemProbe.enableOOMKill only updates the
+  # configmap and the existing pod stays alive (the chart has
+  # no checksum/system_probe annotation tying the pod template
+  # to the configmap content).
+  podAnnotations:
+    discovery-e2e-mode: "{{ .Mode }}"

--- a/test/new-e2e/tests/discovery/config/helm-values.tmpl
+++ b/test/new-e2e/tests/discovery/config/helm-values.tmpl
@@ -7,12 +7,3 @@ datadog:
     enabled: true
   envDict:
     DD_LANGUAGE_DETECTION_ENABLED: "true"
-
-agents:
-  containers:
-    systemProbe:
-      env:
-        - name: DD_DISCOVERY_ENABLED
-          value: "true"
-        - name: DD_DISCOVERY_USE_SYSTEM_PROBE_LITE
-          value: "{{.UseSystemProbeLite}}"

--- a/test/new-e2e/tests/discovery/config/helm-values.tmpl
+++ b/test/new-e2e/tests/discovery/config/helm-values.tmpl
@@ -5,5 +5,14 @@ datadog:
     enabled: false
   discovery:
     enabled: true
+{{- if .EnableOOMKill }}
+  systemProbe:
+    enableOOMKill: true
+{{- end }}
   envDict:
     DD_LANGUAGE_DETECTION_ENABLED: "true"
+
+agents:
+  image:
+    tag: "7.78.0"
+    doNotCheckTag: true

--- a/test/new-e2e/tests/discovery/config/helm-values.tmpl
+++ b/test/new-e2e/tests/discovery/config/helm-values.tmpl
@@ -3,6 +3,8 @@ datadog:
     processCollection: true
   logs:
     enabled: false
+  discovery:
+    enabled: true
   envDict:
     DD_LANGUAGE_DETECTION_ENABLED: "true"
 

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -6,19 +6,13 @@
 package discovery
 
 import (
-	"bytes"
-	"context"
 	_ "embed"
 	"testing"
-	"text/template"
 	"time"
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/nginx"
@@ -27,7 +21,6 @@ import (
 	scenkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/process"
 )
@@ -38,34 +31,7 @@ const (
 )
 
 //go:embed config/helm-values.tmpl
-var helmValuesTemplate string
-
-type helmConfig struct {
-	UseSystemProbeLite bool
-}
-
-func createHelmValues(cfg helmConfig) (string, error) {
-	var buf bytes.Buffer
-	tmpl, err := template.New("helm").Parse(helmValuesTemplate)
-	if err != nil {
-		return "", err
-	}
-	if err := tmpl.Execute(&buf, cfg); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}
-
-func k8sProvisioner(helmValues string) provisioners.TypedProvisioner[environments.Kubernetes] {
-	return provkindvm.Provisioner(
-		provkindvm.WithRunOptions(
-			scenkindvm.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
-				return nginx.K8sAppDefinition(e, kubeProvider, nginxNamespace, nginxPort, "", false, nil)
-			}),
-			scenkindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
-		),
-	)
-}
+var helmValues string
 
 type k8sTestSuite struct {
 	e2e.BaseSuite[environments.Kubernetes]
@@ -74,42 +40,38 @@ type k8sTestSuite struct {
 func TestK8sTestSuite(t *testing.T) {
 	t.Parallel()
 
-	helmValues, err := createHelmValues(helmConfig{UseSystemProbeLite: true})
-	require.NoError(t, err)
-
-	e2e.Run(t, &k8sTestSuite{}, e2e.WithProvisioner(k8sProvisioner(helmValues)))
+	e2e.Run(t, &k8sTestSuite{},
+		e2e.WithProvisioner(
+			provkindvm.Provisioner(
+				provkindvm.WithRunOptions(
+					scenkindvm.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
+						return nginx.K8sAppDefinition(e, kubeProvider, nginxNamespace, nginxPort, "", false, nil)
+					}),
+					scenkindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
+				),
+			),
+		),
+	)
 }
 
+// TestNginxDiscovered verifies that the agent's discovery feature reports
+// the nginx workload to fakeintake. We don't differentiate between
+// system-probe and system-probe-lite modes — this is a sanity check that
+// the discovery flow works at all on k8s, in whichever mode the chart picks.
 func (s *k8sTestSuite) TestNginxDiscovered() {
-	for _, mode := range []discoveryMode{discoveryModeSystemProbeLite, discoveryModeSystemProbe} {
-		s.Run(string(mode), func() {
-			useSystemProbeLite := mode == discoveryModeSystemProbeLite
-			helmValues, err := createHelmValues(helmConfig{UseSystemProbeLite: useSystemProbeLite})
-			require.NoError(s.T(), err)
-			s.UpdateEnv(k8sProvisioner(helmValues))
+	t := s.T()
 
-			require.NoError(s.T(), s.Env().FakeIntake.Client().FlushServerAndResetAggregators())
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		payloads, err := s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
 
-			s.validateDiscoveryMode(mode)
+		procs := process.FilterProcessPayloadsByName(payloads, "nginx")
+		assert.NotEmpty(c, procs, "no nginx process found in payloads")
 
-			t := s.T()
-			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				payloads, err := s.Env().FakeIntake.Client().GetProcesses()
-				assert.NoError(c, err, "failed to get process payloads from fakeintake")
-				assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-
-				procs := process.FilterProcessPayloadsByName(payloads, "nginx")
-				assert.NotEmpty(c, procs, "no nginx process found in payloads")
-
-				assert.True(c, anyProcessListensOnPort(procs, int32(nginxPort)),
-					"no nginx process was reported listening on tcp/%d. processes: %+v", nginxPort, procs)
-			}, 5*time.Minute, 10*time.Second)
-
-			if t.Failed() {
-				s.dumpDebugInfo(t)
-			}
-		})
-	}
+		assert.True(c, anyProcessListensOnPort(procs, int32(nginxPort)),
+			"no nginx process was reported listening on tcp/%d. processes: %+v", nginxPort, procs)
+	}, 5*time.Minute, 10*time.Second)
 }
 
 // anyProcessListensOnPort returns true if any of the given processes reports
@@ -128,60 +90,4 @@ func anyProcessListensOnPort(procs []*agentmodel.Process, port int32) bool {
 		}
 	}
 	return false
-}
-
-func (s *k8sTestSuite) validateDiscoveryMode(mode discoveryMode) {
-	t := s.T()
-	agentPod := s.getAgentPod(t)
-	stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
-		agentPod.Namespace, agentPod.Name, "system-probe",
-		[]string{"sh", "-c", "ps aux | grep system-probe | grep -v grep"})
-	require.NoError(t, err, "failed to exec ps in system-probe container")
-	t.Logf("Process list:\n%s", stdout)
-
-	switch mode {
-	case discoveryModeSystemProbeLite:
-		require.Contains(t, stdout, "system-probe-lite", "system-probe-lite should be running in system-probe-lite mode")
-	case discoveryModeSystemProbe:
-		require.NotContains(t, stdout, "system-probe-lite", "system-probe-lite should not be running in system-probe mode")
-		require.Contains(t, stdout, "system-probe", "system-probe should be running in system-probe mode")
-	}
-	t.Logf("Discovery mode confirmed: %s", mode)
-}
-
-func (s *k8sTestSuite) dumpDebugInfo(t *testing.T) {
-	agentPod := s.getAgentPod(t)
-	if stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
-		agentPod.Namespace, agentPod.Name, "system-probe",
-		[]string{"curl", "-s", "--unix-socket", "/var/run/sysprobe/sysprobe.sock", "http://unix/discovery/debug"}); err == nil {
-		t.Log("system-probe discovery debug:\n", stdout)
-	} else {
-		t.Log("failed to get discovery debug info:", err)
-	}
-	if stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
-		agentPod.Namespace, agentPod.Name, "agent",
-		[]string{"agent", "status"}); err == nil {
-		t.Log("agent status:\n", stdout)
-	} else {
-		t.Log("failed to get agent status:", err)
-	}
-}
-
-func (s *k8sTestSuite) getAgentPod(t testing.TB) corev1.Pod {
-	res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").
-		List(context.Background(), v1.ListOptions{LabelSelector: "app=dda-linux-datadog"})
-	require.NoError(t, err)
-	require.NotEmpty(t, res.Items, "no agent pods found")
-	for _, pod := range res.Items {
-		if pod.DeletionTimestamp != nil {
-			continue
-		}
-		for _, cs := range pod.Status.ContainerStatuses {
-			if cs.Name == "system-probe" && cs.Ready {
-				return pod
-			}
-		}
-	}
-	t.Fatalf("no agent pod with ready system-probe container found")
-	return corev1.Pod{} // unreachable; t.Fatalf doesn't return
 }

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -88,9 +88,9 @@ func (s *k8sTestSuite) TestNginxDiscovered() {
 			require.NoError(s.T(), err)
 			s.UpdateEnv(k8sProvisioner(helmValues))
 
-			s.validateK8sDiscoveryMode(mode)
-
 			require.NoError(s.T(), s.Env().FakeIntake.Client().FlushServerAndResetAggregators())
+
+			s.validateDiscoveryMode(mode)
 
 			t := s.T()
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -106,7 +106,7 @@ func (s *k8sTestSuite) TestNginxDiscovered() {
 			}, 5*time.Minute, 10*time.Second)
 
 			if t.Failed() {
-				s.dumpK8sDebugInfo(t)
+				s.dumpDebugInfo(t)
 			}
 		})
 	}
@@ -130,7 +130,7 @@ func anyProcessListensOnPort(procs []*agentmodel.Process, port int32) bool {
 	return false
 }
 
-func (s *k8sTestSuite) validateK8sDiscoveryMode(mode discoveryMode) {
+func (s *k8sTestSuite) validateDiscoveryMode(mode discoveryMode) {
 	t := s.T()
 	agentPod := s.getAgentPod(t)
 	stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
@@ -149,7 +149,7 @@ func (s *k8sTestSuite) validateK8sDiscoveryMode(mode discoveryMode) {
 	t.Logf("Discovery mode confirmed: %s", mode)
 }
 
-func (s *k8sTestSuite) dumpK8sDebugInfo(t *testing.T) {
+func (s *k8sTestSuite) dumpDebugInfo(t *testing.T) {
 	agentPod := s.getAgentPod(t)
 	if stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
 		agentPod.Namespace, agentPod.Name, "system-probe",
@@ -182,5 +182,6 @@ func (s *k8sTestSuite) getAgentPod(t testing.TB) corev1.Pod {
 			}
 		}
 	}
-	return res.Items[0]
+	t.Fatalf("no agent pod with ready system-probe container found")
+	return corev1.Pod{} // unreachable; t.Fatalf doesn't return
 }

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -140,12 +140,22 @@ func (s *k8sTestSuite) TestNginxDiscovered() {
 				}
 				assert.NotNil(c, matched, "no nginx process was reported listening on tcp/%d", nginxPort)
 			}, 5*time.Minute, 10*time.Second)
+			require.NotNil(t, matched, "no matching nginx process found")
 
-			// Log the matched payload so we can tighten assertions in a follow-up.
-			if matched != nil {
-				t.Logf("matched nginx process payload:\n%+v\nServiceDiscovery: %+v\nPortInfo: %+v",
-					matched, matched.ServiceDiscovery, matched.PortInfo)
-			}
+			t.Logf("matched nginx process payload:\n%+v", matched)
+
+			// nginx is C/native, so no language or tracer-metadata
+			// fields are populated. What discovery does fill in:
+			sd := matched.ServiceDiscovery
+			require.NotNil(t, sd, "ServiceDiscovery is unset on the matched process")
+			require.NotNil(t, sd.GeneratedServiceName, "GeneratedServiceName is unset")
+			assert.Equal(t, "nginx", sd.GeneratedServiceName.Name, "generated service name should be 'nginx'")
+			assert.Equal(t, agentmodel.ServiceNameSource_SERVICE_NAME_SOURCE_COMMAND_LINE, sd.GeneratedServiceName.Source,
+				"service name source should be SERVICE_NAME_SOURCE_COMMAND_LINE")
+			assert.Equal(t, agentmodel.InjectionState_INJECTION_NOT_INJECTED, matched.InjectionState,
+				"nginx isn't instrumented; injection state should be NOT_INJECTED")
+			assert.False(t, sd.ApmInstrumentation, "ServiceDiscovery.ApmInstrumentation should be false for unmodified nginx")
+			assert.NotEmpty(t, matched.ContainerId, "containerId should be populated by the discovery → tagger pipeline")
 		})
 	}
 }

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -128,12 +128,19 @@ func (s *k8sTestSuite) TestNginxDiscovered() {
 			t := s.T()
 			var matched *agentmodel.Process
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				matched = nil
 				payloads, err := s.Env().FakeIntake.Client().GetProcesses()
-				assert.NoError(c, err, "failed to get process payloads from fakeintake")
-				assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+				if !assert.NoError(c, err, "failed to get process payloads from fakeintake") {
+					return
+				}
+				if !assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned") {
+					return
+				}
 
 				procs := process.FilterProcessPayloadsByName(payloads, "nginx")
-				assert.NotEmpty(c, procs, "no nginx process found in payloads")
+				if !assert.NotEmpty(c, procs, "no nginx process found in payloads") {
+					return
+				}
 
 				for _, p := range procs {
 					if p.PortInfo != nil && slices.Contains(p.PortInfo.Tcp, int32(nginxPort)) {
@@ -141,24 +148,29 @@ func (s *k8sTestSuite) TestNginxDiscovered() {
 						break
 					}
 				}
-				assert.NotNil(c, matched, "no nginx process was reported listening on tcp/%d", nginxPort)
+				if !assert.NotNil(c, matched, "no nginx process was reported listening on tcp/%d", nginxPort) {
+					return
+				}
+
+				// nginx is C/native, so no language or tracer-metadata
+				// fields are populated. What discovery does fill in:
+				sd := matched.ServiceDiscovery
+				if !assert.NotNil(c, sd, "ServiceDiscovery is unset on the matched process") {
+					return
+				}
+				if assert.NotNil(c, sd.GeneratedServiceName, "GeneratedServiceName is unset") {
+					assert.Equal(c, "nginx", sd.GeneratedServiceName.Name, "generated service name should be 'nginx'")
+					assert.Equal(c, agentmodel.ServiceNameSource_SERVICE_NAME_SOURCE_COMMAND_LINE, sd.GeneratedServiceName.Source,
+						"service name source should be SERVICE_NAME_SOURCE_COMMAND_LINE")
+				}
+				assert.Equal(c, agentmodel.InjectionState_INJECTION_NOT_INJECTED, matched.InjectionState,
+					"nginx isn't instrumented; injection state should be NOT_INJECTED")
+				assert.False(c, sd.ApmInstrumentation, "ServiceDiscovery.ApmInstrumentation should be false for unmodified nginx")
+				assert.NotEmpty(c, matched.ContainerId, "containerId should be populated by the discovery → tagger pipeline")
 			}, 5*time.Minute, 10*time.Second)
 			require.NotNil(t, matched, "no matching nginx process found")
 
 			t.Logf("matched nginx process payload:\n%+v", matched)
-
-			// nginx is C/native, so no language or tracer-metadata
-			// fields are populated. What discovery does fill in:
-			sd := matched.ServiceDiscovery
-			require.NotNil(t, sd, "ServiceDiscovery is unset on the matched process")
-			require.NotNil(t, sd.GeneratedServiceName, "GeneratedServiceName is unset")
-			assert.Equal(t, "nginx", sd.GeneratedServiceName.Name, "generated service name should be 'nginx'")
-			assert.Equal(t, agentmodel.ServiceNameSource_SERVICE_NAME_SOURCE_COMMAND_LINE, sd.GeneratedServiceName.Source,
-				"service name source should be SERVICE_NAME_SOURCE_COMMAND_LINE")
-			assert.Equal(t, agentmodel.InjectionState_INJECTION_NOT_INJECTED, matched.InjectionState,
-				"nginx isn't instrumented; injection state should be NOT_INJECTED")
-			assert.False(t, sd.ApmInstrumentation, "ServiceDiscovery.ApmInstrumentation should be false for unmodified nginx")
-			assert.NotEmpty(t, matched.ContainerId, "containerId should be populated by the discovery → tagger pipeline")
 		})
 	}
 }

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -7,6 +7,7 @@ package discovery
 
 import (
 	_ "embed"
+	"slices"
 	"testing"
 	"time"
 
@@ -80,13 +81,8 @@ func (s *k8sTestSuite) TestNginxDiscovered() {
 // tracer metadata (those are covered by the VM suite).
 func anyProcessListensOnPort(procs []*agentmodel.Process, port int32) bool {
 	for _, p := range procs {
-		if p.PortInfo == nil {
-			continue
-		}
-		for _, tcp := range p.PortInfo.Tcp {
-			if tcp == port {
-				return true
-			}
+		if p.PortInfo != nil && slices.Contains(p.PortInfo.Tcp, port) {
+			return true
 		}
 	}
 	return false

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -46,12 +46,21 @@ const (
 var helmValuesTemplate string
 
 type helmConfig struct {
-	// EnableOOMKill forces full system-probe to run by enabling a
-	// second system-probe feature alongside discovery. The agent's
-	// shouldExecSPLite logic only exec's into system-probe-lite when
-	// discovery is the *only* enabled system-probe module
-	// (cmd/system-probe/subcommands/run/splite.go).
-	EnableOOMKill bool
+	// Mode controls which discovery mode the chart renders for, and
+	// is also written verbatim as a DaemonSet pod annotation. The
+	// annotation is the mechanism that actually rolls the pod when
+	// we flip modes via UpdateEnv between sub-tests — without it,
+	// only the system-probe configmap changes and the existing pod
+	// stays alive (the chart's daemonset.yaml has no checksum
+	// annotation tying the pod template to that configmap).
+	//
+	// "spl" → discovery alone → agent execs into system-probe-lite
+	// "sp"  → discovery + datadog.systemProbe.enableOOMKill → the
+	//         agent's shouldExecSPLite logic keeps the full binary
+	//         running because discovery is no longer the only
+	//         enabled system-probe module
+	//         (cmd/system-probe/subcommands/run/splite.go).
+	Mode string
 }
 
 func createHelmValues(cfg helmConfig) (string, error) {
@@ -90,8 +99,9 @@ type k8sTestSuite struct {
 func TestK8sTestSuite(t *testing.T) {
 	t.Parallel()
 
-	// Initial helm values: discovery only → SPL mode.
-	helmValues, err := createHelmValues(helmConfig{})
+	// Initial helm values: SPL mode. The first sub-test will UpdateEnv
+	// to the same mode (no-op) and the second to "sp".
+	helmValues, err := createHelmValues(helmConfig{Mode: "spl"})
 	require.NoError(t, err)
 
 	e2e.Run(t, &k8sTestSuite{}, e2e.WithProvisioner(k8sProvisioner(helmValues)))
@@ -100,9 +110,11 @@ func TestK8sTestSuite(t *testing.T) {
 func (s *k8sTestSuite) TestNginxDiscovered() {
 	for _, mode := range []discoveryMode{discoveryModeSystemProbeLite, discoveryModeSystemProbe} {
 		s.Run(string(mode), func() {
-			helmValues, err := createHelmValues(helmConfig{
-				EnableOOMKill: mode == discoveryModeSystemProbe,
-			})
+			modeName := "spl"
+			if mode == discoveryModeSystemProbe {
+				modeName = "sp"
+			}
+			helmValues, err := createHelmValues(helmConfig{Mode: modeName})
 			require.NoError(s.T(), err)
 			s.UpdateEnv(k8sProvisioner(helmValues))
 

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -36,6 +36,10 @@ import (
 const (
 	nginxNamespace = "workload-nginx"
 	nginxPort      = 80
+	// helmChartVersion is the minimum chart version that ships the
+	// discovery-use-system-probe-lite template (added in chart 3.205.0
+	// via DataDog/helm-charts#2598). The framework default predates it.
+	helmChartVersion = "3.208.2"
 )
 
 //go:embed config/helm-values.tmpl
@@ -68,7 +72,13 @@ func k8sProvisioner(helmValues string) provisioners.TypedProvisioner[environment
 			scenkindvm.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
 				return nginx.K8sAppDefinition(e, kubeProvider, nginxNamespace, nginxPort, "", false, nil)
 			}),
-			scenkindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
+			scenkindvm.WithAgentOptions(
+				kubernetesagentparams.WithHelmValues(helmValues),
+				// Pin to a chart version that has the discovery /
+				// system-probe-lite logic. The framework default
+				// (HelmVersion in kubernetes_helm.go) predates it.
+				kubernetesagentparams.WithHelmChartVersion(helmChartVersion),
+			),
 		),
 	)
 }

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -6,14 +6,20 @@
 package discovery
 
 import (
+	"bytes"
+	"context"
 	_ "embed"
 	"slices"
 	"testing"
+	"text/template"
 	"time"
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/nginx"
@@ -22,6 +28,7 @@ import (
 	scenkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/process"
 )
@@ -32,7 +39,39 @@ const (
 )
 
 //go:embed config/helm-values.tmpl
-var helmValues string
+var helmValuesTemplate string
+
+type helmConfig struct {
+	// EnableOOMKill forces full system-probe to run by enabling a
+	// second system-probe feature alongside discovery. The agent's
+	// shouldExecSPLite logic only exec's into system-probe-lite when
+	// discovery is the *only* enabled system-probe module
+	// (cmd/system-probe/subcommands/run/splite.go).
+	EnableOOMKill bool
+}
+
+func createHelmValues(cfg helmConfig) (string, error) {
+	var buf bytes.Buffer
+	tmpl, err := template.New("helm").Parse(helmValuesTemplate)
+	if err != nil {
+		return "", err
+	}
+	if err := tmpl.Execute(&buf, cfg); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func k8sProvisioner(helmValues string) provisioners.TypedProvisioner[environments.Kubernetes] {
+	return provkindvm.Provisioner(
+		provkindvm.WithRunOptions(
+			scenkindvm.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
+				return nginx.K8sAppDefinition(e, kubeProvider, nginxNamespace, nginxPort, "", false, nil)
+			}),
+			scenkindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
+		),
+	)
+}
 
 type k8sTestSuite struct {
 	e2e.BaseSuite[environments.Kubernetes]
@@ -41,49 +80,103 @@ type k8sTestSuite struct {
 func TestK8sTestSuite(t *testing.T) {
 	t.Parallel()
 
-	e2e.Run(t, &k8sTestSuite{},
-		e2e.WithProvisioner(
-			provkindvm.Provisioner(
-				provkindvm.WithRunOptions(
-					scenkindvm.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
-						return nginx.K8sAppDefinition(e, kubeProvider, nginxNamespace, nginxPort, "", false, nil)
-					}),
-					scenkindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
-				),
-			),
-		),
-	)
+	// Initial helm values: discovery only → SPL mode.
+	helmValues, err := createHelmValues(helmConfig{})
+	require.NoError(t, err)
+
+	e2e.Run(t, &k8sTestSuite{}, e2e.WithProvisioner(k8sProvisioner(helmValues)))
 }
 
-// TestNginxDiscovered verifies that the agent's discovery feature reports
-// the nginx workload to fakeintake. We don't differentiate between
-// system-probe and system-probe-lite modes — this is a sanity check that
-// the discovery flow works at all on k8s, in whichever mode the chart picks.
 func (s *k8sTestSuite) TestNginxDiscovered() {
-	t := s.T()
+	for _, mode := range []discoveryMode{discoveryModeSystemProbeLite, discoveryModeSystemProbe} {
+		s.Run(string(mode), func() {
+			helmValues, err := createHelmValues(helmConfig{
+				EnableOOMKill: mode == discoveryModeSystemProbe,
+			})
+			require.NoError(s.T(), err)
+			s.UpdateEnv(k8sProvisioner(helmValues))
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		payloads, err := s.Env().FakeIntake.Client().GetProcesses()
-		assert.NoError(c, err, "failed to get process payloads from fakeintake")
-		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+			s.validateDiscoveryMode(mode)
 
-		procs := process.FilterProcessPayloadsByName(payloads, "nginx")
-		assert.NotEmpty(c, procs, "no nginx process found in payloads")
+			require.NoError(s.T(), s.Env().FakeIntake.Client().FlushServerAndResetAggregators())
 
-		assert.True(c, anyProcessListensOnPort(procs, int32(nginxPort)),
-			"no nginx process was reported listening on tcp/%d. processes: %+v", nginxPort, procs)
-	}, 5*time.Minute, 10*time.Second)
+			t := s.T()
+			var matched *agentmodel.Process
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				payloads, err := s.Env().FakeIntake.Client().GetProcesses()
+				assert.NoError(c, err, "failed to get process payloads from fakeintake")
+				assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+
+				procs := process.FilterProcessPayloadsByName(payloads, "nginx")
+				assert.NotEmpty(c, procs, "no nginx process found in payloads")
+
+				for _, p := range procs {
+					if p.PortInfo != nil && slices.Contains(p.PortInfo.Tcp, int32(nginxPort)) {
+						matched = p
+						break
+					}
+				}
+				assert.NotNil(c, matched, "no nginx process was reported listening on tcp/%d", nginxPort)
+			}, 5*time.Minute, 10*time.Second)
+
+			// Log the matched payload so we can tighten assertions in a follow-up.
+			if matched != nil {
+				t.Logf("matched nginx process payload:\n%+v\nServiceDiscovery: %+v\nPortInfo: %+v",
+					matched, matched.ServiceDiscovery, matched.PortInfo)
+			}
+		})
+	}
 }
 
-// anyProcessListensOnPort returns true if any of the given processes reports
-// a TCP listener on the specified port. The discovery sanity check only cares
-// that the port is detected; we don't assert on language, service name, or
-// tracer metadata (those are covered by the VM suite).
-func anyProcessListensOnPort(procs []*agentmodel.Process, port int32) bool {
-	for _, p := range procs {
-		if p.PortInfo != nil && slices.Contains(p.PortInfo.Tcp, port) {
-			return true
+// validateDiscoveryMode asserts the agent's system-probe container is running
+// the expected binary (full system-probe or system-probe-lite). Wrapped in
+// EventuallyWithT to tolerate the post-UpdateEnv pod-restart window where
+// getAgentPod would otherwise fail with "no agent pod with ready system-probe
+// container found".
+func (s *k8sTestSuite) validateDiscoveryMode(mode discoveryMode) {
+	t := s.T()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		agentPod, ok := tryFindReadyAgentPod(c, s)
+		if !ok {
+			return
+		}
+		stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+			agentPod.Namespace, agentPod.Name, "system-probe",
+			[]string{"sh", "-c", "ps aux | grep system-probe | grep -v grep"})
+		assert.NoError(c, err, "failed to exec ps in system-probe container")
+		t.Logf("Process list (mode=%s):\n%s", mode, stdout)
+		switch mode {
+		case discoveryModeSystemProbeLite:
+			assert.Contains(c, stdout, "system-probe-lite", "system-probe-lite should be running in system-probe-lite mode")
+		case discoveryModeSystemProbe:
+			assert.NotContains(c, stdout, "system-probe-lite", "system-probe-lite should not be running in system-probe mode")
+			assert.Contains(c, stdout, "system-probe", "system-probe should be running in system-probe mode")
+		}
+	}, 2*time.Minute, 5*time.Second)
+}
+
+// tryFindReadyAgentPod returns an agent pod with a Ready system-probe container,
+// or (zeroPod, false) if none is currently ready. Designed for use inside
+// EventuallyWithT, where "not yet" is a normal transient state, not a failure.
+func tryFindReadyAgentPod(c *assert.CollectT, s *k8sTestSuite) (corev1.Pod, bool) {
+	res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").
+		List(context.Background(), v1.ListOptions{LabelSelector: "app=dda-linux-datadog"})
+	if !assert.NoError(c, err, "failed to list agent pods") {
+		return corev1.Pod{}, false
+	}
+	if !assert.NotEmpty(c, res.Items, "no agent pods listed") {
+		return corev1.Pod{}, false
+	}
+	for _, pod := range res.Items {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == "system-probe" && cs.Ready {
+				return pod, true
+			}
 		}
 	}
-	return false
+	assert.Fail(c, "no agent pod has a ready system-probe container yet")
+	return corev1.Pod{}, false
 }

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -36,10 +36,13 @@ import (
 const (
 	nginxNamespace = "workload-nginx"
 	nginxPort      = 80
-	// helmChartVersion is the minimum chart version that ships the
-	// discovery-use-system-probe-lite template (added in chart 3.205.0
-	// via DataDog/helm-charts#2598). The framework default predates it.
-	helmChartVersion = "3.208.2"
+	// helmChartVersion needs to be ≥ 3.205.0 for the
+	// discovery-use-system-probe-lite template (DataDog/helm-charts#2598)
+	// and ≥ 3.213.0 for the get-agent-version fallback fix
+	// (DataDog/helm-charts#2643) that maps "latest"/"7" to ≥ 7.78.0 so
+	// the SPL auto-enable threshold is met without an explicit image
+	// tag pin. The framework's default chart version predates both.
+	helmChartVersion = "3.213.0"
 )
 
 //go:embed config/helm-values.tmpl

--- a/test/new-e2e/tests/discovery/k8s_test.go
+++ b/test/new-e2e/tests/discovery/k8s_test.go
@@ -1,0 +1,186 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package discovery
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"testing"
+	"text/template"
+	"time"
+
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/nginx"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	scenkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/process"
+)
+
+const (
+	nginxNamespace = "workload-nginx"
+	nginxPort      = 80
+)
+
+//go:embed config/helm-values.tmpl
+var helmValuesTemplate string
+
+type helmConfig struct {
+	UseSystemProbeLite bool
+}
+
+func createHelmValues(cfg helmConfig) (string, error) {
+	var buf bytes.Buffer
+	tmpl, err := template.New("helm").Parse(helmValuesTemplate)
+	if err != nil {
+		return "", err
+	}
+	if err := tmpl.Execute(&buf, cfg); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func k8sProvisioner(helmValues string) provisioners.TypedProvisioner[environments.Kubernetes] {
+	return provkindvm.Provisioner(
+		provkindvm.WithRunOptions(
+			scenkindvm.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
+				return nginx.K8sAppDefinition(e, kubeProvider, nginxNamespace, nginxPort, "", false, nil)
+			}),
+			scenkindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(helmValues)),
+		),
+	)
+}
+
+type k8sTestSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+func TestK8sTestSuite(t *testing.T) {
+	t.Parallel()
+
+	helmValues, err := createHelmValues(helmConfig{UseSystemProbeLite: true})
+	require.NoError(t, err)
+
+	e2e.Run(t, &k8sTestSuite{}, e2e.WithProvisioner(k8sProvisioner(helmValues)))
+}
+
+func (s *k8sTestSuite) TestNginxDiscovered() {
+	for _, mode := range []discoveryMode{discoveryModeSystemProbeLite, discoveryModeSystemProbe} {
+		s.Run(string(mode), func() {
+			useSystemProbeLite := mode == discoveryModeSystemProbeLite
+			helmValues, err := createHelmValues(helmConfig{UseSystemProbeLite: useSystemProbeLite})
+			require.NoError(s.T(), err)
+			s.UpdateEnv(k8sProvisioner(helmValues))
+
+			s.validateK8sDiscoveryMode(mode)
+
+			require.NoError(s.T(), s.Env().FakeIntake.Client().FlushServerAndResetAggregators())
+
+			t := s.T()
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				payloads, err := s.Env().FakeIntake.Client().GetProcesses()
+				assert.NoError(c, err, "failed to get process payloads from fakeintake")
+				assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+
+				procs := process.FilterProcessPayloadsByName(payloads, "nginx")
+				assert.NotEmpty(c, procs, "no nginx process found in payloads")
+
+				assert.True(c, anyProcessListensOnPort(procs, int32(nginxPort)),
+					"no nginx process was reported listening on tcp/%d. processes: %+v", nginxPort, procs)
+			}, 5*time.Minute, 10*time.Second)
+
+			if t.Failed() {
+				s.dumpK8sDebugInfo(t)
+			}
+		})
+	}
+}
+
+// anyProcessListensOnPort returns true if any of the given processes reports
+// a TCP listener on the specified port. The discovery sanity check only cares
+// that the port is detected; we don't assert on language, service name, or
+// tracer metadata (those are covered by the VM suite).
+func anyProcessListensOnPort(procs []*agentmodel.Process, port int32) bool {
+	for _, p := range procs {
+		if p.PortInfo == nil {
+			continue
+		}
+		for _, tcp := range p.PortInfo.Tcp {
+			if tcp == port {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *k8sTestSuite) validateK8sDiscoveryMode(mode discoveryMode) {
+	t := s.T()
+	agentPod := s.getAgentPod(t)
+	stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		agentPod.Namespace, agentPod.Name, "system-probe",
+		[]string{"sh", "-c", "ps aux | grep system-probe | grep -v grep"})
+	require.NoError(t, err, "failed to exec ps in system-probe container")
+	t.Logf("Process list:\n%s", stdout)
+
+	switch mode {
+	case discoveryModeSystemProbeLite:
+		require.Contains(t, stdout, "system-probe-lite", "system-probe-lite should be running in system-probe-lite mode")
+	case discoveryModeSystemProbe:
+		require.NotContains(t, stdout, "system-probe-lite", "system-probe-lite should not be running in system-probe mode")
+		require.Contains(t, stdout, "system-probe", "system-probe should be running in system-probe mode")
+	}
+	t.Logf("Discovery mode confirmed: %s", mode)
+}
+
+func (s *k8sTestSuite) dumpK8sDebugInfo(t *testing.T) {
+	agentPod := s.getAgentPod(t)
+	if stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		agentPod.Namespace, agentPod.Name, "system-probe",
+		[]string{"curl", "-s", "--unix-socket", "/var/run/sysprobe/sysprobe.sock", "http://unix/discovery/debug"}); err == nil {
+		t.Log("system-probe discovery debug:\n", stdout)
+	} else {
+		t.Log("failed to get discovery debug info:", err)
+	}
+	if stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		agentPod.Namespace, agentPod.Name, "agent",
+		[]string{"agent", "status"}); err == nil {
+		t.Log("agent status:\n", stdout)
+	} else {
+		t.Log("failed to get agent status:", err)
+	}
+}
+
+func (s *k8sTestSuite) getAgentPod(t testing.TB) corev1.Pod {
+	res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").
+		List(context.Background(), v1.ListOptions{LabelSelector: "app=dda-linux-datadog"})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Items, "no agent pods found")
+	for _, pod := range res.Items {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == "system-probe" && cs.Ready {
+				return pod
+			}
+		}
+	}
+	return res.Items[0]
+}


### PR DESCRIPTION
### What does this PR do?

Adds a Kubernetes E2E sanity test for the Datadog Agent's discovery feature, mirroring (in spirit) the existing Linux VM suite in `test/new-e2e/tests/discovery/linux_test.go`. The new suite at `test/new-e2e/tests/discovery/k8s_test.go`:

- Provisions a Kind-on-EC2 cluster (`provkindvm`) with the agent installed via Helm and an `nginx` workload.
- Runs `TestNginxDiscovered` in two sub-tests covering both discovery modes:
  - `system-probe-lite` — discovery enabled alone; the agent execs into `system-probe-lite` per `cmd/system-probe/subcommands/run/splite.go`.
  - `system-probe` — adds `datadog.systemProbe.enableOOMKill: true` so the agent's `shouldExecSPLite` keeps the full binary running.
- Asserts on the matched nginx process: TCP port 80 listener, `ServiceDiscovery.GeneratedServiceName == {nginx, SOURCE_COMMAND_LINE}`, `ApmInstrumentation == false`, `InjectionState == NOT_INJECTED`, non-empty `ContainerId`.
- Pins the Helm chart version to `3.213.0`; the framework default (`3.155.1`) predates both the discovery template (chart 3.205.0, DataDog/helm-charts#2598) and the `latest`/`7` → `7.78.x` fallback fix (chart 3.213.0, DataDog/helm-charts#2643).

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-385

There is no k8s e2e for discovery today. https://github.com/DataDog/helm-charts/pull/2634 fixed a bug in discovery on k8s related to the seccomp profile; the change went undetected before merge because nothing exercises the discovery flow on a Helm-installed agent. This suite closes that gap with a smoke-level check that the discovery payload reaches fakeintake in both modes.

The k8s suite is narrower than `linux_test.go` (single workload, smoke-level assertions), at least for now. This is to avoid having to add new app definitions at this point for a basic test. The VM suite continues to be the exhaustive per-language source of truth.

### Describe how you validated your changes

Ran locally against AWS twice with `E2E_DEV_MODE=true dda inv -- -e new-e2e-tests.run --targets ./tests/discovery --run TestK8sTestSuite --stack-name-suffix v2`:

```
--- PASS: TestK8sTestSuite (364.64s)
    --- PASS: TestK8sTestSuite/TestNginxDiscovered (...)
        --- PASS: TestK8sTestSuite/TestNginxDiscovered/system-probe-lite
        --- PASS: TestK8sTestSuite/TestNginxDiscovered/system-probe
```

Lint: `golangci-lint run ./test/new-e2e/tests/discovery/...` clean (0 issues).

### Additional Notes

A few quirks worth flagging for reviewers:

- **Forced DaemonSet rollout via pod annotation.** Toggling `datadog.systemProbe.enableOOMKill` between sub-tests only mutates the chart-rendered configmap; the chart's `daemonset.yaml` has no `checksum/system-probe-yaml` annotation tying the pod template to that configmap, so the existing pod stays alive across the change. The suite writes a `agents.podAnnotations.discovery-e2e-mode: "spl"/"sp"` that intentionally differs per sub-test to bump the pod-template hash and force a rollout.
- **Tracer metadata / language detection out of scope.** Nginx is C/native so `language` and `serviceDiscovery.tracerMetadata` aren't populated. The two natural ways to extend this — switch to (or add) an OTel-instrumented Go server (`apps-calendar-go` — no `K8sAppDefinition` yet) or a `dd-trace-go`-instrumented app (`apps-tracegen` predates the memfd-tracer-metadata feature in `dd-trace-go.v1`) — both require cross-repo work in `test-infra-definitions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)