### PR TITLE
label selector for hpa selection

### DIFF
--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
@@ -268,13 +268,15 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 	}
 
 	if w.autoscalerLister != nil {
-		hpaList, err := w.autoscalerLister.List(w.hpaLabelSelector)
+		hpaList, err := w.autoscalerLister.List(labels.Everything())
 		if err != nil {
 			return nil, fmt.Errorf("Could not list HPAs (to update DatadogMetric active status): %v", err)
 		}
 
 		for _, obj := range hpaList {
-			w.processHPAReference(addAutoscalerReference, obj)
+			if w.shouldProcessHPA(obj) {
+				w.processHPAReference(addAutoscalerReference, obj)
+			}
 		}
 	}
 
@@ -316,6 +318,45 @@ type addAutoscalerReferenceFn func(
 	metricName string,
 	labels map[string]string,
 )
+
+func (w *AutoscalerWatcher) shouldProcessHPA(obj runtime.Object) bool {
+	switch hpa := obj.(type) {
+	case *autoscalingv2beta1.HorizontalPodAutoscaler:
+		if w.hpaLabelSelector.Matches(labels.Set(hpa.Labels)) {
+			return true
+		}
+		for _, metric := range hpa.Spec.Metrics {
+			if metric.Type == autoscalingv2beta1.ExternalMetricSourceType && metric.External != nil {
+				if _, parsed, _ := metricNameToDatadogMetricID(metric.External.MetricName); parsed {
+					return true
+				}
+			}
+		}
+	case *autoscalingv2beta2.HorizontalPodAutoscaler:
+		if w.hpaLabelSelector.Matches(labels.Set(hpa.Labels)) {
+			return true
+		}
+		for _, metric := range hpa.Spec.Metrics {
+			if metric.Type == autoscalingv2beta2.ExternalMetricSourceType && metric.External != nil {
+				if _, parsed, _ := metricNameToDatadogMetricID(metric.External.Metric.Name); parsed {
+					return true
+				}
+			}
+		}
+	case *autoscalingv2.HorizontalPodAutoscaler:
+		if w.hpaLabelSelector.Matches(labels.Set(hpa.Labels)) {
+			return true
+		}
+		for _, metric := range hpa.Spec.Metrics {
+			if metric.Type == autoscalingv2.ExternalMetricSourceType && metric.External != nil {
+				if _, parsed, _ := metricNameToDatadogMetricID(metric.External.Metric.Name); parsed {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
 
 func (w *AutoscalerWatcher) processHPAReference(addAutoscalerReference addAutoscalerReferenceFn, obj runtime.Object) {
 	switch hpa := obj.(type) {

--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
@@ -48,6 +48,7 @@ type AutoscalerWatcher struct {
 	autogenEnabled          bool
 	autogenExpirationPeriod time.Duration
 	autogenNamespace        string
+	hpaLabelSelector        labels.Selector
 	autoscalerLister        cache.GenericLister
 	autoscalerListerSynced  cache.InformerSynced
 	wpaLister               cache.GenericLister
@@ -75,6 +76,7 @@ func NewAutoscalerWatcher(
 	autogenEnabled bool,
 	autogenExpirationPeriodHours int64,
 	autogenNamespace string,
+	hpaLabelSelector labels.Selector,
 	client kubernetes.Interface,
 	informer informers.SharedInformerFactory,
 	wpaInformer dynamic_informer.DynamicSharedInformerFactory,
@@ -117,11 +119,16 @@ func NewAutoscalerWatcher(
 		wpaListerSynced = wpaInformer.ForResource(gvr).Informer().HasSynced
 	}
 
+	if hpaLabelSelector == nil {
+		hpaLabelSelector = labels.Everything()
+	}
+
 	autoscalerWatcher := &AutoscalerWatcher{
 		refreshPeriod:           refreshPeriod,
 		autogenEnabled:          autogenEnabled,
 		autogenExpirationPeriod: time.Duration(autogenExpirationPeriodHours) * time.Hour,
 		autogenNamespace:        autogenNamespace,
+		hpaLabelSelector:        hpaLabelSelector,
 		autoscalerLister:        autoscalerLister,
 		autoscalerListerSynced:  autoscalerListerSynced,
 		wpaLister:               wpaLister,
@@ -261,7 +268,7 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 	}
 
 	if w.autoscalerLister != nil {
-		hpaList, err := w.autoscalerLister.List(labels.Everything())
+		hpaList, err := w.autoscalerLister.List(w.hpaLabelSelector)
 		if err != nil {
 			return nil, fmt.Errorf("Could not list HPAs (to update DatadogMetric active status): %v", err)
 		}

--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher_test.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher_test.go
@@ -16,6 +16,7 @@ import (
 	autoscaler "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamic_informer "k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
@@ -60,6 +61,49 @@ func newAutoscalerFixture(t *testing.T) *autoscalerFixture {
 	}
 }
 
+func (f *autoscalerFixture) newAutoscalerWatcherWithSelector(selector labels.Selector) (*AutoscalerWatcher, kube_informer.SharedInformerFactory, dynamic_informer.DynamicSharedInformerFactory) {
+	for _, hpa := range f.hpaLister {
+		f.kubeObjects = append(f.kubeObjects, hpa)
+	}
+	kubeClient := kube_fake.NewSimpleClientset(f.kubeObjects...)
+	kubeClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: fmt.Sprintf("%s/%s", autoscalingGroup, "v2beta1"),
+			APIResources: []metav1.APIResource{
+				{
+					Name:    hpaResource,
+					Group:   autoscalingGroup,
+					Version: "v2beta1",
+				},
+			},
+		},
+	}
+	kubeInformer := kube_informer.NewSharedInformerFactory(kubeClient, noResyncPeriodFunc())
+
+	for _, wpa := range f.wpaLister {
+		f.wpaObjects = append(f.wpaObjects, wpa)
+	}
+	wpaClient := fake.NewSimpleDynamicClient(scheme, f.wpaObjects...)
+	wpaInformer := dynamic_informer.NewDynamicSharedInformerFactory(wpaClient, noResyncPeriodFunc())
+
+	autoscalerWatcher, err := NewAutoscalerWatcher(0, true, 1, "default", selector, kubeClient, kubeInformer, wpaInformer, getIsLeaderFunction(true), &f.store)
+	if err != nil {
+		return nil, nil, nil
+	}
+	autoscalerWatcher.autoscalerListerSynced = alwaysReady
+	autoscalerWatcher.wpaListerSynced = alwaysReady
+
+	for _, hpa := range f.hpaLister {
+		kubeInformer.Autoscaling().V2beta1().HorizontalPodAutoscalers().Informer().GetIndexer().Add(hpa)
+	}
+
+	for _, wpa := range f.wpaLister {
+		wpaInformer.ForResource(gvr).Informer().GetIndexer().Add(wpa)
+	}
+
+	return autoscalerWatcher, kubeInformer, wpaInformer
+}
+
 func (f *autoscalerFixture) newAutoscalerWatcher() (*AutoscalerWatcher, kube_informer.SharedInformerFactory, dynamic_informer.DynamicSharedInformerFactory) {
 	for _, hpa := range f.hpaLister {
 		f.kubeObjects = append(f.kubeObjects, hpa)
@@ -85,7 +129,7 @@ func (f *autoscalerFixture) newAutoscalerWatcher() (*AutoscalerWatcher, kube_inf
 	wpaClient := fake.NewSimpleDynamicClient(scheme, f.wpaObjects...)
 	wpaInformer := dynamic_informer.NewDynamicSharedInformerFactory(wpaClient, noResyncPeriodFunc())
 
-	autoscalerWatcher, err := NewAutoscalerWatcher(0, true, 1, "default", kubeClient, kubeInformer, wpaInformer, getIsLeaderFunction(true), &f.store)
+	autoscalerWatcher, err := NewAutoscalerWatcher(0, true, 1, "default", nil, kubeClient, kubeInformer, wpaInformer, getIsLeaderFunction(true), &f.store)
 	if err != nil {
 		return nil, nil, nil
 	}
@@ -114,10 +158,15 @@ func (f *autoscalerFixture) runWatcherUpdate() {
 }
 
 func newFakeHorizontalPodAutoscaler(ns, name string, metrics []autoscaler.MetricSpec) *autoscaler.HorizontalPodAutoscaler {
+	return newFakeHorizontalPodAutoscalerWithLabels(ns, name, nil, metrics)
+}
+
+func newFakeHorizontalPodAutoscalerWithLabels(ns, name string, hpaLabels map[string]string, metrics []autoscaler.MetricSpec) *autoscaler.HorizontalPodAutoscaler {
 	return &autoscaler.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      name,
+			Labels:    hpaLabels,
 		},
 		Spec: autoscaler.HorizontalPodAutoscalerSpec{
 			Metrics: metrics,
@@ -487,4 +536,75 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 	}
 	ddm.SetQueries("avg:docker.cpu.usage{bar:foo}.rollup(30)")
 	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
+}
+
+func TestHPALabelSelectorFiltering(t *testing.T) {
+	f := newAutoscalerFixture(t)
+
+	// hpa0 has no managed-by label — should be included
+	f.hpaLister = []*autoscaler.HorizontalPodAutoscaler{
+		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa0", map[string]string{"team": "infra"}, []autoscaler.MetricSpec{
+			{
+				Type: autoscaler.ExternalMetricSourceType,
+				External: &autoscaler.ExternalMetricSource{
+					MetricName: "datadogmetric@default:dd-metric-included",
+				},
+			},
+		}),
+		// hpa1 is managed by keda-operator — should be excluded
+		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa1", map[string]string{"app.kubernetes.io/managed-by": "keda-operator"}, []autoscaler.MetricSpec{
+			{
+				Type: autoscaler.ExternalMetricSourceType,
+				External: &autoscaler.ExternalMetricSource{
+					MetricName: "datadogmetric@default:dd-metric-excluded",
+				},
+			},
+		}),
+	}
+
+	ddm := model.DatadogMetricInternal{
+		ID:         "default/dd-metric-included",
+		Active:     false,
+		Valid:      true,
+		Value:      10.0,
+		UpdateTime: time.Now(),
+		Error:      nil,
+	}
+	ddm.SetQueries("metric query included")
+	f.store.Set("default/dd-metric-included", ddm, "utest")
+
+	ddm = model.DatadogMetricInternal{
+		ID:         "default/dd-metric-excluded",
+		Active:     true,
+		Valid:      true,
+		Value:      20.0,
+		UpdateTime: time.Now(),
+		Error:      nil,
+	}
+	ddm.SetQueries("metric query excluded")
+	f.store.Set("default/dd-metric-excluded", ddm, "utest")
+
+	// Parse a selector that excludes HPAs with app.kubernetes.io/managed-by=keda-operator
+	selector, err := labels.Parse("app.kubernetes.io/managed-by!=keda-operator")
+	assert.NoError(t, err)
+
+	autoscalerWatcher, kubeInformer, wpaInformer := f.newAutoscalerWatcherWithSelector(selector)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	kubeInformer.Start(stopCh)
+	wpaInformer.Start(stopCh)
+
+	autoscalerWatcher.processAutoscalers()
+
+	// dd-metric-included should be active (its HPA passes the selector)
+	includedMetric := f.store.Get("default/dd-metric-included")
+	assert.NotNil(t, includedMetric)
+	assert.True(t, includedMetric.Active)
+	assert.Equal(t, "hpa:ns0/hpa0", includedMetric.AutoscalerReferences)
+
+	// dd-metric-excluded should be inactive (its HPA is filtered out by the selector)
+	excludedMetric := f.store.Get("default/dd-metric-excluded")
+	assert.NotNil(t, excludedMetric)
+	assert.False(t, excludedMetric.Active)
+	assert.Equal(t, "", excludedMetric.AutoscalerReferences)
 }

--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher_test.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher_test.go
@@ -541,48 +541,48 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 func TestHPALabelSelectorFiltering(t *testing.T) {
 	f := newAutoscalerFixture(t)
 
-	// hpa0 has no managed-by label — should be included
 	f.hpaLister = []*autoscaler.HorizontalPodAutoscaler{
+		// hpa0 matches label selector, no datadogmetric@ reference — included via label match
 		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa0", map[string]string{"team": "infra"}, []autoscaler.MetricSpec{
 			{
 				Type: autoscaler.ExternalMetricSourceType,
 				External: &autoscaler.ExternalMetricSource{
-					MetricName: "datadogmetric@default:dd-metric-included",
+					MetricName:     "requests_per_s",
+					MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kube_container_name": "app"}},
 				},
 			},
 		}),
-		// hpa1 is managed by keda-operator — should be excluded
+		// hpa1 does NOT match label selector, but has datadogmetric@ reference — included via OR
 		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa1", map[string]string{"app.kubernetes.io/managed-by": "keda-operator"}, []autoscaler.MetricSpec{
 			{
 				Type: autoscaler.ExternalMetricSourceType,
 				External: &autoscaler.ExternalMetricSource{
-					MetricName: "datadogmetric@default:dd-metric-excluded",
+					MetricName: "datadogmetric@default:dd-metric-ref",
+				},
+			},
+		}),
+		// hpa2 does NOT match label selector and has no datadogmetric@ reference — excluded
+		newFakeHorizontalPodAutoscalerWithLabels("ns0", "hpa2", map[string]string{"app.kubernetes.io/managed-by": "keda-operator"}, []autoscaler.MetricSpec{
+			{
+				Type: autoscaler.ExternalMetricSourceType,
+				External: &autoscaler.ExternalMetricSource{
+					MetricName:     "keda_metric",
+					MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"queue": "jobs"}},
 				},
 			},
 		}),
 	}
 
 	ddm := model.DatadogMetricInternal{
-		ID:         "default/dd-metric-included",
+		ID:         "default/dd-metric-ref",
 		Active:     false,
-		Valid:      true,
-		Value:      10.0,
-		UpdateTime: time.Now(),
-		Error:      nil,
-	}
-	ddm.SetQueries("metric query included")
-	f.store.Set("default/dd-metric-included", ddm, "utest")
-
-	ddm = model.DatadogMetricInternal{
-		ID:         "default/dd-metric-excluded",
-		Active:     true,
 		Valid:      true,
 		Value:      20.0,
 		UpdateTime: time.Now(),
 		Error:      nil,
 	}
-	ddm.SetQueries("metric query excluded")
-	f.store.Set("default/dd-metric-excluded", ddm, "utest")
+	ddm.SetQueries("metric query ref")
+	f.store.Set("default/dd-metric-ref", ddm, "utest")
 
 	// Parse a selector that excludes HPAs with app.kubernetes.io/managed-by=keda-operator
 	selector, err := labels.Parse("app.kubernetes.io/managed-by!=keda-operator")
@@ -596,15 +596,27 @@ func TestHPALabelSelectorFiltering(t *testing.T) {
 
 	autoscalerWatcher.processAutoscalers()
 
-	// dd-metric-included should be active (its HPA passes the selector)
-	includedMetric := f.store.Get("default/dd-metric-included")
-	assert.NotNil(t, includedMetric)
-	assert.True(t, includedMetric.Active)
-	assert.Equal(t, "hpa:ns0/hpa0", includedMetric.AutoscalerReferences)
+	// Check all store entries for autoscaler references
+	foundHpa0Ref := false
+	foundHpa2Ref := false
+	for _, m := range f.store.GetAll() {
+		if m.AutoscalerReferences == "hpa:ns0/hpa0" {
+			foundHpa0Ref = true
+		}
+		if m.AutoscalerReferences == "hpa:ns0/hpa2" {
+			foundHpa2Ref = true
+		}
+	}
 
-	// dd-metric-excluded should be inactive (its HPA is filtered out by the selector)
-	excludedMetric := f.store.Get("default/dd-metric-excluded")
-	assert.NotNil(t, excludedMetric)
-	assert.False(t, excludedMetric.Active)
-	assert.Equal(t, "", excludedMetric.AutoscalerReferences)
+	// hpa0 matched label selector — should be included and create autogen metric
+	assert.True(t, foundHpa0Ref, "hpa0 should be included (matches label selector)")
+
+	// hpa1 has datadogmetric@ reference — dd-metric-ref should be active despite failing label selector
+	refMetric := f.store.Get("default/dd-metric-ref")
+	assert.NotNil(t, refMetric)
+	assert.True(t, refMetric.Active)
+	assert.Equal(t, "hpa:ns0/hpa1", refMetric.AutoscalerReferences)
+
+	// hpa2 should be excluded — no label match, no datadogmetric@ reference
+	assert.False(t, foundHpa2Ref, "hpa2 should be excluded (no label match and no datadogmetric@ reference)")
 }

--- a/pkg/clusteragent/autoscaling/externalmetrics/provider.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/provider.go
@@ -86,6 +86,15 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient, d
 	}
 	go metricsRetriever.Run(ctx.Done())
 
