### PR TITLE
support CNM direct send without event stream

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -22,6 +22,7 @@ import (
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	secmodule "github.com/DataDog/datadog-agent/pkg/security/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -93,33 +94,40 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 		}
 	}
 
-	netconfig := netconfig.New()
+	ncfg := netconfig.New()
 	// only add the network consumer if the pkg/network/events
 	// module was initialized by the network tracer module
 	// (this will happen only if the network consumer is enabled
 	// in config and the network tracer module is loaded successfully)
-	if events.Initialized() {
-		network, err := events.NewNetworkConsumer(evm)
-		if err != nil {
-			return nil, err
-		}
-		evm.RegisterEventConsumer(network)
-		log.Info("event monitoring network consumer initialized")
-
-		if netconfig.DirectSend {
-			ds, err := sender.NewDirectSenderConsumer(evm, deps.Log, deps.SysprobeConfig)
+	if module.IsLoaded(config.NetworkTracerModule) {
+		if events.Initialized() {
+			network, err := events.NewNetworkConsumer(evm)
 			if err != nil {
 				return nil, err
 			}
-			if ds != nil {
-				evm.RegisterEventConsumer(ds)
-				log.Info("event monitoring direct sender consumer initialized")
+			evm.RegisterEventConsumer(network)
+			log.Info("event monitoring network consumer initialized")
+
+			if ncfg.DirectSend {
+				ds, err := sender.NewDirectSenderConsumer(evm, deps.Log, deps.SysprobeConfig)
+				if err != nil {
+					return nil, err
+				}
+				if ds != nil {
+					evm.RegisterEventConsumer(ds)
+					log.Info("event monitoring direct sender consumer initialized")
+				}
+			}
+		} else if ncfg.DirectSend {
+			err := sender.NewDirectSenderPoller(deps.Log, deps.SysprobeConfig)
+			if err != nil {
+				return nil, err
 			}
 		}
 	}
 
-	if netconfig.EnableUSMEventStream {
-		if err := createProcessMonitorConsumer(evm, netconfig); err != nil {
+	if ncfg.EnableUSMEventStream {
+		if err := createProcessMonitorConsumer(evm, ncfg); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/network/sender/event_consumer_linux.go
+++ b/pkg/network/sender/event_consumer_linux.go
@@ -206,8 +206,7 @@ func (d *directSenderConsumer) collectProcesses() error {
 				// start fields after process name
 				for field := range bytes.FieldsSeq(stat[processNameEndIndex+1:]) {
 					fieldNum++
-					switch fieldNum {
-					case 2:
+					if fieldNum == 2 {
 						ppid, _ = strconv.ParseInt(string(field), 10, 32)
 						break
 					}

--- a/pkg/network/sender/event_consumer_linux.go
+++ b/pkg/network/sender/event_consumer_linux.go
@@ -223,16 +223,13 @@ func (d *directSenderConsumer) collectProcesses() error {
 			}
 		}
 
-		cwd, _ := os.Readlink(filepath.Join(pidPath, "cwd"))
-
 		p := &process{
 			Pid:       uint32(pid),
 			PPid:      uint32(ppid),
 			Cmdline:   cmdline,
-			Cwd:       cwd,
 			EventType: model.ExecEventType,
 		}
-		d.process(p)
+		d.HandleEvent(p)
 	}
 
 	return nil

--- a/pkg/network/sender/event_consumer_linux.go
+++ b/pkg/network/sender/event_consumer_linux.go
@@ -10,6 +10,7 @@ package sender
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -52,6 +53,7 @@ type directSenderConsumer struct {
 	extractor            *serviceExtractor
 	processNameExtractor *processNameExtractor
 	pidAliveFunc         func(pid int) bool
+	fetchProcesses       bool
 }
 
 // NewDirectSenderConsumer creates the direct sender consumer and returns it for event monitor registration
@@ -70,6 +72,20 @@ func NewDirectSenderConsumer(em EventConsumerRegistry, log log.Component, syspro
 	}
 	directSenderConsumerInstance.Store(dsc)
 	return dsc, nil
+}
+
+// NewDirectSenderPoller creates the direct sender consumer using manual process polling
+func NewDirectSenderPoller(log log.Component, sysprobeconfig sysprobeconfig.Component) error {
+	dsc := &directSenderConsumer{
+		log:            log,
+		processes:      make(map[uint32]*process),
+		proxyFilter:    newDockerProxyFilter(log),
+		extractor:      newServiceExtractor(sysprobeconfig),
+		pidAliveFunc:   ddos.PidExists,
+		fetchProcesses: true,
+	}
+	directSenderConsumerInstance.Store(dsc)
+	return nil
 }
 
 // ID implements eventmonitor.EventConsumer and eventmonitor.EventConsumerHandler
@@ -165,6 +181,62 @@ func (d *directSenderConsumer) HandleEvent(ev any) {
 	d.proxyFilter.process(p)
 	d.extractor.process(p)
 	d.processNameExtractor.process(p)
+}
+
+func (d *directSenderConsumer) collectProcesses() error {
+	if !d.fetchProcesses {
+		return nil
+	}
+
+	rootProc := kernel.ProcFSRoot()
+	pids, err := kernel.AllPidsProcs(rootProc)
+	if err != nil {
+		return err
+	}
+
+	for _, pid := range pids {
+		pidPath := filepath.Join(rootProc, strconv.Itoa(pid))
+
+		var ppid int64
+		stat, err := os.ReadFile(filepath.Join(pidPath, "stat"))
+		if err == nil {
+			processNameEndIndex := bytes.LastIndexByte(stat, byte(')'))
+			if processNameEndIndex > 0 && processNameEndIndex+1 < len(stat) {
+				fieldNum := 0
+				// start fields after process name
+				for field := range bytes.FieldsSeq(stat[processNameEndIndex+1:]) {
+					fieldNum++
+					switch fieldNum {
+					case 2:
+						ppid, _ = strconv.ParseInt(string(field), 10, 32)
+						break
+					}
+				}
+			}
+		}
+
+		var cmdline []string
+		cmd, err := os.ReadFile(filepath.Join(pidPath, "cmdline"))
+		if err == nil {
+			cmd = bytes.TrimSpace(cmd)
+			for cmdPiece := range bytes.SplitSeq(cmd, []byte{'\x00'}) {
+				cmdline = append(cmdline, string(cmdPiece))
+			}
+		}
+
+		cwd, _ := os.Readlink(filepath.Join(pidPath, "cwd"))
+
+		p := &process{
+			Pid:       uint32(pid),
+			PPid:      uint32(ppid),
+			Cmdline:   cmdline,
+			Cwd:       cwd,
+			EventType: model.ExecEventType,
+		}
+		d.process(p)
+	}
+
+	return nil
 }
 
 func (d *directSenderConsumer) process(p *process) {

--- a/pkg/network/sender/event_consumer_unsupported.go
+++ b/pkg/network/sender/event_consumer_unsupported.go
@@ -17,3 +17,8 @@ import (
 func NewDirectSenderConsumer(_ EventConsumerRegistry, _ log.Component, _ sysprobeconfig.Component) (eventmonitor.EventConsumer, error) {
 	return nil, nil
 }
+
+// NewDirectSenderPoller is not supported on non-linux systems
+func NewDirectSenderPoller(_ log.Component, _ sysprobeconfig.Component) error {
+	return nil
+}

--- a/pkg/network/sender/sender_linux.go
+++ b/pkg/network/sender/sender_linux.go
@@ -313,6 +313,9 @@ func (d *directSender) collect() {
 	defer network.Reclaim(conns)
 
 	if dsc := directSenderConsumerInstance.Load(); dsc != nil {
+		if err := dsc.collectProcesses(); err != nil {
+			d.log.Warnf("error getting processes: %s", err)
+		}
 		dsc.proxyFilter.FilterProxies(conns)
 		defer dsc.cleanupProcesses()
 	}

--- a/pkg/system-probe/api/module/loader.go
+++ b/pkg/system-probe/api/module/loader.go
@@ -96,21 +96,19 @@ func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []*Fact
 		// In case a module failed to be started, do not make the whole `system-probe` abort.
 		// Let `system-probe` run the other modules.
 		if err != nil {
-			l.errors[factory.Name] = err
+			l.moduleError(factory.Name, err)
 			log.Errorf("error creating module %s: %s", factory.Name, err)
 			continue
 		}
 
 		subRouter := NewRouter(string(factory.Name), httpMux)
 		if err = module.Register(subRouter); err != nil {
-			l.errors[factory.Name] = err
+			l.moduleError(factory.Name, err)
 			log.Errorf("error registering HTTP endpoints for module %s: %s", factory.Name, err)
 			continue
 		}
 
-		l.routers[factory.Name] = subRouter
-		l.modules[factory.Name] = module
-
+		l.registerModule(factory.Name, module, subRouter)
 		log.Infof("module %s started", factory.Name)
 	}
 
@@ -132,6 +130,28 @@ func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []*Fact
 	go updateGlobalStats()
 
 	return nil
+}
+
+func (l *loader) registerModule(name sysconfigtypes.ModuleName, module Module, subRouter *Router) {
+	l.Lock()
+	defer l.Unlock()
+	l.routers[name] = subRouter
+	l.modules[name] = module
+}
+
+func (l *loader) moduleError(name sysconfigtypes.ModuleName, err error) {
+	l.Lock()
+	defer l.Unlock()
+	l.errors[name] = err
+}
+
+// IsLoaded returns whether the named module has successfully loaded
+func IsLoaded(name sysconfigtypes.ModuleName) bool {
+	l.Lock()
+	defer l.Unlock()
+
+	_, found := l.modules[name]
+	return found
 }
 
 // GetStats returns the stats from all modules, namespaced by their names
@@ -166,10 +186,12 @@ func RestartModule(factory *Factory, deps FactoryDependencies) error {
 	withModule(factory.Name, func() {
 		currentRouter.Unregister()
 		currentModule.Close()
+		delete(l.modules, factory.Name)
 		newModule, err = factory.Fn(l.cfg, deps)
 	})
 	if err != nil {
 		l.errors[factory.Name] = err
+		delete(l.routers, factory.Name)
 		return err
 	}
 	delete(l.errors, factory.Name)
@@ -200,6 +222,7 @@ func Close() {
 			currentRouter.Unregister()
 		}
 		mod.Close()
+		delete(l.modules, name)
 	})
 }
 

--- a/pkg/util/kernel/proc.go
+++ b/pkg/util/kernel/proc.go
@@ -33,8 +33,8 @@ func AllPidsProcs(procRoot string) ([]int, error) {
 
 	pids := make([]int, 0, len(dirs))
 	for _, name := range dirs {
-		if pid, err := strconv.Atoi(name); err == nil {
-			pids = append(pids, pid)
+		if pid, err := strconv.ParseInt(name, 10, 32); err == nil {
+			pids = append(pids, int(pid))
 		}
 	}
 	return pids, nil


### PR DESCRIPTION
### What does this PR do?

Adds a way to collect processes when process event data stream is not supported on the kernel.

### Motivation

Support direct send on all kernels.

### Describe how you validated your changes

### Additional Notes
