### PR TITLE
[codex] Handle SNMP non-increasing OID responses

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -261,6 +261,9 @@ func setDefaultsFromAgent(connParams *snmpparse.SNMPConfig, agentParams *snmppar
 	if connParams.Timeout == 0 {
 		connParams.Timeout = agentParams.Timeout
 	}
+	if !connParams.IgnoreNonincreasingOid {
+		connParams.IgnoreNonincreasingOid = agentParams.IgnoreNonincreasingOid
+	}
 }
 
 func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmpscan.Component, conf config.Component, client ipc.HTTPClient) error {

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -62,7 +62,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 		)
 	}
 	err = s.runDeviceScan(ctx, snmp, namespace, deviceID,
-		scanParams.CallInterval, scanParams.MaxCallCount)
+		scanParams.CallInterval, scanParams.MaxCallCount, connParams.IgnoreNonincreasingOid)
 	if err != nil {
 		errs := []error{err}
 
@@ -104,9 +104,10 @@ func (s snmpScannerImpl) runDeviceScan(
 	deviceID string,
 	callInterval time.Duration,
 	maxCallCount int,
+	ignoreNonIncreasingOid bool,
 ) error {
 	// execute the scan
-	pdus, err := gatherPDUs(ctx, snmpConnection, callInterval, maxCallCount)
+	pdus, err := gatherPDUs(ctx, snmpConnection, callInterval, maxCallCount, ignoreNonIncreasingOid)
 	if err != nil {
 		return err
 	}
@@ -134,7 +135,7 @@ func (s snmpScannerImpl) runDeviceScan(
 
 // gatherPDUs returns PDUs from the given SNMP device that should cover ever
 // scalar value and at least one row of every table.
-func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Duration, maxCallCount int) ([]*gosnmp.SnmpPDU, error) {
+func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Duration, maxCallCount int, ignoreNonIncreasingOid bool) ([]*gosnmp.SnmpPDU, error) {
 	var pdus []*gosnmp.SnmpPDU
 	err := gosnmplib.ConditionalWalk(
 		ctx,
@@ -143,6 +144,7 @@ func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Dura
 		false,
 		callInterval,
 		maxCallCount,
+		ignoreNonIncreasingOid,
 		func(dataUnit gosnmp.SnmpPDU) (string, error) {
 			pdus = append(pdus, &dataUnit)
 			return gosnmplib.SkipOIDRowsNaive(dataUnit.Name), nil

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -402,7 +402,7 @@ func (d *DeviceCheck) getValuesAndTags(sess session.Session, deviceReachable boo
 	tags = append(tags, profile.StaticTags...)
 
 	valuesStore, err := fetch.Fetch(sess, d.profileCache.scalarOIDs, d.profileCache.columnOIDs,
-		d.oidBatchSizeOptimizers, d.config.BulkMaxRepetitions)
+		d.oidBatchSizeOptimizers, d.config.BulkMaxRepetitions, d.config.IgnoreNonincreasingOid, d.config.IPAddress)
 	if log.ShouldLog(log.TraceLvl) {
 		log.Tracef("fetched values: %v", valuestore.ResultValueStoreAsString(valuesStore))
 	}

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch.go
@@ -7,6 +7,7 @@
 package fetch
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -37,7 +38,7 @@ func (c columnFetchStrategy) String() string {
 
 // Fetch oid values from device
 func Fetch(sess session.Session, scalarOIDs, columnOIDs []string, batchSizeOptimizers *OidBatchSizeOptimizers,
-	bulkMaxRepetitions uint32) (*valuestore.ResultValueStore, error) {
+	bulkMaxRepetitions uint32, ignoreNonIncreasingOid bool, deviceAddress string) (*valuestore.ResultValueStore, error) {
 	now := time.Now()
 
 	batchSizeOptimizers.refreshIfOutdated(now)
@@ -49,14 +50,21 @@ func Fetch(sess session.Session, scalarOIDs, columnOIDs []string, batchSizeOptim
 	}
 
 	columnResults, err := fetchColumnOidsWithBatching(sess, columnOIDs, batchSizeOptimizers.snmpGetBulkOptimizer,
-		bulkMaxRepetitions, useGetBulk)
+		bulkMaxRepetitions, useGetBulk, ignoreNonIncreasingOid, deviceAddress)
 	if err != nil {
+		var nonIncreasingErr *nonIncreasingOidError
+		if errors.As(err, &nonIncreasingErr) {
+			return &valuestore.ResultValueStore{ScalarValues: scalarResults, ColumnValues: columnResults},
+				fmt.Errorf("failed to fetch oids with GetBulk batching: %v", err)
+		}
+
 		log.Debugf("failed to fetch oids with GetBulk batching: %v", err)
 
 		columnResults, err = fetchColumnOidsWithBatching(sess, columnOIDs, batchSizeOptimizers.snmpGetNextOptimizer,
-			bulkMaxRepetitions, useGetNext)
+			bulkMaxRepetitions, useGetNext, ignoreNonIncreasingOid, deviceAddress)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch oids with GetNext batching: %v", err)
+			return &valuestore.ResultValueStore{ScalarValues: scalarResults, ColumnValues: columnResults},
+				fmt.Errorf("failed to fetch oids with GetNext batching: %v", err)
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -20,7 +21,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeOptimizer *oidBatchSizeOptimizer, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
+type nonIncreasingOidError struct {
+	oids []string
+}
+
+func newNonIncreasingOidError(oids []string) *nonIncreasingOidError {
+	oids = sortedUniqueOids(oids)
+	return &nonIncreasingOidError{oids: oids}
+}
+
+func (e *nonIncreasingOidError) Error() string {
+	return fmt.Sprintf("non-increasing OID response detected for OIDs: %s", strings.Join(e.oids, ", "))
+}
+
+func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeOptimizer *oidBatchSizeOptimizer, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy, ignoreNonIncreasingOid bool, deviceAddress string) (valuestore.ColumnResultValuesType, error) {
 	retValues := make(valuestore.ColumnResultValuesType, len(oids))
 	if len(oids) == 0 {
 		return retValues, nil
@@ -32,25 +46,28 @@ func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeO
 	}
 
 	for _, batchColumnOids := range batches {
-		results, err := fetchColumnOids(sess, batchColumnOids, bulkMaxRepetitions, fetchStrategy)
-		if err != nil {
-			var fetchErr *fetchError
-			if errors.As(err, &fetchErr) {
-				shouldRetry := batchSizeOptimizer.onBatchSizeFailure()
-				if shouldRetry {
-					return fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, bulkMaxRepetitions, fetchStrategy)
-				}
-			}
-
-			return nil, fmt.Errorf("failed to fetch column oids: %s", err.Error())
-		}
-
+		results, err := fetchColumnOids(sess, batchColumnOids, bulkMaxRepetitions, fetchStrategy, ignoreNonIncreasingOid, deviceAddress)
 		for columnOid, instanceOids := range results {
 			if _, ok := retValues[columnOid]; !ok {
 				retValues[columnOid] = instanceOids
 				continue
 			}
 			maps.Copy(retValues[columnOid], instanceOids)
+		}
+		if err != nil {
+			var fetchErr *fetchError
+			if errors.As(err, &fetchErr) {
+				shouldRetry := batchSizeOptimizer.onBatchSizeFailure()
+				if shouldRetry {
+					return fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, bulkMaxRepetitions, fetchStrategy, ignoreNonIncreasingOid, deviceAddress)
+				}
+			}
+
+			var nonIncreasingErr *nonIncreasingOidError
+			if errors.As(err, &nonIncreasingErr) {
+				return retValues, fmt.Errorf("failed to fetch column oids: %w", err)
+			}
+			return nil, fmt.Errorf("failed to fetch column oids: %w", err)
 		}
 	}
 
@@ -63,7 +80,7 @@ func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeO
 // bulkMaxRepetitions is the number of entries to request per OID per SNMP
 // request when fetchStrategy = useGetBulk; it is ignored when fetchStrategy is
 // useGetNext.
-func fetchColumnOids(sess session.Session, oids []string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
+func fetchColumnOids(sess session.Session, oids []string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy, ignoreNonIncreasingOid bool, deviceAddress string) (valuestore.ColumnResultValuesType, error) {
 	returnValues := make(valuestore.ColumnResultValuesType, len(oids))
 	alreadyProcessedOids := make(map[string]bool)
 	curOids := make(map[string]string, len(oids))
@@ -76,14 +93,22 @@ func fetchColumnOids(sess session.Session, oids []string, bulkMaxRepetitions uin
 		}
 		log.Debugf("fetch column: request oids (maxRep:%d,fetchStrategy:%s): %v", bulkMaxRepetitions, fetchStrategy, curOids)
 		var columnOids, requestOids []string
+		var repeatedOids []string
 		for k, v := range curOids {
 			if alreadyProcessedOids[v] {
 				log.Debugf("fetch column: OID already processed: %s", v)
+				repeatedOids = append(repeatedOids, v)
 				continue
 			}
 			alreadyProcessedOids[v] = true
 			columnOids = append(columnOids, k)
 			requestOids = append(requestOids, v)
+		}
+		if len(repeatedOids) > 0 {
+			warnNonIncreasingOids(deviceAddress, repeatedOids)
+			if !ignoreNonIncreasingOid {
+				return returnValues, newNonIncreasingOidError(repeatedOids)
+			}
 		}
 		if len(columnOids) == 0 {
 			break
@@ -96,11 +121,47 @@ func fetchColumnOids(sess session.Session, oids []string, bulkMaxRepetitions uin
 		if err != nil {
 			return nil, err
 		}
-		newValues, nextOids := valuestore.ResultToColumnValues(columnOids, results)
+		newValues, nextOids, nonMonotonicOids := valuestore.ResultToColumnValues(columnOids, results)
 		updateColumnResultValues(returnValues, newValues)
+		if len(nonMonotonicOids) > 0 {
+			warnNonIncreasingOids(deviceAddress, nonMonotonicOids)
+			if !ignoreNonIncreasingOid {
+				return returnValues, newNonIncreasingOidError(nonMonotonicOids)
+			}
+		}
 		curOids = nextOids
 	}
 	return returnValues, nil
+}
+
+func warnNonIncreasingOids(deviceAddress string, oids []string) {
+	oids = sortedUniqueOids(oids)
+	if deviceAddress == "" {
+		log.Warnf("SNMP device returned non-increasing OIDs; stopping affected column walks for OIDs: %s", strings.Join(oids, ", "))
+		return
+	}
+	log.Warnf("SNMP device %s returned non-increasing OIDs; stopping affected column walks for OIDs: %s", deviceAddress, strings.Join(oids, ", "))
+}
+
+func sortedUniqueOids(oids []string) []string {
+	oids = append([]string(nil), oids...)
+	sort.Strings(oids)
+	return slicesCompact(oids)
+}
+
+func slicesCompact(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	writeIndex := 1
+	for readIndex := 1; readIndex < len(values); readIndex++ {
+		if values[readIndex] == values[readIndex-1] {
+			continue
+		}
+		values[writeIndex] = values[readIndex]
+		writeIndex++
+	}
+	return values[:writeIndex]
 }
 
 func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (*gosnmp.SnmpPacket, error) {

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
@@ -93,7 +93,7 @@ func Test_fetchColumnOids(t *testing.T) {
 
 	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 100)
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk, false, "")
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -186,7 +186,7 @@ func Test_fetchColumnOidsBatch_usingGetBulk(t *testing.T) {
 
 	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 2)
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, 10, useGetBulk)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, 10, useGetBulk, false, "")
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -285,11 +285,11 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 
 	batchSizeOptimizers := NewOidBatchSizeOptimizers(2)
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizers.snmpGetBulkOptimizer, 10, useGetBulk)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizers.snmpGetBulkOptimizer, 10, useGetBulk, false, "")
 	assert.EqualError(t, err, "failed to fetch column oids: GetBulk not supported in SNMP v1")
 	assert.Nil(t, columnValues)
 
-	columnValues, err = fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizers.snmpGetNextOptimizer, 10, useGetNext)
+	columnValues, err = fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizers.snmpGetNextOptimizer, 10, useGetNext, false, "")
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -345,7 +345,7 @@ func Test_fetchColumnOidsBatch_truncatedResponse_reducesBatchSize(t *testing.T) 
 	oids := []string{"1.1.1", "1.1.2"}
 	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 2)
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk, false, "")
 	require.NoError(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -374,7 +374,7 @@ func Test_fetchColumnOidsBatch_truncatedResponseAtBatchSizeOne_returnsError(t *t
 	oids := []string{"1.1.1"}
 	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 1)
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk, false, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "response truncated")
 	assert.Nil(t, columnValues)
