### PR TITLE
[CWS] guard bpf_get_current_cgroup_id behind pure v2 availability

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/cgroup.h
+++ b/pkg/security/ebpf/c/include/helpers/cgroup.h
@@ -1,0 +1,28 @@
+#ifndef _HELPERS_CGROUP_H_
+#define _HELPERS_CGROUP_H_
+
+static __attribute__((always_inline)) u64 get_current_cgroup_id() {
+    u64 is_pure_cgroupv2_available = 0;
+    LOAD_CONSTANT("is_pure_cgroupv2_available", is_pure_cgroupv2_available);
+    if (!is_pure_cgroupv2_available) {
+        return 0;
+    }
+
+    u64 has_current_cgroup_id_helper = 0;
+    LOAD_CONSTANT("has_current_cgroup_id_helper", has_current_cgroup_id_helper);
+    if (!has_current_cgroup_id_helper) {
+        return 0;
+    }
+
+    u64 cgroup_id = bpf_get_current_cgroup_id();
+
+    u64 is_cgroup_id_u64 = 0;
+    LOAD_CONSTANT("is_cgroup_id_u64", is_cgroup_id_u64);
+    if (!is_cgroup_id_u64) {
+        cgroup_id = (u32)cgroup_id;
+    }
+
+    return cgroup_id;
+}
+
+#endif

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -3,6 +3,7 @@
 
 #include "constants/syscall_macro.h"
 #include "constants/offsets/filesystem.h"
+#include "helpers/cgroup.h"
 #include "helpers/filesystem.h"
 #include "helpers/syscalls.h"
 #include "helpers/network/stats.h"
@@ -799,10 +800,9 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
             if ((fork_entry->fork_flags & CLONE_INTO_CGROUP) == 0) {
                 fill_cgroup_context(parent_pc, &pc.cgroup);
             } else {
-                u64 has_current_cgroup_id_helper = 0;
-                LOAD_CONSTANT("has_current_cgroup_id_helper", has_current_cgroup_id_helper);
-                if (has_current_cgroup_id_helper) {
-                    pc.cgroup.path_key.ino = bpf_get_current_cgroup_id();
+                u64 cgroup_id = get_current_cgroup_id();
+                if (cgroup_id) {
+                    pc.cgroup.cgroup_file.ino = cgroup_id;
                 }
             }
         }

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -802,7 +802,7 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
             } else {
                 u64 cgroup_id = get_current_cgroup_id();
                 if (cgroup_id) {
-                    pc.cgroup.cgroup_file.ino = cgroup_id;
+                    pc.cgroup.path_key.ino = cgroup_id;
                 }
             }
         }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2806,6 +2806,15 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 			Name:  "has_current_cgroup_id_helper",
 			Value: utils.BoolTouint64(p.kernelVersion.HasBpfGetCurrentCgroupID()),
 		},
+		// https://github.com/torvalds/linux/commit/96c0a6a72d181a330db6dc9848ff2e6584b1aa5b
+		manager.ConstantEditor{
+			Name:  "is_cgroup_id_u64",
+			Value: utils.BoolTouint64(p.kernelVersion.Code >= kernel.Kernel5_12),
+		},
+		manager.ConstantEditor{
+			Name:  "is_pure_cgroupv2_available",
+			Value: utils.BoolTouint64(utils.IsPureCGroupV2Available()),
+		},
 		manager.ConstantEditor{
 			Name:  "event_sampling_open_enabled",
 			Value: utils.BoolTouint64(p.config.RuntimeSecurity.EventSamplingOpenEnabled),

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -427,3 +427,10 @@ func (cfs *CGroupFS) detectCurrentCgroupPath(currentPid, currentNSPid uint32) {
 func (cfs *CGroupFS) GetRootCGroupPath() string {
 	return cfs.rootCGroupPath
 }
+
+// IsPureCGroupV2Available returns whether the host is running on a pure
+// (non-hybrid) cgroup v2 hierarchy.
+func IsPureCGroupV2Available() bool {
+	_, err := os.Stat(kernel.HostSys("/fs/cgroup/cgroup.controllers"))
+	return err == nil
+}


### PR DESCRIPTION
bpf_get_current_cgroup_id reports the unified-hierarchy cgroup id and returns random ids on systems without a pure cgroup v2 hierarchy, which would corrupt the cached cgroup inode if used unconditionally.

Centralize the call in a new get_current_cgroup_id() helper that gates on:
- helper availability (HasBpfGetCurrentCgroupID)
- pure cgroup v2 hierarchy (no hybrid v1+v2)
- pre-5.12 truncation to u32, since the cgroup id was u32 before torvalds/linux@96c0a6a72d18

Replace the inline call site in send_exec_event (CLONE_INTO_CGROUP path) with the helper, and add the matching userspace plumbing (is_cgroup_id_u64, is_pure_cgroupv2_available constants; utils.IsPureCGroupV2Available).

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
