### PR TITLE
feat(host-tags): add device/OS host tags in end_user_device mode

### DIFF
--- a/comp/metadata/host/impl/hosttags/eudm.go
+++ b/comp/metadata/host/impl/hosttags/eudm.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package hosttags
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/gohai/cpu"
+	"github.com/DataDog/datadog-agent/pkg/gohai/memory"
+	"github.com/DataDog/datadog-agent/pkg/gohai/platform"
+	"github.com/DataDog/datadog-agent/pkg/inventory/systeminfo"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const infrastructureModeEndUserDevice = "end_user_device"
+
+// collectEUDMTagsFunc is overridable in tests.
+var collectEUDMTagsFunc = collectEUDMHardwareTags
+
+// getEUDMTags returns host tags describing the device when running in
+// end_user_device infrastructure mode. Hardware/OS tags are only collected on
+// macOS and Windows to mirror the hostsysteminfo metadata gate.
+func getEUDMTags() []string {
+	tags := []string{"infrastructure_mode:" + infrastructureModeEndUserDevice}
+	return append(tags, collectEUDMTagsFunc()...)
+}
+
+func collectEUDMHardwareTags() []string {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		return nil
+	}
+
+	tags := []string{"os_name:" + runtime.GOOS}
+
+	platformInfo := platform.CollectInfo()
+	if v, err := platformInfo.KernelRelease.Value(); err == nil && v != "" {
+		tags = append(tags, "os_version:"+sanitizeEUDMTagValue(v))
+	} else if err != nil {
+		log.Debugf("EUDM host tags: os_version unavailable: %v", err)
+	}
+
+	cpuInfo := cpu.CollectInfo()
+	if v, err := cpuInfo.ModelName.Value(); err == nil && v != "" {
+		tags = append(tags, "cpu_model:"+sanitizeEUDMTagValue(v))
+	} else if err != nil {
+		log.Debugf("EUDM host tags: cpu_model unavailable: %v", err)
+	}
+
+	memInfo := memory.CollectInfo()
+	if v, err := memInfo.TotalBytes.Value(); err == nil && v > 0 {
+		tags = append(tags, fmt.Sprintf("total_memory_gb:%d", bytesToGB(v)))
+	} else if err != nil {
+		log.Debugf("EUDM host tags: total_memory_gb unavailable: %v", err)
+	}
+
+	sysInfo, err := systeminfo.Collect()
+	if err != nil {
+		log.Debugf("EUDM host tags: device_model unavailable: %v", err)
+	} else if sysInfo != nil && sysInfo.Identifier != "" {
+		tags = append(tags, "device_model:"+sanitizeEUDMTagValue(sysInfo.Identifier))
+	}
+
+	return tags
+}
+
+// bytesToGB converts bytes to gibibytes, rounding to the nearest GB.
+func bytesToGB(b uint64) uint64 {
+	const gib = 1024 * 1024 * 1024
+	return (b + gib/2) / gib
+}
+
+// sanitizeEUDMTagValue normalises a free-form value for use as a tag value:
+// whitespace becomes underscores so a single token-style tag is produced.
+func sanitizeEUDMTagValue(v string) string {
+	v = strings.TrimSpace(v)
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\t', '\n', '\r':
+			return '_'
+		}
+		return r
+	}, v)
+}

--- a/comp/metadata/host/impl/hosttags/eudm.go
+++ b/comp/metadata/host/impl/hosttags/eudm.go
@@ -74,15 +74,11 @@ func bytesToGB(b uint64) uint64 {
 	return (b + gib/2) / gib
 }
 
-// sanitizeEUDMTagValue normalises a free-form value for use as a tag value:
-// whitespace becomes underscores so a single token-style tag is produced.
+// eudmTagValueReplacer collapses whitespace in tag values to underscores so a
+// single token-style tag is produced.
+var eudmTagValueReplacer = strings.NewReplacer(" ", "_", "\t", "_", "\n", "_", "\r", "_")
+
+// sanitizeEUDMTagValue normalises a free-form value for use as a tag value.
 func sanitizeEUDMTagValue(v string) string {
-	v = strings.TrimSpace(v)
-	return strings.Map(func(r rune) rune {
-		switch r {
-		case ' ', '\t', '\n', '\r':
-			return '_'
-		}
-		return r
-	}, v)
+	return eudmTagValueReplacer.Replace(strings.TrimSpace(v))
 }

--- a/comp/metadata/host/impl/hosttags/tags.go
+++ b/comp/metadata/host/impl/hosttags/tags.go
@@ -151,6 +151,10 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 		hostTags = appendToHostTags(hostTags, []string{tags.KubeDistribution + ":" + kubeDistro})
 	}
 