@@ -462,7 +462,7 @@ func Test_fetchColumnOidsBatch_usingGetBulkAndGetNextFallback(t *testing.T) {
 
 	batchSizeOptimizers := NewOidBatchSizeOptimizers(2)
 
-	columnValues, err := Fetch(sess, nil, columnOIDs, batchSizeOptimizers, checkconfig.DefaultBulkMaxRepetitions)
+	columnValues, err := Fetch(sess, nil, columnOIDs, batchSizeOptimizers, checkconfig.DefaultBulkMaxRepetitions, false, "")
 	assert.Nil(t, err)
 
 	expectedColumnValues := &valuestore.ResultValueStore{
@@ -937,7 +937,7 @@ func Test_fetchValues_errors(t *testing.T) {
 
 			batchSizeOptimizers := NewOidBatchSizeOptimizers(tt.batchSize)
 
-			_, err := Fetch(sess, tt.ScalarOIDs, tt.ColumnOIDs, batchSizeOptimizers, tt.maxReps)
+			_, err := Fetch(sess, tt.ScalarOIDs, tt.ColumnOIDs, batchSizeOptimizers, tt.maxReps, false, "")
 
 			assert.Equal(t, tt.expectedError, err)
 		})
@@ -1047,7 +1047,7 @@ func Test_fetchColumnOids_alreadyProcessed(t *testing.T) {
 
 	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 100)
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk, true, "")
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -1074,7 +1074,117 @@ func Test_fetchColumnOids_alreadyProcessed(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, 1, strings.Count(logs, "[DEBUG] fetchColumnOids: fetch column: OID already processed: 1.1.1.5"), logs)
-	assert.Equal(t, 1, strings.Count(logs, "[DEBUG] fetchColumnOids: fetch column: OID already processed: 1.1.2.5"), logs)
+	assert.Equal(t, 0, strings.Count(logs, "[DEBUG] fetchColumnOids: fetch column: OID already processed: 1.1.2.5"), logs)
+	assert.Equal(t, 1, strings.Count(logs, "[WARN] warnNonIncreasingOids: SNMP device returned non-increasing OIDs; stopping affected column walks for OIDs: 1.1.1.5"), logs)
+	assert.Equal(t, 1, strings.Count(logs, "[WARN] warnNonIncreasingOids: SNMP device returned non-increasing OIDs; stopping affected column walks for OIDs: 1.1.2.5"), logs)
+}
+
+func Test_fetchColumnOids_nonIncreasingOid(t *testing.T) {
+	tests := []struct {
+		name                   string
+		ignoreNonIncreasingOid bool
+		expectedError          string
+	}{
+		{
+			name:                   "returns partial values and error when flag is disabled",
+			ignoreNonIncreasingOid: false,
+			expectedError:          "failed to fetch column oids: non-increasing OID response detected for OIDs: 1.1.1.1",
+		},
+		{
+			name:                   "returns partial values without error when flag is enabled",
+			ignoreNonIncreasingOid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+			w := bufio.NewWriter(&b)
+			l, err := log.LoggerFromWriterWithMinLevelAndLvlFuncMsgFormat(w, log.DebugLvl)
+			require.NoError(t, err)
+			log.SetupLogger(l, "debug")
+
+			sess := session.CreateMockSession()
+			packet := gosnmp.SnmpPacket{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  "1.1.1.1",
+						Type:  gosnmp.TimeTicks,
+						Value: 11,
+					},
+					{
+						Name:  "1.1.1.2",
+						Type:  gosnmp.TimeTicks,
+						Value: 12,
+					},
+					{
+						Name:  "1.1.1.1",
+						Type:  gosnmp.TimeTicks,
+						Value: 11,
+					},
+				},
+			}
+			sess.On("GetBulk", []string{"1.1.1"}, checkconfig.DefaultBulkMaxRepetitions).Return(&packet, nil)
+
+			batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 100)
+			columnValues, err := fetchColumnOidsWithBatching(sess, []string{"1.1.1"}, batchSizeOptimizer,
+				checkconfig.DefaultBulkMaxRepetitions, useGetBulk, tt.ignoreNonIncreasingOid, "1.2.3.4")
+
+			expectedColumnValues := valuestore.ColumnResultValuesType{
+				"1.1.1": {
+					"1": valuestore.ResultValue{Value: float64(11)},
+					"2": valuestore.ResultValue{Value: float64(12)},
+				},
+			}
+			assert.Equal(t, expectedColumnValues, columnValues)
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			_ = w.Flush()
+			assert.Contains(t, b.String(), "SNMP device 1.2.3.4 returned non-increasing OIDs; stopping affected column walks for OIDs: 1.1.1.1")
+		})
+	}
+}
+
+func TestFetchNonIncreasingOidDoesNotFallback(t *testing.T) {
+	sess := session.CreateMockSession()
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 11,
+			},
+			{
+				Name:  "1.1.1.2",
+				Type:  gosnmp.TimeTicks,
+				Value: 12,
+			},
+			{
+				Name:  "1.1.1.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 11,
+			},
+		},
+	}
+	sess.On("GetBulk", []string{"1.1.1"}, checkconfig.DefaultBulkMaxRepetitions).Return(&packet, nil)
+
+	values, err := Fetch(sess, nil, []string{"1.1.1"}, NewOidBatchSizeOptimizers(100), checkconfig.DefaultBulkMaxRepetitions, false, "1.2.3.4")
+
+	assert.EqualError(t, err, "failed to fetch oids with GetBulk batching: failed to fetch column oids: non-increasing OID response detected for OIDs: 1.1.1.1")
+	assert.Equal(t, &valuestore.ResultValueStore{
+		ScalarValues: valuestore.ScalarResultValuesType{},
+		ColumnValues: valuestore.ColumnResultValuesType{
+			"1.1.1": {
+				"1": valuestore.ResultValue{Value: float64(11)},
+				"2": valuestore.ResultValue{Value: float64(12)},
+			},
+		},
+	}, values)
+	assert.Equal(t, uint32(0), sess.GetSnmpGetNextCount())
 }
 
 func Test_batchSizeOptimizers(t *testing.T) {
@@ -1536,7 +1646,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sess := tt.sessionFactory()
-			values, err := Fetch(sess, tt.scalarOids, tt.columnOids, tt.batchSizeOptimizers, checkconfig.DefaultBulkMaxRepetitions)
+			values, err := Fetch(sess, tt.scalarOids, tt.columnOids, tt.batchSizeOptimizers, checkconfig.DefaultBulkMaxRepetitions, false, "")
 			if tt.expectedError != nil {
 				assert.Equal(t, tt.expectedError, err)
 			} else {
@@ -1588,7 +1698,7 @@ func Test_batchSizeOptimizers_notFetchErrors(t *testing.T) {
 	}, batchSizeOptimizers)
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, []string{"1.1.1"}, batchSizeOptimizers.snmpGetBulkOptimizer,
-		checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
+		checkconfig.DefaultBulkMaxRepetitions, useGetBulk, false, "")
 	assert.EqualError(t, err, "failed to fetch column oids: GetBulk not supported in SNMP v1")
 	assert.Nil(t, columnValues)
 	assert.Equal(t, &OidBatchSizeOptimizers{
@@ -1625,7 +1735,7 @@ func Test_batchSizeOptimizers_areRefreshed(t *testing.T) {
 
 	oldLastRefreshTs := batchSizeOptimizers.lastRefreshTs
 
-	values, err := Fetch(sess, nil, nil, batchSizeOptimizers, checkconfig.DefaultBulkMaxRepetitions)
+	values, err := Fetch(sess, nil, nil, batchSizeOptimizers, checkconfig.DefaultBulkMaxRepetitions, false, "")
 	assert.Nil(t, err)
 	assert.Equal(t, &valuestore.ResultValueStore{
 		ScalarValues: valuestore.ScalarResultValuesType{},

--- a/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value.go
@@ -54,9 +54,16 @@ func ResultToScalarValues(result *gosnmp.SnmpPacket) ScalarResultValuesType {
 // ResultToColumnValues builds column values
 // - ColumnResultValuesType: column values
 // - nextOidsMap: represent the oids that can be used to retrieve following rows/values
-func ResultToColumnValues(columnOids []string, snmpPacket *gosnmp.SnmpPacket) (ColumnResultValuesType, map[string]string) {
+// - nonMonotonicOids: OIDs that are not after the previous OID for the same column
+func ResultToColumnValues(columnOids []string, snmpPacket *gosnmp.SnmpPacket) (ColumnResultValuesType, map[string]string, []string) {
 	returnValues := make(ColumnResultValuesType, len(columnOids))
 	nextOidsMap := make(map[string]string, len(columnOids))
+	if len(columnOids) == 0 {
+		return returnValues, nextOidsMap, nil
+	}
+
+	lastOidPerColumn := make(map[string]string, len(columnOids))
+	var nonMonotonicOids []string
 	maxRowsPerCol := int(math.Ceil(float64(len(snmpPacket.Variables)) / float64(len(columnOids))))
 	for i, pduVariable := range snmpPacket.Variables {
 		if shouldSkip(pduVariable.Type) {
@@ -77,16 +84,40 @@ func ResultToColumnValues(columnOids []string, snmpPacket *gosnmp.SnmpPacket) (C
 
 		prefix := columnOid + "."
 		if strings.HasPrefix(oid, prefix) {
+			if lastOid, ok := lastOidPerColumn[columnOid]; ok {
+				isAfter, err := isOidAfter(oid, lastOid)
+				if err != nil {
+					log.Debugf("Cannot compare OIDs `%s` and `%s`: %v", oid, lastOid, err)
+				} else if !isAfter {
+					nonMonotonicOids = append(nonMonotonicOids, oid)
+					delete(nextOidsMap, columnOid)
+					continue
+				}
+			}
+
 			index := oid[len(prefix):]
 			returnValues[columnOid][index] = value
 			nextOidsMap[columnOid] = oid
+			lastOidPerColumn[columnOid] = oid
 		} else {
 			// If oid is not prefixed by columnOid, it means it's not part of the column
 			// and we can stop requesting the next row of this column. This is expected.
 			delete(nextOidsMap, columnOid)
 		}
 	}
-	return returnValues, nextOidsMap
+	return returnValues, nextOidsMap, nonMonotonicOids
+}
+
+func isOidAfter(oid, lastOid string) (bool, error) {
+	oidInts, err := gosnmplib.OIDToInts(oid)
+	if err != nil {
+		return false, err
+	}
+	lastOidInts, err := gosnmplib.OIDToInts(lastOid)
+	if err != nil {
+		return false, err
+	}
+	return gosnmplib.CmpOIDs(oidInts, lastOidInts).IsAfter(), nil
 }
 
 func shouldSkip(berType gosnmp.Asn1BER) bool {

--- a/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value_test.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value_test.go
@@ -278,11 +278,12 @@ func Test_getValueFromPDU(t *testing.T) {
 
 func Test_resultToColumnValues(t *testing.T) {
 	tests := []struct {
-		name                string
-		columnOids          []string
-		snmpPacket          *gosnmp.SnmpPacket
-		expectedValues      ColumnResultValuesType
-		expectedNextOidsMap map[string]string
+		name                     string
+		columnOids               []string
+		snmpPacket               *gosnmp.SnmpPacket
+		expectedValues           ColumnResultValuesType
+		expectedNextOidsMap      map[string]string
+		expectedNonMonotonicOids []string
 	}{
 		{
 			"simple nominal case",
@@ -352,6 +353,7 @@ func Test_resultToColumnValues(t *testing.T) {
 				"1.3.6.1.2.1.2.2.1.2":  "1.3.6.1.2.1.2.2.1.2.2",
 				"1.3.6.1.2.1.2.2.1.20": "1.3.6.1.2.1.2.2.1.20.2",
 			},
+			nil,
 		},
 		{
 			"no such object is skipped",
@@ -399,13 +401,62 @@ func Test_resultToColumnValues(t *testing.T) {
 				"1.3.6.1.2.1.2.2.1.14": "1.3.6.1.2.1.2.2.1.14.2",
 				"1.3.6.1.2.1.2.2.1.2":  "1.3.6.1.2.1.2.2.1.2.2",
 			},
+			nil,
+		},
+		{
+			"non-monotonic column oid stops that column",
+			[]string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2"},
+			&gosnmp.SnmpPacket{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  "1.3.6.1.2.1.2.2.1.14.2",
+						Type:  gosnmp.Integer,
+						Value: 142,
+					},
+					{
+						Name:  "1.3.6.1.2.1.2.2.1.2.1",
+						Type:  gosnmp.OctetString,
+						Value: []byte("desc1"),
+					},
+					{
+						Name:  "1.3.6.1.2.1.2.2.1.14.1",
+						Type:  gosnmp.Integer,
+						Value: 141,
+					},
+					{
+						Name:  "1.3.6.1.2.1.2.2.1.2.2",
+						Type:  gosnmp.OctetString,
+						Value: []byte("desc2"),
+					},
+				},
+			},
+			ColumnResultValuesType{
+				"1.3.6.1.2.1.2.2.1.14": {
+					"2": ResultValue{
+						Value: float64(142),
+					},
+				},
+				"1.3.6.1.2.1.2.2.1.2": {
+					"1": ResultValue{
+						Value: []byte("desc1"),
+					},
+					"2": ResultValue{
+						Value: []byte("desc2"),
+					},
+				},
+			},
+			map[string]string{
+				"1.3.6.1.2.1.2.2.1.2": "1.3.6.1.2.1.2.2.1.2.2",
+			},
+			[]string{"1.3.6.1.2.1.2.2.1.14.1"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			values, nextOidsMap := ResultToColumnValues(tt.columnOids, tt.snmpPacket)
+			values, nextOidsMap, nonMonotonicOids := ResultToColumnValues(tt.columnOids, tt.snmpPacket)
 			assert.Equal(t, tt.expectedValues, values)
 			assert.Equal(t, tt.expectedNextOidsMap, nextOidsMap)
+			assert.Equal(t, tt.expectedNonMonotonicOids, nonMonotonicOids)
 		})
 	}
 }

--- a/pkg/snmp/gosnmplib/walk.go
+++ b/pkg/snmp/gosnmplib/walk.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -34,6 +36,47 @@ func ConditionalWalk(
 	useBulk bool,
 	callInterval time.Duration,
 	maxCallCount int,
+	ignoreNonIncreasingOid bool,
+	walkFn func(dataUnit gosnmp.SnmpPDU) (string, error),
+) error {
+	return conditionalWalk(ctx, gosnmpConditionalWalkSession{session: session}, rootOID, useBulk, callInterval, maxCallCount, ignoreNonIncreasingOid, walkFn)
+}
+
+type conditionalWalkSession interface {
+	getBulk(oids []string, nonRepeaters uint8, maxRepetitions uint32) (*gosnmp.SnmpPacket, error)
+	getNext(oids []string) (*gosnmp.SnmpPacket, error)
+	maxRepetitions() uint32
+	logf(format string, v ...interface{})
+}
+
+type gosnmpConditionalWalkSession struct {
+	session *gosnmp.GoSNMP
+}
+
+func (s gosnmpConditionalWalkSession) getBulk(oids []string, nonRepeaters uint8, maxRepetitions uint32) (*gosnmp.SnmpPacket, error) {
+	return s.session.GetBulk(oids, nonRepeaters, maxRepetitions)
+}
+
+func (s gosnmpConditionalWalkSession) getNext(oids []string) (*gosnmp.SnmpPacket, error) {
+	return s.session.GetNext(oids)
+}
+
+func (s gosnmpConditionalWalkSession) maxRepetitions() uint32 {
+	return s.session.MaxRepetitions
+}
+
+func (s gosnmpConditionalWalkSession) logf(format string, v ...interface{}) {
+	s.session.Logger.Printf(format, v...)
+}
+
+func conditionalWalk(
+	ctx context.Context,
+	session conditionalWalkSession,
+	rootOID string,
+	useBulk bool,
+	callInterval time.Duration,
+	maxCallCount int,
+	ignoreNonIncreasingOid bool,
 	walkFn func(dataUnit gosnmp.SnmpPDU) (string, error),
 ) error {
 	if rootOID == "" || rootOID == "." {
@@ -46,7 +89,7 @@ func ConditionalWalk(
 
 	oid := rootOID
 	requests := 0
-	maxReps := session.MaxRepetitions
+	maxReps := session.maxRepetitions()
 
 	if maxReps == 0 {
 		maxReps = defaultMaxRepetitions
@@ -56,7 +99,7 @@ RequestLoop:
 	for {
 		select {
 		case <-ctx.Done():
-			session.Logger.Printf("ConditionalWalk cancelled after %d requests", requests)
+			session.logf("ConditionalWalk cancelled after %d requests", requests)
 			return ctx.Err()
 		default:
 		}
@@ -67,16 +110,16 @@ RequestLoop:
 
 		requests++
 		if maxCallCount > 0 && requests >= maxCallCount {
-			session.Logger.Printf("ConditionalWalk exceeded the maximum request limit (%d)", maxCallCount)
+			session.logf("ConditionalWalk exceeded the maximum request limit (%d)", maxCallCount)
 			return fmt.Errorf("exceeded the maximum request limit (%d)", maxCallCount)
 		}
 
 		var response *gosnmp.SnmpPacket
 		var err error
 		if useBulk {
-			response, err = session.GetBulk([]string{oid}, 0, maxReps)
+			response, err = session.getBulk([]string{oid}, 0, maxReps)
 		} else {
-			response, err = session.GetNext([]string{oid})
+			response, err = session.getNext([]string{oid})
 		}
 		if err != nil {
 			return NewConnectionError(err)
@@ -85,7 +128,7 @@ RequestLoop:
 			break RequestLoop
 		}
 		if response.Error != gosnmp.NoError {
-			session.Logger.Printf("ConditionalWalk terminated with %s", response.Error.String())
+			session.logf("ConditionalWalk terminated with %s", response.Error.String())
 			break RequestLoop
 		}
 
@@ -93,7 +136,7 @@ RequestLoop:
 
 		for i, pdu := range response.Variables {
 			if pdu.Type == gosnmp.EndOfMibView || pdu.Type == gosnmp.NoSuchObject || pdu.Type == gosnmp.NoSuchInstance {
-				session.Logger.Printf("ConditionalWalk terminated with type 0x%x", pdu.Type)
+				session.logf("ConditionalWalk terminated with type 0x%x", pdu.Type)
 				break RequestLoop
 			}
 			// skip PDUs that are less than our next OID when we're handling
@@ -132,11 +175,18 @@ RequestLoop:
 			return err
 		}
 		if !CmpOIDs(next, last).IsAfter() {
-			session.Logger.Printf("Error: detected infinite cycle: next OID '%s' is not after last OID '%s'", oid, lastOid)
+			if ignoreNonIncreasingOid {
+				message := fmt.Sprintf("detected non-increasing OID while walking: next OID '%s' is not after last OID '%s'; skipping affected row", oid, lastOid)
+				session.logf("Warning: %s", message)
+				log.Warn(message)
+				oid = SkipOIDRowsNaive(lastOid)
+				continue
+			}
+			session.logf("Error: detected infinite cycle: next OID '%s' is not after last OID '%s'", oid, lastOid)
 			return fmt.Errorf("detected infinite cycle: next OID '%s' is not after last OID '%s'", oid, lastOid)
 		}
 	}
-	session.Logger.Printf("ConditionalWalk completed in %d requests", requests)
+	session.logf("ConditionalWalk completed in %d requests", requests)
 	return nil
 }
 

--- a/pkg/snmp/gosnmplib/walk_test.go
+++ b/pkg/snmp/gosnmplib/walk_test.go
@@ -6,10 +6,96 @@
 package gosnmplib
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 )
+
+type fakeConditionalWalkSession struct {
+	responses []*gosnmp.SnmpPacket
+	requests  [][]string
+	logs      []string
+	maxReps   uint32
+}
+
+func (s *fakeConditionalWalkSession) getBulk(oids []string, _ uint8, _ uint32) (*gosnmp.SnmpPacket, error) {
+	s.requests = append(s.requests, append([]string(nil), oids...))
+	return s.nextResponse(), nil
+}
+
+func (s *fakeConditionalWalkSession) getNext(oids []string) (*gosnmp.SnmpPacket, error) {
+	s.requests = append(s.requests, append([]string(nil), oids...))
+	return s.nextResponse(), nil
+}
+
+func (s *fakeConditionalWalkSession) nextResponse() *gosnmp.SnmpPacket {
+	if len(s.responses) == 0 {
+		return &gosnmp.SnmpPacket{}
+	}
+	response := s.responses[0]
+	s.responses = s.responses[1:]
+	return response
+}
+
+func (s *fakeConditionalWalkSession) maxRepetitions() uint32 {
+	return s.maxReps
+}
+
+func (s *fakeConditionalWalkSession) logf(format string, v ...interface{}) {
+	s.logs = append(s.logs, fmt.Sprintf(format, v...))
+}
+
+func TestConditionalWalkNonIncreasingOid(t *testing.T) {
+	pdu := gosnmp.SnmpPDU{
+		Name:  ".1.3.6.1.2.1.2.2.1.2.1",
+		Type:  gosnmp.OctetString,
+		Value: []byte("desc"),
+	}
+
+	t.Run("errors when flag is disabled", func(t *testing.T) {
+		session := &fakeConditionalWalkSession{
+			responses: []*gosnmp.SnmpPacket{
+				{Variables: []gosnmp.SnmpPDU{pdu}},
+				{Variables: []gosnmp.SnmpPDU{pdu}},
+			},
+		}
+		var visited []string
+
+		err := conditionalWalk(context.Background(), session, "", false, 0, 0, false, func(dataUnit gosnmp.SnmpPDU) (string, error) {
+			visited = append(visited, dataUnit.Name)
+			return dataUnit.Name, nil
+		})
+
+		assert.EqualError(t, err, "detected infinite cycle: next OID '.1.3.6.1.2.1.2.2.1.2.1' is not after last OID '.1.3.6.1.2.1.2.2.1.2.1'")
+		assert.Equal(t, []string{pdu.Name, pdu.Name}, visited)
+		assert.Equal(t, [][]string{{".0.0"}, {pdu.Name}}, session.requests)
+	})
+
+	t.Run("skips when flag is enabled", func(t *testing.T) {
+		session := &fakeConditionalWalkSession{
+			responses: []*gosnmp.SnmpPacket{
+				{Variables: []gosnmp.SnmpPDU{pdu}},
+				{Variables: []gosnmp.SnmpPDU{pdu}},
+				{Variables: []gosnmp.SnmpPDU{{Name: ".1.3.6.1.2.1.2.2.1.3.1", Type: gosnmp.EndOfMibView}}},
+			},
+		}
+		var visited []string
+
+		err := conditionalWalk(context.Background(), session, "", false, 0, 0, true, func(dataUnit gosnmp.SnmpPDU) (string, error) {
+			visited = append(visited, dataUnit.Name)
+			return dataUnit.Name, nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{pdu.Name, pdu.Name}, visited)
+		assert.Equal(t, [][]string{{".0.0"}, {pdu.Name}, {SkipOIDRowsNaive(pdu.Name)}}, session.requests)
+		assert.Contains(t, strings.Join(session.logs, "\n"), "detected non-increasing OID while walking")
+	})
+}
 
 func TestSkipOIDRowsNaive(t *testing.T) {
 	for _, tc := range []struct{ oid, expected string }{

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -48,6 +48,8 @@ type SNMPConfig struct {
 	SecurityLevel           string `yaml:"-"`
 	UseUnconnectedUDPSocket bool   `yaml:"-"`
 
+	IgnoreNonincreasingOid bool `yaml:"ignore_nonincreasing_oid"`
+
 	// NamespaceInternal is for internal use only and should not be used outside of this package.
 	NamespaceInternal string `yaml:"namespace"`
 }

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -57,6 +57,24 @@ func TestDefaultSet(t *testing.T) {
 	assertSNMP(t, input, Exoutput)
 }
 
+func TestIgnoreNonincreasingOid(t *testing.T) {
+	type Data = integration.Data
+	input := integration.Config{
+		Name:      "snmp",
+		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\",\"ignore_nonincreasing_oid\":true}")},
+	}
+	expectedOutput := []SNMPConfig{
+		{
+			IPAddress:              "98.6.18.158",
+			Port:                   161,
+			Timeout:                2,
+			Retries:                3,
+			IgnoreNonincreasingOid: true,
+		},
+	}
+	assertSNMP(t, input, expectedOutput)
+}
+
 func TestSeveralInstances(t *testing.T) {
 	// define the input
 	type Data = integration.Data


### PR DESCRIPTION
## Summary

This is PR 2 for AI-6781, stacked on PR #50712. It implements the real `ignore_nonincreasing_oid` behavior:

- detects non-monotonic column OIDs while converting SNMP results
- warns unconditionally when non-increasing OIDs cause affected column walks to stop
- returns a soft fetch error by default, while preserving partial values
- suppresses that soft error when `ignore_nonincreasing_oid: true`
- wires the flag through the device check, SNMP CLI config, and snmpscan `ConditionalWalk`
- keeps the existing hard error behavior for snmpscan unless the flag is enabled

## Validation

- `dda inv test --targets=./pkg/collector/corechecks/snmp/internal/checkconfig,./pkg/collector/corechecks/snmp/internal/valuestore,./pkg/collector/corechecks/snmp/internal/fetch,./pkg/snmp/gosnmplib,./pkg/snmp/snmpparse,./comp/snmpscan/impl`
