### PR TITLE
Make histogram count aggregation unitless

### DIFF
--- a/pkg/metrics/histogram.go
+++ b/pkg/metrics/histogram.go
@@ -128,6 +128,8 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 	for _, aggregate := range h.aggregates {
 		var value float64
 		mType := APIGaugeType
+		unit := h.unit
+
 		switch aggregate {
 		case maxAgg:
 			value = h.samples[len(h.samples)-1].value
@@ -150,6 +152,7 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 		case countAgg:
 			value = float64(h.count) / float64(h.interval)
 			mType = APIRateType
+			unit = "" // counts are dimensionless
 		default:
 			log.Infof("Configured aggregate '%s' is not implemented, skipping", aggregate)
 			continue
@@ -159,7 +162,7 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 			Points:     []Point{{Ts: timestamp, Value: value}},
 			MType:      mType,
 			NameSuffix: "." + aggregate,
-			Unit:       h.unit,
+			Unit:       unit,
 		})
 	}
 

--- a/pkg/metrics/histogram_test.go
+++ b/pkg/metrics/histogram_test.go
@@ -370,7 +370,11 @@ func TestHistogramUnitPropagation(t *testing.T) {
 	require.Nil(t, err)
 	require.NotEmpty(t, series)
 	for _, s := range series {
-		assert.Equal(t, UnitMilliseconds, s.Unit, "serie %s should carry unit", s.NameSuffix)
+		if s.NameSuffix == ".count" {
+			assert.Emptyf(t, s.Unit, "serie %s should be dimensionless", s.NameSuffix)
+		} else {
+			assert.Equal(t, UnitMilliseconds, s.Unit, "serie %s should carry unit", s.NameSuffix)
+		}
 	}
 
 	// Plain histogram sample (no unit): every flushed serie must have empty unit.


### PR DESCRIPTION
### What does this PR do?

Make histogram count aggregation unitless. In particular, recently added millisecond unit should not be applied to timing histogram counts.

### Motivation

Correctness fix.

### Describe how you validated your changes

Unit tests.

### Additional Notes
