### PR TITLE
`test/new-e2e`: leave room for cleanup before GitLab CI timeout

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -4,6 +4,7 @@ Running E2E Tests with infra based on Pulumi
 
 from __future__ import annotations
 
+import datetime
 import json
 import multiprocessing
 import os
@@ -419,6 +420,100 @@ def _download_prebuilt_binaries(ctx, s3_base_uri, targets):
     return True
 
 
+# Buffer subtracted from the remaining GitLab job time to derive the go test
+# timeout. It gives the test framework (TearDownSuite: pulumi destroy, cluster
+# state dump, dashboard URL log) a window to run after go test panics on its
+# own timeout and before GitLab kills the whole job.
+GO_TEST_CI_TIMEOUT_BUFFER_SECONDS = 5 * 60
+
+# Floor for the go test timeout: below this, attempting cleanup is pointless,
+# but we still want go test to exit with its own timeout (and stack dump)
+# rather than be killed mid-run by GitLab with no output.
+GO_TEST_MIN_TIMEOUT_SECONDS = 60
+
+# Fallback go test timeout when no GitLab CI timeout is available (local runs).
+DEFAULT_GO_TEST_TIMEOUT = "4h"
+
+
+def _format_go_duration(seconds: int) -> str:
+    """Format an integer number of seconds as a Go duration literal (e.g. "1h55m0s")."""
+    if seconds < 0:
+        seconds = 0
+    hours, remainder = divmod(seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours}h{minutes}m{secs}s"
+
+
+def _ci_job_elapsed_seconds(now: datetime.datetime | None = None) -> int | None:
+    """Return seconds elapsed since the GitLab job started, or None when unknown.
+
+    Uses `CI_JOB_STARTED_AT` (ISO 8601 UTC) set by GitLab, so the value
+    accounts for `before_script` time and any earlier retry attempts within
+    the same job.
+    """
+    started_at = os.environ.get("CI_JOB_STARTED_AT")
+    if not started_at:
+        return None
+    try:
+        # GitLab uses trailing 'Z' for UTC; datetime.fromisoformat needs '+00:00'.
+        parsed = datetime.datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    except ValueError:
+        print(f"WARNING: CI_JOB_STARTED_AT={started_at!r} is not a valid ISO 8601 datetime")
+        return None
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+    return int((now - parsed).total_seconds())
+
+
+def _compute_go_test_timeout(explicit: str | None, now: datetime.datetime | None = None) -> str:
+    """Resolve the value passed to `go test -timeout`.
+
+    Priority:
+      1. Explicit CLI value (`--timeout`).
+      2. Remaining GitLab job time (`CI_JOB_TIMEOUT` minus elapsed since
+         `CI_JOB_STARTED_AT`) minus a teardown buffer, so go test panics a
+         few minutes before GitLab kills the job and TearDownSuite can
+         complete.
+      3. Hardcoded fallback (`DEFAULT_GO_TEST_TIMEOUT`).
+    """
+    if explicit:
+        print(f"Using explicit go test timeout: {explicit}")
+        return explicit
+
+    ci_job_timeout = os.environ.get("CI_JOB_TIMEOUT")
+    if not ci_job_timeout:
+        return DEFAULT_GO_TEST_TIMEOUT
+    try:
+        job_seconds = int(ci_job_timeout)
+    except ValueError:
+        print(
+            f"WARNING: CI_JOB_TIMEOUT={ci_job_timeout!r} is not an integer, "
+            f"falling back to default go test timeout {DEFAULT_GO_TEST_TIMEOUT}"
+        )
+        return DEFAULT_GO_TEST_TIMEOUT
+
+    elapsed = _ci_job_elapsed_seconds(now=now) or 0
+    remaining = job_seconds - elapsed
+    go_seconds = remaining - GO_TEST_CI_TIMEOUT_BUFFER_SECONDS
+
+    if go_seconds < GO_TEST_MIN_TIMEOUT_SECONDS:
+        print(
+            f"WARNING: only {remaining}s left in the GitLab job (CI_JOB_TIMEOUT={job_seconds}s, "
+            f"elapsed={elapsed}s); the {GO_TEST_CI_TIMEOUT_BUFFER_SECONDS}s teardown buffer does "
+            f"not fit. Clamping go test timeout to {GO_TEST_MIN_TIMEOUT_SECONDS}s — cleanup may "
+            f"not finish before GitLab kills the job."
+        )
+        return _format_go_duration(GO_TEST_MIN_TIMEOUT_SECONDS)
+
+    go_timeout = _format_go_duration(go_seconds)
+    print(
+        f"Derived go test timeout from remaining GitLab job time "
+        f"(CI_JOB_TIMEOUT={job_seconds}s, elapsed={elapsed}s, "
+        f"buffer={GO_TEST_CI_TIMEOUT_BUFFER_SECONDS}s): {go_timeout}"
+    )
+    return go_timeout
+
+
 @task(
     iterable=['tags', 'targets', 'configparams', 'run', 'skip'],
     help={
@@ -436,6 +531,7 @@ def _download_prebuilt_binaries(ctx, s3_base_uri, targets):
         "max_retries": "Maximum number of retries for failed tests, default 3",
         "impacted": "Only run tests that are impacted by the changes (only available in CI for now)",
         "keep_stack": "Keep the stack after running the test, you are responsible for destroying the stack later.",
+        "timeout": "Go test timeout (Go duration string, e.g. '1h55m'). Defaults to CI_JOB_TIMEOUT minus a teardown buffer when running in GitLab CI, otherwise to 4h.",
     },
 )
 def run(
@@ -471,6 +567,7 @@ def run(
     osdescriptors="",
     module_name="test/new-e2e",
     recursive=True,
+    timeout="",
 ):
     """
     Run E2E Tests based on test-infra-definitions infrastructure provisioning.
@@ -670,7 +767,9 @@ def run(
 
     args = {
         "go_mod": "readonly",
-        "timeout": "4h",
+        # Set per-attempt inside the retry loop so each attempt reflects the
+        # remaining GitLab job budget.
+        "timeout": "",
         "verbose": "-test.v" if verbose else "",
         "nocache": "-test.count=1" if not cache else "",
         "REPO_PATH": REPO_PATH,
@@ -692,6 +791,10 @@ def run(
     result_jsons: list[str] = []
     result_junits: list[str] = []
     for attempt in range(max_retries + 1):
+        # Recomputed each attempt because retries eat into the GitLab job
+        # budget; a stale value would overshoot the kill deadline.
+        args["timeout"] = _compute_go_test_timeout(timeout)
+
         remaining_tries = max_retries - attempt
         if remaining_tries > 0:
             # If any tries are left, avoid destroying infra on failure

--- a/tasks/unit_tests/e2e_testing_tests.py
+++ b/tasks/unit_tests/e2e_testing_tests.py
@@ -1,10 +1,19 @@
+import datetime
 import os
 import unittest
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
 from tasks.libs.testing.e2e import create_test_selection_gotest_regex, filter_only_leaf_tests
-from tasks.new_e2e_tests import post_process_output, pretty_print_logs, write_result_to_log_files
+from tasks.new_e2e_tests import (
+    DEFAULT_GO_TEST_TIMEOUT,
+    GO_TEST_MIN_TIMEOUT_SECONDS,
+    _compute_go_test_timeout,
+    _format_go_duration,
+    post_process_output,
+    pretty_print_logs,
+    write_result_to_log_files,
+)
 
 
 class TestE2ETesting(unittest.TestCase):
@@ -198,3 +207,61 @@ class TestCreateTestSelectionGotestRegex(unittest.TestCase):
         self.assertEqual(
             create_test_selection_gotest_regex(["TestA/B", "TestA/C", "TestB/B"]), '"^(?:TestA|TestB)$/^(?:B|C)$"'
         )
+
+
+class TestComputeGoTestTimeout(unittest.TestCase):
+    _CI_VARS = ("CI_JOB_TIMEOUT", "CI_JOB_STARTED_AT")
+
+    def setUp(self):
+        self._saved = {var: os.environ.pop(var, None) for var in self._CI_VARS}
+
+    def tearDown(self):
+        for var, value in self._saved.items():
+            if value is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = value
+
+    @staticmethod
+    def _utc(year, month, day, hour=0, minute=0, second=0):
+        return datetime.datetime(year, month, day, hour, minute, second, tzinfo=datetime.timezone.utc)
+
+    def test_explicit_argument_wins_over_env(self):
+        os.environ["CI_JOB_TIMEOUT"] = "7200"
+        self.assertEqual(_compute_go_test_timeout("30m"), "30m")
+
+    def test_ci_env_no_started_at_uses_full_budget(self):
+        os.environ["CI_JOB_TIMEOUT"] = "7200"
+        # Without CI_JOB_STARTED_AT, elapsed is treated as 0.
+        self.assertEqual(_compute_go_test_timeout(""), "1h55m0s")
+
+    def test_ci_env_with_started_at_subtracts_elapsed(self):
+        os.environ["CI_JOB_TIMEOUT"] = "7200"
+        os.environ["CI_JOB_STARTED_AT"] = "2026-05-12T10:00:00Z"
+        now = self._utc(2026, 5, 12, 10, 10, 0)  # 10 min elapsed
+        # 7200 - 600 - 300 = 6300s = 1h45m
+        self.assertEqual(_compute_go_test_timeout("", now=now), "1h45m0s")
+
+    def test_remaining_too_small_clamps_to_minimum(self):
+        os.environ["CI_JOB_TIMEOUT"] = "60"
+        result = _compute_go_test_timeout("")
+        # 60s budget - 300s buffer = -240s → clamped to GO_TEST_MIN_TIMEOUT_SECONDS
+        self.assertEqual(result, _format_go_duration(GO_TEST_MIN_TIMEOUT_SECONDS))
+
+    def test_ci_env_not_integer_falls_back_to_default(self):
+        os.environ["CI_JOB_TIMEOUT"] = "not-a-number"
+        self.assertEqual(_compute_go_test_timeout(""), DEFAULT_GO_TEST_TIMEOUT)
+
+    def test_invalid_started_at_treated_as_no_elapsed(self):
+        os.environ["CI_JOB_TIMEOUT"] = "7200"
+        os.environ["CI_JOB_STARTED_AT"] = "not-a-date"
+        self.assertEqual(_compute_go_test_timeout(""), "1h55m0s")
+
+    def test_no_ci_env_returns_default(self):
+        self.assertEqual(_compute_go_test_timeout(""), DEFAULT_GO_TEST_TIMEOUT)
+
+    def test_format_go_duration(self):
+        self.assertEqual(_format_go_duration(6900), "1h55m0s")
+        self.assertEqual(_format_go_duration(60), "0h1m0s")
+        self.assertEqual(_format_go_duration(0), "0h0m0s")
+        self.assertEqual(_format_go_duration(-10), "0h0m0s")

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -580,17 +580,17 @@ func (bs *BaseSuite[Env]) buildEnvFromResources(resources provisioners.RawResour
 }
 
 func (bs *BaseSuite[Env]) providerContext(opTimeout time.Duration) (context.Context, context.CancelFunc) {
-	var ctx context.Context
-	var cancel func()
-
-	if deadline, ok := bs.T().Deadline(); ok {
-		deadline = deadline.Add(-provisionerGracePeriod)
-		ctx, cancel = context.WithDeadlineCause(context.Background(), deadline, errors.New("go test timeout almost reached, cancelling provisioners"))
-	} else {
-		ctx, cancel = context.WithTimeout(context.Background(), opTimeout)
+	if deadline, ok := bs.T().Deadline(); ok && time.Now().Before(deadline) {
+		// Normal case: clamp the provisioner context just before the real go
+		// test deadline so it cancels itself before the binary panics.
+		return context.WithDeadlineCause(context.Background(), deadline.Add(-provisionerGracePeriod), errors.New("go test timeout almost reached, cancelling provisioners"))
 	}
 
-	return ctx, cancel
+	// Either the suite has no go test deadline, or it has already passed
+	// (e.g. TearDownSuite running after go test -timeout fired). Falling back
+	// to opTimeout gives cleanup (pulumi destroy, cluster state dump) a fair
+	// window before GitLab kills the job.
+	return context.WithTimeout(context.Background(), opTimeout)
 }
 
 //

--- a/test/new-e2e/tests/containers/cluster_agent_sgc_binary_test.go
+++ b/test/new-e2e/tests/containers/cluster_agent_sgc_binary_test.go
@@ -6,7 +6,6 @@
 package containers
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestClusterAgentBinarySuite(t *testing.T) {
 // cluster agent image with the correct permissions (550) and ownership
 // (root:secret-manager).
 func (suite *clusterAgentBinarySuite) TestSecretGenericConnectorPresenceAndPermissions() {
-	pods, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.Background(), metav1.ListOptions{
+	pods, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(suite.T().Context(), metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", suite.Env().Agent.LinuxClusterAgent.LabelSelectors["app"]).String(),
 		Limit:         1,
 	})

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -6,7 +6,6 @@
 package containers
 
 import (
-	"context"
 	"regexp"
 	"strings"
 	"testing"
@@ -117,7 +116,7 @@ func (suite *ecsSuite) TearDownSuite() {
 // The 00 in Test00UpAndRunning is here to guarantee that this test, waiting for all tasks to be ready
 // is run first.
 func (suite *ecsSuite) Test00UpAndRunning() {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	suite.Require().NoErrorf(err, "Failed to load AWS config")

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -6,7 +6,6 @@
 package containers
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -118,7 +117,7 @@ func (suite *k8sSuite) TestZZUpAndRunning() {
 }
 
 func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	suite.Run("agent pods are ready and not restarting", func() {
 		suite.EventuallyWithTf(func(c *assert.CollectT) {
@@ -179,7 +178,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 }
 
 func (suite *k8sSuite) TestAdmissionControllerWebhooksExist() {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 	expectedWebhookName := "datadog-webhook"
 
 	suite.Run("agent registered mutating webhook configuration", func() {
@@ -212,7 +211,7 @@ func selectPodForExec(pods []corev1.Pod, containerName string) *corev1.Pod {
 }
 
 func (suite *k8sSuite) TestVersion() {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 	versionExtractor := regexp.MustCompile(`Commit: ([[:xdigit:]]+)`)
 
 	for _, tt := range []struct {
@@ -277,7 +276,7 @@ func (suite *k8sSuite) TestCLI() {
 }
 
 func (suite *k8sSuite) testAgentCLI() {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	pod, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", suite.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]).String(),
@@ -649,7 +648,7 @@ func (suite *k8sSuite) testClusterAgentCLI() {
 }
 
 func (suite *k8sSuite) testDCALeaderElection(restartLeader bool) string {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 	var leaderPodName string
 
 	success := suite.EventuallyWithTf(func(c *assert.CollectT) {
@@ -1409,7 +1408,7 @@ func (suite *k8sSuite) TestAdmissionControllerWithAutoDetectedLanguage() {
 }
 
 func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string, language string, languageShouldBeAutoDetected bool) {
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	// When the language should be auto-detected, we need to wait for the
 	// deployment to be created and the annotation with the languages to be set
@@ -1557,7 +1556,7 @@ func (suite *k8sSuite) TestAdmissionControllerExcludesSystemNamespaces() {
 		return
 	}
 
-	ctx := context.Background()
+	ctx := suite.T().Context()
 
 	suite.Run("webhooks should not mutate pods in kube-system namespace", func() {
 		// Get a pod from kube-system namespace
@@ -1804,7 +1803,7 @@ func (suite *k8sSuite) TestContainerLifecycleEvents() {
 	var nginxPod corev1.Pod
 
 	suite.Require().EventuallyWithTf(func(c *assert.CollectT) {
-		pods, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("workload-nginx").List(context.Background(), metav1.ListOptions{
+		pods, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("workload-nginx").List(suite.T().Context(), metav1.ListOptions{
 			LabelSelector: fields.OneTermEqualSelector("app", "nginx").String(),
 			FieldSelector: fields.OneTermEqualSelector("status.phase", "Running").String(),
 		})
@@ -1819,7 +1818,7 @@ func (suite *k8sSuite) TestContainerLifecycleEvents() {
 		})
 	}, 1*time.Minute, 10*time.Second, "Failed to find an nginx pod")
 
-	err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("workload-nginx").Delete(context.Background(), nginxPod.Name, metav1.DeleteOptions{})
+	err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("workload-nginx").Delete(suite.T().Context(), nginxPod.Name, metav1.DeleteOptions{})
 	suite.Require().NoError(err)
 
 	suite.EventuallyWithTf(func(collect *assert.CollectT) {


### PR DESCRIPTION
### What does this PR do?

Makes `go test` time out a few minutes before the GitLab CI job timeout, so the
test framework's `TearDownSuite` (pulumi destroy, kind/eks cluster state dump,
dashboard URL log) and the `go test` summary all run before GitLab kills the
process.

Concretely:

1. **`tasks/new_e2e_tests.py`** — new helper `_compute_go_test_timeout()`
   derives `go test -timeout` from
   `CI_JOB_TIMEOUT - elapsed(CI_JOB_STARTED_AT) - 5min`. Called inside the
   retry loop so each attempt reflects the remaining job budget. Falls back to
   the existing `4h` default locally, and to a `60s` floor when the GitLab
   budget is too small to keep the buffer. A new `--timeout` CLI flag lets
   callers override the auto-detection.
2. **`test/e2e-framework/testing/e2e/suite.go`** — `providerContext` now falls
   back to `WithTimeout(Background, opTimeout)` when `T().Deadline()` has
   already passed, so `TearDownSuite` running after `go test -timeout` fired
   still receives a usable context (instead of one cancelled the instant it's
   created).
3. **`test/new-e2e/tests/containers/*_test.go`** — replace 11 occurrences of
   `context.Background()` with `suite.T().Context()` (and drop the
   now-unused `"context"` imports). In-flight Kubernetes/AWS calls now honor
   the test lifecycle.

### Motivation

CI jobs `new-e2e-containers` time out at GitLab's default 2h
(e.g. jobs [1674280865](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1674280865)
and [1673750820](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1673750820))
while `go test` is hardcoded to `-timeout 4h`. GitLab kills the script before
`go test` ever times out, so:

- the `go test` summary (PASS/FAIL per test, durations) is missing,
- `DumpKindClusterState` / `DumpEKSClusterState` aren't called,
- the dashboard URL printed by `TearDownSuite` (e.g.
  `test/new-e2e/tests/containers/k8s_test.go:75`,
  `test/new-e2e/tests/containers/ecs_test.go:96`) never appears.

The pattern affects all e2e jobs whose tests can take a long time when
`EventuallyWithT` blocks have to wait their full duration after systematic
failures, not just the containers tests that triggered the investigation.
This PR addresses it framework-wide while focusing the `T().Context()`
conversion on containers/.

### Describe how you validated your changes

- [x] New unit tests cover the helper: `dda inv invoke-unit-tests.run --tests=e2e_testing`
      (8 new cases, 24 total ok).
- [x] `go vet -tags=test ./tests/containers/...` clean.
- [x] `go vet ./testing/e2e/...` clean.
- [x] CI run on this branch to confirm the derived timeout shows up in the
      `dda inv -- -e new-e2e-tests.run …` log and that the GitLab timeout no
      longer truncates the test framework output.

### Additional Notes

- Sized as a regular change; no `qa/rc-required` because the change is
  scoped to test infrastructure and the new behavior is opt-in via env vars
  set automatically by GitLab.
- The `suite.T().Context()` migration is intentionally limited to
  `test/new-e2e/tests/containers/`, as discussed; other directories can
  follow the same pattern incrementally.

/kind enhancement
/team agent-devx