### PR TITLE
[cluster-agent/kubernetes_metadata_stream] Allow multiple subscribers per node

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_stream.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_stream.go
@@ -10,6 +10,7 @@ package v1
 import (
 	"context"
 	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -49,9 +50,13 @@ type KubeMetadataStreamServer struct {
 	store *controllers.MetaBundleStore
 	wmeta workloadmeta.Component
 
-	namespacesMutex      sync.RWMutex
-	namespaces           map[string]namespaceEntry // keys are namespace names
-	namespaceSubscribers map[string]chan struct{}  // keys are node names
+	namespacesMutex sync.RWMutex
+	namespaces      map[string]namespaceEntry // keys are namespace names
+	// namespaceSubscribers holds notification channels per node name. A node
+	// can have multiple subscribers because more than one process (for example,
+	// the running agent plus "agent diagnose", "agent check", etc.) may stream
+	// metadata for the same node concurrently.
+	namespaceSubscribers map[string][]chan struct{}
 }
 
 // NewKubeMetadataStreamServer creates a new KubeMetadataStreamServer
@@ -60,7 +65,7 @@ func NewKubeMetadataStreamServer(store *controllers.MetaBundleStore, wmeta workl
 		store:                store,
 		wmeta:                wmeta,
 		namespaces:           make(map[string]namespaceEntry),
-		namespaceSubscribers: make(map[string]chan struct{}),
+		namespaceSubscribers: make(map[string][]chan struct{}),
 	}
 }
 
