### PR TITLE
fix(e2e): Ignore crash dumps from non-agent processes in Windows E2E tests

### DIFF
--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -305,12 +305,21 @@ func (s *BaseSuite) AfterTest(suiteName, testName string) {
 			}
 			time.Sleep(1 * time.Second)
 		}
+		// Dumps from processes in DefaultIgnoredCrashDumpImages are still
+		// downloaded as artifacts but do not fail the test.
 		dumps, err := windowscommon.DownloadAllWERDumps(s.Env().RemoteHost, s.dumpFolder, s.SessionOutputDir())
 		s.Assert().NoError(err, "should download crash dumps")
-		if !s.Assert().Empty(dumps, "should not have crash dumps") {
-			s.T().Logf("Found crash dumps:")
-			for _, dump := range dumps {
-				s.T().Logf("  %s", dump)
+		failing, ignored := windowscommon.PartitionDownloadedWERDumps(dumps, windowscommon.DefaultIgnoredCrashDumpImages)
+		if len(ignored) > 0 {
+			s.T().Logf("Ignoring %d crash dumps from known-noisy processes:", len(ignored))
+			for _, dump := range ignored {
+				s.T().Logf("  %s -> %s", dump.Source.FileName, dump.LocalPath)
+			}
+		}
+		if !s.Assert().Empty(failing, "should not have crash dumps") {
+			s.T().Logf("Found unexpected crash dumps:")
+			for _, dump := range failing {
+				s.T().Logf("  %s -> %s", dump.Source.FileName, dump.LocalPath)
 			}
 		}
 	}

--- a/test/new-e2e/tests/windows/common/crashdump.go
+++ b/test/new-e2e/tests/windows/common/crashdump.go
@@ -130,27 +130,87 @@ func DownloadWERDump(host *components.RemoteHost, dump WERDumpFile, outputDir st
 	return outPath, nil
 }
 
-// DownloadAllWERDumps collects WER dumps from a folder on a remote host and saves them to a local folder
+// DownloadedWERDump pairs the source metadata for a WER dump with the local
+// artifact path produced by downloading it. Callers get both the image name
+// (for filtering against an ignore list) and the local path (for logs /
+// artifact pointers) in one record.
+//
+// Source.Path is the *remote* path on the test VM (e.g. C:\dumps\agent.exe.1234.dmp);
+// LocalPath is the path on the test runner (e.g. e2e-output/<host>-agent.exe.1234.dmp).
+type DownloadedWERDump struct {
+	Source    WERDumpFile
+	LocalPath string
+}
+
+// DefaultIgnoredCrashDumpImages is the denylist of process image names whose
+// WER crash dumps are recorded as artifacts but do NOT fail tests that use
+// PartitionDownloadedWERDumps. These are third-party processes whose crashes
+// have routinely been observed to be unrelated to Datadog agent behavior.
+//
+// Add entries here when a new noisy image is observed in CI. Comparison is
+// case-insensitive and tolerates names with or without a ".exe" suffix.
+var DefaultIgnoredCrashDumpImages = []string{
+	"svchost.exe",
+	"WmiPrvSE.exe",
+	"powershell.exe",
+}
+
+// IsIgnoredCrashDump reports whether the dump's image name appears in ignore
+// (case-insensitive, tolerates names with or without a ".exe" suffix).
+func IsIgnoredCrashDump(dump DownloadedWERDump, ignore []string) bool {
+	name := normalizeImageName(dump.Source.ImageName)
+	for _, ign := range ignore {
+		if normalizeImageName(ign) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// PartitionDownloadedWERDumps splits dumps into (failing, ignored) using the
+// given ignore list. Use it to keep test assertions focused on dumps that
+// represent real agent regressions while still preserving the others as
+// downloaded artifacts.
+func PartitionDownloadedWERDumps(dumps []DownloadedWERDump, ignore []string) (failing, ignored []DownloadedWERDump) {
+	for _, d := range dumps {
+		if IsIgnoredCrashDump(d, ignore) {
+			ignored = append(ignored, d)
+		} else {
+			failing = append(failing, d)
+		}
+	}
+	return failing, ignored
+}
+
+func normalizeImageName(name string) string {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if !strings.HasSuffix(n, ".exe") {
+		n += ".exe"
+	}
+	return n
+}
+
+// DownloadAllWERDumps collects WER dumps from a folder on a remote host and saves them to a local folder.
 //
 // See DownloadWERDump for the naming convention used for the output files.
 //
 // This function continues collecting dumps even if some of them fail to be collected, and returns
 // an error with all the errors encountered.
-func DownloadAllWERDumps(host *components.RemoteHost, dumpFolder string, outputPath string) ([]string, error) {
+func DownloadAllWERDumps(host *components.RemoteHost, dumpFolder string, outputPath string) ([]DownloadedWERDump, error) {
 	return DownloadAllWERDumpsFunc(host, dumpFolder, outputPath,
 		// collect all dumps
 		func(_ WERDumpFile) bool { return true },
 	)
 }
 
-// DownloadAllWERDumpsFunc is like DownloadAllWERDumps, but allows to filter the dumps to collect
-func DownloadAllWERDumpsFunc(host *components.RemoteHost, dumpFolder string, outputPath string, f func(WERDumpFile) bool) ([]string, error) {
+// DownloadAllWERDumpsFunc is like DownloadAllWERDumps, but allows to filter the dumps to collect.
+func DownloadAllWERDumpsFunc(host *components.RemoteHost, dumpFolder string, outputPath string, f func(WERDumpFile) bool) ([]DownloadedWERDump, error) {
 	dumps, err := ListWERDumps(host, dumpFolder)
 	if err != nil {
 		return nil, err
 	}
 
-	collectedDumps := []string{}
+	collected := []DownloadedWERDump{}
 	var retErr error
 	for _, dump := range dumps {
 		if !f(dump) {
@@ -161,10 +221,10 @@ func DownloadAllWERDumpsFunc(host *components.RemoteHost, dumpFolder string, out
 			retErr = errors.Join(retErr, fmt.Errorf("error getting WER dump file %s: %w", dump.Path, err))
 			continue
 		}
-		collectedDumps = append(collectedDumps, outPath)
+		collected = append(collected, DownloadedWERDump{Source: dump, LocalPath: outPath})
 	}
 
-	return collectedDumps, retErr
+	return collected, retErr
 }
 
 // DownloadSystemCrashDump downloads a system crash dump from a remote host.

--- a/test/new-e2e/tests/windows/install-test/base.go
+++ b/test/new-e2e/tests/windows/install-test/base.go
@@ -100,13 +100,22 @@ func (s *baseAgentMSISuite) AfterTest(suiteName, testName string) {
 
 	vm := s.Env().RemoteHost
 
-	// Look for and download crash dumps
+	// Look for and download crash dumps. Dumps from processes in
+	// DefaultIgnoredCrashDumpImages are still downloaded as artifacts but do
+	// not fail the test.
 	dumps, err := windowsCommon.DownloadAllWERDumps(vm, s.dumpFolder, s.SessionOutputDir())
 	s.Assert().NoError(err, "should download crash dumps")
-	if !s.Assert().Empty(dumps, "should not have crash dumps") {
-		s.T().Logf("Found crash dumps:")
-		for _, dump := range dumps {
-			s.T().Logf("  %s", dump)
+	failing, ignored := windowsCommon.PartitionDownloadedWERDumps(dumps, windowsCommon.DefaultIgnoredCrashDumpImages)
+	if len(ignored) > 0 {
+		s.T().Logf("Ignoring %d crash dumps from known-noisy processes:", len(ignored))
+		for _, dump := range ignored {
+			s.T().Logf("  %s -> %s", dump.Source.FileName, dump.LocalPath)
+		}
+	}
+	if !s.Assert().Empty(failing, "should not have crash dumps") {
+		s.T().Logf("Found unexpected crash dumps:")
+		for _, dump := range failing {
+			s.T().Logf("  %s -> %s", dump.Source.FileName, dump.LocalPath)
 		}
 	}
 

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -671,13 +671,22 @@ func (s *baseStartStopSuite) BeforeTest(suiteName, testName string) {
 func (s *baseStartStopSuite) AfterTest(suiteName, testName string) {
 	s.BaseSuite.AfterTest(suiteName, testName)
 
-	// look for and download crashdumps
+	// look for and download crashdumps. Dumps from processes in
+	// DefaultIgnoredCrashDumpImages are still downloaded as artifacts but do
+	// not fail the test.
 	dumps, err := windowsCommon.DownloadAllWERDumps(s.Env().RemoteHost, s.dumpFolder, s.SessionOutputDir())
 	s.Assert().NoError(err, "should download crash dumps")
-	if !s.Assert().Empty(dumps, "should not have crash dumps") {
-		s.T().Logf("Found crash dumps:")
-		for _, dump := range dumps {
-			s.T().Logf("  %s", dump)
+	failing, ignored := windowsCommon.PartitionDownloadedWERDumps(dumps, windowsCommon.DefaultIgnoredCrashDumpImages)
+	if len(ignored) > 0 {
+		s.T().Logf("Ignoring %d crash dumps from known-noisy processes:", len(ignored))
+		for _, dump := range ignored {
+			s.T().Logf("  %s -> %s", dump.Source.FileName, dump.LocalPath)
+		}
+	}
+	if !s.Assert().Empty(failing, "should not have crash dumps") {
+		s.T().Logf("Found unexpected crash dumps:")
+		for _, dump := range failing {
+			s.T().Logf("  %s -> %s", dump.Source.FileName, dump.LocalPath)
 		}
 		// Run !analyze -v on each crash dump on the remote VM
 		if analyzeErr := windowsCommon.AnalyzeAllWERDumps(s.Env().RemoteHost, s.dumpFolder, s.SessionOutputDir(), s.T()); analyzeErr != nil {


### PR DESCRIPTION
### What does this PR do?

Adds a denylist of process image names (`svchost.exe`, `WmiPrvSE.exe`, `powershell.exe`) whose WER crash dumps are still captured as artifacts but no longer fail Windows E2E tests. Failure assertions now operate on a partitioned slice; ignored dumps are logged separately so it's visible at each call site that they were filtered.

`DownloadAllWERDumps` / `DownloadAllWERDumpsFunc` return type is changed from `[]string` to `[]DownloadedWERDump`, pairing the source metadata (image name, PID) with the local artifact path. All three existing call sites are updated.

### Motivation

Crashes in unrelated third-party processes on the test VM have been turning into failed-CI Jira tickets (WINA-1846, WINA-2278, WINA-2509, WINA-2695 and others) even though they are not regressions in the agent itself. The denylist removes that noise while keeping the dumps available as artifacts for inspection.

A denylist (rather than an agent allowlist) was chosen so adding a new agent binary doesn't risk silently dropping coverage.