### PR TITLE
fix(e2e): retry agent integration install in persisting-integrations tests

### DIFF
--- a/test/new-e2e/tests/agent-platform/tests/persisting_integrations_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/persisting_integrations_test.go
@@ -5,7 +5,6 @@
 package agentplatform
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -158,7 +157,7 @@ func (is *persistingIntegrationsSuite) SetupTestClient() *common.TestClient {
 // once a day at 5AM CET and can also run during working hours. Retry to
 // absorb that window. 30 tries × 30s = 15 min max wait.
 func (is *persistingIntegrationsSuite) retryRemoteCommand(VMclient *common.TestClient, cmd string) {
-	_, err := backoff.Retry(context.Background(), func() (any, error) {
+	_, err := backoff.Retry(is.T().Context(), func() (any, error) {
 		_, execErr := VMclient.Host.Execute(cmd)
 		return nil, execErr
 	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(30))

--- a/test/new-e2e/tests/agent-platform/tests/persisting_integrations_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/persisting_integrations_test.go
@@ -5,9 +5,13 @@
 package agentplatform
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
@@ -145,14 +149,30 @@ func (is *persistingIntegrationsSuite) SetupTestClient() *common.TestClient {
 	return VMclient
 }
 
+// retryRemoteCommand runs a remote shell command with bounded retry.
+//
+// The agent integration install command and pip resolve wheels from the
+// integrations-core CDN. During a release-pipeline rotation the TUF
+// metadata.staged snapshot returns 403 for a few minutes at a time, causing
+// the command to fail. The integrations-core release pipeline runs at least
+// once a day at 5AM CET and can also run during working hours. Retry to
+// absorb that window. 30 tries × 30s = 15 min max wait.
+func (is *persistingIntegrationsSuite) retryRemoteCommand(VMclient *common.TestClient, cmd string) {
+	_, err := backoff.Retry(context.Background(), func() (any, error) {
+		_, execErr := VMclient.Host.Execute(cmd)
+		return nil, execErr
+	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(30))
+	is.Require().NoError(err, "command failed after retries: %s", cmd)
+}
+
 func (is *persistingIntegrationsSuite) InstallNVMLIntegration(VMclient *common.TestClient) {
 	// Make sure that the integration is not installed
 	freezeRequirement := VMclient.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))
 	is.Assert().NotContains(freezeRequirement, "datadog-nvml")
 
 	// Install the integration and its dependencies
-	VMclient.Host.MustExecute("sudo -u dd-agent datadog-agent integration install -t datadog-nvml==1.0.0")
-	VMclient.Host.MustExecute("sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip3 install grpcio==1.80.0 pynvml==13.0.1")
+	is.retryRemoteCommand(VMclient, "sudo -u dd-agent datadog-agent integration install -t datadog-nvml==1.0.0")
+	is.retryRemoteCommand(VMclient, "sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip3 install grpcio==1.80.0 pynvml==13.0.1")
 
 	// Check that the integration is installed successfully
 	freezeRequirement = VMclient.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))
@@ -165,7 +185,7 @@ func (is *persistingIntegrationsSuite) InstallPackage(VMclient *common.TestClien
 	is.Assert().NotContains(freezeRequirement, packageName)
 
 	// Install the package
-	VMclient.Host.MustExecute("sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip3 install " + packageName)
+	is.retryRemoteCommand(VMclient, "sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip3 install "+packageName)
 
 	// Check that the package is installed successfully
 	freezeRequirement = VMclient.AgentClient.Integration(agentclient.WithArgs([]string{"freeze"}))

--- a/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
+++ b/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
@@ -6,7 +6,6 @@
 package installtest
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -536,7 +535,7 @@ func (s *baseAgentMSISuite) installThirdPartyIntegration(vm *components.RemoteHo
 	s.Require().NoError(err, "should get install path from registry")
 
 	cmd := fmt.Sprintf(`& "%s\bin\agent.exe" integration install -t %s`, installPath, integration)
-	_, err = backoff.Retry(context.Background(), func() (any, error) {
+	_, err = backoff.Retry(s.T().Context(), func() (any, error) {
 		_, execErr := vm.Execute(cmd)
 		return nil, execErr
 	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(30))
@@ -558,7 +557,7 @@ func (s *baseAgentMSISuite) installPipPackage(vm *components.RemoteHost, package
 	s.Require().NoError(err, "should get install path from registry")
 
 	cmd := fmt.Sprintf(`& "%s\embedded3\python.exe" -m pip install %s`, installPath, packageToInstall)
-	_, err = backoff.Retry(context.Background(), func() (any, error) {
+	_, err = backoff.Retry(s.T().Context(), func() (any, error) {
 		_, execErr := vm.Execute(cmd)
 		return nil, execErr
 	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(30))

--- a/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
+++ b/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
@@ -6,10 +6,14 @@
 package installtest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
@@ -521,12 +525,21 @@ func (s *testPersistingIntegrationsDuringUninstall) TestPersistingIntegrationsDu
 }
 
 // install third party integration
+//
+// The agent integration install command can fail transiently when the
+// integrations-core release pipeline is mid-rotation: the TUF metadata.staged
+// snapshot returns 403 for a few minutes at a time. Wheels can be unavailable
+// for several minutes; their release pipeline runs at least once a day at
+// 5AM CET and can also run during working hours. Retry to absorb that window.
 func (s *baseAgentMSISuite) installThirdPartyIntegration(vm *components.RemoteHost, integration string) error {
 	installPath, err := windowsAgent.GetInstallPathFromRegistry(s.Env().RemoteHost)
 	s.Require().NoError(err, "should get install path from registry")
 
 	cmd := fmt.Sprintf(`& "%s\bin\agent.exe" integration install -t %s`, installPath, integration)
-	_, err = vm.Execute(cmd)
+	_, err = backoff.Retry(context.Background(), func() (any, error) {
+		_, execErr := vm.Execute(cmd)
+		return nil, execErr
+	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(30))
 
 	if err != nil {
 		s.T().Logf("Error installing integration %s:\n%s", integration, err)
@@ -536,12 +549,19 @@ func (s *baseAgentMSISuite) installThirdPartyIntegration(vm *components.RemoteHo
 }
 
 // install pip package
+//
+// pip resolves wheels from the same integrations-core CDN that the agent
+// integration installer uses, so the same transient 403 window applies.
+// Retry to absorb it.
 func (s *baseAgentMSISuite) installPipPackage(vm *components.RemoteHost, packageToInstall string) error {
 	installPath, err := windowsAgent.GetInstallPathFromRegistry(s.Env().RemoteHost)
 	s.Require().NoError(err, "should get install path from registry")
 
 	cmd := fmt.Sprintf(`& "%s\embedded3\python.exe" -m pip install %s`, installPath, packageToInstall)
-	_, err = vm.Execute(cmd)
+	_, err = backoff.Retry(context.Background(), func() (any, error) {
+		_, execErr := vm.Execute(cmd)
+		return nil, execErr
+	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(30))
 
 	if err != nil {
 		s.T().Logf("Error installing pip package %s:\n%s", packageToInstall, err)


### PR DESCRIPTION
### What does this PR do?

Wraps `agent integration install` and `pip install` calls in the Windows and Linux persisting-integrations E2E tests with a bounded `backoff.Retry` (30s × 30 tries), matching the existing pattern in `agent-platform/common/agent_integration.go::installIntegration`.

### Motivation

Both test families share one flake mode: the embedded TUF client fetches `metadata.staged/*.snapshot.json` from the integrations-core CDN, which returns 403 for a few minutes during release-pipeline rotations. 14d on `main`:

- `agent-platform/tests.TestPersistingIntegrations` (Linux): 89 fail / 2114 pass (~4.0%), distributed evenly across ubuntu / amazonlinux / debian / centos.
- `windows/install-test.TestPersistingIntegrations` family (WINA-2666 / 2667 / 2103, all closed today as known flakes): ~73 fail / 14d.

### Describe how you validated your changes

Existing tests; no new tests added. Retry is exercised by the same call sites already covered by `TestPersistingIntegrations` / `TestDisablePersistingIntegrations` / `TestPersistingIntegrationsDuringUninstall`.