### PR TITLE
[CONTP-1678] feat: Surface instrumentation check API endpoint in DCA

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -211,6 +211,7 @@ func isExternalPath(path string) bool {
 		strings.HasPrefix(path, "/api/v1/cluster/id") && len(strings.Split(path, "/")) == 5 ||
 		strings.HasPrefix(path, "/api/v1/clusterchecks/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/endpointschecks/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/instrumentation/") && len(strings.Split(path, "/")) == 5 ||
 		strings.HasPrefix(path, "/api/v1/metadata/namespace/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/tags/cf/apps/") && len(strings.Split(path, "/")) == 7 ||
 		strings.HasPrefix(path, "/api/v1/tags/namespace/") && len(strings.Split(path, "/")) == 6 ||

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -33,5 +33,10 @@ func InstallChecksEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
 	log.Debug("Registering checks endpoints")
 	installClusterCheckEndpoints(r, sc)
 	installEndpointsCheckEndpoints(r, sc)
-	installInstrumentationCheckEndpoints(r, sc)
+}
+
+// InstallInstrumentationChecksEndpoints registers endpoint for instrumentation checks
+func InstallInstrumentationChecksEndpoints(r *mux.Router, configLister clusteragent.ConfigLister) {
+	log.Debug("Registering instrumentation checks endpoints")
+	installInstrumentationCheckEndpoints(r, configLister)
 }

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -33,4 +33,5 @@ func InstallChecksEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
 	log.Debug("Registering checks endpoints")
 	installClusterCheckEndpoints(r, sc)
 	installEndpointsCheckEndpoints(r, sc)
+	installInstrumentationCheckEndpoints(r, sc)
 }

--- a/cmd/cluster-agent/api/v1/instrumentationchecks.go
+++ b/cmd/cluster-agent/api/v1/instrumentationchecks.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
+	cctypes "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+)
+
+func installInstrumentationCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
+	r.HandleFunc("/instrumentation/configs", api.WithTelemetryWrapper("getInstrumentationConfigs", getInstrumentationConfigs(sc))).Methods("GET")
+}
+
+func getInstrumentationConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
+	if sc.InstrumentationConfigLister == nil {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "instrumentation config provider not available", http.StatusServiceUnavailable)
+		}
+	}
+
+	return func(w http.ResponseWriter, _ *http.Request) {
+		response := cctypes.ConfigResponse{
+			Configs: sc.InstrumentationConfigLister.ListConfigs(),
+		}
+		slcB, err := json.Marshal(response)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(slcB) //nolint:errcheck
+	}
+}

