### PR TITLE
Remove unused ProcessingTags field from message struct

### DIFF
--- a/comp/logs-library/processor/raw.go
+++ b/comp/logs-library/processor/raw.go
@@ -58,7 +58,7 @@ func (r *rawEncoder) Encode(msg *message.Message, hostname string) error {
 		extraContent = append(extraContent, []byte(" - - ")...)
 
 		// Tags
-		tagsPayload := msg.Origin.TagsPayload(msg.ProcessingTags)
+		tagsPayload := msg.Origin.TagsPayload(nil)
 		if len(tagsPayload) > 0 {
 			extraContent = append(extraContent, tagsPayload...)
 		} else {

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter_test.go
@@ -318,7 +318,7 @@ func TestLogsExporter(t *testing.T) {
 				} else {
 					assert.Equal(t, tt.args.logSourceName, output.Origin.Source())
 				}
-				assert.Equal(t, tt.expectedTags[i], output.Origin.Tags(nil))
+				assert.Equal(t, tt.expectedTags[i], output.Origin.Tags())
 				ans = append(ans, outputJSON)
 			}
 			assert.Equal(t, tt.want, ans)

--- a/pkg/logs/launchers/listener/tcp_test.go
+++ b/pkg/logs/launchers/listener/tcp_test.go
@@ -489,7 +489,7 @@ func TestTCPPlaintextHasNoTLSTags(t *testing.T) {
 	fmt.Fprint(conn, "plaintext msg\n")
 	msg := <-msgChan
 	assert.Equal(t, "plaintext msg", string(msg.GetContent()))
-	for _, tag := range msg.Origin.Tags(nil) {
+	for _, tag := range msg.Origin.Tags() {
 		assert.False(t, strings.HasPrefix(tag, "tls_"), "plaintext message should not have TLS tags, got %q", tag)
 	}
 

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -397,12 +397,12 @@ func (m *Message) GetStatus() string {
 	return m.MessageMetadata.GetStatus()
 }
 
-// GetTags returns the message processing tags.
+// GetTags returns the message tags.
 func (m *Message) GetTags() []string {
 	if m.Origin == nil {
-		return m.ProcessingTags
+		return nil
 	}
-	return m.Origin.Tags(m.ProcessingTags)
+	return m.Origin.Tags()
 }
 
 // GetHostname returns the message hostname.
@@ -471,12 +471,12 @@ func (m *MessageMetadata) GetLatency() int64 {
 
 // Tags returns all tags that this message is attached with.
 func (m *MessageMetadata) Tags() []string {
-	return m.Origin.Tags(nil)
+	return m.Origin.Tags()
 }
 
 // TagsToString returns all tags that this message is attached with, as a string.
 func (m *MessageMetadata) TagsToString() string {
-	return m.Origin.TagsToString(nil)
+	return m.Origin.TagsToString()
 }
 
 // Count returns the number of messages

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -84,8 +84,6 @@ type MessageMetadata struct {
 	// This is also used to track the original content size before the message is processed and encoded later
 	// in the pipeline.
 	RawDataLen int
-	// Tags added on processing
-	ProcessingTags []string
 	// Extra information from the parsers
 	ParsingExtra
 	// Extra information for Serverless Logs messages
@@ -473,12 +471,12 @@ func (m *MessageMetadata) GetLatency() int64 {
 
 // Tags returns all tags that this message is attached with.
 func (m *MessageMetadata) Tags() []string {
-	return m.Origin.Tags(m.ProcessingTags)
+	return m.Origin.Tags(nil)
 }
 
 // TagsToString returns all tags that this message is attached with, as a string.
 func (m *MessageMetadata) TagsToString() string {
-	return m.Origin.TagsToString(m.ProcessingTags)
+	return m.Origin.TagsToString(nil)
 }
 
 // Count returns the number of messages

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -38,8 +38,8 @@ func NewOrigin(source *sources.LogSource) *Origin {
 // Tags returns the tags of the origin.
 //
 // The returned slice must not be modified by the caller.
-func (o *Origin) Tags(processingTags []string) []string {
-	return o.tagsToStringArray(processingTags)
+func (o *Origin) Tags() []string {
+	return o.tagsToStringArray()
 }
 
 // TagsPayload returns the raw tag payload of the origin.
@@ -74,8 +74,8 @@ func (o *Origin) TagsPayload(processingTags []string) []byte {
 }
 
 // TagsToString encodes tags to a single string, in a comma separated format
-func (o *Origin) TagsToString(processingTags []string) string {
-	tags := o.tagsToStringArray(processingTags)
+func (o *Origin) TagsToString() string {
+	tags := o.tagsToStringArray()
 
 	if tags == nil {
 		return ""
@@ -84,15 +84,15 @@ func (o *Origin) TagsToString(processingTags []string) string {
 	return strings.Join(tags, ",")
 }
 
-func (o *Origin) tagsToStringArray(processingTags []string) []string {
+func (o *Origin) tagsToStringArray() []string {
 	if o == nil || o.LogSource == nil {
-		return processingTags
+		return nil
 	}
 	sourceCategory := o.LogSource.Config.SourceCategory
 	configTags := o.LogSource.Config.Tags
 
 	// Calculate total capacity needed
-	totalLen := len(o.tags) + len(configTags) + len(processingTags)
+	totalLen := len(o.tags) + len(configTags)
 	if sourceCategory != "" {
 		totalLen++
 	}
@@ -106,7 +106,6 @@ func (o *Origin) tagsToStringArray(processingTags []string) []string {
 	}
 
 	result = append(result, configTags...)
-	result = append(result, processingTags...)
 
 	return result
 }

--- a/pkg/logs/message/origin_slice_aliasing_test.go
+++ b/pkg/logs/message/origin_slice_aliasing_test.go
@@ -36,13 +36,11 @@ func TestTags_NoMutation(t *testing.T) {
 	originalTags := origin.tags
 	originalLen := len(originalTags)
 
-	result := origin.Tags([]string{"proc1", "proc2"})
+	result := origin.Tags()
 
 	// Verify: Result contains all expected tags
 	assert.Contains(t, result, "tag1:value1")
 	assert.Contains(t, result, "tag2:value2")
-	assert.Contains(t, result, "proc1")
-	assert.Contains(t, result, "proc2")
 
 	// Verify: Original wasn't mutated
 	assert.Len(t, originalTags, originalLen, "origin.tags should not be modified")

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -19,8 +19,8 @@ func TestSetTagsEmpty(t *testing.T) {
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{})
-	assert.Equal(t, []string{}, origin.Tags(nil))
-	assert.Equal(t, "", origin.TagsToString(nil))
+	assert.Equal(t, []string{}, origin.Tags())
+	assert.Equal(t, "", origin.TagsToString())
 	assert.Equal(t, []byte{}, origin.TagsPayload(nil))
 }
 
@@ -32,9 +32,9 @@ func TestTagsWithConfigTagsOnly(t *testing.T) {
 	}
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
-	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags(nil))
+	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload(nil)))
-	assert.Equal(t, "sourcecategory:b,c:d,e", origin.TagsToString(nil))
+	assert.Equal(t, "sourcecategory:b,c:d,e", origin.TagsToString())
 }
 
 func TestSetTagsWithNoConfigTags(t *testing.T) {
@@ -45,8 +45,8 @@ func TestSetTagsWithNoConfigTags(t *testing.T) {
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags(nil))
-	assert.Equal(t, "foo:bar,baz,sourcecategory:b", origin.TagsToString(nil))
+	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags())
+	assert.Equal(t, "foo:bar,baz,sourcecategory:b", origin.TagsToString())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload(nil)))
 }
 
@@ -59,12 +59,12 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags(nil))
-	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e", origin.TagsToString(nil))
+	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags())
+	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e", origin.TagsToString())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload(nil)))
 }
 
-func TestSetTagsWithConfigTagsAndExtraTags(t *testing.T) {
+func TestTagsPayloadWithConfigTagsAndExtraTags(t *testing.T) {
 	cfg := &config.LogsConfig{
 		Source:         "a",
 		SourceCategory: "b",
@@ -73,8 +73,6 @@ func TestSetTagsWithConfigTagsAndExtraTags(t *testing.T) {
 	source := sources.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e", "processing:tag", "second:tag"}, origin.Tags([]string{"processing:tag", "second:tag"}))
-	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e,processing:tag,second:tag", origin.TagsToString([]string{"processing:tag", "second:tag"}))
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz,processing:tag,second:tag\"]", string(origin.TagsPayload([]string{"processing:tag", "second:tag"})))
 }
 

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -64,7 +64,7 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload(nil)))
 }
 
-func TestSetTagsWithConfigTagsAndProcessingTags(t *testing.T) {
+func TestSetTagsWithConfigTagsAndExtraTags(t *testing.T) {
 	cfg := &config.LogsConfig{
 		Source:         "a",
 		SourceCategory: "b",


### PR DESCRIPTION
### What does this PR do?

Removes the unused `ProcessingTags` field from `pkg/logs/message.MessageMetadata` and updates the remaining logs message code paths to use the existing origin tag handling directly.

This also renames the related origin unit test so it no longer refers to the removed field.

### Motivation

`ProcessingTags` no longer appears to be written anywhere in the logs pipeline. The dynamic tags that are still produced during parsing and preprocessing already flow through `ParsingExtra.Tags` into `Origin`, so keeping the unused field adds dead state and makes the tag path harder to reason about.

### Describe how you validated your changes

Ran:
- `dda inv test --targets=./pkg/logs/...`
- `dda inv test --targets=./pkg/logs/message,./pkg/logs/processor`

### Additional Notes

This is intended as a no-behavior-change cleanup. No release note was added.