### PR TITLE
test(windows/install-test): collect agent logs on failure

### DIFF
--- a/test/new-e2e/tests/windows/install-test/base.go
+++ b/test/new-e2e/tests/windows/install-test/base.go
@@ -124,6 +124,36 @@ func (s *baseAgentMSISuite) AfterTest(suiteName, testName string) {
 				s.T().Logf("Errors and warnings from %s event log:\n%s", logName, out)
 			}
 		}
+		// collect agent logs
+		s.collectAgentLogs(vm)
+	}
+}
+
+// collectAgentLogs downloads the agent log folder from the remote host into the session output dir.
+// Best-effort: missing logs (e.g. on a failed install) are surfaced as assertion failures but do
+// not abort the test cleanup.
+func (s *baseAgentMSISuite) collectAgentLogs(vm *components.RemoteHost) {
+	s.T().Logf("Collecting agent logs")
+	logsFolder, err := vm.GetLogsFolder()
+	if !s.Assert().NoError(err, "should get logs folder") {
+		return
+	}
+	entries, err := vm.ReadDir(logsFolder)
+	if !s.Assert().NoError(err, "should read log folder") {
+		return
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(logsFolder, entry.Name())
+		destPath := filepath.Join(s.SessionOutputDir(), entry.Name())
+
+		if entry.IsDir() {
+			s.T().Logf("Found log directory: %s", entry.Name())
+			err = vm.GetFolder(sourcePath, destPath)
+		} else {
+			s.T().Logf("Found log file: %s", entry.Name())
+			err = vm.GetFile(sourcePath, destPath)
+		}
+		s.Assert().NoError(err, "should download %s", entry.Name())
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds `collectAgentLogs` to `baseAgentMSISuite` and calls it from `AfterTest` on test failure, downloading `C:\ProgramData\Datadog\logs` into the session output dir alongside the existing event log export.

### Motivation

Diagnosing recent `start_when_stopped` / `Stop-Service` failures on `test_7.80.0-devel` (e.g. WINA-1672, WINA-1865, WINA-2308) requires the agent service logs to see what the supervisor was doing during the failure window. Today the install-test artifacts only contain MSI logs and Windows event logs — `agent.log` / `process-agent.log` / `trace-agent.log` etc. are not collected, so the root cause has to be inferred from ETW alone.

Mirrors the equivalent collection in `test/new-e2e/tests/windows/service-test` so the two suites match.