@@ -229,10 +234,15 @@ func (srv *KubeMetadataStreamServer) processNamespaceEvents(events []workloadmet
 }
 
 func (srv *KubeMetadataStreamServer) notifyNamespaceSubscribers() {
-	for _, ch := range srv.namespaceSubscribers {
-		select {
-		case ch <- struct{}{}:
-		default:
+	for _, channels := range srv.namespaceSubscribers {
+		for _, ch := range channels {
+			select {
+			// Non-blocking send: if a signal is already pending, we drop it.
+			// This is safe because the consumer re-reads the full state from
+			// the store on each signal.
+			case ch <- struct{}{}:
+			default:
+			}
 		}
 	}
 }
@@ -242,7 +252,12 @@ func (srv *KubeMetadataStreamServer) subscribeToNamespaceEvents(nodeName string)
 	defer srv.namespacesMutex.Unlock()
 
 	ch := make(chan struct{}, 1)
-	srv.namespaceSubscribers[nodeName] = ch
+	srv.namespaceSubscribers[nodeName] = append(srv.namespaceSubscribers[nodeName], ch)
+
+	log.Debugf("Subscribed to namespace metadata updates for node %s (subscribers=%d)",
+		nodeName,
+		len(srv.namespaceSubscribers[nodeName]))
+
 	return ch
 }
 
@@ -250,9 +265,20 @@ func (srv *KubeMetadataStreamServer) unsubscribeFromNamespaceEvents(nodeName str
 	srv.namespacesMutex.Lock()
 	defer srv.namespacesMutex.Unlock()
 
-	if srv.namespaceSubscribers[nodeName] == ch {
+	channels := srv.namespaceSubscribers[nodeName]
+	for i, c := range channels {
+		if c == ch {
+			srv.namespaceSubscribers[nodeName] = slices.Delete(channels, i, i+1)
+			break
+		}
+	}
+
+	remaining := len(srv.namespaceSubscribers[nodeName])
+	if remaining == 0 {
 		delete(srv.namespaceSubscribers, nodeName)
 	}
+
+	log.Debugf("Unsubscribed from namespace metadata updates for node %s (subscribers=%d)", nodeName, remaining)
 }
 
 func (srv *KubeMetadataStreamServer) buildNamespacesSnapshot() map[string]namespaceEntry {

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_stream_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_stream_test.go
@@ -92,34 +92,58 @@ func TestStart(t *testing.T) {
 	assert.Empty(t, srv.buildNamespacesSnapshot())
 }
 
-func TestUnsubscribeFromNamespaceEvents(t *testing.T) {
+func TestSubscribeToNamespaceEvents(t *testing.T) {
 	srv := NewKubeMetadataStreamServer(nil, nil)
 
-	// First connection subscribes, then new connection subscribes
-	// (overwriting), then old connection's deferred unsubscribe runs.
-	oldCh := srv.subscribeToNamespaceEvents("node1")
-	newCh := srv.subscribeToNamespaceEvents("node1")
-	srv.unsubscribeFromNamespaceEvents("node1", oldCh)
+	// Two subscriptions for the same node. Both must receive notifications.
+	ch1 := srv.subscribeToNamespaceEvents("node1")
+	defer srv.unsubscribeFromNamespaceEvents("node1", ch1)
+	ch2 := srv.subscribeToNamespaceEvents("node1")
+	defer srv.unsubscribeFromNamespaceEvents("node1", ch2)
 
-	// The new subscriber should still be registered and receive notifications.
-	srv.processNamespaceEvents([]workloadmeta.Event{
-		{
-			Type: workloadmeta.EventTypeSet,
-			Entity: &workloadmeta.KubernetesMetadata{
-				EntityMeta: workloadmeta.EntityMeta{
-					Name:   "ns1",
-					Labels: map[string]string{"l1": "v1"},
-				},
-			},
-		},
+	srv.processNamespaceEvents(testNamespaceSetEvents())
+
+	assertNotified(t, "first", ch1)
+	assertNotified(t, "second", ch2)
+}
+
+func TestUnsubscribeFromNamespaceEvents(t *testing.T) {
+	t.Run("unsubscribing the older subscriber leaves the newer one working", func(t *testing.T) {
+		srv := NewKubeMetadataStreamServer(nil, nil)
+		olderCh := srv.subscribeToNamespaceEvents("node1")
+		newerCh := srv.subscribeToNamespaceEvents("node1")
+
+		srv.unsubscribeFromNamespaceEvents("node1", olderCh)
+		srv.processNamespaceEvents(testNamespaceSetEvents())
+
+		assertNotified(t, "newer", newerCh)
+		assertNotNotified(t, "older", olderCh)
 	})
 
-	select {
-	case <-newCh:
-		// expected
-	case <-time.After(1 * time.Second):
-		t.Fatal("new subscriber was not notified after old unsubscribe")
-	}
+	t.Run("unsubscribing the newer subscriber leaves the older one working", func(t *testing.T) {
+		srv := NewKubeMetadataStreamServer(nil, nil)
+		olderCh := srv.subscribeToNamespaceEvents("node1")
+		newerCh := srv.subscribeToNamespaceEvents("node1")
+
+		srv.unsubscribeFromNamespaceEvents("node1", newerCh)
+		srv.processNamespaceEvents(testNamespaceSetEvents())
+
+		assertNotified(t, "older", olderCh)
+		assertNotNotified(t, "newer", newerCh)
+	})
+
+	t.Run("unsubscribing an unknown channel is a no-op", func(t *testing.T) {
+		srv := NewKubeMetadataStreamServer(nil, nil)
+		olderCh := srv.subscribeToNamespaceEvents("node1")
+		newerCh := srv.subscribeToNamespaceEvents("node1")
+
+		unknown := make(chan struct{}, 1)
+		srv.unsubscribeFromNamespaceEvents("node1", unknown)
+		srv.processNamespaceEvents(testNamespaceSetEvents())
+
+		assertNotified(t, "older", olderCh)
+		assertNotified(t, "newer", newerCh)
+	})
 }
 
 func TestBundleToPodServiceMappingsSnapshot(t *testing.T) {
@@ -466,4 +490,36 @@ func TestFullStateResponse(t *testing.T) {
 	}
 
 	assert.True(t, proto.Equal(expected, resp))
+}
+
+func testNamespaceSetEvents() []workloadmeta.Event {
+	return []workloadmeta.Event{
+		{
+			Type: workloadmeta.EventTypeSet,
+			Entity: &workloadmeta.KubernetesMetadata{
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:   "ns1",
+					Labels: map[string]string{"l1": "v1"},
+				},
+			},
+		},
+	}
+}
+
+func assertNotified(t *testing.T, name string, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("%s subscriber was not notified", name)
+	}
+}
+
+func assertNotNotified(t *testing.T, name string, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatalf("%s subscriber was notified but should not have been", name)
+	case <-time.After(50 * time.Millisecond):
+	}
 }

--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller_test.go
@@ -49,7 +49,7 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 	// it being modified by other tests.
 	metaController.store = &MetaBundleStore{
 		cache:       gocache.New(gocache.NoExpiration, 5*time.Second),
-		subscribers: make(map[string]chan struct{}),
+		subscribers: make(map[string][]chan struct{}),
 	}
 
 	pod1 := newFakePod(
@@ -371,7 +371,7 @@ func TestMetadataControllerSyncEndpointSlices(t *testing.T) {
 
 	metaController.store = &MetaBundleStore{
 		cache:       gocache.New(gocache.NoExpiration, 5*time.Second),
-		subscribers: make(map[string]chan struct{}),
+		subscribers: make(map[string][]chan struct{}),
 	}
 
 	pod1 := newFakePod(

--- a/pkg/util/kubernetes/apiserver/controllers/store.go
+++ b/pkg/util/kubernetes/apiserver/controllers/store.go
@@ -8,6 +8,7 @@
 package controllers
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/patrickmn/go-cache"
@@ -20,7 +21,7 @@ import (
 // globalMetaBundleStore uses the global cache instance for the Agent.
 var globalMetaBundleStore = &MetaBundleStore{
 	cache:       agentcache.Cache,
-	subscribers: make(map[string]chan struct{}),
+	subscribers: make(map[string][]chan struct{}),
 }
 
 // GetGlobalMetaBundleStore returns the global MetaBundleStore instance.
@@ -39,10 +40,13 @@ type MetaBundleStore struct {
 	// from going missing until the next resync period.
 	cache *cache.Cache
 
-	// subscribers holds a notification channel per node name.
-	// When a bundle is updated or deleted, the subscriber for that node
-	// receives a signal.
-	subscribers map[string]chan struct{}
+	// subscribers holds notification channels per node name. A node can have
+	// multiple subscribers because more than one process (for example, the
+	// running agent plus "agent diagnose", "agent check", etc.) may need to
+	// subscribe.
+	// When a bundle is updated or deleted, the subscribers for that node
+	// receive a signal.
+	subscribers map[string][]chan struct{}
 }
 
 // Get returns the bundle for a given node, or false if not found.
@@ -118,28 +122,37 @@ func (m *MetaBundleStore) Subscribe(nodeName string) <-chan struct{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.subscribers[nodeName]; exists {
-		log.Warnf("Overwriting existing subscriber for node %s", nodeName)
-	}
-
-	m.subscribers[nodeName] = ch
+	m.subscribers[nodeName] = append(m.subscribers[nodeName], ch)
+	log.Debugf("Subscribed to kube metadata updates for node %s (subscribers=%d)", nodeName, len(m.subscribers[nodeName]))
 	return ch
 }
 
-// Unsubscribe removes a subscriber.
+// Unsubscribe removes the given channel from the subscriber list for the node.
+// It is a no-op if the channel is not registered.
 func (m *MetaBundleStore) Unsubscribe(nodeName string, ch <-chan struct{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.subscribers[nodeName] == ch {
+	channels := m.subscribers[nodeName]
+	for i, c := range channels {
+		if c == ch {
+			m.subscribers[nodeName] = slices.Delete(channels, i, i+1)
+			break
+		}
+	}
+
+	remaining := len(m.subscribers[nodeName])
+	if remaining == 0 {
 		delete(m.subscribers, nodeName)
 	}
+
+	log.Debugf("Unsubscribed from kube metadata updates for node %s (subscribers=%d)", nodeName, remaining)
 }
 
-// notifyLocked signals the subscriber for the given node.
+// notifyLocked signals every subscriber for the given node.
 // Must be called with mutex held.
 func (m *MetaBundleStore) notifyLocked(nodeName string) {
-	if ch, ok := m.subscribers[nodeName]; ok {
+	for _, ch := range m.subscribers[nodeName] {
 		// Non-blocking send: if a signal is already pending, we drop it. This
 		// is safe because the consumer re-reads the full state from the store
 		// on each signal.

--- a/pkg/util/kubernetes/apiserver/controllers/store_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/store_test.go
@@ -27,18 +27,8 @@ func TestSubscribe(t *testing.T) {
 	bundle.Services.Set("default", "pod1", "svc1")
 	store.set("node1", bundle)
 
-	select {
-	case <-ch:
-		// expected
-	case <-time.After(1 * time.Second):
-		t.Fatal("was not notified")
-	}
-
-	select {
-	case <-ch:
-		t.Fatal("received unexpected notification")
-	default:
-	}
+	assertNotified(t, "subscriber", ch)
+	assertNotNotified(t, "subscriber", ch)
 }
 
 func TestSubscribe_WithDelete(t *testing.T) {
@@ -53,12 +43,7 @@ func TestSubscribe_WithDelete(t *testing.T) {
 
 	store.delete("node1")
 
-	select {
-	case <-ch:
-		// expected
-	case <-time.After(1 * time.Second):
-		t.Fatal("was not notified")
-	}
+	assertNotified(t, "subscriber", ch)
 
 	_, ok := store.Get("node1")
 	assert.False(t, ok)
@@ -75,53 +60,75 @@ func TestSubscribe_OtherNodes(t *testing.T) {
 	bundle := apiserver.NewMetadataMapperBundle()
 	store.set("node2", bundle)
 
-	select {
-	case <-ch:
-		t.Fatal("node1 subscriber received notification for node2 events")
-	case <-time.After(50 * time.Millisecond):
-		// expected
-	}
+	assertNotNotified(t, "node1", ch)
 }
 
-func TestUnsubscribe(_ *testing.T) {
-	store := newTestStore()
+func TestUnsubscribe(t *testing.T) {
+	t.Run("unsubscribing the older subscriber leaves the newer one working", func(t *testing.T) {
+		store := newTestStore()
+		olderCh := store.Subscribe("node1")
+		newerCh := store.Subscribe("node1")
 
-	ch := store.Subscribe("node1")
-	store.Unsubscribe("node1", ch)
+		store.Unsubscribe("node1", olderCh)
+		bundle := apiserver.NewMetadataMapperBundle()
+		bundle.Services.Set("default", "pod1", "svc1")
+		store.set("node1", bundle)
 
-	bundle := apiserver.NewMetadataMapperBundle()
-	bundle.Services.Set("default", "pod1", "svc1")
-	store.set("node1", bundle)
+		assertNotified(t, "newer", newerCh)
+		assertNotNotified(t, "older", olderCh)
+	})
 
-	// No subscriber for node1, so this shouldn't do anything. Just testing that
-	// this doesn't panic or block.
-}
+	t.Run("unsubscribing the newer subscriber leaves the older one working", func(t *testing.T) {
+		store := newTestStore()
+		olderCh := store.Subscribe("node1")
+		newerCh := store.Subscribe("node1")
 
-func TestUnsubscribe_DoesNotRemoveNewerSubscriber(t *testing.T) {
-	store := newTestStore()
+		store.Unsubscribe("node1", newerCh)
+		bundle := apiserver.NewMetadataMapperBundle()
+		bundle.Services.Set("default", "pod1", "svc1")
+		store.set("node1", bundle)
 
-	// First connection subscribes, then new connection subscribes
-	// (overwriting), then old connection's deferred unsubscribe runs.
-	oldCh := store.Subscribe("node1")
-	newCh := store.Subscribe("node1")
-	store.Unsubscribe("node1", oldCh)
+		assertNotified(t, "older", olderCh)
+		assertNotNotified(t, "newer", newerCh)
+	})
 
-	// The new subscriber should still be registered and receive notifications.
-	bundle := apiserver.NewMetadataMapperBundle()
-	bundle.Services.Set("default", "pod1", "svc1")
-	store.set("node1", bundle)
+	t.Run("unsubscribing an unknown channel is a no-op", func(t *testing.T) {
+		store := newTestStore()
+		olderCh := store.Subscribe("node1")
+		newerCh := store.Subscribe("node1")
 
-	select {
-	case <-newCh:
-		// expected
-	case <-time.After(1 * time.Second):
-		t.Fatal("new subscriber was not notified after old unsubscribe")
-	}
+		unknown := make(chan struct{}, 1)
+		store.Unsubscribe("node1", unknown)
+		bundle := apiserver.NewMetadataMapperBundle()
+		bundle.Services.Set("default", "pod1", "svc1")
+		store.set("node1", bundle)
+
+		assertNotified(t, "older", olderCh)
+		assertNotified(t, "newer", newerCh)
+	})
 }
 
 func newTestStore() *MetaBundleStore {
 	return &MetaBundleStore{
 		cache:       gocache.New(gocache.NoExpiration, 5*time.Second),
-		subscribers: make(map[string]chan struct{}),
+		subscribers: make(map[string][]chan struct{}),
+	}
+}
+
+func assertNotified(t *testing.T, name string, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("%s subscriber was not notified", name)
+	}
+}
+
+func assertNotNotified(t *testing.T, name string, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatalf("%s subscriber was notified but should not have been", name)
+	case <-time.After(50 * time.Millisecond):
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the Kubernetes metadata streaming endpoint of the Cluster Agent.

The code assumed there could only be one subscriber per node. That's a valid assumption in the normal case, when only the running node agent is subscribed. However, there are several subcommands (check, diagnose, maybe others) that instantiate their own workloadmeta, including the kubemetadata collector that uses the streaming endpoint. When that happens, we have multiple subscribers for the same node, and it's a valid use case.

The problem is that the code didn't handle this case. When a new subscriber for the same node appeared, it simply overwrote the channel used by the old subscriber.

So after running agent check, agent diagnose, etc., the running agent stopped receiving notifications from the Cluster Agent, and `kube_service` tags were no longer updated.

I discovered this because CI started being flaky after enabling the streaming option (https://github.com/DataDog/datadog-agent/pull/50577). The tests run agent check on running agents and may check for the `kube_service` tag before or after. I think that's why they were flaky.

### Describe how you validated your changes

Added new tests. Also checked on a local kind cluster with `kubernetes_metadata_streaming` set to true.
- Deploy a pod that belongs to a service and check that the `kube_service` tag is there.
- Run `agent diagnose`.
- Deploy another pod that belongs to another service. The `kube_service` tag should be there now. It was missing before this fix.
