### PR TITLE
test/new-e2e/tests/autoscaling/spot: wait for node-agent before running CI tests

### DIFF
--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -137,6 +137,7 @@ type spotSchedulingSuite struct {
 	spotNode      string
 	onDemandNode  string
 	testNamespace string // namespace for the current test, set by SetupTest
+	waitForLogs   bool   // wait for node-agent readiness before running tests to get cluster-agent logs.
 }
 
 // TestSpotSchedulingKind runs spot scheduling integration tests on a local kind cluster.
@@ -168,7 +169,7 @@ func TestSpotSchedulingKindCI(t *testing.T) {
 	if os.Getenv("E2E_PIPELINE_ID") == "" {
 		t.Skip("E2E_PIPELINE_ID not set; this test is for CI use only")
 	}
-	e2e.Run(t, new(spotSchedulingSuite), e2e.WithProvisioner(awskindvm.Provisioner(
+	e2e.Run(t, &spotSchedulingSuite{waitForLogs: true}, e2e.WithProvisioner(awskindvm.Provisioner(
 		awskindvm.WithRunOptions(
 			kindvmscen.WithName(kindClusterName),
 			kindvmscen.WithKindWorkerNodes(workerNodes...),
@@ -188,6 +189,9 @@ func (s *spotSchedulingSuite) SetupSuite() {
 	s.kubeClient = s.Env().KubernetesCluster.Client()
 	s.identifyNodes()
 	s.waitForWebhook()
+	if s.waitForLogs {
+		s.waitForNodeAgent()
+	}
 }
 
 func (s *spotSchedulingSuite) SetupTest() {
@@ -284,6 +288,34 @@ func (s *spotSchedulingSuite) waitForWebhook() {
 		}
 		return false
 	}, 5*time.Minute, 5*time.Second, "spot scheduling webhook not registered; is the cluster-agent running?")
+}
+
+// waitForNodeAgent waits until all node-agent DaemonSet pods are Running and Ready.
+func (s *spotSchedulingSuite) waitForNodeAgent() {
+	s.T().Helper()
+
+	nodeAgentApp := s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]
+	s.Require().NotEmpty(nodeAgentApp, "LinuxNodeAgent label selector not set")
+
+	s.Require().Eventually(func() bool {
+		pods, err := s.kubeClient.CoreV1().Pods(s.Env().Agent.LinuxNodeAgent.Namespace).List(s.T().Context(), metav1.ListOptions{
+			LabelSelector: "app=" + nodeAgentApp,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase != corev1.PodRunning {
+				return false
+			}
+			for _, cs := range pod.Status.ContainerStatuses {
+				if !cs.Ready {
+					return false
+				}
+			}
+		}
+		return true
+	}, 5*time.Minute, 5*time.Second, "node-agent pods not ready; cluster-agent logs won't be collected")
 }
 
 func (s *spotSchedulingSuite) createTestNamespace() {

--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -93,6 +93,9 @@ clusterAgent:
 # node-agent DaemonSet collects cluster-agent logs via the annotation above
 agents:
   enabled: true
+  # tolerate all taints so the DaemonSet runs on all nodes
+  tolerations:
+    - operator: Exists
 # cluster check runners not needed for spot scheduling
 clusterChecksRunner:
   enabled: false


### PR DESCRIPTION
### What does this PR do?

Add waitForNodeAgent() to SetupSuite for TestSpotSchedulingKindCI: polls the node-agent DaemonSet until all pods are Running and Ready before any test runs.

### Motivation

This ensures cluster-agent DEBUG logs are collected throughout the test suite.


### Describe how you validated your changes

- [x] Verified full CA logs availabale for CI pipeline.

### Additional Notes

Updates https://datadoghq.atlassian.net/browse/CASCL-1222