--- a/cmd/cluster-agent/api/v1/instrumentationchecks.go
+++ b/cmd/cluster-agent/api/v1/instrumentationchecks.go
@@ -18,12 +18,12 @@ import (
 	cctypes "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 )
 
-func installInstrumentationCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
-	r.HandleFunc("/instrumentation/configs", api.WithTelemetryWrapper("getInstrumentationConfigs", getInstrumentationConfigs(sc))).Methods("GET")
+func installInstrumentationCheckEndpoints(r *mux.Router, confLister clusteragent.ConfigLister) {
+	r.HandleFunc("/instrumentation/configs", api.WithTelemetryWrapper("getInstrumentationConfigs", getInstrumentationConfigs(confLister))).Methods("GET")
 }
 
-func getInstrumentationConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
-	if sc.InstrumentationConfigLister == nil {
+func getInstrumentationConfigs(confLister clusteragent.ConfigLister) func(w http.ResponseWriter, r *http.Request) {
+	if confLister == nil {
 		return func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "instrumentation config provider not available", http.StatusServiceUnavailable)
 		}
@@ -31,7 +31,7 @@ func getInstrumentationConfigs(sc clusteragent.ServerContext) func(w http.Respon
 
 	return func(w http.ResponseWriter, _ *http.Request) {
 		response := cctypes.ConfigResponse{
-			Configs: sc.InstrumentationConfigLister.ListConfigs(),
+			Configs: confLister.ListConfigs(),
 		}
 		slcB, err := json.Marshal(response)
 		if err != nil {

--- a/cmd/cluster-agent/api/v1/instrumentationchecks_nocompile.go
+++ b/cmd/cluster-agent/api/v1/instrumentationchecks_nocompile.go
@@ -14,4 +14,4 @@ import (
 )
 
 // installInstrumentationCheckEndpoints not implemented
-func installInstrumentationCheckEndpoints(_ *mux.Router, _ clusteragent.ServerContext) {}
+func installInstrumentationCheckEndpoints(_ *mux.Router, _ clusteragent.ConfigLister) {}

--- a/cmd/cluster-agent/api/v1/instrumentationchecks_nocompile.go
+++ b/cmd/cluster-agent/api/v1/instrumentationchecks_nocompile.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+package v1
+
+import (
+	"github.com/gorilla/mux"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent"
+)
+
+// installInstrumentationCheckEndpoints not implemented
+func installInstrumentationCheckEndpoints(_ *mux.Router, _ clusteragent.ServerContext) {}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -385,7 +385,15 @@ func start(log log.Component,
 	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: apiCl.Cl.CoreV1().Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "datadog-cluster-agent"})
 
-	instrHandlers := instrumentationhandlers.DefaultHandlers(instrumentationhandlers.Deps{IsLeader: le.IsLeader})
+	checkStore := instrumentationhandlers.NewCheckStore()
+	instrHandlers := instrumentationhandlers.DefaultHandlers(&instrumentationhandlers.Deps{
+		IsLeader:   le.IsLeader,
+		CheckStore: checkStore,
+	})
+
+	api.ModifyAPIRouter(func(r *mux.Router) {
+		dcav1.InstallInstrumentationChecksEndpoints(r, checkStore)
+	})
 
 	ctx := controllers.ControllerContext{
 		InformerFactory:             apiCl.InformerFactory,
@@ -508,22 +516,13 @@ func start(log log.Component,
 	// start the autoconfig, this will immediately run any configured check
 	ac.LoadAndRun(mainCtx)
 
-	// Find the AutodiscoveryHandler from instrumentation handlers to expose configs via API.
-	var adConfigLister clusteragent.InstrumentationConfigLister
-	for _, h := range instrHandlers {
-		if ad, ok := h.(*instrumentationhandlers.AutodiscoveryHandler); ok {
-			adConfigLister = ad
-			break
-		}
-	}
-
-	sc := clusteragent.ServerContext{InstrumentationConfigLister: adConfigLister}
-
 	if config.GetBool("cluster_checks.enabled") {
 		// Start the cluster check Autodiscovery
 		clusterCheckHandler, err := setupClusterCheck(mainCtx, ac, taggerComp)
 		if err == nil {
-			sc.ClusterCheckHandler = clusterCheckHandler
+			api.ModifyAPIRouter(func(r *mux.Router) {
+				dcav1.InstallChecksEndpoints(r, clusteragent.ServerContext{ClusterCheckHandler: clusterCheckHandler})
+			})
 			// Set cluster checks handler in clusterchecks component
 			clusterChecksMetadataComp.SetClusterHandler(clusterCheckHandler)
 		} else {
@@ -532,10 +531,6 @@ func start(log log.Component,
 	} else {
 		pkglog.Debug("Cluster check Autodiscovery disabled")
 	}
-
-	api.ModifyAPIRouter(func(r *mux.Router) {
-		dcav1.InstallChecksEndpoints(r, sc)
-	})
 
 	wg := sync.WaitGroup{}
 	// Autoscaler Controller Goroutine

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -508,14 +508,22 @@ func start(log log.Component,
 	// start the autoconfig, this will immediately run any configured check
 	ac.LoadAndRun(mainCtx)
 
+	// Find the AutodiscoveryHandler from instrumentation handlers to expose configs via API.
+	var adConfigLister clusteragent.InstrumentationConfigLister
+	for _, h := range instrHandlers {
+		if ad, ok := h.(*instrumentationhandlers.AutodiscoveryHandler); ok {
+			adConfigLister = ad
+			break
+		}
+	}
+
+	sc := clusteragent.ServerContext{InstrumentationConfigLister: adConfigLister}
+
 	if config.GetBool("cluster_checks.enabled") {
 		// Start the cluster check Autodiscovery
 		clusterCheckHandler, err := setupClusterCheck(mainCtx, ac, taggerComp)
 		if err == nil {
-			api.ModifyAPIRouter(func(r *mux.Router) {
-				dcav1.InstallChecksEndpoints(r, clusteragent.ServerContext{ClusterCheckHandler: clusterCheckHandler})
-			})
-
+			sc.ClusterCheckHandler = clusterCheckHandler
 			// Set cluster checks handler in clusterchecks component
 			clusterChecksMetadataComp.SetClusterHandler(clusterCheckHandler)
 		} else {
@@ -524,6 +532,10 @@ func start(log log.Component,
 	} else {
 		pkglog.Debug("Cluster check Autodiscovery disabled")
 	}
+
+	api.ModifyAPIRouter(func(r *mux.Router) {
+		dcav1.InstallChecksEndpoints(r, sc)
+	})
 
 	wg := sync.WaitGroup{}
 	// Autoscaler Controller Goroutine

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery.go
@@ -27,22 +27,32 @@ import (
 const (
 	checksReadyConditionType = "ChecksReady"
 
-	// autodiscoveryProvider is the integration.Config Provider value used for configs
+	// autodiscoveryProvider is the integration.Config Source value used for configs
 	// translated from a DatadogInstrumentation CR by the Autodiscovery handler.
 	autodiscoveryProvider = "datadoginstrumentation"
 )
 
-// AutodiscoveryHandler translates DatadogInstrumentation check sections into
-// integration.Config entries and stores them in memory for delivery to node agents.
-type AutodiscoveryHandler struct {
+type CheckStore struct {
 	mu      sync.RWMutex
 	configs map[string][]integration.Config
 }
 
-// NewAutodiscoveryHandler returns the Autodiscovery DatadogInstrumentation handler.
-func NewAutodiscoveryHandler(_ Deps) *AutodiscoveryHandler {
-	return &AutodiscoveryHandler{
+func NewCheckStore() *CheckStore {
+	return &CheckStore{
 		configs: make(map[string][]integration.Config),
+	}
+}
+
+// AutodiscoveryHandler translates DatadogInstrumentation check sections into
+// integration.Config entries and stores them in memory for delivery to node agents.
+type AutodiscoveryHandler struct {
+	checkStore *CheckStore
+}
+
+// NewAutodiscoveryHandler returns the Autodiscovery DatadogInstrumentation handler.
+func NewAutodiscoveryHandler(dep *Deps) *AutodiscoveryHandler {
+	return &AutodiscoveryHandler{
+		checkStore: dep.CheckStore,
 	}
 }
 
@@ -121,7 +131,7 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 	key := cr.Namespace + "/" + cr.Name
 
 	if event == instrumentation.EventDelete {
-		h.deleteConfigs(key)
+		h.checkStore.deleteConfigs(key)
 		return instrumentation.HandlerStatus{
 			Type:    checksReadyConditionType,
 			Status:  metav1.ConditionTrue,
@@ -144,7 +154,7 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 		configs = append(configs, cfg)
 	}
 
-	h.setConfigs(key, configs)
+	h.checkStore.setConfigs(key, configs)
 
 	return instrumentation.HandlerStatus{
 		Type:    checksReadyConditionType,
@@ -157,29 +167,33 @@ func (h *AutodiscoveryHandler) Handle(_ context.Context, event instrumentation.E
 // ListConfigs returns a snapshot of all stored integration.Config entries
 // across all DatadogInstrumentation CRs handled by this instance.
 func (h *AutodiscoveryHandler) ListConfigs() []integration.Config {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	return h.checkStore.ListConfigs()
+}
+
+func (c *CheckStore) ListConfigs() []integration.Config {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	out := make([]integration.Config, 0)
-	for _, cfgs := range h.configs {
+	for _, cfgs := range c.configs {
 		out = append(out, cfgs...)
 	}
 	return out
 }
 
-func (h *AutodiscoveryHandler) setConfigs(key string, configs []integration.Config) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+func (c *CheckStore) setConfigs(key string, configs []integration.Config) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if len(configs) == 0 {
-		delete(h.configs, key)
+		delete(c.configs, key)
 		return
 	}
-	h.configs[key] = configs
+	c.configs[key] = configs
 }
 
-func (h *AutodiscoveryHandler) deleteConfigs(key string) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	delete(h.configs, key)
+func (c *CheckStore) deleteConfigs(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.configs, key)
 }
 
 func translateCheck(cr *datadoghq.DatadogInstrumentation, check datadoghq.DatadogInstrumentationCheckConfig) (integration.Config, error) {

--- a/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/autodiscovery_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func newHandler() *AutodiscoveryHandler {
-	return NewAutodiscoveryHandler(Deps{})
+	return NewAutodiscoveryHandler(&Deps{
+		CheckStore: NewCheckStore(),
+	})
 }
 
 func newCR(name, namespace string, targetKind, targetName string, checks []datadoghq.DatadogInstrumentationCheckConfig) *datadoghq.DatadogInstrumentation {
@@ -251,7 +253,7 @@ func TestHandle_Delete(t *testing.T) {
 		},
 	})
 
-	// First create configs
+	// First create checkStore
 	_, err := h.Handle(context.Background(), instrumentation.EventCreate, cr)
 	require.NoError(t, err)
 	assert.Len(t, h.ListConfigs(), 1)

--- a/pkg/clusteragent/instrumentation/handlers/registry.go
+++ b/pkg/clusteragent/instrumentation/handlers/registry.go
@@ -8,7 +8,9 @@
 // Package handlers provide product-specific handlers for the Datadog Instrumentation CRD controller.
 package handlers
 
-import "github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+import (
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
+)
 
 // Deps contains dependencies used to construct DatadogInstrumentation product handlers.
 // Product-specific services that are shared with other integration surfaces, such as
@@ -17,10 +19,13 @@ import "github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation"
 type Deps struct {
 	// IsLeader should be used if the handler should only perform actions when the cluster agent is the leader.
 	IsLeader func() bool
+
+	// CheckStore is used as a shared store for check configurations between the AD handler and cluster agent API.
+	CheckStore *CheckStore
 }
 
 // DefaultHandlers returns the product handlers registered for the shared controller.
-func DefaultHandlers(deps Deps) []instrumentation.Handler {
+func DefaultHandlers(deps *Deps) []instrumentation.Handler {
 	return []instrumentation.Handler{
 		NewAutodiscoveryHandler(deps),
 	}

--- a/pkg/clusteragent/servercontext.go
+++ b/pkg/clusteragent/servercontext.go
@@ -6,9 +6,18 @@
 // Package clusteragent contains the functionality of the Cluster Agent.
 package clusteragent
 
-import "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
+import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
+)
+
+// InstrumentationConfigLister exposes integration.Configs derived from DatadogInstrumentation CRs.
+type InstrumentationConfigLister interface {
+	ListConfigs() []integration.Config
+}
 
 // ServerContext holds business logic classes required to setup API endpoints
 type ServerContext struct {
-	ClusterCheckHandler *clusterchecks.Handler
+	ClusterCheckHandler         *clusterchecks.Handler
+	InstrumentationConfigLister InstrumentationConfigLister
 }

--- a/pkg/clusteragent/servercontext.go
+++ b/pkg/clusteragent/servercontext.go
@@ -11,13 +11,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 )
 
-// InstrumentationConfigLister exposes integration.Configs derived from DatadogInstrumentation CRs.
-type InstrumentationConfigLister interface {
+// ConfigLister exposes integration.Configs derived from DatadogInstrumentation CRs.
+type ConfigLister interface {
 	ListConfigs() []integration.Config
 }
 
 // ServerContext holds business logic classes required to setup API endpoints
 type ServerContext struct {
-	ClusterCheckHandler         *clusterchecks.Handler
-	InstrumentationConfigLister InstrumentationConfigLister
+	ClusterCheckHandler *clusterchecks.Handler
 }


### PR DESCRIPTION
### What does this PR do?

Registers a new `/api/v1/instrumentation/configs` cluster agent endpoint that returns the complete list of check configs created by the Autodiscovery instrumentation handler.

### Motivation

`/api/v1/instrumentation/configs`  will be used by a node agent AD provider to poll for check configurations.

### Describe how you validated your changes

1. Ensure `DatadogInstrumentation` CRD is installed on cluster & cluster agent given necessary RBAC permissions.
2. Deploy cluster agent with `DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED` set to true.
3. Deploy instrumentation CR with check section.
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogInstrumentation
metadata:
  name: redis-instrumentation
  namespace: cache
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: redis
  config:
    checks:
      - integration: redisdb
        containerImage:
          - redis
        initConfig: {}
        instances:
          - host: "%%host%%"
            port: "%%port%%"
        logs:
          - type: docker
            source: redis
            service: redis
```
4. Query the endpoint from within the DCA pod. (`instances` and `logs` fields are base64 encoded)
```bash
curl -k -H "Authorization: Bearer $DD_CLUSTER_AGENT_AUTH_TOKEN" \                                                                                                                                                                     
https://localhost:5005/api/v1/instrumentation/configs
```

<img width="1669" height="856" alt="image" src="https://github.com/user-attachments/assets/2ae8405a-29aa-42b4-b3a2-8c684ed85b4f" />

### Additional Notes
