### PR TITLE
feat[DSEM-706]: make registry hot-swappable for Remote Config 

### DIFF
--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -229,16 +229,17 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 	svc, _ := a.normalizeService(ts, s.Service, ts.Lang)
 	s.Service = svc
 
+	reg := semantics.DefaultRegistry()
 	spanAccessor := semantics.NewDDSpanAccessor(s.Meta, s.Metrics)
-	if pSvc := semantics.LookupString(semantics.DefaultRegistry(), spanAccessor, semantics.ConceptPeerService); pSvc != "" {
+	if pSvc := semantics.LookupString(reg, spanAccessor, semantics.ConceptPeerService); pSvc != "" {
 		s.Meta[string(semantics.ConceptPeerService)] = a.normalizePeerService(ts, pSvc)
 	}
-	if bSvc := semantics.LookupString(semantics.DefaultRegistry(), spanAccessor, semantics.ConceptDDBaseService); bSvc != "" {
+	if bSvc := semantics.LookupString(reg, spanAccessor, semantics.ConceptDDBaseService); bSvc != "" {
 		s.Meta[string(semantics.ConceptDDBaseService)] = a.normalizeBaseService(ts, bSvc)
 	}
 
 	if a.conf.HasFeature("component2name") {
-		if v := semantics.LookupString(semantics.DefaultRegistry(), spanAccessor, semantics.ConceptComponent); v != "" {
+		if v := semantics.LookupString(reg, spanAccessor, semantics.ConceptComponent); v != "" {
 			s.Name = v
 		}
 	}
@@ -261,7 +262,7 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 
 	s.Type = a.validateAndFixType(ts, s.Type)
 
-	if env := semantics.LookupString(semantics.DefaultRegistry(), spanAccessor, semantics.ConceptDDEnv); env != "" {
+	if env := semantics.LookupString(reg, spanAccessor, semantics.ConceptDDEnv); env != "" {
 		s.Meta["env"] = normalizeutil.NormalizeTagValue(env)
 	}
 
@@ -290,11 +291,12 @@ func (a *Agent) normalizeV1(ts *info.TagStats, s *idx.InternalSpan) error {
 	svc, _ := a.normalizeService(ts, s.Service(), ts.Lang)
 	s.SetService(svc)
 
+	reg := semantics.DefaultRegistry()
 	spanAccessorV1 := semantics.NewDDSpanAccessorV1(s)
-	if pSvc := semantics.LookupString(semantics.DefaultRegistry(), spanAccessorV1, semantics.ConceptPeerService); pSvc != "" {
+	if pSvc := semantics.LookupString(reg, spanAccessorV1, semantics.ConceptPeerService); pSvc != "" {
 		s.SetStringAttribute(string(semantics.ConceptPeerService), a.normalizePeerService(ts, pSvc))
 	}
-	if bSvc := semantics.LookupString(semantics.DefaultRegistry(), spanAccessorV1, semantics.ConceptDDBaseService); bSvc != "" {
+	if bSvc := semantics.LookupString(reg, spanAccessorV1, semantics.ConceptDDBaseService); bSvc != "" {
 		s.SetStringAttribute(string(semantics.ConceptDDBaseService), a.normalizeBaseService(ts, bSvc))
 	}
 
@@ -348,14 +350,15 @@ func (a *Agent) normalizeV1(ts *info.TagStats, s *idx.InternalSpan) error {
 // * populates Priority field if it wasn't populated
 // * promotes the decision maker found in any internal span to a chunk tag
 func setChunkAttributes(chunk *pb.TraceChunk, root *pb.Span) {
+	reg := semantics.DefaultRegistry()
 	// check if priority is already populated
 	if chunk.Priority == int32(sampler.PriorityNone) {
 		// Older tracers set sampling priority in the root span.
-		if p, ok := semantics.LookupFloat64(semantics.DefaultRegistry(), semantics.NewMetricsMapAccessor(root.Metrics), semantics.ConceptSamplingPriority); ok {
+		if p, ok := semantics.LookupFloat64(reg, semantics.NewMetricsMapAccessor(root.Metrics), semantics.ConceptSamplingPriority); ok {
 			chunk.Priority = int32(p)
 		} else {
 			for _, s := range chunk.Spans {
-				if p, ok := semantics.LookupFloat64(semantics.DefaultRegistry(), semantics.NewMetricsMapAccessor(s.Metrics), semantics.ConceptSamplingPriority); ok {
+				if p, ok := semantics.LookupFloat64(reg, semantics.NewMetricsMapAccessor(s.Metrics), semantics.ConceptSamplingPriority); ok {
 					chunk.Priority = int32(p)
 					break
 				}
@@ -364,7 +367,7 @@ func setChunkAttributes(chunk *pb.TraceChunk, root *pb.Span) {
 	}
 	if chunk.Origin == "" && root.Meta != nil {
 		// Older tracers set origin in the root span.
-		chunk.Origin = semantics.LookupString(semantics.DefaultRegistry(), semantics.NewStringMapAccessor(root.Meta), semantics.ConceptDDOrigin)
+		chunk.Origin = semantics.LookupString(reg, semantics.NewStringMapAccessor(root.Meta), semantics.ConceptDDOrigin)
 	}
 
 	if _, ok := chunk.Tags[tagDecisionMaker]; !ok {

--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -33,7 +33,6 @@ const (
 var (
 	// Year2000NanosecTS is an arbitrary cutoff to spot weird-looking values
 	Year2000NanosecTS = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC).UnixNano()
-	registry          = semantics.DefaultRegistry()
 )
 
 // normalizeService handles service normalization for both pb.Span and idx.InternalSpan
@@ -231,15 +230,15 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 	s.Service = svc
 
 	spanAccessor := semantics.NewDDSpanAccessor(s.Meta, s.Metrics)
-	if pSvc := semantics.LookupString(registry, spanAccessor, semantics.ConceptPeerService); pSvc != "" {
+	if pSvc := semantics.LookupString(semantics.DefaultRegistry(), spanAccessor, semantics.ConceptPeerService); pSvc != "" {
 		s.Meta[string(semantics.ConceptPeerService)] = a.normalizePeerService(ts, pSvc)
 	}
-	if bSvc := semantics.LookupString(registry, spanAccessor, semantics.ConceptDDBaseService); bSvc != "" {
+	if bSvc := semantics.LookupString(semantics.DefaultRegistry(), spanAccessor, semantics.ConceptDDBaseService); bSvc != "" {
 		s.Meta[string(semantics.ConceptDDBaseService)] = a.normalizeBaseService(ts, bSvc)
 	}
 
 	if a.conf.HasFeature("component2name") {
-		if v := semantics.LookupString(registry, spanAccessor, semantics.ConceptComponent); v != "" {
+		if v := semantics.LookupString(semantics.DefaultRegistry(), spanAccessor, semantics.ConceptComponent); v != "" {
 			s.Name = v
 		}
 	}
@@ -262,7 +261,7 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 
 	s.Type = a.validateAndFixType(ts, s.Type)
 
-	if env := semantics.LookupString(registry, spanAccessor, semantics.ConceptDDEnv); env != "" {
+	if env := semantics.LookupString(semantics.DefaultRegistry(), spanAccessor, semantics.ConceptDDEnv); env != "" {
 		s.Meta["env"] = normalizeutil.NormalizeTagValue(env)
 	}
 
@@ -292,10 +291,10 @@ func (a *Agent) normalizeV1(ts *info.TagStats, s *idx.InternalSpan) error {
 	s.SetService(svc)
 
 	spanAccessorV1 := semantics.NewDDSpanAccessorV1(s)
-	if pSvc := semantics.LookupString(registry, spanAccessorV1, semantics.ConceptPeerService); pSvc != "" {
+	if pSvc := semantics.LookupString(semantics.DefaultRegistry(), spanAccessorV1, semantics.ConceptPeerService); pSvc != "" {
 		s.SetStringAttribute(string(semantics.ConceptPeerService), a.normalizePeerService(ts, pSvc))
 	}
-	if bSvc := semantics.LookupString(registry, spanAccessorV1, semantics.ConceptDDBaseService); bSvc != "" {
+	if bSvc := semantics.LookupString(semantics.DefaultRegistry(), spanAccessorV1, semantics.ConceptDDBaseService); bSvc != "" {
 		s.SetStringAttribute(string(semantics.ConceptDDBaseService), a.normalizeBaseService(ts, bSvc))
 	}
 
@@ -352,11 +351,11 @@ func setChunkAttributes(chunk *pb.TraceChunk, root *pb.Span) {
 	// check if priority is already populated
 	if chunk.Priority == int32(sampler.PriorityNone) {
 		// Older tracers set sampling priority in the root span.
-		if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(root.Metrics), semantics.ConceptSamplingPriority); ok {
+		if p, ok := semantics.LookupFloat64(semantics.DefaultRegistry(), semantics.NewMetricsMapAccessor(root.Metrics), semantics.ConceptSamplingPriority); ok {
 			chunk.Priority = int32(p)
 		} else {
 			for _, s := range chunk.Spans {
-				if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(s.Metrics), semantics.ConceptSamplingPriority); ok {
+				if p, ok := semantics.LookupFloat64(semantics.DefaultRegistry(), semantics.NewMetricsMapAccessor(s.Metrics), semantics.ConceptSamplingPriority); ok {
 					chunk.Priority = int32(p)
 					break
 				}
@@ -365,7 +364,7 @@ func setChunkAttributes(chunk *pb.TraceChunk, root *pb.Span) {
 	}
 	if chunk.Origin == "" && root.Meta != nil {
 		// Older tracers set origin in the root span.
-		chunk.Origin = semantics.LookupString(registry, semantics.NewStringMapAccessor(root.Meta), semantics.ConceptDDOrigin)
+		chunk.Origin = semantics.LookupString(semantics.DefaultRegistry(), semantics.NewStringMapAccessor(root.Meta), semantics.ConceptDDOrigin)
 	}
 
 	if _, ok := chunk.Tags[tagDecisionMaker]; !ok {

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
 	gzip "github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip"
@@ -1003,4 +1004,23 @@ func TestNormalizeSpanLinkNameV1(t *testing.T) {
 	assert.NoError(t, a.normalizeV1(ts, validLinkNameSpan))
 	linkName, _ = validLinkNameSpan.Links()[0].GetAttributeAsString("link.name")
 	assert.Equal(t, linkName, "valid_name")
+}
+
+func TestNormalizeUsesLiveRegistry(t *testing.T) {
+	// Custom registry: ConceptDDEnv maps to "x.test.env" instead of "env".
+	customJSON := `{"version":"test","concepts":{"env":{"canonical":"env","fallbacks":[{"name":"x.test.env","provider":"datadog","type":"string"}]}}}`
+	custom, err := semantics.NewRegistryFromJSON([]byte(customJSON))
+	require.NoError(t, err)
+	original, err := semantics.NewEmbeddedRegistry()
+	require.NoError(t, err)
+	t.Cleanup(func() { semantics.UpdateRegistry(original) })
+
+	semantics.UpdateRegistry(custom)
+
+	a := &Agent{conf: config.New()}
+	ts := newTagStats()
+	s := newTestSpan()
+	s.Meta["x.test.env"] = "staging"
+	require.NoError(t, a.normalize(ts, s))
+	assert.Equal(t, "staging", s.Meta["env"])
 }

--- a/pkg/trace/api/converter.go
+++ b/pkg/trace/api/converter.go
@@ -17,8 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/semantics"
 )
 
-var registry = semantics.DefaultRegistry()
-
 // isPromotedTag returns true if the key is a promoted tag that should be set as a field instead of an attribute
 func isPromotedTag(key string) bool {
 	return key == "env" || key == "version" || key == "component" || key == "span.kind"
@@ -27,6 +25,7 @@ func isPromotedTag(key string) bool {
 // ConvertToIdx converts a TracerPayload to the new string indexed TracerPayload format
 // originPayloadVersion is the version of the original payload, this is used to set the _dd.convertedv1 attribute on the spans (for debugging purposes)
 func ConvertToIdx(payload *pb.TracerPayload, originPayloadVersion string) *idx.InternalTracerPayload {
+	reg := semantics.DefaultRegistry()
 	stringTable := idx.NewStringTable()
 	payloadAttrs := convertAttributesMap(payload.Tags, stringTable)
 	idxChunks := make([]*idx.InternalTraceChunk, len(payload.Chunks))
@@ -57,7 +56,7 @@ func ConvertToIdx(payload *pb.TracerPayload, originPayloadVersion string) *idx.I
 					},
 				}
 			}
-			if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(span.Metrics), semantics.ConceptSamplingPriority); ok {
+			if p, ok := semantics.LookupFloat64(reg, semantics.NewMetricsMapAccessor(span.Metrics), semantics.ConceptSamplingPriority); ok {
 				spanConvertedFields.SamplingPriority = int32(p)
 			}
 			for k, v := range span.Metrics {
@@ -107,25 +106,25 @@ func ConvertToIdx(payload *pb.TracerPayload, originPayloadVersion string) *idx.I
 			// the first occurrence to chunk/payload level via spanConvertedFields
 			metaAccessor := semantics.NewStringMapAccessor(span.Meta)
 			var spanEnvRef, spanVersionRef uint32
-			if env := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDEnv); env != "" {
+			if env := semantics.LookupString(reg, metaAccessor, semantics.ConceptDDEnv); env != "" {
 				spanEnvRef = stringTable.Add(env)
 				if spanConvertedFields.EnvRef == 0 {
 					spanConvertedFields.EnvRef = spanEnvRef
 				}
 			}
-			if spanHost := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDHostname); spanHost != "" && spanConvertedFields.HostnameRef == 0 {
+			if spanHost := semantics.LookupString(reg, metaAccessor, semantics.ConceptDDHostname); spanHost != "" && spanConvertedFields.HostnameRef == 0 {
 				spanConvertedFields.HostnameRef = stringTable.Add(spanHost)
 			}
-			if spanVersion := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDVersion); spanVersion != "" {
+			if spanVersion := semantics.LookupString(reg, metaAccessor, semantics.ConceptDDVersion); spanVersion != "" {
 				spanVersionRef = stringTable.Add(spanVersion)
 				if spanConvertedFields.AppVersionRef == 0 {
 					spanConvertedFields.AppVersionRef = spanVersionRef
 				}
 			}
-			if spanGitCommitSha := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDGitCommitSHA); spanGitCommitSha != "" && spanConvertedFields.GitCommitShaRef == 0 {
+			if spanGitCommitSha := semantics.LookupString(reg, metaAccessor, semantics.ConceptDDGitCommitSHA); spanGitCommitSha != "" && spanConvertedFields.GitCommitShaRef == 0 {
 				spanConvertedFields.GitCommitShaRef = stringTable.Add(spanGitCommitSha)
 			}
-			if spanDecisionMaker := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDDecisionMaker); spanDecisionMaker != "" && spanConvertedFields.SamplingMechanism == 0 {
+			if spanDecisionMaker := semantics.LookupString(reg, metaAccessor, semantics.ConceptDDDecisionMaker); spanDecisionMaker != "" && spanConvertedFields.SamplingMechanism == 0 {
 				spanDecisionMaker, _ = strings.CutPrefix(spanDecisionMaker, "-")
 				samplingMechanism, err := strconv.ParseUint(spanDecisionMaker, 10, 32)
 				if err != nil {
@@ -133,14 +132,14 @@ func ConvertToIdx(payload *pb.TracerPayload, originPayloadVersion string) *idx.I
 				}
 				spanConvertedFields.SamplingMechanism = uint32(samplingMechanism)
 			}
-			if spanAPMMode := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDAPMMode); spanAPMMode != "" && spanConvertedFields.APMModeRef == 0 {
+			if spanAPMMode := semantics.LookupString(reg, metaAccessor, semantics.ConceptDDAPMMode); spanAPMMode != "" && spanConvertedFields.APMModeRef == 0 {
 				spanConvertedFields.APMModeRef = stringTable.Add(spanAPMMode)
 			}
-			if spanOrigin := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDOrigin); spanOrigin != "" && spanConvertedFields.OriginRef == 0 {
+			if spanOrigin := semantics.LookupString(reg, metaAccessor, semantics.ConceptDDOrigin); spanOrigin != "" && spanConvertedFields.OriginRef == 0 {
 				spanConvertedFields.OriginRef = stringTable.Add(spanOrigin)
 			}
-			component := semantics.LookupString(registry, metaAccessor, semantics.ConceptComponent)
-			kindStr := semantics.LookupString(registry, metaAccessor, semantics.ConceptSpanKind)
+			component := semantics.LookupString(reg, metaAccessor, semantics.ConceptComponent)
+			kindStr := semantics.LookupString(reg, metaAccessor, semantics.ConceptSpanKind)
 			var kind idx.SpanKind
 			switch kindStr {
 			case "server":

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -345,7 +345,7 @@ func (o *OTLPReceiver) receiveResourceSpansV2(ctx context.Context, rspans ptrace
 			}
 			ddspan := transform.OtelSpanToDDSpan(otelspan, otelres, libspans.Scope(), o.conf)
 
-			if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(ddspan.Metrics), semantics.ConceptSamplingPriority); ok {
+			if p, ok := semantics.LookupFloat64(semantics.DefaultRegistry(), semantics.NewMetricsMapAccessor(ddspan.Metrics), semantics.ConceptSamplingPriority); ok {
 				priorityByID[traceID] = sampler.SamplingPriority(p)
 			}
 			tracesByID[traceID] = append(tracesByID[traceID], ddspan)

--- a/pkg/trace/config/BUILD.bazel
+++ b/pkg/trace/config/BUILD.bazel
@@ -33,5 +33,6 @@ go_test(
         "//pkg/obfuscate",
         "//pkg/trace/semantics",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -826,7 +826,7 @@ func (c *AgentConfig) ConfiguredPeerTags() []string {
 	if !c.PeerTagsAggregation {
 		return nil
 	}
-	return preparePeerTags(append(basePeerTags, c.PeerTags...))
+	return preparePeerTags(append(basePeerTags(), c.PeerTags...))
 }
 
 // ConfiguredSpanDerivedPrimaryTagKeys returns the configured span-derived primary

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	"github.com/DataDog/datadog-agent/pkg/trace/semantics"
 )
 
 const (
@@ -47,7 +49,7 @@ func TestPeerTagsAggregation(t *testing.T) {
 	t.Run("default-enabled", func(t *testing.T) {
 		cfg := New()
 		assert.Empty(t, cfg.PeerTags)
-		assert.Equal(t, basePeerTags, cfg.ConfiguredPeerTags())
+		assert.Equal(t, basePeerTags(), cfg.ConfiguredPeerTags())
 	})
 	t.Run("disabled-user-tags", func(t *testing.T) {
 		cfg := New()
@@ -59,12 +61,12 @@ func TestPeerTagsAggregation(t *testing.T) {
 	t.Run("enabled-user-tags", func(t *testing.T) {
 		cfg := New()
 		cfg.PeerTags = []string{"user_peer_tag"}
-		assert.Equal(t, append(basePeerTags, "user_peer_tag"), cfg.ConfiguredPeerTags())
+		assert.Equal(t, append(basePeerTags(), "user_peer_tag"), cfg.ConfiguredPeerTags())
 	})
 	t.Run("dedup", func(t *testing.T) {
 		cfg := New()
-		cfg.PeerTags = basePeerTags[:2]
-		assert.Equal(t, basePeerTags, cfg.ConfiguredPeerTags())
+		cfg.PeerTags = basePeerTags()[:2]
+		assert.Equal(t, basePeerTags(), cfg.ConfiguredPeerTags())
 	})
 }
 
@@ -193,4 +195,21 @@ func TestEnableOPMFetchDefault(t *testing.T) {
 	cfg := New()
 	assert.False(t, cfg.EnableOPMFetch, "EnableOPMFetch must default to false so library users of pkg/trace are unaffected")
 	assert.Empty(t, cfg.OPMValidateURL, "OPMValidateURL must default to empty when EnableOPMFetch is false")
+}
+
+func TestConfiguredPeerTagsUsesLiveRegistry(t *testing.T) {
+	// Custom registry: ConceptPeerService maps to "x.custom.peer" instead of "peer.service".
+	customJSON := `{"version":"test","concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.custom.peer","provider":"datadog","type":"string"}]}}}`
+	custom, err := semantics.NewRegistryFromJSON([]byte(customJSON))
+	require.NoError(t, err)
+	original, err := semantics.NewEmbeddedRegistry()
+	require.NoError(t, err)
+	t.Cleanup(func() { semantics.UpdateRegistry(original) })
+
+	semantics.UpdateRegistry(custom)
+
+	cfg := New()
+	tags := cfg.ConfiguredPeerTags()
+	assert.Contains(t, tags, "x.custom.peer")
+	assert.NotContains(t, tags, "peer.service")
 }

--- a/pkg/trace/config/peer_tags.go
+++ b/pkg/trace/config/peer_tags.go
@@ -33,6 +33,7 @@ var peerTagConcepts = []semantics.Concept{
 }
 
 // basePeerTags returns the base set of peer tag precursors derived from the live registry.
+// This is intentionally a function (not a cached var) so RC registry updates are reflected on each call.
 func basePeerTags() []string {
 	r := semantics.DefaultRegistry()
 	var precursors []string

--- a/pkg/trace/config/peer_tags.go
+++ b/pkg/trace/config/peer_tags.go
@@ -32,9 +32,8 @@ var peerTagConcepts = []semantics.Concept{
 	semantics.ConceptPeerAWSKinesisStream,
 }
 
-// basePeerTags is the base set of peer tag precursors (tags from which peer tags
-// are derived) we aggregate on when peer tag aggregation is enabled.
-var basePeerTags = func() []string {
+// basePeerTags returns the base set of peer tag precursors derived from the live registry.
+func basePeerTags() []string {
 	r := semantics.DefaultRegistry()
 	var precursors []string
 	for _, concept := range peerTagConcepts {
@@ -44,7 +43,7 @@ var basePeerTags = func() []string {
 	}
 	sort.Strings(precursors)
 	return precursors
-}()
+}
 
 func preparePeerTags(tags []string) []string {
 	if len(tags) == 0 {

--- a/pkg/trace/config/peer_tags_test.go
+++ b/pkg/trace/config/peer_tags_test.go
@@ -33,8 +33,8 @@ func TestPreparePeerTags(t *testing.T) {
 			output: []string{"db.name", "db.instance", "peer.service", "some.other.tag", "zz_tag"},
 		},
 		{
-			input:  append([]string{"zz_tag"}, basePeerTags...),
-			output: append(basePeerTags, "zz_tag"),
+			input:  append([]string{"zz_tag"}, basePeerTags()...),
+			output: append(basePeerTags(), "zz_tag"),
 		},
 	} {
 		sort.Strings(tc.output)
@@ -43,8 +43,8 @@ func TestPreparePeerTags(t *testing.T) {
 }
 
 func TestDefaultPeerTags(t *testing.T) {
-	assert.Contains(t, basePeerTags, "db.name")
-	assert.Contains(t, basePeerTags, "_dd.base_service")
+	assert.Contains(t, basePeerTags(), "db.name")
+	assert.Contains(t, basePeerTags(), "_dd.base_service")
 }
 
 func TestPeerTagConceptsHaveMappings(t *testing.T) {
@@ -139,6 +139,6 @@ func TestBasePeerTagsMatchINISource(t *testing.T) {
 	}
 
 	for _, key := range expectedFromINI {
-		assert.Contains(t, basePeerTags, key, "basePeerTags is missing key %q that was present in peer_tags.ini", key)
+		assert.Contains(t, basePeerTags(), key, "basePeerTags is missing key %q that was present in peer_tags.ini", key)
 	}
 }

--- a/pkg/trace/sampler/probabilistic.go
+++ b/pkg/trace/sampler/probabilistic.go
@@ -18,8 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/semantics"
 )
 
-var registry = semantics.DefaultRegistry()
-
 const (
 	// These constants exist to match the behavior of the OTEL probabilistic sampler.
 	// See: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6229c6ad1c49e9cc4b41a8aab8cb5a94a7b82ea5/processor/probabilisticsamplerprocessor/tracesprocessor.go#L38-L42
@@ -115,9 +113,10 @@ func (ps *ProbabilisticSampler) SampleV1(traceID []byte, root *idx.InternalSpan)
 }
 
 func get128BitTraceID(span *trace.Span) ([]byte, error) {
+	reg := semantics.DefaultRegistry()
 	metaAccessor := semantics.NewStringMapAccessor(span.Meta)
 	// If it's an otel span the whole trace ID is in otel.trace_id
-	if tid := semantics.LookupString(registry, metaAccessor, semantics.ConceptOTelTraceID); tid != "" {
+	if tid := semantics.LookupString(reg, metaAccessor, semantics.ConceptOTelTraceID); tid != "" {
 		bs, err := hex.DecodeString(tid)
 		if err != nil {
 			return nil, err
@@ -128,7 +127,7 @@ func get128BitTraceID(span *trace.Span) ([]byte, error) {
 	binary.BigEndian.PutUint64(tid[8:], span.TraceID)
 	// Get hex encoded upper bits for datadog spans
 	// If no value is found we can use the default `0` value as that's what will have been propagated
-	if upper := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDTraceIDHigh); upper != "" {
+	if upper := semantics.LookupString(reg, metaAccessor, semantics.ConceptDDTraceIDHigh); upper != "" {
 		u, err := strconv.ParseUint(upper, 16, 64)
 		if err != nil {
 			return nil, err

--- a/pkg/trace/semantics/BUILD.bazel
+++ b/pkg/trace/semantics/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "lookup_dd_test.go",
         "lookup_pdata_test.go",
         "lookup_test.go",
+        "registry_update_test.go",
         "semantics_test.go",
     ],
     embed = [":semantics"],

--- a/pkg/trace/semantics/registry.go
+++ b/pkg/trace/semantics/registry.go
@@ -6,9 +6,10 @@
 package semantics
 
 import (
-	_ "embed" //nolint:revive
+	_ "embed"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 )
 
 //go:embed mappings.json
@@ -25,9 +26,14 @@ type EmbeddedRegistry struct {
 	mappings map[Concept][]TagInfo
 }
 
-var globalRegistry = mustLoadRegistry()
+var globalRegistry atomic.Pointer[Registry]
 
-func mustLoadRegistry() *EmbeddedRegistry {
+func init() {
+	r := mustLoadRegistry()
+	globalRegistry.Store(&r)
+}
+
+func mustLoadRegistry() Registry {
 	r, err := NewEmbeddedRegistry()
 	if err != nil {
 		panic(fmt.Sprintf("failed to load semantic registry: %v", err))
@@ -35,9 +41,28 @@ func mustLoadRegistry() *EmbeddedRegistry {
 	return r
 }
 
-// DefaultRegistry returns the default semantic registry.
+// DefaultRegistry returns the live semantic registry.
 func DefaultRegistry() Registry {
-	return globalRegistry
+	return *globalRegistry.Load()
+}
+
+// UpdateRegistry atomically replaces the live registry.
+// Called by RemoteConfigHandler only after successful validation.
+func UpdateRegistry(r Registry) {
+	globalRegistry.Store(&r)
+}
+
+// NewRegistryFromJSON constructs a Registry from raw JSON without affecting the live registry.
+// Returns an error if the JSON is malformed or contains no concepts.
+func NewRegistryFromJSON(data []byte) (Registry, error) {
+	r := &EmbeddedRegistry{}
+	if err := r.loadFromJSON(data); err != nil {
+		return nil, err
+	}
+	if len(r.mappings) == 0 {
+		return nil, fmt.Errorf("registry JSON contains no concepts")
+	}
+	return r, nil
 }
 
 // NewEmbeddedRegistry creates a registry from embedded JSON mappings.

--- a/pkg/trace/semantics/registry.go
+++ b/pkg/trace/semantics/registry.go
@@ -8,6 +8,7 @@ package semantics
 import (
 	_ "embed" //nolint:revive
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync/atomic"
 )
@@ -61,7 +62,7 @@ func NewRegistryFromJSON(data []byte) (Registry, error) {
 		return nil, err
 	}
 	if len(r.mappings) == 0 {
-		return nil, fmt.Errorf("registry JSON contains no concepts")
+		return nil, errors.New("registry JSON contains no concepts")
 	}
 	return r, nil
 }

--- a/pkg/trace/semantics/registry.go
+++ b/pkg/trace/semantics/registry.go
@@ -6,7 +6,7 @@
 package semantics
 
 import (
-	_ "embed"
+	_ "embed" //nolint:revive
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
@@ -47,6 +47,7 @@ func DefaultRegistry() Registry {
 }
 
 // UpdateRegistry atomically replaces the live registry.
+// Callers are responsible for refreshing any derived state (e.g. concentrator peer tag keys) after the swap.
 // Called by RemoteConfigHandler only after successful validation.
 func UpdateRegistry(r Registry) {
 	globalRegistry.Store(&r)

--- a/pkg/trace/semantics/registry_update_test.go
+++ b/pkg/trace/semantics/registry_update_test.go
@@ -46,7 +46,7 @@ func TestUpdateRegistry_AtomicSwap(t *testing.T) {
 	assert.Equal(t, "test-version", DefaultRegistry().Version())
 }
 
-func TestUpdateRegistry_ConcurrentReadWrite(t *testing.T) {
+func TestUpdateRegistry_ConcurrentReadWrite(_ *testing.T) {
 	const goroutines = 10
 	const iterations = 500
 

--- a/pkg/trace/semantics/registry_update_test.go
+++ b/pkg/trace/semantics/registry_update_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package semantics
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegistryFromJSON_ValidJSON(t *testing.T) {
+	r, err := NewRegistryFromJSON(mappingsJSON)
+	require.NoError(t, err)
+	embedded, err := NewEmbeddedRegistry()
+	require.NoError(t, err)
+	for concept := range embedded.mappings {
+		assert.NotNil(t, r.GetAttributePrecedence(concept), "concept %s should be present", concept)
+	}
+}
+
+func TestNewRegistryFromJSON_MalformedJSON(t *testing.T) {
+	_, err := NewRegistryFromJSON([]byte("not valid json"))
+	assert.Error(t, err)
+}
+
+func TestNewRegistryFromJSON_EmptyConcepts(t *testing.T) {
+	_, err := NewRegistryFromJSON([]byte(`{"version":"0.1.0","concepts":{}}`))
+	assert.Error(t, err)
+}
+
+func TestUpdateRegistry_AtomicSwap(t *testing.T) {
+	original, err := NewEmbeddedRegistry()
+	require.NoError(t, err)
+	t.Cleanup(func() { UpdateRegistry(original) })
+
+	customJSON := `{"version":"test-version","concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
+	custom, err := NewRegistryFromJSON([]byte(customJSON))
+	require.NoError(t, err)
+
+	UpdateRegistry(custom)
+	assert.Equal(t, "test-version", DefaultRegistry().Version())
+}
+
+func TestUpdateRegistry_ConcurrentReadWrite(t *testing.T) {
+	const goroutines = 10
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = DefaultRegistry().GetAttributePrecedence(ConceptDBStatement)
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < iterations; j++ {
+			r, err := NewEmbeddedRegistry()
+			if err == nil {
+				UpdateRegistry(r)
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/pkg/trace/stats/BUILD.bazel
+++ b/pkg/trace/stats/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/proto/pbgo/trace/idx",
         "//pkg/trace/config",
         "//pkg/trace/sampler",
+        "//pkg/trace/semantics",
         "//pkg/trace/traceutil",
         "@com_github_datadog_datadog_go_v5//statsd",
         "@com_github_datadog_sketches_go//ddsketch",

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -19,8 +19,6 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/code"
 )
 
-var ddRegistry = semantics.DefaultRegistry()
-
 const (
 	tagSynthetics    = "synthetics"
 	tagServiceSource = "_dd.svc_src"
@@ -72,7 +70,7 @@ func toStatusCode(v int64) (uint32, bool) {
 
 func getStatusCode(meta map[string]string, metrics map[string]float64) uint32 {
 	a := semantics.NewDDSpanAccessor(meta, metrics)
-	v, ok := semantics.LookupInt64(ddRegistry, a, semantics.ConceptHTTPStatusCode)
+	v, ok := semantics.LookupInt64(semantics.DefaultRegistry(), a, semantics.ConceptHTTPStatusCode)
 	if !ok {
 		return 0
 	}
@@ -85,7 +83,7 @@ func getStatusCode(meta map[string]string, metrics map[string]float64) uint32 {
 
 func getStatusCodeV1(s *idx.InternalSpan) uint32 {
 	a := semantics.NewDDSpanAccessorV1(s)
-	v, ok := semantics.LookupInt64(ddRegistry, a, semantics.ConceptHTTPStatusCode)
+	v, ok := semantics.LookupInt64(semantics.DefaultRegistry(), a, semantics.ConceptHTTPStatusCode)
 	if !ok {
 		return 0
 	}
@@ -212,7 +210,7 @@ func parseGRPCStatusString(strC string) string {
 
 func getGRPCStatusCode(meta map[string]string, metrics map[string]float64) string {
 	a := semantics.NewDDSpanAccessor(meta, metrics)
-	strC := semantics.LookupString(ddRegistry, a, semantics.ConceptGRPCStatusCode)
+	strC := semantics.LookupString(semantics.DefaultRegistry(), a, semantics.ConceptGRPCStatusCode)
 	if strC == "" {
 		return ""
 	}
@@ -221,7 +219,7 @@ func getGRPCStatusCode(meta map[string]string, metrics map[string]float64) strin
 
 func getGRPCStatusCodeV1(s *idx.InternalSpan) string {
 	a := semantics.NewDDSpanAccessorV1(s)
-	strC := semantics.LookupString(ddRegistry, a, semantics.ConceptGRPCStatusCode)
+	strC := semantics.LookupString(semantics.DefaultRegistry(), a, semantics.ConceptGRPCStatusCode)
 	if strC == "" {
 		return ""
 	}

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
+	"github.com/DataDog/datadog-agent/pkg/trace/semantics"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
@@ -439,4 +441,21 @@ func TestIsRootSpan(t *testing.T) {
 		agg := NewAggregationFromSpan(statSpan, "", PayloadAggregationKey{})
 		assert.Equal(t, tt.isTraceRoot, agg.IsTraceRoot)
 	}
+}
+
+func TestGetStatusCodeUsesLiveRegistry(t *testing.T) {
+	// A registry where http.status_code only maps to "x.custom.status", not the standard key.
+	customJSON := `{"version":"test","concepts":{"http.status_code":{"canonical":"http.status_code","fallbacks":[{"name":"x.custom.status","provider":"datadog","type":"string"}]}}}`
+	custom, err := semantics.NewRegistryFromJSON([]byte(customJSON))
+	require.NoError(t, err)
+	original, err := semantics.NewEmbeddedRegistry()
+	require.NoError(t, err)
+	t.Cleanup(func() { semantics.UpdateRegistry(original) })
+
+	semantics.UpdateRegistry(custom)
+
+	// Standard key should not resolve — custom registry remapped the concept.
+	assert.Equal(t, uint32(0), getStatusCode(map[string]string{"http.status_code": "200"}, nil))
+	// Custom key should resolve.
+	assert.Equal(t, uint32(404), getStatusCode(map[string]string{"x.custom.status": "404"}, nil))
 }

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -211,7 +211,7 @@ func (c *Concentrator) addNow(pt *traceutil.ProcessedTrace, tags infraTags) {
 		ImageTag:        pt.ImageTag,
 		Lang:            pt.Lang,
 		ProcessTagsHash: tags.processTagsHash,
-		BaseService:     semantics.LookupString(ddRegistry, semantics.NewDDSpanAccessor(pt.Root.Meta, pt.Root.Metrics), semantics.ConceptDDBaseService),
+		BaseService:     semantics.LookupString(semantics.DefaultRegistry(), semantics.NewDDSpanAccessor(pt.Root.Meta, pt.Root.Metrics), semantics.ConceptDDBaseService),
 	}
 	for _, s := range pt.TraceChunk.Spans {
 		statSpan, ok := c.spanConcentrator.NewStatSpanFromPB(s, c.peerTagKeys, c.additionalMetricTagKeys)
@@ -238,7 +238,7 @@ func (c *Concentrator) addNowV1(pt *traceutil.ProcessedTraceV1, tags infraTags) 
 		env = c.agentEnv
 	}
 	weight := weightV1(pt.Root)
-	baseService := semantics.LookupString(ddRegistry, semantics.NewDDSpanAccessorV1(pt.Root), semantics.ConceptDDBaseService)
+	baseService := semantics.LookupString(semantics.DefaultRegistry(), semantics.NewDDSpanAccessorV1(pt.Root), semantics.ConceptDDBaseService)
 	aggKey := PayloadAggregationKey{
 		Env:             env,
 		Hostname:        hostname,

--- a/pkg/trace/stats/span_concentrator.go
+++ b/pkg/trace/stats/span_concentrator.go
@@ -55,9 +55,10 @@ func matchingPeerTags(meta map[string]string, peerTagKeys []string) []string {
 	if len(peerTagKeys) == 0 {
 		return nil
 	}
+	reg := semantics.DefaultRegistry()
 	a := semantics.NewStringMapAccessor(meta)
-	spanKind := semantics.LookupString(semantics.DefaultRegistry(), a, semantics.ConceptSpanKind)
-	baseService := semantics.LookupString(semantics.DefaultRegistry(), a, semantics.ConceptDDBaseService)
+	spanKind := semantics.LookupString(reg, a, semantics.ConceptSpanKind)
+	baseService := semantics.LookupString(reg, a, semantics.ConceptDDBaseService)
 	var pt []string
 	for _, t := range peerTagKeysToAggregateForSpan(spanKind, baseService, peerTagKeys) {
 		if v, ok := meta[t]; ok && v != "" {

--- a/pkg/trace/stats/span_concentrator.go
+++ b/pkg/trace/stats/span_concentrator.go
@@ -56,8 +56,8 @@ func matchingPeerTags(meta map[string]string, peerTagKeys []string) []string {
 		return nil
 	}
 	a := semantics.NewStringMapAccessor(meta)
-	spanKind := semantics.LookupString(ddRegistry, a, semantics.ConceptSpanKind)
-	baseService := semantics.LookupString(ddRegistry, a, semantics.ConceptDDBaseService)
+	spanKind := semantics.LookupString(semantics.DefaultRegistry(), a, semantics.ConceptSpanKind)
+	baseService := semantics.LookupString(semantics.DefaultRegistry(), a, semantics.ConceptDDBaseService)
 	var pt []string
 	for _, t := range peerTagKeysToAggregateForSpan(spanKind, baseService, peerTagKeys) {
 		if v, ok := meta[t]; ok && v != "" {
@@ -73,7 +73,7 @@ func matchingPeerTagsV1(s *idx.InternalSpan, peerTagKeys []string) []string {
 		return nil
 	}
 	a := semantics.NewDDSpanAccessorV1(s)
-	baseService := semantics.LookupString(ddRegistry, a, semantics.ConceptDDBaseService)
+	baseService := semantics.LookupString(semantics.DefaultRegistry(), a, semantics.ConceptDDBaseService)
 	var pt []string
 	for _, t := range peerTagKeysToAggregateForSpan(s.SpanKind(), baseService, peerTagKeys) {
 		if v, ok := s.GetAttributeAsString(t); ok && v != "" {
@@ -212,7 +212,7 @@ func (sc *SpanConcentrator) NewStatSpanWithConfig(config StatSpanConfig) (statSp
 		config.Metrics = make(map[string]float64)
 	}
 	a := semantics.NewDDSpanAccessor(config.Meta, config.Metrics)
-	spanKind := semantics.LookupString(ddRegistry, a, semantics.ConceptSpanKind)
+	spanKind := semantics.LookupString(semantics.DefaultRegistry(), a, semantics.ConceptSpanKind)
 	eligibleSpanKind := sc.computeStatsBySpanKind && computeStatsForSpanKind(spanKind)
 	isTopLevel := traceutil.HasTopLevelMetrics(config.Metrics)
 	if !(isTopLevel || traceutil.IsMeasuredMetrics(config.Metrics) || eligibleSpanKind) {


### PR DESCRIPTION
## Make the semantic registry hot-swappable for Remote Config (DSEM-706)

## Summary

This PR implements the DSEM-owned consuming-side work for [DSEM-706](https://datadoghq.atlassian.net/browse/DSEM-706): making the trace-agent's semantic registry updatable at runtime via Remote Config, without requiring an agent restart or redeploy.

Today, `mappings.json` is embedded at build time and the registry is write-once. This PR decouples config deployment from agent deployment by providing the infrastructure the RC handler (trace-agent team, follow-on PR) will use to push live updates.

**Changes:**

- **`pkg/trace/semantics/registry.go`** — replaces the bare `globalRegistry` pointer with `atomic.Pointer[Registry]`. Adds two new public functions:
  - `UpdateRegistry(r Registry)` — atomically swaps in a new registry; called by the RC handler after validation
  - `NewRegistryFromJSON(data []byte) (Registry, error)` — parses and validates a raw JSON payload without touching the live registry; returns an error on malformed JSON or empty concept map

- **`pkg/trace/agent/normalizer.go`, `pkg/trace/stats/aggregation.go`, `pkg/trace/stats/concentrator.go`, `pkg/trace/stats/span_concentrator.go`, `pkg/trace/config/peer_tags.go`** — removes init-time `DefaultRegistry()` snapshots (module-level vars) and replaces them with per-call `DefaultRegistry()` invocations. These snapshots would have silently served stale data after any `UpdateRegistry` call.

**Testing:**

All new tests run with `-race`:
- `TestNewRegistryFromJSON_ValidJSON/MalformedJSON/EmptyConcepts`
- `TestUpdateRegistry_AtomicSwap` — verifies a swap is reflected by `DefaultRegistry()`
- `TestUpdateRegistry_ConcurrentReadWrite` — concurrent readers + writer, no data race
- `TestGetStatusCodeUsesLiveRegistry` — verifies `aggregation.go` uses the live registry post-swap
- `TestNormalizeUsesLiveRegistry` — verifies `normalizer.go` uses the live registry post-swap
- `TestConfiguredPeerTagsUsesLiveRegistry` — verifies `peer_tags.go` recomputes from the live registry post-swap

## What's not in this PR

- The RC handler subscription (`onSemanticCoreUpdate`, `ProductAPMSemanticCore` constant, wiring in `Start()`) — owned by the trace-agent team, depends on this PR merging first
- Product registration of `APM_SEMANTIC_CORE_DD` in `rc-employee-configurations` — coordination with Dario's RC team

## Test plan
- [ ] `go test -race ./pkg/trace/semantics/... ./pkg/trace/stats/... ./pkg/trace/config/...` passes
- [ ] Confirm with APM Platform that microsecond transition window (goroutines mid-flight finishing on old registry during swap) is acceptable before merge

[DSEM-706]: https://datadoghq.atlassian.net/browse/DSEM-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