### PR TITLE
[AGENTRUN-1283] Improve the RAR server helper test

### DIFF
--- a/comp/core/remoteagent/helper/serverhelper_test.go
+++ b/comp/core/remoteagent/helper/serverhelper_test.go
@@ -352,15 +352,13 @@ func TestRegistrationRefreshContention(t *testing.T) {
 	require.NoError(t, err)
 	defer lc.Stop(context.Background())
 
-	// Wait for multiple registration attempts
-	time.Sleep(3 * time.Second)
-
-	// Verify that registration was retried after the first timeout
-	mu.Lock()
-	regCount := registerCallCount
-	mu.Unlock()
-
-	require.Equal(t, regCount, 3, "Registration should have been retried after timeout")
+	// Wait for registration to be retried after the first two timeouts.
+	// The third attempt should succeed and bring the counter to 3.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return registerCallCount == 3
+	}, 3*time.Second, 50*time.Millisecond, "Registration should have been retried after timeout")
 
 	// Now test refresh contention - the server should be registered by now
 	// Wait a bit more to ensure refresh is called


### PR DESCRIPTION
### What does this PR do?

- Change the strict Equal with a sleep to an Eventually, causing the test to pass faster in the common case
- Change the order of the values so on failure the error message is correct

### Motivation

Make the test a bit better

### Describe how you validated your changes

Ran the test with the changes, observed that it still passes

### Additional Notes

Cows go moo