### PR TITLE
[Backport 7.79.x] pkg/clusteragent/autoscaling/cluster/spot: use custom node selector for spot nodes

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/spot/README.md
+++ b/pkg/clusteragent/autoscaling/cluster/spot/README.md
@@ -34,10 +34,9 @@ Important:
   so Cluster Agent cannot directly fix spot-assigned pods that fail to schedule — it must evict them and let the workload to recreate them.
 - spot nodes carry a `NoSchedule` taint to repel unrelated workloads.
 
-The spot node label is currently Karpenter-specific [[2]](#karpenter-nodepool):
-- label: `karpenter.sh/capacity-type=spot`
-
-The spot node taint uses the Datadog namespace and must be configured separately on spot nodes:
+Both the nodeSelector and the taint use the same Datadog-namespaced key and must be configured on spot nodes
+(see the Karpenter NodePool example [[2]](#karpenter-nodepool) for how to set them automatically):
+- label: `autoscaling.datadoghq.com/capacity-type=interruptible`
 - taint: `autoscaling.datadoghq.com/capacity-type=interruptible:NoSchedule`
 
 When a pod is assigned to a spot instance at admission time, Cluster Agent begins tracking it.
@@ -60,6 +59,9 @@ metadata:
   name: spot
 spec:
   template:
+    metadata:
+      labels:
+        autoscaling.datadoghq.com/capacity-type: interruptible
     spec:
       requirements:
         - key: karpenter.sh/capacity-type

--- a/pkg/clusteragent/autoscaling/cluster/spot/cluster_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/cluster_test.go
@@ -108,7 +108,7 @@ func (c *fakeCluster) AddOnDemandNode(name string) {
 	})
 }
 
-// AddSpotNode adds a spot node with the Karpenter capacity-type label and NoSchedule taint.
+// AddSpotNode adds a spot node with the capacity-type node selector label and NoSchedule taint.
 func (c *fakeCluster) AddSpotNode(name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/clusteragent/autoscaling/cluster/spot/const.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/const.go
@@ -27,3 +27,12 @@ const (
 	// SpotAssignedLabelValue is the SpotAssignedLabel value for pods assigned to spot instances.
 	SpotAssignedLabelValue = "true"
 )
+
+// Spot node label and taint.
+// Use our own namespace so we control it independently of the cluster autoscaler.
+const (
+	spotNodeLabelKey   = "autoscaling.datadoghq.com/capacity-type"
+	spotNodeLabelValue = "interruptible"
+	spotNodeTaintKey   = "autoscaling.datadoghq.com/capacity-type"
+	spotNodeTaintValue = "interruptible"
+)

--- a/pkg/clusteragent/autoscaling/cluster/spot/scheduler.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/scheduler.go
@@ -220,16 +220,6 @@ func (s *scheduler) spotEligibleFilter(entity workloadmeta.Entity) bool {
 	return ok
 }
 
-// Spot node label and taint.
-// The node label is Karpenter-specific; the taint uses our own namespace so we
-// control it independently of the cluster autoscaler.
-const (
-	spotNodeLabelKey   = "karpenter.sh/capacity-type"
-	spotNodeLabelValue = "spot"
-	spotNodeTaintKey   = "autoscaling.datadoghq.com/capacity-type"
-	spotNodeTaintValue = "interruptible"
-)
-
 func assignToSpot(pod *corev1.Pod) {
 	if pod.Spec.NodeSelector == nil {
 		pod.Spec.NodeSelector = map[string]string{}


### PR DESCRIPTION
### What does this PR do?

Backports https://github.com/DataDog/datadog-agent/pull/50312 to 7.79.x

### Motivation

### Describe how you validated your changes

### Additional Notes