+	if conf.GetString("infrastructure_mode") == infrastructureModeEndUserDevice {
+		hostTags = appendToHostTags(hostTags, getEUDMTags())
+	}
+
 	gceTags := []string{}
 	providers := getProvidersDefinitionsFunc(conf)
 	for {

--- a/comp/metadata/host/impl/hosttags/tags_test.go
+++ b/comp/metadata/host/impl/hosttags/tags_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -100,6 +101,72 @@ func TestCombineExtraTags(t *testing.T) {
 	hostTags := Get(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"tag1:value1", "tag1:value2", "tag2", "tag3", "tag4"}, hostTags.System)
+}
+
+func TestGetWithoutEUDM(t *testing.T) {
+	mockConfig, ctx := setupTest(t)
+	mockConfig.SetWithoutSource("infrastructure_mode", "full")
+
+	hostTags := Get(ctx, false, mockConfig)
+	for _, tag := range hostTags.System {
+		assert.NotContains(t, tag, "infrastructure_mode:")
+		assert.NotContains(t, tag, "os_name:")
+		assert.NotContains(t, tag, "os_version:")
+		assert.NotContains(t, tag, "cpu_model:")
+		assert.NotContains(t, tag, "device_model:")
+		assert.NotContains(t, tag, "total_memory_gb:")
+	}
+}
+
+func TestGetWithEUDM(t *testing.T) {
+	mockConfig, ctx := setupTest(t)
+	mockConfig.SetWithoutSource("infrastructure_mode", "end_user_device")
+
+	original := collectEUDMTagsFunc
+	t.Cleanup(func() { collectEUDMTagsFunc = original })
+	collectEUDMTagsFunc = func() []string {
+		return []string{
+			"os_name:darwin",
+			"os_version:23.5.0",
+			"cpu_model:Apple_M1_Pro",
+			"total_memory_gb:16",
+			"device_model:MacBookPro18,3",
+		}
+	}
+
+	hostTags := Get(ctx, false, mockConfig)
+	assert.Contains(t, hostTags.System, "infrastructure_mode:end_user_device")
+	assert.Contains(t, hostTags.System, "os_name:darwin")
+	assert.Contains(t, hostTags.System, "os_version:23.5.0")
+	assert.Contains(t, hostTags.System, "cpu_model:Apple_M1_Pro")
+	assert.Contains(t, hostTags.System, "total_memory_gb:16")
+	assert.Contains(t, hostTags.System, "device_model:MacBookPro18,3")
+}
+
+func TestEUDMTagsOnUnsupportedOS(t *testing.T) {
+	// collectEUDMHardwareTags should return nil on non-darwin/windows so the
+	// only EUDM tag emitted on Linux is the infrastructure_mode marker.
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("test asserts behavior on non-darwin/non-windows hosts")
+	}
+	assert.Nil(t, collectEUDMHardwareTags())
+
+	tags := getEUDMTags()
+	assert.Equal(t, []string{"infrastructure_mode:end_user_device"}, tags)
+}
+
+func TestBytesToGB(t *testing.T) {
+	assert.Equal(t, uint64(16), bytesToGB(16*1024*1024*1024))
+	assert.Equal(t, uint64(0), bytesToGB(0))
+	assert.Equal(t, uint64(1), bytesToGB(1024*1024*1024))
+	// 15.9 GiB rounds to 16
+	assert.Equal(t, uint64(16), bytesToGB(15*1024*1024*1024+900*1024*1024))
+}
+
+func TestSanitizeEUDMTagValue(t *testing.T) {
+	assert.Equal(t, "Apple_M1_Pro", sanitizeEUDMTagValue("Apple M1 Pro"))
+	assert.Equal(t, "MacBookPro18,3", sanitizeEUDMTagValue("MacBookPro18,3"))
+	assert.Equal(t, "trim_me", sanitizeEUDMTagValue("  trim me  "))
 }
 
 func TestHostTagsCache(t *testing.T) {

--- a/releasenotes/notes/eudm-host-tags-6dd3c169ed4c77bf.yaml
+++ b/releasenotes/notes/eudm-host-tags-6dd3c169ed4c77bf.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    When ``infrastructure_mode`` is set to ``end_user_device``, the Agent now
+    attaches additional host tags to identify the device:
+    ``infrastructure_mode:end_user_device``, ``os_name``, ``os_version``,
+    ``cpu_model``, ``total_memory_gb``, and ``device_model``. Hardware and OS
+    tags are collected on macOS and Windows only.

--- a/test/new-e2e/tests/agent-runtimes/infra_eudm_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/infra_eudm_common_test.go
@@ -98,12 +98,17 @@ func (s *eudmSuite) TestEUDMHostTags() {
 	// Hardware tag keys are populated by the agent on macOS and Windows only
 	// (see comp/metadata/host/impl/hosttags/eudm.go). Linux EUDM hosts only
 	// receive the infrastructure_mode marker tag.
+	//
+	// device_model is intentionally omitted: it derives from
+	// Win32_ComputerSystem.SystemSKUNumber on Windows, which is empty on
+	// many hosts (notably EC2 instances). On OEM hardware where the SKU is
+	// populated, the agent will emit device_model — the unit tests cover
+	// that path.
 	hardwareTagKeys := []string{
 		"os_name:",
 		"os_version:",
 		"cpu_model:",
 		"total_memory_gb:",
-		"device_model:",
 	}
 	expectHardwareTags := s.descriptor.Family() == e2eos.WindowsFamily ||
 		s.descriptor.Family() == e2eos.MacOSFamily

--- a/test/new-e2e/tests/agent-runtimes/infra_eudm_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/infra_eudm_common_test.go
@@ -6,6 +6,7 @@
 package agentruntimes
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -85,4 +86,67 @@ func (s *eudmSuite) TestEUDMChecks() {
 			}, 4*time.Minute, 10*time.Second, "%s check should run in EUDM mode", checkName)
 		})
 	}
