### PR TITLE
ci: upload ELF debug symbols for host profiler symbolization

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -137,6 +137,7 @@ internal_kubernetes_deploy*            @Datadog/agent-delivery
 # Deploy packages
 deploy_agent*                          @DataDog/agent-delivery
 deploy_host_profiler_to_reliability_env_*  @DataDog/profiling-full-host
+upload_debug_symbols                       @DataDog/profiling-full-host
 deploy_installer*                      @DataDog/agent-delivery
 deploy_ddot_oci*                       @DataDog/agent-delivery
 deploy_packages*                       @DataDog/agent-delivery

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -137,12 +137,12 @@ internal_kubernetes_deploy*            @Datadog/agent-delivery
 # Deploy packages
 deploy_agent*                          @DataDog/agent-delivery
 deploy_host_profiler_to_reliability_env_*  @DataDog/profiling-full-host
-upload_debug_symbols                       @DataDog/profiling-full-host
 deploy_installer*                      @DataDog/agent-delivery
 deploy_ddot_oci*                       @DataDog/agent-delivery
 deploy_packages*                       @DataDog/agent-delivery
 deploy_macos_install_script            @DataDog/agent-delivery
 deploy_staging*                        @DataDog/agent-delivery
+upload_debug_symbols                       @DataDog/agent-delivery
 publish_winget*                        @DataDog/windows-products
 powershell_script_signing              @DataDog/windows-products
 windows_bootstrapper_deploy            @DataDog/windows-products

--- a/.gitlab/deploy/symbols/linux.yml
+++ b/.gitlab/deploy/symbols/linux.yml
@@ -12,12 +12,12 @@ upload_debug_symbols:
     - job: datadog-agent-7-arm64
       artifacts: true
   script:
-    - datadog-ci --version || { echo "ERROR: datadog-ci not found in PATH"; exit 1; }
+    - 'datadog-ci --version || { echo "ERROR: datadog-ci not found in PATH"; exit 1; }'
     - DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?
     - export DATADOG_API_KEY
     - export DD_BETA_COMMANDS_ENABLED=1
     - |
-      while IFS= read -r pkg; do
+      find "$OMNIBUS_PACKAGE_DIR" -name '*-dbg-*.tar.xz' 2>/dev/null | while IFS= read -r pkg; do
         echo "Uploading ELF debug symbols from $(basename "$pkg")"
         SYMBOL_TMPDIR=$(mktemp -d)
         if ! tar xf "$pkg" -C "$SYMBOL_TMPDIR"; then
@@ -28,4 +28,4 @@ upload_debug_symbols:
         datadog-ci elf-symbols upload "$SYMBOL_TMPDIR" || \
           echo "WARNING: elf-symbols upload failed for $(basename "$pkg") (non-fatal)"
         rm -rf "$SYMBOL_TMPDIR"
-      done < <(find "$OMNIBUS_PACKAGE_DIR" -name '*-dbg-*.tar.xz' 2>/dev/null)
+      done

--- a/.gitlab/deploy/symbols/linux.yml
+++ b/.gitlab/deploy/symbols/linux.yml
@@ -4,21 +4,28 @@ upload_debug_symbols:
   rules: !reference [.on_deploy_internal_or_internal_image_change_or_manual]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
+  timeout: 30m
+  retry: 2
   needs:
     - job: datadog-agent-7-x64
       artifacts: true
     - job: datadog-agent-7-arm64
       artifacts: true
   script:
+    - datadog-ci --version || { echo "ERROR: datadog-ci not found in PATH"; exit 1; }
     - DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?
     - export DATADOG_API_KEY
     - export DD_BETA_COMMANDS_ENABLED=1
     - |
-      for pkg in $(find "$OMNIBUS_PACKAGE_DIR" -name '*-dbg-*.tar.xz' 2>/dev/null); do
-        echo "Uploading ELF debug symbols from $(basename $pkg)"
+      while IFS= read -r pkg; do
+        echo "Uploading ELF debug symbols from $(basename "$pkg")"
         SYMBOL_TMPDIR=$(mktemp -d)
