### PR TITLE
dyninst: detach before unregistering sink

### DIFF
--- a/pkg/dyninst/module/runtime_impl.go
+++ b/pkg/dyninst/module/runtime_impl.go
@@ -299,8 +299,11 @@ func (l *loadedProgramImpl) EvictBufferOlderThan(cutoffKtimeNs uint64) {
 
 func (l *loadedProgramImpl) Close() error {
 	l.loadedProgram.Close()
-	l.runtime.dispatcher.UnregisterSink(l.programID)
+	// Detach before unregistering: UnregisterSink drains the sink, which
+	// emits buffered events and would otherwise re-report diagnostics for a
+	// runtimeID whose tracker entries were just cleared.
 	l.runtime.onProgramDetached(l.programID)
+	l.runtime.dispatcher.UnregisterSink(l.programID)
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

`loadedProgramImpl.Close` previously called `dispatcher.UnregisterSink` before `onProgramDetached`. `UnregisterSink` synchronously drains the sink: `sink.Close` force-finalizes any buffered invocations and calls `emit` on each, which calls `setProbeMaybeEmitting` → `diagnostics.reportEmitting`. That lookup is keyed on `procRuntimeIDbyProgramID`, which `onProgramDetached` clears — but only after the drain has run, so the drain still reports "emitting" diagnostics for a runtimeID whose process has already been removed (and whose diagnostics tracker entries were just cleared by `processStore.remove`). The re-inserted entry has no future event that would ever clear it, so `DiagnosticsStates` never drains.

Fix: clear the programID→runtimeID mapping before draining the sink so the final-drain emits become no-ops at the lookup. Same fix applies to `reportProbeError`, which has the same lookup pattern.

### Motivation

This surfaced as flakes in `TestDropNotifications/S4_partial_return_under_pressure`: the `EventuallyWithT(... DiagnosticsStates ... Empty)` assertion would time out with a stranded `capture_bytes_return: [emitted]` entry. S4 is the scenario most likely to hit this — a small entry that decodes cleanly sits buffered waiting on a PARTIAL_RETURN notification that may not arrive before shutdown, then force-finalizes and decodes successfully during sink.Close. S3 (entry-side drops) leaves no decodable entry; S5 (RETURN_LOST with huge entries) often has nothing decodable either; both hit emit()'s "nothing to decode" early return and skip the re-emit.

### Describe how you validated your changes

It deflakes the test

### Additional Notes