+}
+
+// TestEUDMHostTags verifies that the EUDM host tags are attached to the
+// agent's host-tags payload when running in end_user_device infrastructure
+// mode. The marker tag is emitted on every supported OS; OS/hardware tag
+// keys are emitted on macOS and Windows.
+func (s *eudmSuite) TestEUDMHostTags() {
+	fakeintake := s.Env().FakeIntake.Client()
+
+	// Hardware tag keys are populated by the agent on macOS and Windows only
+	// (see comp/metadata/host/impl/hosttags/eudm.go). Linux EUDM hosts only
+	// receive the infrastructure_mode marker tag.
+	hardwareTagKeys := []string{
+		"os_name:",
+		"os_version:",
+		"cpu_model:",
+		"total_memory_gb:",
+		"device_model:",
+	}
+	expectHardwareTags := s.descriptor.Family() == e2eos.WindowsFamily ||
+		s.descriptor.Family() == e2eos.MacOSFamily
+
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		hosts, err := fakeintake.GetHosts()
+		if !assert.NoError(c, err, "failed to fetch hosts from fakeintake") {
+			return
+		}
+		if !assert.NotEmpty(c, hosts, "no hosts have sent host-tags payloads yet") {
+			return
+		}
+
+		for _, host := range hosts {
+			payloads, err := fakeintake.GetHostTags(host)
+			if !assert.NoError(c, err, "failed to fetch host-tags for host %s", host) {
+				continue
+			}
+			if !assert.NotEmpty(c, payloads, "no host-tags payloads for host %s", host) {
+				continue
+			}
+
+			// Latest payload — host_tags are eventually consistent.
+			tags := payloads[len(payloads)-1].HostTags
+
+			assert.Contains(c, tags, "infrastructure_mode:end_user_device",
+				"expected infrastructure_mode marker on host %s; got %v", host, tags)
+
+			if expectHardwareTags {
+				for _, key := range hardwareTagKeys {
+					assert.Truef(c, hasTagWithPrefix(tags, key),
+						"expected a tag with prefix %q on host %s; got %v", key, host, tags)
+				}
+			}
+		}
+	}, 5*time.Minute, 15*time.Second, "EUDM host tags did not appear in fakeintake host-tags payload")
+}
+
+func hasTagWithPrefix(tags []string, prefix string) bool {
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, prefix) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### What does this PR do?

When `infrastructure_mode` is set to `end_user_device`, the Agent now appends additional host tags inside `comp/metadata/host/impl/hosttags/tags.go:Get()`:

- `infrastructure_mode:end_user_device` — emitted on every OS
- macOS / Windows only:
  - `os_name:<runtime.GOOS>`
  - `os_version:<kernel release>` (gohai `platform`)
  - `cpu_model:<model>` (gohai `cpu`, whitespace → `_`)
  - `total_memory_gb:<int>` (gohai `memory`, rounded to nearest GiB)
  - `device_model:<systeminfo.Identifier>` (e.g. `MacBookPro18,3`)

Hardware/OS tags are gated to macOS and Windows to mirror the existing `hostsysteminfo` metadata component. Linux EUDM hosts only emit the `infrastructure_mode` marker.

Collection happens once and rides the existing `tagsCacheKey` cache in `tags.go`, so steady-state cost is zero.

### Motivation

[WINA-2708](https://datadoghq.atlassian.net/browse/WINA-2708) 

### Describe how you validated your changes

- `dda inv test --targets=./comp/metadata/host/impl/hosttags/` — 12 passed, 1 skipped (Linux-only path skipped on macOS host).
- `dda inv linter.go --targets=./comp/metadata/host/impl/hosttags/` — 0 issues.
- Unit tests cover: EUDM-off (no extra tags), EUDM-on (marker + injected hardware tags), unsupported-OS path returns nil, byte→GB rounding, sanitizer.
- E2E: `TestEUDMHostTags` added to the shared `eudmSuite` in `test/new-e2e/tests/agent-runtimes/infra_eudm_common_test.go`. It runs via the existing `TestEUDMWindowsSuite` entry point and asserts that `infrastructure_mode:end_user_device` plus all five hardware tag keys (`os_name:`, `os_version:`, `cpu_model:`, `total_memory_gb:`, `device_model:`) appear in fakeintake's host-tags payload on Windows. The macOS branch is dormant — it will activate automatically if a macOS entry point is added later.

### Additional Notes

- Cardinality cost: each EUDM host adds ~6 host tags. For typical EUDM fleets this is a small per-host fixed cost on payload size, not a multiplicative tag explosion.


[WINA-2708]: https://datadoghq.atlassian.net/browse/WINA-2708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