-        tar xf "$pkg" -C "$SYMBOL_TMPDIR"
+        if ! tar xf "$pkg" -C "$SYMBOL_TMPDIR"; then
+          echo "WARNING: failed to extract $(basename "$pkg"), skipping"
+          rm -rf "$SYMBOL_TMPDIR"
+          continue
+        fi
         datadog-ci elf-symbols upload "$SYMBOL_TMPDIR" || \
-          echo "WARNING: elf-symbols upload failed for $(basename $pkg) (non-fatal)"
+          echo "WARNING: elf-symbols upload failed for $(basename "$pkg") (non-fatal)"
         rm -rf "$SYMBOL_TMPDIR"
-      done
+      done < <(find "$OMNIBUS_PACKAGE_DIR" -name '*-dbg-*.tar.xz' 2>/dev/null)

--- a/.gitlab/deploy/symbols/linux.yml
+++ b/.gitlab/deploy/symbols/linux.yml
@@ -1,0 +1,24 @@
+---
+upload_debug_symbols:
+  stage: internal_image_deploy
+  rules: !reference [.on_deploy_internal_or_internal_image_change_or_manual]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:amd64", "specific:true"]
+  needs:
+    - job: datadog-agent-7-x64
+      artifacts: true
+    - job: datadog-agent-7-arm64
+      artifacts: true
+  script:
+    - DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?
+    - export DATADOG_API_KEY
+    - export DD_BETA_COMMANDS_ENABLED=1
+    - |
+      for pkg in $(find "$OMNIBUS_PACKAGE_DIR" -name '*-dbg-*.tar.xz' 2>/dev/null); do
+        echo "Uploading ELF debug symbols from $(basename $pkg)"
+        SYMBOL_TMPDIR=$(mktemp -d)
+        tar xf "$pkg" -C "$SYMBOL_TMPDIR"
+        datadog-ci elf-symbols upload "$SYMBOL_TMPDIR" || \
+          echo "WARNING: elf-symbols upload failed for $(basename $pkg) (non-fatal)"
+        rm -rf "$SYMBOL_TMPDIR"
+      done


### PR DESCRIPTION
### What does this PR do?

Adds an `upload_debug_symbols` job to the `internal_image_deploy` stage that uploads ELF debug symbol files to the Datadog symbol server using `datadog-ci elf-symbols upload`.

The job downloads the `*-dbg-*.tar.xz` tarballs produced by `datadog-agent-7-x64` and `datadog-agent-7-arm64`, extracts them, and uploads the `.dbg` files for both amd64 and arm64. Upload failures are non-fatal — they log a warning and continue, so a transient symbol-server error cannot break a deploy pipeline.

### Motivation

The Full Host Profiler requires ELF debug symbols for remote symbolication. Without them, stack traces from non-Go agent code show only addresses (Go has symbol information even for stripped binaries). This unblocks full symbolized profiles for the non-Go portions of the agent process family when using the Full Host Profiler on internal deployments.

Previous attempt: #42863 (closed, targeted `.gitlab/packaging/deb.yml` which no longer exists; the main agent now produces `*-dbg-*.tar.xz` tarballs, not debug debs).

### Describe how you validated your changes

Manually triggered `upload_debug_symbols` from a normal branch pipeline after the package builds completed. The job ran successfully and uploaded 262 ELF files (amd64 + arm64) in ~9 minutes:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1675657302

The job's triggering behaviour was also verified:
- Normal branch pipeline: appears as manual-only with `allow_failure: true` ✓
- Would auto-run on nightly/RC/stable: same rules as `publish_internal_container_image-jmx` ✓

### Additional Notes

`DD_BETA_COMMANDS_ENABLED=1` is still required for `datadog-ci elf-symbols upload` with the current build image version.

The job currently covers the base agent (amd64 + arm64). FIPS and other flavours (dogstatsd, IoT) can be added later by extending the `needs:` list.