### PR TITLE
[ACIX-1497] Reapply and fix "Improve otel docker images caching performance"

### DIFF
--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -104,7 +104,7 @@ docker_image_build_otel:
     # localhost:5000 (the local OCI registry started in the before_script).
     - docker buildx create --use --driver docker-container --driver-opt network=host --bootstrap
     - |
-      CACHE_REGISTRY="${IMAGE}-amd64:cache"
+      CACHE_REGISTRY="${IMAGE}:cache"
       CACHE_FROM="--cache-from type=registry,ref=${CACHE_REGISTRY}"
       CACHE_TO=""
       NO_CACHE=""

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -65,8 +65,6 @@ docker_image_build_otel:
     - export GO_VERSION=$(cat .go-version)
     # See .ddot_byoc_build_cache_setup for the rationale behind this docker buildx create call.
     - docker buildx create --use --driver docker-container --bootstrap
-    # TEMP: trick .docker_build_job_definition's cache logic into pushing cache on PR branches so we can test it
-    - export CI_COMMIT_BRANCH="$CI_DEFAULT_BRANCH"
   after_script:
     # Compute the image name and tag the template will push to, so after_script can reference them.
     # ECR_RELEASE_SUFFIX mirrors the logic in .docker_build_job_definition.
@@ -110,9 +108,7 @@ docker_image_build_otel:
       CACHE_FROM="--cache-from type=registry,ref=${CACHE_REGISTRY}"
       CACHE_TO=""
       NO_CACHE=""
