### PR TITLE
[Backport 7.79.x] fix(jetson): restore 'sh -c' to correctly execute the tegrastats command

### DIFF
--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -154,9 +154,9 @@ func (c *JetsonCheck) Run() error {
 	var cmd *exec.Cmd
 	if c.useSudo {
 		// -n, non-interactive mode, no prompts are used
-		cmd = exec.CommandContext(ctx, "sudo", "-n", cmdStr)
+		cmd = exec.CommandContext(ctx, "sudo", "-n", "sh", "-c", cmdStr)
 	} else {
-		cmd = exec.CommandContext(ctx, cmdStr)
+		cmd = exec.CommandContext(ctx, "sh", "-c", cmdStr)
 	}
 
 	tegrastatsOutput, err := cmd.Output()


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug introduced in https://github.com/DataDog/datadog-agent/pull/45057, it made the tegrastats command fail because `sh -c` was removed.

This PR restores only this change.

### Motivation

Fix bug in 7.78.x introduced in a previous PR and solve the issue https://github.com/DataDog/datadog-agent/issues/50654.
This PR fixed a vulnerability because we executed a shell string without any prior verification. However, the fix was too strict and prevent the command to be properly executed.


### Describe how you validated your changes

### Additional Notes
