### PR TITLE
[process/runner] Fix runner realtime stop deadlock

### DIFF
--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -444,6 +444,7 @@ func (l *CheckRunner) UpdateRTStatus(statuses []*model.CollectorStatus) {
 			select {
 			case l.rtIntervalCh <- l.realTimeInterval:
 			case <-l.stop:
+				// Stop sending when shutting down to avoid blocking forever without receivers.
 				return
 			}
 		}

--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -441,7 +441,11 @@ func (l *CheckRunner) UpdateRTStatus(statuses []*model.CollectorStatus) {
 		// Pass along the real-time interval, one per check, so that every
 		// check routine will see the new interval.
 		for range l.enabledChecks {
-			l.rtIntervalCh <- l.realTimeInterval
+			select {
+			case l.rtIntervalCh <- l.realTimeInterval:
+			case <-l.stop:
+				return
+			}
 		}
 		log.Infof("real time interval updated to %s", l.realTimeInterval)
 	}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d8a906af-f1aa-4a09-974c-cb6334076c9f","source":"chat","resourceId":"6076c6ad-ebcc-4ba0-a7ed-162cc71ed4c3","workflowId":"a236d4fc-50e9-46ec-86a6-dc37862f7e54","codeChangeId":"a236d4fc-50e9-46ec-86a6-dc37862f7e54","sourceType":"slack"} -->
### What does this PR do?
- Prevents a potential shutdown deadlock in the process check runner when realtime status updates are processed during stop.
- Updates `CheckRunner.UpdateRTStatus` to make realtime-interval channel sends interruptible by the runner stop signal.

### Motivation
`comp/process/runner/impl.TestRunnerRealtime/rt_allowed` intermittently times out during fx app shutdown (`application didn't stop cleanly: context deadline exceeded`).

The runner previously sent to `rtIntervalCh` in a plain loop. During shutdown, check goroutines may exit on `l.stop` before draining `rtIntervalCh`, leaving `UpdateRTStatus` blocked on send and preventing `wg.Wait()` from completing.

### Describe how you validated your changes
Ran the affected test 20x, validated that CI passes.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/6076c6ad-ebcc-4ba0-a7ed-162cc71ed4c3)

Comment @datadog to request changes

---
https://datadoghq.atlassian.net/browse/CXP-3480