### PR TITLE
[CONTP-1651] nccl-webhook: document NCCL 2.27.3 (torch 2.8.x) workarounds

### DIFF
--- a/pkg/clusteragent/admission/mutate/ncclprofiler/mutator.go
+++ b/pkg/clusteragent/admission/mutate/ncclprofiler/mutator.go
@@ -23,6 +23,33 @@ const (
 	// soDestPath is the full in-container path to the Inspector .so after injection.
 	// NCCL_PROFILER_PLUGIN points here; NCCL dlopens this and the patched Inspector
 	// emits events directly to the agent's Unix socket (no wrapper layer).
+	//
+	// Why a full path (and not a basename + LD_LIBRARY_PATH):
+	// - This matches NVIDIA's documented K8s deployment pattern for NCCL
+	//   Inspector. Sending a full path lets NCCL's loader dlopen it directly
+	//   without consulting LD_LIBRARY_PATH, which means we never override
+	//   image-defined LD_LIBRARY_PATH (e.g. nvidia/cuda's /usr/local/nvidia/lib).
+	// - Works on every NCCL version with a profiler API (2.23+) EXCEPT NCCL
+	//   2.27.3, which has an upstream loader bug (NVIDIA/nccl#1732) that
+	//   rejects path-style values. NCCL 2.27.3 ships only with torch 2.8.x;
+	//   fixed in NCCL 2.27.5 (torch 2.9.0+).
+	//
+	// Customer workarounds for torch 2.8.x (NCCL 2.27.3):
+	//   A. (recommended) Upgrade just NCCL: `pip install nvidia-nccl-cu12==2.27.5`.
+	//      Torch dlopens NCCL at runtime, so the wheel upgrade is transparent.
+	//   B. Upgrade to torch 2.9.0+ (bundles NCCL 2.27.5+).
+	//   C. Override the env vars in the PodSpec. NCCL_PROFILER_PLUGIN must be
+	//      the basename, and LD_LIBRARY_PATH must include /datadog-nccl plus
+	//      every directory the image's Dockerfile sets (read out of the
+	//      image with: `docker run --rm <image> sh -c 'echo $LD_LIBRARY_PATH'`):
+	//        env:
+	//        - name: NCCL_PROFILER_PLUGIN
+	//          value: "libnccl-profiler-inspector.so"
+	//        - name: LD_LIBRARY_PATH
+	//          value: "/datadog-nccl:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+	//      Setting only "/datadog-nccl" here would drop the image's CUDA / NVIDIA
+	//      lib directories — Kubernetes PodSpec env overrides image env and
+	//      $LD_LIBRARY_PATH is not expanded against image vars.
 	soDestPath = "/datadog-nccl/libnccl-profiler-inspector.so"
 
 	// soSourcePathInspector is where the Inspector .so lives inside the injector image.


### PR DESCRIPTION
### What does this PR do?
Docs-only follow-up to the NCCL profiler injection webhook
([PR #47293](https://github.com/DataDog/datadog-agent/pull/47293)).

Adds an inline code comment near `soDestPath` in`pkg/clusteragent/admission/mutate/ncclprofiler/mutator.go` explaining the rationale for using a full-path value in `NCCL_PROFILER_PLUGIN` and documenting three customer-side workarounds for torch 2.8.x — the one torch version blocked by an upstream NCCL loader bug.

No behavior change. No test change.

### Motivation

The webhook currently sets:
```go
NCCL_PROFILER_PLUGIN=/datadog-nccl/libnccl-profiler-inspector.so
```

But NCCL 2.27.3's buggy profiler plugin loader (`src/plugin/plugin_open.cc`) requires the env value to either:
- start with `lib` and end with `.so` (treated as filename, then searched via `LD_LIBRARY_PATH`), or
- be a bare plugin name with no `/` (wrapped as `libnccl-profiler-<value>.so`, then searched via `LD_LIBRARY_PATH`).

Sending a full path like `/datadog-nccl/libnccl-profiler-inspector.so` fails both conditions: it doesn't start with `lib`, and the wrap path constructs the invalid filename `libnccl-profiler-/datadog-nccl/libnccl-profiler-inspector.so.so`,which `dlopen` rejects. 

This comment provide a work around solution for this version. 

