### PR TITLE
[CWS] rename cgroup_context_t::cgroup_file to path_key

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/activity_dump.h
+++ b/pkg/security/ebpf/c/include/helpers/activity_dump.h
@@ -111,7 +111,7 @@ static __attribute__((always_inline)) bool reserve_traced_cgroup_spot(struct cgr
         return false;
     }
 
-    u64 cgroup_inode = cgroup->cgroup_file.ino;
+    u64 cgroup_inode = cgroup->path_key.ino;
     int ret = bpf_map_update_elem(&traced_cgroups, &cgroup_inode, &cookie, BPF_NOEXIST);
     if (ret < 0) {
         // we didn't get a lock, skip this cgroup for now and go back to it later
@@ -168,13 +168,13 @@ static __attribute__((always_inline)) u64 should_trace_new_process_cgroup(void *
     bpf_probe_read(&cgroup_context, sizeof(cgroup_context), cgroup);
 
     u32 cgroup_filter = get_cgroup_mount_id_filter();
-    if (!is_cgroup_mount_id_filter_valid(cgroup_filter, &cgroup_context.cgroup_file)) {
+    if (!is_cgroup_mount_id_filter_valid(cgroup_filter, &cgroup_context.path_key)) {
         return 0;
     }
 
     if (is_cgroup_activity_dumps_enabled()) {
 
-        u64 cgroup_inode = cgroup_context.cgroup_file.ino;
+        u64 cgroup_inode = cgroup_context.path_key.ino;
 
         // is this cgroup discarded ?
         u8 *discarded = bpf_map_lookup_elem(&traced_cgroups_discarded, &cgroup_inode);

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -185,17 +185,17 @@ bool __attribute__((always_inline)) is_current_kworker_dying() {
 
 static void __attribute__((always_inline)) fill_cgroup_context(struct proc_cache_t *entry, struct cgroup_context_t *cgroup) {
     if (entry) {
-        cgroup->cgroup_file = entry->cgroup.cgroup_file;
+        cgroup->path_key = entry->cgroup.path_key;
     } else {
-        cgroup->cgroup_file.mount_id = 0;
-        cgroup->cgroup_file.path_id = 0;
-        cgroup->cgroup_file.ino = 0;
+        cgroup->path_key.mount_id = 0;
+        cgroup->path_key.path_id = 0;
+        cgroup->path_key.ino = 0;
     }
 }
 
 u64 __attribute__((always_inline)) get_cgroup_id(u32 tgid) {
     struct proc_cache_t *entry = get_proc_cache(tgid);
-    return entry ? entry->cgroup.cgroup_file.ino : 0;
+    return entry ? entry->cgroup.path_key.ino : 0;
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -130,7 +130,7 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
         return 0;
     }
 
-    new_entry.cgroup.cgroup_file = resolver->key;
+    new_entry.cgroup.path_key = resolver->key;
 
 #ifdef DEBUG_CGROUP
     bpf_printk("container id: %s\n", container_qstr.name);

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -802,7 +802,7 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
                 u64 has_current_cgroup_id_helper = 0;
                 LOAD_CONSTANT("has_current_cgroup_id_helper", has_current_cgroup_id_helper);
                 if (has_current_cgroup_id_helper) {
-                    pc.cgroup.cgroup_file.ino = bpf_get_current_cgroup_id();
+                    pc.cgroup.path_key.ino = bpf_get_current_cgroup_id();
                 }
             }
         }

--- a/pkg/security/ebpf/c/include/hooks/network/tc.h
+++ b/pkg/security/ebpf/c/include/hooks/network/tc.h
@@ -36,7 +36,7 @@ __attribute__((always_inline)) int prepare_raw_packet_event(struct __sk_buff *sk
     }
 
     evt->process.pid = pkt->pid;
-    evt->cgroup.cgroup_file.ino = pkt->cgroup_id;
+    evt->cgroup.path_key.ino = pkt->cgroup_id;
 
     bpf_skb_pull_data(skb, 0);
 

--- a/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
+++ b/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
@@ -22,7 +22,7 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     // check if this event should trigger a syscall drift event
     if (is_anomaly_syscalls_enabled()) {
         // fetch the profile for the current cgroup
-        struct security_profile_t *profile = bpf_map_lookup_elem(&security_profiles, &event.cgroup.cgroup_file.ino);
+        struct security_profile_t *profile = bpf_map_lookup_elem(&security_profiles, &event.cgroup.path_key.ino);
         if (profile) {
             u64 cookie = profile->cookie;
             struct security_profile_syscalls_t *syscalls = bpf_map_lookup_elem(&secprofs_syscalls, &cookie);

--- a/pkg/security/ebpf/c/include/structs/events_context.h
+++ b/pkg/security/ebpf/c/include/structs/events_context.h
@@ -61,7 +61,7 @@ struct file_t {
 };
 
 struct cgroup_context_t {
-    struct path_key_t cgroup_file;
+    struct path_key_t path_key;
 };
 
 #endif

--- a/pkg/security/ebpf/c/include/tests/raw_packet_test.h
+++ b/pkg/security/ebpf/c/include/tests/raw_packet_test.h
@@ -31,7 +31,7 @@ SEC("test/raw_packet_drop_action")
 int raw_packet_drop_action(struct __sk_buff *skb) {
     struct raw_packet_event_t *evt = get_raw_packet_event();
     evt->process.pid = 123;
-    evt->cgroup.cgroup_file.ino = 456;
+    evt->cgroup.path_key.ino = 456;
 
     // assert_not_null(evt, "unable to get raw packet event")
     assert_not_null(evt, "unable to get raw packet event")


### PR DESCRIPTION
The field type is path_key_t; the new name matches the type and is consistent with other path_key_t members in the eBPF code.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
