### PR TITLE
[ AGNTLOG-602 ] Syslog v5.3: syslog file decoder and structured message preservation

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -523,6 +523,10 @@ func (c *LogsConfig) Validate() error {
 		return fmt.Errorf("unsupported format %q (supported: %q or empty)", c.Format, SyslogFormat)
 	}
 
+	if c.Format == SyslogFormat && c.Encoding != "" {
+		log.Warn("non-UTF-8 encodings are not currently supported by the syslog format. The encoding setting will be ignored.")
+	}
+
 	err := ValidateFingerprintConfig(c.FingerprintConfig)
 	if err != nil {
 		return err

--- a/comp/logs/agent/config/integration_config_test.go
+++ b/comp/logs/agent/config/integration_config_test.go
@@ -510,6 +510,30 @@ func TestValidateWildcardWithBeginningMode(t *testing.T) {
 	}
 }
 
+func TestValidateSyslogFormatWithEncoding(t *testing.T) {
+	t.Run("syslog format with non-UTF8 encoding warns but passes", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:     FileType,
+			Path:     "/var/log/syslog",
+			Source:   "mysource",
+			Format:   SyslogFormat,
+			Encoding: UTF16LE,
+		}
+		err := cfg.Validate()
+		assert.Nil(t, err)
+	})
+
+	t.Run("syslog format without encoding passes", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:   FileType,
+			Path:   "/var/log/syslog",
+			Format: SyslogFormat,
+		}
+		err := cfg.Validate()
+		assert.Nil(t, err)
+	})
+}
+
 func TestValidateIPFilter(t *testing.T) {
 	t.Run("valid CIDR entries pass", func(t *testing.T) {
 		cfg := &LogsConfig{

--- a/pkg/logs/internal/decoder/file_decoder.go
+++ b/pkg/logs/internal/decoder/file_decoder.go
@@ -17,6 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/integrations"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
+	syslogparser "github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/syslog"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 )
@@ -28,6 +30,12 @@ func NewDecoderFromSource(source *sources.ReplaceableSource, tailerInfo *status.
 
 // NewDecoderFromSourceWithPattern creates a new decoder from a log source with a multiline pattern
 func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLinePattern *regexp.Regexp, tailerInfo *status.InfoRegistry) Decoder {
+	// Syslog-formatted files get a specialized pipeline that produces
+	// StateStructured messages and bypasses multi-line/truncation logic.
+	if source.Config().Format == config.SyslogFormat {
+		return newSyslogFileDecoder(source, tailerInfo)
+	}
+
 	var lineParser parsers.Parser
 	framing := framer.UTF8Newline
 	switch source.GetSourceType() {
@@ -66,4 +74,31 @@ func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLin
 	}
 
 	return NewDecoderWithFraming(source, lineParser, framing, multiLinePattern, tailerInfo)
+}
+
+// newSyslogFileDecoder builds a decoder for syslog-formatted log files.
+//
+// It uses UTF-8 newline framing (one syslog message per line) paired with
+// a syslog parser that produces StateStructured messages containing all
+// syslog metadata. A NoopLineHandler is used instead of SingleLineHandler
+// to prevent truncation logic from corrupting the structured messages.
+func newSyslogFileDecoder(source *sources.ReplaceableSource, tailerInfo *status.InfoRegistry) Decoder {
+	maxMessageSize := source.Config().GetMaxMessageSizeBytes(pkgconfigsetup.Datadog())
+	inputChan := make(chan *message.Message)
+	outputChan := make(chan *message.Message)
+	detectedPattern := &DetectedPattern{}
+
+	lineHandler := NewNoopLineHandler(outputChan)
+	lineParser := NewSingleLineParser(lineHandler, syslogparser.NewParser(source.Config().IsSIEMParsingEnabled()))
+	f := framer.NewFramer(lineParser.process, framer.UTF8Newline, maxMessageSize)
+
+	encodingInfo := status.NewMappedInfo("Encoding")
+	encodingInfo.SetMessage("Encoding", "utf-8")
+	tailerInfo.Register(encodingInfo)
+
+	formatInfo := status.NewMappedInfo("Format")
+	formatInfo.SetMessage("Format", config.SyslogFormat)
+	tailerInfo.Register(formatInfo)
+
+	return New(inputChan, outputChan, f, lineParser, lineHandler, detectedPattern)
 }

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -195,6 +195,9 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 		dictionary["Path"] = c.Path
 		dictionary["TailingMode"] = c.TailingMode
 		dictionary["Identifier"] = c.Identifier
+		if c.Format != "" {
+			dictionary["Format"] = c.Format
+		}
 	case config.DockerType:
 		dictionary["Image"] = c.Image
 		dictionary["Label"] = c.Label

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -416,20 +416,22 @@ func (t *Tailer) forwardMessages() {
 		tags = append(tags, t.tagProvider.GetTags()...)
 		tags = append(tags, output.ParsingExtra.Tags...)
 		origin.SetTags(tags)
-		// Ignore empty lines once the registry offset is updated
-		if len(output.GetContent()) == 0 {
+		if !output.HasContent() {
 			continue
 		}
 
-		// Preserve ParsingExtra information from decoder output (including IsTruncated flag)
-		msg := message.NewMessageWithParsingExtra(output.GetContent(), origin, output.Status, output.IngestionTimestamp, output.ParsingExtra)
+		// Enrich the decoder output with the file-tailer origin.
+		// This mutates in-place to preserve the message's content state
+		// (e.g. StateStructured from syslog parser, StateUnstructured from
+		// plain text) rather than destructively re-wrapping via NewMessage.
+		output.Origin = origin
 		// Make the write to the output chan cancellable to be able to stop the tailer
 		// after a file rotation when it is stuck on it.
 		// We don't return directly to keep the same shutdown sequence that in the
 		// normal case.
 		select {
-		case t.outputChan <- msg:
-			t.CapacityMonitor.AddIngress(msg)
+		case t.outputChan <- output:
+			t.CapacityMonitor.AddIngress(output)
 		case <-t.forwardContext.Done():
 		}
 	}

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -498,6 +499,99 @@ func toInt(str string) int {
 		return int(value)
 	}
 	return 0
+}
+
+// TestStructuredMessagePreserved verifies that forwardMessages preserves
+// StateStructured messages (produced by the syslog file parser) instead of
+// re-wrapping them as StateUnstructured. The output message must carry the
+// full structured content (syslog metadata) and have a properly populated origin.
+func TestStructuredMessagePreserved(t *testing.T) {
+	testDir := t.TempDir()
+	testPath := filepath.Join(testDir, "syslog.log")
+	f, err := os.Create(testPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	outputChan := make(chan *message.Message, chanSize)
+	source := sources.NewReplaceableSource(sources.NewLogSource("syslog-test", &config.LogsConfig{
+		Type:   config.FileType,
+		Path:   testPath,
+		Format: config.SyslogFormat,
+	}))
+	info := status.NewInfoRegistry()
+
+	tailerOptions := &TailerOptions{
+		OutputChan:      outputChan,
+		File:            NewFile(testPath, source.UnderlyingSource(), false),
+		SleepDuration:   10 * time.Millisecond,
+		Decoder:         decoder.NewDecoderFromSource(source, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditor.NewMockRegistry(),
+		FileOpener:      opener.NewFileOpener(),
+	}
+
+	tailer := NewTailer(tailerOptions)
+
+	syslogLine := "<165>1 2024-01-15T10:30:00Z myhost myapp 1234 - - Hello structured world\n"
+	_, err = f.WriteString(syslogLine)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tailer.StartFromBeginning()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tailer.Stop()
+
+	select {
+	case msg := <-outputChan:
+		if msg.State != message.StateStructured {
+			t.Fatalf("expected StateStructured (%d), got state %d", message.StateStructured, msg.State)
+		}
+
+		rendered, err := msg.Render()
+		if err != nil {
+			t.Fatalf("failed to render structured message: %v", err)
+		}
+
+		renderedStr := string(rendered)
+		if !strings.Contains(renderedStr, `"syslog"`) {
+			t.Errorf("rendered output missing syslog metadata: %s", renderedStr)
+		}
+		if !strings.Contains(renderedStr, `"message"`) {
+			t.Errorf("rendered output missing message field: %s", renderedStr)
+		}
+		if !strings.Contains(renderedStr, "Hello structured world") {
+			t.Errorf("rendered output missing message body: %s", renderedStr)
+		}
+		if !strings.Contains(renderedStr, "myapp") {
+			t.Errorf("rendered output missing appname: %s", renderedStr)
+		}
+
+		if msg.Origin == nil {
+			t.Fatal("message origin is nil")
+		}
+		if msg.Origin.FilePath != testPath {
+			t.Errorf("expected origin FilePath %q, got %q", testPath, msg.Origin.FilePath)
+		}
+		if msg.Origin.Offset == "" {
+			t.Error("expected non-empty origin Offset")
+		}
+
+		if msg.Origin.Source() != "" {
+			t.Errorf("expected empty origin Source (syslog does not override source directly), got %q", msg.Origin.Source())
+		}
+		if msg.Origin.Service() != "" {
+			t.Errorf("expected empty origin Service (syslog does not override service), got %q", msg.Origin.Service())
+		}
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
 }
 
 // Test_RotationThenShutdownNoGoroutineLeak tests the following scenario:


### PR DESCRIPTION
### What does this PR do?

**Part 5.3** of the syslog ingestion stack. This PR adds syslog-aware decoding for file-based log sources and fixes the file tailer to preserve structured messages through its forwarding path.

- **Syslog file decoder** (`pkg/logs/internal/decoder/file_decoder.go`): When a file source's `format` is set to `syslog`, `NewDecoderFromSourceWithPattern` now returns a specialised decoder that uses UTF-8 newline framing (one syslog message per line) paired with the syslog parser. A `NoopLineHandler` replaces the normal `SingleLineHandler` so truncation logic cannot corrupt the `StateStructured` messages.
- **File tailer forwarding** (`pkg/logs/tailers/file/tailer.go`): `forwardMessages` now mutates the decoder output in-place (setting `output.Origin`) instead of re-wrapping it through `NewMessageWithParsingExtra`. This preserves the message's content state (e.g. `StateStructured` from the syslog parser) and its `RawDataLen` metadata.
- **Status builder** (`pkg/logs/status/builder.go`): Added `Format` to the `FileType` case in `toDictionary`, so `agent status` now displays the configured format for file log sources when set.

### Motivation

Prior to this change, file sources with `format: syslog` were parsed as plain text — they went through the generic line parser which produced `StateUnstructured` messages, losing all syslog metadata. Additionally, `forwardMessages` destructively re-wrapped every message through `NewMessage`, which discarded `StateStructured` status and `RawDataLen`. This meant that even if a syslog parser were wired in, its structured output would be silently flattened before reaching the pipeline.

### Describe how you validated your changes

- `inv test --only-modified-packages` — tests pass across decoder, file tailer, and status packages
- `inv linter.go --only-modified-packages` — 0 issues
- Key test coverage: `TestStructuredMessagePreserved` verifies that a syslog line written to a file is received as a `StateStructured` message with full syslog metadata, correct origin, and proper rendering

### Additional Notes

Stacked on `ryan.hall/syslog-v5.2` (#49031).