### PR TITLE
AI Guidelines hint in contributing.md

### DIFF
--- a/docs/public/guidelines/contributing.md
+++ b/docs/public/guidelines/contributing.md
@@ -44,6 +44,14 @@ Adding GitHub labels is only possible for contributors with write access.
 
 **Your pull request must pass all CI tests before we will merge it**. If you're seeing an error and don't think it's your fault, it may not be! [Join us on Slack](https://chat.datadoghq.com) or [send us an email](mailto:support@datadoghq.com), and together we'll get it sorted out.
 
+### AI Guidance
+
+Additional review guidance (specific to AI) can be found [here](https://datadoghq.atlassian.net/wiki/x/ggCTjgE).
+
+It's encouraged that both submitters and reviewers take a look at these guidelines before contributing/reviewing.
+
+*To note, this page is currently only accessible internally. The guidelines will be codified into an in-repo tool/docs once they're ironed out.*
+
 ### Merge protection
 
 We have safety measures to protect our repository. As an external contributor, you are required to:


### PR DESCRIPTION
### What does this PR do?

- updates the contributing.md to hint at the AI Guidelines

### Motivation

Discoverability of docs is always hard. This is to make it slightly easier for folks to stumble on the guidelines in a natural way.

### Describe how you validated your changes

N/A

### Additional Notes

N/A