+	var hpaLabelSelector labels.Selector
+	if selectorStr := pkgconfigsetup.Datadog().GetString("external_metrics_provider.hpa_label_selector"); selectorStr != "" {
+		hpaLabelSelector, err = labels.Parse(selectorStr)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse external_metrics_provider.hpa_label_selector %q: %v", selectorStr, err)
+		}
+		log.Infof("HPA label selector configured: %s", selectorStr)
+	}
+
 	var wpaInformer dynamicinformer.DynamicSharedInformerFactory
 	if wpaEnabled {
 		wpaInformer = apiCl.DynamicInformerFactory
@@ -98,6 +107,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient, d
 		autogenEnabled,
 		autogenExpirationPeriodHours,
 		autogenNamespace,
+		hpaLabelSelector,
 		apiCl.Cl,
 		apiCl.InformerFactory,
 		wpaInformer,

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -591,6 +591,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("external_metrics_provider.wpa_controller", false)              // Activates the controller for Watermark Pod Autoscalers.
 	config.BindEnvAndSetDefault("external_metrics_provider.use_datadogmetric_crd", false)       // Use DatadogMetric CRD with custom Datadog Queries instead of ConfigMap
 	config.BindEnvAndSetDefault("external_metrics_provider.enable_datadogmetric_autogen", true) // Enables autogeneration of DatadogMetrics when the DatadogMetric CRD is in use
+	config.BindEnvAndSetDefault("external_metrics_provider.hpa_label_selector", "")             // Label selector to filter which HPAs the DCA watches (e.g. "app.kubernetes.io/managed-by!=not-dca")
 	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)                     // timeout between two successful event collections in milliseconds.
 	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)                     // value in seconds. Default to 5 minutes
 	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})        // list of options that can be used to configure the external metrics server


### PR DESCRIPTION
What does this PR do?
Allow users to define a label selector for hpa selection. This allows us to add a proxy to multiple external metrics providers.

Motivation
Added an external metrics proxy to DCA and Keda. Keda metrics are currently getting picked up by DCA due to the fact we have the auto discovery on.

Describe how you validated your changes
Unit tests. its just a label selector. 

Additional Notes
n/a