### PR TITLE
dyninst: add WithForceMultiAttach loader option and use it in -short

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -133,6 +133,12 @@ func testDyninst(
 	if debug {
 		loaderOpts = append(loaderOpts, loader.WithDebugLevel(100))
 	}
+	// In short mode (which never runs in CI), force uprobe_multi attachment
+	// to speed up integration tests on hosts whose kernel supports the
+	// feature but is excluded by canUseMultiAttach's 6.10 floor.
+	if testing.Short() {
+		loaderOpts = append(loaderOpts, loader.WithForceMultiAttach())
+	}
 	cfg.TestingKnobs.LoaderOptions = loaderOpts
 	cfg.DiskCacheConfig.DirPath = filepath.Join(tempDir, "disk-cache")
 	cfg.LogUploaderURL = testServer.getLogsURL()

--- a/pkg/dyninst/loader/loader.go
+++ b/pkg/dyninst/loader/loader.go
@@ -69,6 +69,16 @@ func WithAdditionalSerializer(serializer compiler.CodeSerializer) Option {
 	return additionalSerializerOption{serializer}
 }
 
+// WithForceMultiAttach forces the loader to use uprobe_multi attachment,
+// bypassing the kernel-version gate in canUseMultiAttach. Intended for use
+// in tests on kernels that support BPF_LINK_TYPE_UPROBE_MULTI but are
+// excluded by the conservative 6.10 floor (e.g. Ubuntu 24.04's 6.8 kernel).
+// The caller is responsible for ensuring the workload is unaffected by the
+// pre-6.10 multi-uprobe PID-filter bug — see canUseMultiAttach for details.
+func WithForceMultiAttach() Option {
+	return forceMultiAttachOption{}
+}
+
 // NewLoader creates a new Loader.
 func NewLoader(opts ...Option) (*Loader, error) {
 	l := &Loader{}
@@ -108,7 +118,7 @@ func (l *Loader) Load(program compiler.Program) (*Program, error) {
 	}
 	ringbufMapSpec.MaxEntries = uint32(l.config.ringBufSize)
 
-	useMultiAttach := canUseMultiAttach()
+	useMultiAttach := l.config.forceMultiAttach || canUseMultiAttach()
 	if useMultiAttach {
 		progSpec, ok := spec.Programs["probe_run_with_cookie"]
 		if !ok {
@@ -310,6 +320,8 @@ type config struct {
 	dyninstDebugLevel   uint8
 	dyninstDebugEnabled bool
 
+	forceMultiAttach bool
+
 	additionalSerializer compiler.CodeSerializer
 }
 
@@ -343,6 +355,12 @@ type additionalSerializerOption struct {
 
 func (o additionalSerializerOption) apply(c *config) {
 	c.additionalSerializer = o
+}
+
+type forceMultiAttachOption struct{}
+
+func (forceMultiAttachOption) apply(c *config) {
+	c.forceMultiAttach = true
 }
 
 func (l *Loader) init(opts ...Option) error {


### PR DESCRIPTION
### What does this PR do?

Adds a testing knob to the loader that forces uprobe_multi attachment, bypassing canUseMultiAttach's conservative 6.10 kernel-version floor.

The 6.10 floor exists because of upstream commit 46ba0e49b642 ("bpf: fix multi-uprobe PID filtering logic") — which fixed uprobe_prog_run() to use same_thread_group(current, link->task) instead of comparing current->mm to link->task->mm. Without the fix, probes silently drop events from threads other than the one looked up at attach time, which Go programs hit constantly because goroutines run across many OS threads.

Original patch:

    From    Jiri Olsa
    Subject [PATCHv2 bpf-next 1/4] bpf: Fix uprobe multi pid filter check
    Date    Thu, 5 Sep 2024 14:51:21 +0300

    Uprobe multi link does its own process (thread leader) filtering
    before running the bpf program by comparing task's vm pointers.
    But as Oleg pointed out there can be processes sharing the vm
    (CLONE_VM), so we can't just compare task->vm pointers, but instead
    we need to use same_thread_group call.

    -    if (link->task && current->mm != link->task->mm)
    +    if (link->task && !same_thread_group(current, link->task))
             return 0;


### Motivation

The pain of not having multi-attach on local 6.8 hosts (Ubuntu 24.04) is large enough — full TestDyninst runs take ~150s vs a few seconds with multi-attach — that TestDyninst now opts in via testing.Short(), which never runs in CI. 

### Describe how you validated your changes

only testing. 

### Additional Notes

Note that the strictly correct fix landed in a later 6.9 patch, but distros may have backported it further. Callers of WithForceMultiAttach are responsible for ensuring the workload is unaffected by the PID-filter bug on whatever kernel they target.