-      # TEMP: always push cache so we can test cache export on PR branches without waiting for a merge to main
-      CACHE_TO="--cache-to type=registry,ref=${CACHE_REGISTRY},mode=max"
-      if false && [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" || "$BUCKET_BRANCH" == "nightly" ]]; then
+      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" || "$BUCKET_BRANCH" == "nightly" ]]; then
         CACHE_TO="--cache-to type=registry,ref=${CACHE_REGISTRY},mode=max"
       fi
       if [[ "$BUCKET_BRANCH" == "nightly" ]]; then

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -65,6 +65,8 @@ docker_image_build_otel:
     - export GO_VERSION=$(cat .go-version)
     # See .ddot_byoc_build_cache_setup for the rationale behind this docker buildx create call.
     - docker buildx create --use --driver docker-container --bootstrap
+    # TEMP: trick .docker_build_job_definition's cache logic into pushing cache on PR branches so we can test it
+    - export CI_COMMIT_BRANCH="$CI_DEFAULT_BRANCH"
   after_script:
     # Compute the image name and tag the template will push to, so after_script can reference them.
     # ECR_RELEASE_SUFFIX mirrors the logic in .docker_build_job_definition.
@@ -105,7 +107,9 @@ docker_image_build_otel:
       CACHE_FROM="--cache-from type=registry,ref=${CACHE_REGISTRY}"
       CACHE_TO=""
       NO_CACHE=""
-      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" || "$BUCKET_BRANCH" == "nightly" ]]; then
+      # TEMP: always push cache so we can test cache export on PR branches without waiting for a merge to main
+      CACHE_TO="--cache-to type=registry,ref=${CACHE_REGISTRY},mode=max"
+      if false && [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" || "$BUCKET_BRANCH" == "nightly" ]]; then
         CACHE_TO="--cache-to type=registry,ref=${CACHE_REGISTRY},mode=max"
       fi
       if [[ "$BUCKET_BRANCH" == "nightly" ]]; then

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -101,7 +101,10 @@ docker_image_build_otel:
     # capable driver (docker-container or remote) pre-configured at the runner level. DinD runners
     # don't — they start with a fresh Docker daemon whose default buildx driver is "docker", which
     # does not support --cache-to type=registry. We therefore create an explicit builder here.
-    - docker buildx create --use --driver docker-container --bootstrap
+    # --driver-opt network=host is required so that the BuildKit daemon container shares the DinD
+    # host's network namespace; without it, build steps using --network=host cannot reach
+    # localhost:5000 (the local OCI registry started in the before_script).
+    - docker buildx create --use --driver docker-container --driver-opt network=host --bootstrap
     - |
       CACHE_REGISTRY="${IMAGE}-amd64:cache"
       CACHE_FROM="--cache-from type=registry,ref=${CACHE_REGISTRY}"

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -21,16 +21,36 @@ integration_tests_otel:
 
 docker_image_build_otel:
   stage: integration_test
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: ["integration_tests_otel"]
+  extends: [.docker_build_amd64, .docker_build_job_definition]
+  # TODO: switch back to ["arch:amd64"] runners (from `.docker_build_amd64`) once
+  # the docker Python SDK in the `docker_x64` build image is upgraded to >=7.0.0.
+  # The older SDK uses an `http+docker://` URL scheme internally when connecting
+  # via Unix socket, which newer urllib3 rejects — breaking the after_script
+  # tests on non-DinD runners. DinD runners avoid the code path entirely (Docker
+  # is reached over TCP), which is why the same image worked there before.
   tags: ["docker-in-docker:amd64"]
   variables:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_MEMORY_LIMIT: 32Gi
+    AFTER_SCRIPT_IGNORE_ERRORS: false # We run tests in the after_script
+    BUILD_ARG: |
+      --build-arg AGENT_VERSION=$CI_COMMIT_REF_NAME
+      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME
+      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev
+      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx
+      --build-arg BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror
+      --build-arg CI
+      --build-arg GOPROXY
+      --build-arg GONOSUMDB
+      --build-arg GO_VERSION
+    BUILD_CONTEXT: /tmp/otel-ci
+    IMAGE: registry.ddbuild.io/ci/datadog-agent/agent-byoc
+    CACHE_TARGET: builder_base
   before_script:
     - mkdir -p /tmp/otel-ci
     - cp comp/otelcol/collector-contrib/impl/manifest.yaml /tmp/otel-ci/
-    - cp Dockerfiles/agent-ddot/Dockerfile.agent-otel /tmp/otel-ci/
+    - cp Dockerfiles/agent-ddot/Dockerfile.agent-otel /tmp/otel-ci/Dockerfile
     - cp test/integration/docker/otel_agent_build_tests.py /tmp/otel-ci/
     - export OTELCOL_VERSION=$(yq eval '.processors[] | select(.gomod | test("opentelemetry-collector-contrib")) | .gomod' /tmp/otel-ci/manifest.yaml | head -1 | awk '{print $NF}')
     - >-
@@ -41,31 +61,50 @@ docker_image_build_otel:
       yq eval -i
       '.processors += [{"gomod": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor " + env(OTELCOL_VERSION)}]'
       /tmp/otel-ci/manifest.yaml
-  script:
     - !reference [.login_to_docker_readonly]
-    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
-    - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
+    - export GO_VERSION=$(cat .go-version)
+  after_script:
+    # Compute the image name and tag the template will push to, so after_script can reference them.
+    # ECR_RELEASE_SUFFIX mirrors the logic in .docker_build_job_definition.
     - |
-      docker build \
-      --build-arg AGENT_VERSION=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
-      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
-      --build-arg BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror \
-      --build-arg CI \
-      --build-arg DDA_VERSION=$DDA_VERSION \
-      --build-arg GOPROXY \
-      --build-arg GONOSUMDB \
-      --tag agent-byoc:latest \
-      -f /tmp/otel-ci/Dockerfile.agent-otel \
-      /tmp/otel-ci
-    - |
-      OT_AGENT_IMAGE_NAME=agent-byoc \
-      OT_AGENT_TAG=latest python3 \
-      /tmp/otel-ci/otel_agent_build_tests.py
+      if [[ "$BUCKET_BRANCH" == "nightly" && "$IMAGE" =~ "ci/datadog-agent/agent" ]]; then
+        ECR_RELEASE_SUFFIX="-nightly"
+      else
+        ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG:+-release}"
+      fi
+      export OT_AGENT_IMAGE_NAME="${IMAGE}${ECR_RELEASE_SUFFIX}"
+      export OT_AGENT_TAG="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-${ARCH}"
+    - python3 /tmp/otel-ci/otel_agent_build_tests.py
+
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
+
+# Shared caching logic for all DDOT BYOC build jobs.
+# Expects BUILD_ARGS and IMAGE to be set before referencing.
+# Defines CACHE_FROM and CACHE_TO for use in subsequent build steps.
+.ddot_byoc_build_cache_setup:
+  script:
+    - |
+      CACHE_REGISTRY="${IMAGE}-amd64:cache"
+      CACHE_FROM="--cache-from type=registry,ref=${CACHE_REGISTRY}"
+      CACHE_TO=""
+      NO_CACHE=""
+      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" || "$BUCKET_BRANCH" == "nightly" ]]; then
+        CACHE_TO="--cache-to type=registry,ref=${CACHE_REGISTRY},mode=max"
+      fi
+      if [[ "$BUCKET_BRANCH" == "nightly" ]]; then
+        CACHE_FROM=""
+        NO_CACHE="--no-cache"
+      fi
+      docker buildx build \
+        --target builder_base \
+        ${NO_CACHE} \
+        ${CACHE_FROM} \
+        ${CACHE_TO} \
+        ${BUILD_ARGS} \
+        -f /tmp/otel-ci/Dockerfile \
+        /tmp/otel-ci
 
 # Test that the BYOC packages can be built with the existing Dockerfile
 .ddot_byoc_oci_build_test:
@@ -73,35 +112,39 @@ docker_image_build_otel:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: ["integration_tests_otel"]
   tags: ["docker-in-docker:amd64"]
+  variables:
+    IMAGE: registry.ddbuild.io/ci/datadog-agent/$DDOT_BYOC_OCI_REPO-builder
   before_script:
     - !reference [docker_image_build_otel, before_script]
     - apt-get update && apt-get install -y --no-install-recommends zstd
-  script:
-    - !reference [.login_to_docker_readonly]
-    - AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
-    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
-    - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     # Start a local OCI registry to receive both the source agent OCI and the output image
     - docker run -d -p 5000:5000 --name local-registry registry:2
-    - OUTPUT_OCI="localhost:5000/${DDOT_BYOC_OCI_REPO}:${AGENT_VERSION}"
+    - export AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
+    - export OUTPUT_OCI="localhost:5000/${DDOT_BYOC_OCI_REPO}:${AGENT_VERSION}"
+  script:
+    - |
+      BUILD_ARGS="\
+        --build-arg AGENT_VERSION=$AGENT_VERSION \
+        --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
+        --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
+        --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
+        --build-arg PACKAGE_TYPE=$DDOT_BYOC_PACKAGE_TYPE \
+        --build-arg AGENT_OCI=registry.ddbuild.io/ci/remote-updates/datadog-agent:7.78.0-beta-byoc-integration-test-1 \
+        --build-arg OUTPUT_OCI=$OUTPUT_OCI \
+        --build-arg CI \
+        --build-arg GOPROXY=$GOPROXY \
+        --build-arg GONOSUMDB=$GONOSUMDB \
+        --build-arg GO_VERSION=$(cat .go-version)"
+    - !reference [.ddot_byoc_build_cache_setup, script]
     # TODO: use staging package for AGENT_OCI until DDOT extension is released in 7.78.0
     - |
-      docker build \
-      --target builder \
-      --network=host \
-      --build-arg AGENT_VERSION=$AGENT_VERSION \
-      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
-      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
-      --build-arg PACKAGE_TYPE=$DDOT_BYOC_PACKAGE_TYPE \
-      --build-arg AGENT_OCI=registry.ddbuild.io/ci/remote-updates/datadog-agent:7.78.0-beta-byoc-integration-test-1 \
-      --build-arg OUTPUT_OCI=$OUTPUT_OCI \
-      --build-arg CI \
-      --build-arg DDA_VERSION=$DDA_VERSION \
-      --build-arg GOPROXY=$GOPROXY \
-      --build-arg GONOSUMDB=$GONOSUMDB \
-      -f /tmp/otel-ci/Dockerfile.agent-otel \
-      /tmp/otel-ci
+      docker buildx build \
+        --target builder \
+        --network=host \
+        ${CACHE_FROM} \
+        ${BUILD_ARGS} \
+        -f /tmp/otel-ci/Dockerfile \
+        /tmp/otel-ci
     # Verify the OCI image index was pushed and the replaced binary is present in the ddot layer
     - |
       REGISTRY_BASE="http://localhost:5000/v2/${DDOT_BYOC_OCI_REPO}"
@@ -142,28 +185,33 @@ ddot_byoc_binary_build_test_ubuntu2004:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: ["integration_tests_otel"]
   tags: ["docker-in-docker:amd64"]
+  variables:
+    IMAGE: registry.ddbuild.io/ci/datadog-agent/ddot-byoc-ubuntu2004-builder
   before_script:
     - !reference [docker_image_build_otel, before_script]
+    - export AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
   script:
-    - !reference [.login_to_docker_readonly]
-    - AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
-    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
-    - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     - |
-      docker build \
-      --target builder \
-      --tag otel-builder-tmp \
-      --build-arg AGENT_VERSION=$AGENT_VERSION \
-      --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
-      --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
-      --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
-      --build-arg UBUNTU_VERSION=20.04 \
-      --build-arg CI \
-      --build-arg DDA_VERSION=$DDA_VERSION \
-      --build-arg GOPROXY=$GOPROXY \
-      --build-arg GONOSUMDB=$GONOSUMDB \
-      -f /tmp/otel-ci/Dockerfile.agent-otel \
-      /tmp/otel-ci
+      BUILD_ARGS="\
+        --build-arg AGENT_VERSION=$AGENT_VERSION \
+        --build-arg AGENT_GIT_REF=$CI_COMMIT_REF_NAME \
+        --build-arg AGENT_DOCKER_REPO=datadog/agent-dev \
+        --build-arg AGENT_DOCKER_TAG=nightly-full-main-jmx \
+        --build-arg UBUNTU_VERSION=20.04 \
+        --build-arg CI \
+        --build-arg GOPROXY=$GOPROXY \
+        --build-arg GONOSUMDB=$GONOSUMDB \
+        --build-arg GO_VERSION=$(cat .go-version)"
+    - !reference [.ddot_byoc_build_cache_setup, script]
+    - |
+      docker buildx build \
+        --target builder \
+        --load \
+        --tag otel-builder-tmp \
+        ${CACHE_FROM} \
+        ${BUILD_ARGS} \
+        -f /tmp/otel-ci/Dockerfile \
+        /tmp/otel-ci
     - mkdir -p ddot-byoc
     - docker run --rm -v "$(pwd)/ddot-byoc:/out" otel-builder-tmp cp /workspace/datadog-agent/bin/otel-agent/otel-agent /out/otel-agent
     - BIN_PATH=ddot-byoc/otel-agent

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -63,7 +63,7 @@ docker_image_build_otel:
       /tmp/otel-ci/manifest.yaml
     - !reference [.login_to_docker_readonly]
     - export GO_VERSION=$(cat .go-version)
-    # See .ddot_byoc_build_cache_setup for the rationale behind this docker buildx create call.
+    # Create a buildx builder, see .ddot_byoc_build_cache_setup for the rationale behind this.
     - docker buildx create --use --driver docker-container --bootstrap
   after_script:
     # Compute the image name and tag the template will push to, so after_script can reference them.

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -129,6 +129,7 @@ docker_image_build_otel:
   stage: integration_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: ["integration_tests_otel"]
+  # TODO: Switch to standard `amd64` runners - see comment above in docker_image_build_otel
   tags: ["docker-in-docker:amd64"]
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/$DDOT_BYOC_OCI_REPO-builder

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -63,6 +63,8 @@ docker_image_build_otel:
       /tmp/otel-ci/manifest.yaml
     - !reference [.login_to_docker_readonly]
     - export GO_VERSION=$(cat .go-version)
+    # See .ddot_byoc_build_cache_setup for the rationale behind this docker buildx create call.
+    - docker buildx create --use --driver docker-container --bootstrap
   after_script:
     # Compute the image name and tag the template will push to, so after_script can reference them.
     # ECR_RELEASE_SUFFIX mirrors the logic in .docker_build_job_definition.
@@ -85,6 +87,19 @@ docker_image_build_otel:
 # Defines CACHE_FROM and CACHE_TO for use in subsequent build steps.
 .ddot_byoc_build_cache_setup:
   script:
+    # These jobs run on docker-in-docker:amd64 runners rather than the standard arch:amd64 runners
+    # used by .docker_build_job_definition, for two reasons:
+    #   1. The Python docker SDK in the docker_x64 image is <7.0.0, which uses an http+docker://
+    #      URL scheme over the Unix socket that newer urllib3 rejects. DinD runners expose Docker
+    #      over TCP, avoiding this entirely.
+    #   2. The BYOC OCI tests start a local registry and reach it via --network=host; this only
+    #      works cleanly inside DinD's isolated network namespace.
+    #
+    # The arch:amd64 runners used by .docker_build_job_definition have a buildx builder with a
+    # capable driver (docker-container or remote) pre-configured at the runner level. DinD runners
+    # don't — they start with a fresh Docker daemon whose default buildx driver is "docker", which
+    # does not support --cache-to type=registry. We therefore create an explicit builder here.
+    - docker buildx create --use --driver docker-container --bootstrap
     - |
       CACHE_REGISTRY="${IMAGE}-amd64:cache"
       CACHE_FROM="--cache-from type=registry,ref=${CACHE_REGISTRY}"

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -57,7 +57,7 @@ RUN if [ "$PACKAGE_TYPE" = "windows" ]; then \
     fi
 
 # Install Go based on architecture
-ARG GO_VERSION=1.25.9
+ARG GO_VERSION=1.25.10
 RUN ARCH=$(dpkg --print-architecture) && \
 if [ "$ARCH" = "amd64" ]; then \
 GO_ARCH="linux-amd64"; \

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -6,21 +6,10 @@ ARG AGENT_DOCKER_TAG=${AGENT_VERSION}-full
 ARG AGENT_GIT_REF=${AGENT_VERSION}
 ARG BASE_IMAGE_REGISTRY=docker.io
 
-# Required for PACKAGE_TYPE=linux or windows: source agent OCI URL and output OCI URL.
-ARG AGENT_OCI
-ARG OUTPUT_OCI
-
 # Use the Ubuntu Slim AMD64 base image
-FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$UBUNTU_VERSION AS builder
+FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$UBUNTU_VERSION AS builder_base
 
 # Set environment variables
-ARG AGENT_VERSION
-ARG AGENT_GIT_REF
-ARG CI
-ARG DDA_VERSION=v0.29.0
-ARG PACKAGE_TYPE
-ARG GOPROXY
-ARG GONOSUMDB
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set the working directory
@@ -32,8 +21,7 @@ WORKDIR /workspace
 # cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
 # indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
 # should be reliable enough in combination and also well maintained.
-RUN if [ "$CI" = "true" ]; then \
-  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
+RUN echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
   echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
   for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
     if [ -f "$f" ]; then \
@@ -41,8 +29,7 @@ RUN if [ "$CI" = "true" ]; then \
              -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
              -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; \
     fi; \
-  done; \
-  fi
+  done;
 
 # Update and install necessary packages
 RUN apt-get update && \
@@ -56,6 +43,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Windows cross-compilation tools if building for Windows
+ARG PACKAGE_TYPE
 RUN if [ "$PACKAGE_TYPE" = "windows" ]; then \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -68,28 +56,19 @@ RUN if [ "$PACKAGE_TYPE" = "windows" ]; then \
     && update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix; \
     fi
 
-# We can't get tarballs for dev branches, so we can't just pull the tarball from github.
-# Instead we make a treeless clone at the reference provided, and build from the repo.
-# We also have to use the repo clone because some invoke tasks rely on git coommands unavailable
-# in repo tarball archives. For the same reason a shallow clone will also not work.
-RUN git clone --branch ${AGENT_GIT_REF} --filter=tree:0 https://github.com/DataDog/datadog-agent.git datadog-agent
-
-# Set the working directory to the source code
-WORKDIR /workspace/datadog-agent
-
 # Install Go based on architecture
-RUN GO_VERSION=$(cat .go-version) && \
-    ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then \
-    GO_ARCH="linux-amd64"; \
-    elif [ "$ARCH" = "arm64" ]; then \
-    GO_ARCH="linux-arm64"; \
-    else \
-    echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi && \
-    curl -fsSLO --retry 4 https://golang.org/dl/go${GO_VERSION}.$GO_ARCH.tar.gz && \
-    tar -C /usr/local -xzf go${GO_VERSION}.$GO_ARCH.tar.gz && \
-    rm go${GO_VERSION}.$GO_ARCH.tar.gz
+ARG GO_VERSION=1.25.9
+RUN ARCH=$(dpkg --print-architecture) && \
+if [ "$ARCH" = "amd64" ]; then \
+GO_ARCH="linux-amd64"; \
+elif [ "$ARCH" = "arm64" ]; then \
+GO_ARCH="linux-arm64"; \
+else \
+echo "Unsupported architecture: $ARCH" && exit 1; \
+fi && \
+curl -fsSLO --retry 4 https://golang.org/dl/go${GO_VERSION}.$GO_ARCH.tar.gz && \
+tar -C /usr/local -xzf go${GO_VERSION}.$GO_ARCH.tar.gz && \
+rm go${GO_VERSION}.$GO_ARCH.tar.gz
 
 # Set up Go environment
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -100,6 +79,7 @@ ENV GOPATH=/go
 RUN go version && \
     curl --version
 
+ARG DDA_VERSION=v0.33.1
 ENV DDA_INTERACTIVE=false
 # Install prebuilt dda and sync tasks
 RUN ARCH=$(dpkg --print-architecture) && \
@@ -112,10 +92,24 @@ RUN ARCH=$(dpkg --print-architecture) && \
     dda self dep sync -f legacy-tasks
 
 
+FROM builder_base AS builder
+# We can't get tarballs for dev branches, so we can't just pull the tarball from github.
+# Instead we make a treeless clone at the reference provided, and build from the repo.
+# We also have to use the repo clone because some invoke tasks rely on git commands unavailable
+# in repo tarball archives. For the same reason a shallow clone will also not work.
+ARG AGENT_GIT_REF
+ARG PACKAGE_TYPE
+RUN git clone --branch ${AGENT_GIT_REF} --filter=tree:0 https://github.com/DataDog/datadog-agent.git datadog-agent
+
+# Set the working directory to the source code
+WORKDIR /workspace/datadog-agent
+
 # Copy the manifest file
 COPY manifest.yaml /workspace/datadog-agent/comp/otelcol/collector-contrib/impl/manifest.yaml
 
 # Generate the files and clean up go cache to free space
+ARG GOPROXY
+ARG GONOSUMDB
 RUN GOPROXY=$GOPROXY GONOSUMDB=$GONOSUMDB dda inv collector.generate && \
     go clean -cache -modcache
 
@@ -147,6 +141,8 @@ RUN if [ "$PACKAGE_TYPE" = "linux" ] || [ "$PACKAGE_TYPE" = "windows" ]; then \
 #       --build-arg REGISTRY_AUTH=password \
 #       --secret id=registry_username,env=REGISTRY_USERNAME \
 #       --secret id=registry_password,env=REGISTRY_PASSWORD ...
+
+# Required for PACKAGE_TYPE=linux or windows: source agent OCI URL and output OCI URL.
 ARG AGENT_OCI
 ARG OUTPUT_OCI
 ARG REGISTRY_AUTH=""

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -21,6 +21,7 @@ WORKDIR /workspace
 # cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
 # indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
 # should be reliable enough in combination and also well maintained.
+ARG CI
 RUN if [ "$CI" = "true" ]; then \
   echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
   echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -21,7 +21,8 @@ WORKDIR /workspace
 # cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
 # indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
 # should be reliable enough in combination and also well maintained.
-RUN echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
+RUN if [ "$CI" = "true" ]; then \
+  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
   echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
   for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
     if [ -f "$f" ]; then \
@@ -29,7 +30,8 @@ RUN echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://arc
              -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
              -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; \
     fi; \
-  done;
+  done; \
+  fi
 
 # Update and install necessary packages
 RUN apt-get update && \

--- a/renovate.json
+++ b/renovate.json
@@ -215,6 +215,17 @@
       },
       {
         "customType": "regex",
+        "managerFilePatterns": [
+          "Dockerfiles/agent-ddot/Dockerfile.agent-otel"
+        ],
+        "matchStrings": [
+          "DDA_VERSION=v(?<currentValue>[0-9]+.[0-9]+.[0-9]+)"
+        ],
+        "depNameTemplate": "DataDog/datadog-agent-dev",
+        "datasourceTemplate": "github-releases"
+      },
+      {
+        "customType": "regex",
         "managerFilePatterns": ["release.json"],
         "matchStrings": [
           "[ ]+\"OMNIBUS_RUBY_VERSION\": \"(?<currentDigest>[a-z0-9]+)\""

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -33,6 +33,7 @@ GO_VERSION_REFERENCES: list[tuple[str, str, str, bool]] = [
     ("./.wwhrd.yml", "raw.githubusercontent.com/golang/go/go", "/LICENSE", True),
     ("./renovate.json", '"go": "', '"', True),
     ("./go.work", "go ", "", True),
+    ("./Dockerfiles/agent-ddot/Dockerfile.agent-otel", "ARG GO_VERSION=", "", True),
 ]
 
 PATTERN_MAJOR_MINOR = r'1\.\d+'


### PR DESCRIPTION
### What does this PR do?
Reapplies #50173 which was reverted in #50671 with a fix: using a manually-created build container which supports cache export

### Motivation
Getting my PR back in without breaking CI !
See original PR

### Describe how you validated your changes
Running with a TEMP commit that allows pushing to the cache inside a PR branch, then reverted.
See for instance: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1689464320#L1344

### Additional Notes
See comment explaining why we can't use the standard `arch:amd64` runners and have to use the DinD ones, which explains why we can't use remote buildx executors like the more "standard build jobs"