### PR TITLE
fix(apm-inject): apm-inject systemd service should not depend on a shell

### DIFF
--- a/pkg/fleet/installer/packages/apminject/apm_inject.go
+++ b/pkg/fleet/installer/packages/apminject/apm_inject.go
@@ -288,15 +288,19 @@ func (a *InjectorInstaller) verifySharedLib(ctx context.Context, libPath string)
 // This is called by the systemd service via "datadog-installer apm instrument-start host"
 // and must not attempt to manage systemd (it would loop).
 func (a *InjectorInstaller) InstrumentLDPreload(ctx context.Context) (err error) {
-	if err := a.verifySharedLib(ctx, path.Join(a.installPath, "inject", "launcher.preload.so")); err != nil {
+	launcherPath := path.Join(a.installPath, "inject", "launcher.preload.so")
+	log.Infof("Verifying APM injector launcher %s", launcherPath)
+	if err := a.verifySharedLib(ctx, launcherPath); err != nil {
 		return err
 	}
+	log.Infof("Adding APM injector launcher %s to %s", launcherPath, ldSoPreloadPath)
 	a.cleanups = append(a.cleanups, a.ldPreloadFileInstrument.cleanup)
 	rollback, err := a.ldPreloadFileInstrument.mutate(ctx)
 	if err != nil {
 		return err
 	}
 	a.rollbacks = append(a.rollbacks, rollback)
+	log.Infof("APM injector launcher present in %s", ldSoPreloadPath)
 	return nil
 }
 
@@ -304,8 +308,13 @@ func (a *InjectorInstaller) InstrumentLDPreload(ctx context.Context) (err error)
 // This is called by the systemd service via "datadog-installer apm instrument-stop host"
 // and must not attempt to manage systemd (it would loop).
 func (a *InjectorInstaller) UninstrumentLDPreload(ctx context.Context) error {
+	log.Infof("Removing APM injector launcher from %s", ldSoPreloadPath)
 	_, err := a.ldPreloadFileUninstrument.mutate(ctx)
-	return err
+	if err != nil {
+		return err
+	}
+	log.Infof("APM injector launcher removed from %s", ldSoPreloadPath)
+	return nil
 }
 
 // addInstrumentScripts writes the instrument scripts that come with the APM injector

--- a/pkg/fleet/installer/packages/apminject/datadog-apm-inject.service
+++ b/pkg/fleet/installer/packages/apminject/datadog-apm-inject.service
@@ -6,8 +6,9 @@ Before=shutdown.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'p=/opt/datadog-packages/datadog-installer/stable/bin/installer/installer; [ -x "$p" ] || p=/opt/datadog-packages/run/datadog-installer-ssi; [ -x "$p" ] || p=/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer; [ -x "$p" ] || p=/usr/bin/datadog-installer; exec "$p" apm instrument-start host'
-ExecStop=/bin/sh -c 'p=/opt/datadog-packages/datadog-installer/stable/bin/installer/installer; [ -x "$p" ] || p=/opt/datadog-packages/run/datadog-installer-ssi; [ -x "$p" ] || p=/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer; [ -x "$p" ] || p=/usr/bin/datadog-installer; exec "$p" apm instrument-stop host'
+Environment=DD_LOG_LEVEL=info
+ExecStart={{INSTALLER_PATH}} apm instrument-start host
+ExecStop={{INSTALLER_PATH}} apm instrument-stop host
 RemainAfterExit=yes
 StandardOutput=journal
 StandardError=journal

--- a/pkg/fleet/installer/packages/apminject/systemd.go
+++ b/pkg/fleet/installer/packages/apminject/systemd.go
@@ -8,6 +8,7 @@
 package apminject
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
@@ -21,22 +22,49 @@ import (
 
 const (
 	systemdServiceName = "datadog-apm-inject.service"
+	// installerPathPlaceholder is replaced in the embedded unit file with the
+	// absolute path to the datadog-installer binary resolved at install time.
+	installerPathPlaceholder = "{{INSTALLER_PATH}}"
 )
+
+// installerPathCandidates lists the locations the static datadog-installer
+// binary may live in.
+var installerPathCandidates = []string{
+	"/opt/datadog-packages/datadog-installer/stable/bin/installer/installer",
+	"/opt/datadog-packages/run/datadog-installer-ssi",
+	"/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer",
+	"/usr/bin/datadog-installer",
+}
 
 //go:embed datadog-apm-inject.service
 var apmInjectServiceFile []byte
 
 // SystemdServiceManager manages the APM injector systemd service
 type SystemdServiceManager struct {
-	servicePath string
-	serviceName string
+	servicePath   string
+	serviceName   string
+	installerPath string
 }
 
-// NewSystemdServiceManager creates a new SystemdServiceManager
+// NewSystemdServiceManager builds a manager pointing at whichever
+// datadog-installer binary is on disk at call time. Every supported install
+// flow leaves at least one candidate present before apm-inject's post-install
+// runs:
+//   - SSI / DD_NO_AGENT_INSTALL: copyInstallerSSI is invoked before the
+//     package install loop in pkg/fleet/installer/setup/common/setup.go,
+//     so /opt/datadog-packages/run/datadog-installer-ssi is in place.
+//   - Regular OCI agent install: datadog-agent is installed before
+//     datadog-apm-inject, so the agent's embedded installer is in place.
+//   - Legacy deb/rpm: /usr/bin/datadog-installer ships with the package.
 func NewSystemdServiceManager() *SystemdServiceManager {
+	installerPath, err := resolveInstallerPath(installerPathCandidates)
+	if err != nil {
+		log.Warnf("could not resolve datadog-installer path for APM inject service: %v; writeServiceFile will refuse to render the unit", err)
+	}
 	return &SystemdServiceManager{
-		servicePath: filepath.Join(systemd.UserUnitsPath, systemdServiceName),
-		serviceName: systemdServiceName,
+		servicePath:   filepath.Join(systemd.UserUnitsPath, systemdServiceName),
+		serviceName:   systemdServiceName,
+		installerPath: installerPath,
 	}
 }
 
@@ -52,7 +80,7 @@ func (s *SystemdServiceManager) Setup(ctx context.Context) (err error) {
 	if err := s.writeServiceFile(); err != nil {
 		return err
 	}
-	log.Infof("Installed systemd service file at %s", s.servicePath)
+	log.Infof("Installed systemd service file at %s (installer: %s)", s.servicePath, s.installerPath)
 
 	if err := systemd.Reload(ctx); err != nil {
 		return fmt.Errorf("failed to reload systemd: %w", err)
@@ -105,8 +133,29 @@ func (s *SystemdServiceManager) writeServiceFile() error {
 		return fmt.Errorf("failed to create systemd directory: %w", err)
 	}
 
-	if err := os.WriteFile(s.servicePath, apmInjectServiceFile, 0644); err != nil {
+	if s.installerPath == "" {
+		return fmt.Errorf("refusing to write %s with empty installer path", s.servicePath)
+	}
+	content := bytes.ReplaceAll(apmInjectServiceFile, []byte(installerPathPlaceholder), []byte(s.installerPath))
+
+	if err := os.WriteFile(s.servicePath, content, 0644); err != nil {
 		return fmt.Errorf("failed to write systemd service file at %s: %w", s.servicePath, err)
 	}
 	return nil
+}
+
+func resolveInstallerPath(candidates []string) (string, error) {
+	for _, p := range candidates {
+		info, err := os.Stat(p)
+		// Skip if doesn't exist.
+		if err != nil {
+			continue
+		}
+		// Skip if dir or not executable.
+		if info.IsDir() || info.Mode()&0111 == 0 {
+			continue
+		}
+		return p, nil
+	}
+	return "", fmt.Errorf("no datadog-installer binary found among %v", candidates)
 }

--- a/pkg/fleet/installer/packages/apminject/systemd_test.go
+++ b/pkg/fleet/installer/packages/apminject/systemd_test.go
@@ -41,8 +41,9 @@ func TestSystemdServiceManager_Setup(t *testing.T) {
 	testServicePath := filepath.Join(tmpDir, "etc", "systemd", "system", "datadog-apm-inject.service")
 
 	mgr := &SystemdServiceManager{
-		servicePath: testServicePath,
-		serviceName: "test-datadog-apm-inject.service",
+		servicePath:   testServicePath,
+		serviceName:   "test-datadog-apm-inject.service",
+		installerPath: "/usr/bin/datadog-installer",
 	}
 
 	ctx := context.Background()
@@ -55,7 +56,11 @@ func TestSystemdServiceManager_Setup(t *testing.T) {
 	assert.FileExists(t, testServicePath)
 	content, err := os.ReadFile(testServicePath)
 	require.NoError(t, err)
-	assert.Equal(t, string(apmInjectServiceFile), string(content))
+	// The placeholder must have been substituted with the configured path,
+	// and the placeholder itself must not appear in the rendered file.
+	assert.Contains(t, string(content), "/usr/bin/datadog-installer apm instrument-start host")
+	assert.Contains(t, string(content), "/usr/bin/datadog-installer apm instrument-stop host")
+	assert.NotContains(t, string(content), installerPathPlaceholder)
 
 	_ = mgr.Uninstall(ctx)
 }
@@ -65,7 +70,8 @@ func TestSystemdServiceManager_writeServiceFile(t *testing.T) {
 	testDestPath := filepath.Join(tmpDir, "dest", "datadog-apm-inject.service")
 
 	mgr := &SystemdServiceManager{
-		servicePath: testDestPath,
+		servicePath:   testDestPath,
+		installerPath: "/opt/datadog-packages/datadog-installer/stable/bin/installer/installer",
 	}
 
 	err := mgr.writeServiceFile()
@@ -74,26 +80,76 @@ func TestSystemdServiceManager_writeServiceFile(t *testing.T) {
 	assert.FileExists(t, testDestPath)
 	content, err := os.ReadFile(testDestPath)
 	require.NoError(t, err)
-	assert.Equal(t, string(apmInjectServiceFile), string(content))
+	assert.Contains(t, string(content), "ExecStart=/opt/datadog-packages/datadog-installer/stable/bin/installer/installer apm instrument-start host")
+	assert.Contains(t, string(content), "ExecStop=/opt/datadog-packages/datadog-installer/stable/bin/installer/installer apm instrument-stop host")
+	assert.NotContains(t, string(content), installerPathPlaceholder)
 }
 
-func TestSystemdServiceManager_writeServiceFile_ContainsInstallerCommand(t *testing.T) {
+func TestSystemdServiceManager_writeServiceFile_NoShWrapper(t *testing.T) {
 	tmpDir := t.TempDir()
 	testDestPath := filepath.Join(tmpDir, "datadog-apm-inject.service")
 
 	mgr := &SystemdServiceManager{
-		servicePath: testDestPath,
+		servicePath:   testDestPath,
+		installerPath: "/usr/bin/datadog-installer",
 	}
-
-	err := mgr.writeServiceFile()
-	require.NoError(t, err)
+	require.NoError(t, mgr.writeServiceFile())
 
 	content, err := os.ReadFile(testDestPath)
 	require.NoError(t, err)
+	rendered := string(content)
 
-	assert.Contains(t, string(content), "instrument-start host")
-	assert.Contains(t, string(content), "instrument-stop host")
-	assert.Contains(t, string(content), "/usr/bin/datadog-installer")
+	assert.NotContains(t, rendered, "/bin/sh", "unit file must not delegate to /bin/sh")
+	assert.NotContains(t, rendered, "sh -c", "unit file must not wrap commands in a shell")
+	assert.Contains(t, rendered, "instrument-start host")
+	assert.Contains(t, rendered, "instrument-stop host")
+}
+
+func TestSystemdServiceManager_writeServiceFile_EmptyInstallerPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := &SystemdServiceManager{
+		servicePath:   filepath.Join(tmpDir, "datadog-apm-inject.service"),
+		installerPath: "",
+	}
+	err := mgr.writeServiceFile()
+	assert.Error(t, err, "writing the unit file with no installer path should fail loudly rather than ship a broken unit")
+}
+
+func TestResolveInstallerPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Set up a mix of candidates: missing, non-executable, executable. The
+	// resolver must skip the first two and pick the third.
+	missing := filepath.Join(tmpDir, "missing")
+	nonExec := filepath.Join(tmpDir, "non-exec")
+	require.NoError(t, os.WriteFile(nonExec, []byte("#!/bin/sh\n"), 0644))
+	executable := filepath.Join(tmpDir, "executable")
+	require.NoError(t, os.WriteFile(executable, []byte("#!/bin/sh\n"), 0755))
+
+	got, err := resolveInstallerPath([]string{missing, nonExec, executable})
+	require.NoError(t, err)
+	assert.Equal(t, executable, got)
+}
+
+func TestResolveInstallerPath_AllMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	_, err := resolveInstallerPath([]string{
+		filepath.Join(tmpDir, "a"),
+		filepath.Join(tmpDir, "b"),
+	})
+	assert.Error(t, err)
+}
+
+func TestResolveInstallerPath_SkipsDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "candidate-dir")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	exe := filepath.Join(tmpDir, "candidate-exe")
+	require.NoError(t, os.WriteFile(exe, []byte{}, 0755))
+
+	got, err := resolveInstallerPath([]string{dir, exe})
+	require.NoError(t, err)
+	assert.Equal(t, exe, got)
 }
 
 func TestSystemdServiceManager_Uninstall(t *testing.T) {

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -181,6 +181,15 @@ func (s *Setup) Run() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to write install info: %w", err)
 	}
+	// Lay down the SSI installer copy before installing packages so that
+	// package post-install hooks (notably datadog-apm-inject's, which renders
+	// the systemd unit's ExecStart/ExecStop to point at a concrete installer
+	// binary) can resolve to it.
+	if s.Packages.copyInstallerSSI {
+		if err := copyInstallerSSI(); err != nil {
+			return err
+		}
+	}
 	for _, p := range packages {
 		url := oci.PackageURL(s.Env, p.name, p.version)
 		err = s.installPackage(p.name, url)
@@ -190,11 +199,6 @@ func (s *Setup) Run() (err error) {
 	}
 	if err = s.postInstallPackages(); err != nil {
 		return fmt.Errorf("failed during post-package installation: %w", err)
-	}
-	if s.Packages.copyInstallerSSI {
-		if err := copyInstallerSSI(); err != nil {
-			return err
-		}
 	}
 	if !s.NoConfig && runtime.GOOS == "windows" && len(freshConfigs) > 0 {
 		s.backfillConfigTemplates(freshConfigs)

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -15,6 +15,7 @@ import (
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -595,6 +596,120 @@ func (s *packageApmInjectSuite) TestSystemdService() {
 	state = s.host.State()
 	state.AssertPathDoesNotExist("/etc/systemd/system/datadog-apm-inject.service")
 	state.AssertUnitsNotLoaded("datadog-apm-inject.service")
+	s.assertLDPreloadNotInstrumented()
+}
+
+// crashyConstructorSrc is a tiny C source compiled into a shared library
+// whose ELF constructor calls _exit(1) — but only when the library was
+// loaded via the LD_PRELOAD environment variable (i.e., the deliberate
+// "is this .so loadable?" probe that verifySharedLib runs via
+// `LD_PRELOAD=lib echo 1`). When the library is loaded via
+// /etc/ld.so.preload alone, the constructor returns without crashing,
+// because /etc/ld.so.preload entries do not propagate into the loading
+// process's LD_PRELOAD env var. That selectivity is what makes this
+// fixture testable from userspace: every dynamically-linked program
+// (bash, sudo, systemctl, ssh-spawned shells) still loads the .so at
+// startup via /etc/ld.so.preload, but stays alive because LD_PRELOAD is
+// not set in its environment — so the test can actually invoke
+// `systemctl stop` after the bad lib is in place.
+//
+// The unconditional-crash variant (no getenv guard) is what the
+// production bug actually requires for the brick to occur, because
+// during shutdown systemd execs ExecStop with no /bin/sh wrapper and
+// the static installer doesn't consult ld.so at all. Reproducing that
+// here would also kill the test's own ssh/sudo/systemctl chain, so it
+// can only be exercised via a real shutdown — covered by the no-shell
+// unit-file unit test (TestSystemdServiceManager_writeServiceFile_NoShWrapper)
+// and by manual / pre-merge reboot testing.
+const crashyConstructorSrc = `#include <stdlib.h>
+#include <unistd.h>
+__attribute__((constructor)) static void crash(void) {
+    const char *p = getenv("LD_PRELOAD");
+    if (p && *p) _exit(1);
+}
+`
+
+// installGCC installs the C compiler used by buildCrashyInjectorSO.
+func (s *packageApmInjectSuite) installGCC() {
+	s.T().Helper()
+	host := s.Env().RemoteHost
+	switch s.os.Flavor {
+	case e2eos.Ubuntu, e2eos.Debian:
+		host.MustExecute("sudo apt-get update -qq && sudo apt-get install -y gcc libc6-dev")
+	case e2eos.Suse:
+		host.MustExecute("sudo zypper --non-interactive install -y gcc glibc-devel")
+	default:
+		s.T().Skipf("test does not know how to install gcc on %s", s.os.Flavor)
+	}
+}
+
+// buildCrashyInjectorSO writes crashyConstructorSrc to a temp file,
+// compiles it as a shared library, and places the resulting .so at dst.
+// The result is a real, ld.so-loadable ELF — not a missing file or a
+// junk-content blob — which matches the user-facing failure shape: the
+// library is on disk and looks fine to ld.so, but its constructor
+// rejects the verifySharedLib probe.
+func (s *packageApmInjectSuite) buildCrashyInjectorSO(dst string) {
+	s.T().Helper()
+	s.installGCC()
+	host := s.Env().RemoteHost
+	host.MustExecute("sudo tee /tmp/crashy.c >/dev/null <<'CRASHY_EOF'\n" + crashyConstructorSrc + "CRASHY_EOF")
+	host.MustExecute("sudo gcc -shared -fPIC -o " + dst + " /tmp/crashy.c")
+	host.MustExecute("sudo chmod 0755 " + dst)
+}
+
+// TestSystemdServiceStopBrokenInjector verifies the safety property the unit
+// file's no-shell design exists to provide: `systemctl stop
+// datadog-apm-inject.service` succeeds at clearing /etc/ld.so.preload even
+// when the on-disk launcher.preload.so is a real, ld.so-loadable shared
+// object whose ELF constructor crashes any program that LD_PRELOADs it via
+// the env var (the probe verifySharedLib uses). ExecStop is
+// `<installer> apm instrument-stop host` invoked directly by systemd via
+// execve — the static, CGO_ENABLED=0 installer does not consult
+// /etc/ld.so.preload, so a broken injector on disk never blocks cleanup.
+//
+// See crashyConstructorSrc's commentary for why the fixture crashes
+// selectively (via LD_PRELOAD env var only, not via /etc/ld.so.preload)
+// rather than unconditionally.
+func (s *packageApmInjectSuite) TestSystemdServiceStopBrokenInjector() {
+	if _, err := s.Env().RemoteHost.Execute("test \"$(cat /proc/1/comm 2>/dev/null)\" = systemd"); err != nil {
+		s.T().Skip("systemd is not running as PID 1 on this host")
+	}
+
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python")
+	defer s.Purge()
+
+	s.host.WaitForUnitActive(s.T(), "datadog-apm-inject.service")
+	s.assertLDPreloadInstrumented(injectOCIPath)
+
+	// Move the original launcher aside (rename, not truncate) so any
+	// process that still has it mmapped keeps a valid backing inode,
+	// then write a real ELF .so at the same path. /etc/ld.so.preload
+	// still references this path — the fixture's getenv guard is what
+	// keeps the surrounding system runnable. Restoring the original on
+	// cleanup keeps the host sane for Purge() and any retries.
+	launcherPath := filepath.Join(injectOCIPath, "stable", "inject", "launcher.preload.so")
+	host := s.Env().RemoteHost
+	host.MustExecute(fmt.Sprintf("sudo mv %[1]s %[1]s.bak", launcherPath))
+	s.buildCrashyInjectorSO(launcherPath)
+	defer host.Execute(fmt.Sprintf("sudo mv -f %[1]s.bak %[1]s 2>/dev/null || true", launcherPath)) //nolint:errcheck
+
+	// Confirm the shared object actually crashes the same probe
+	// verifySharedLib uses. Without this, a silently-non-crashing fixture
+	// would make the rest of the test a misleading no-op (no broken
+	// injector → "systemctl stop succeeded" tells us nothing about the
+	// safety property).
+	out, err := host.Execute(fmt.Sprintf("LD_PRELOAD=%s /bin/true; echo $?", launcherPath))
+	require.NoError(s.T(), err, "could not even run the LD_PRELOAD probe — environment is unusable")
+	require.Equal(s.T(), "1", strings.TrimSpace(out), "shared object did not crash LD_PRELOAD=lib /bin/true as expected; the rest of this test would be a misleading no-op")
+
+	// ExecStop is exec'd directly against the static installer binary —
+	// no /bin/sh wrapper, no dynamic-linker dependency on the broken .so —
+	// so it must succeed and clear /etc/ld.so.preload despite the crashy
+	// injector sitting at the path /etc/ld.so.preload still references.
+	_, err = host.Execute("sudo systemctl stop datadog-apm-inject.service")
+	require.NoError(s.T(), err, "systemctl stop must succeed despite the broken injector on disk")
+
 	s.assertLDPreloadNotInstrumented()
 }
 


### PR DESCRIPTION
In case of a broken injector, the shell itself will crash.

We need to call 'uninstrument' directly from systemd, without
going through a shell to be able to successfully disable injection.
