### PR TITLE
Fix system-probe.yaml missing trailing newline on Linux

### DIFF
--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -236,9 +236,7 @@
 #     # Set to true to activate the CWS network detections.
 #
 #     enabled: true
-
-{{- if (eq .OS "windows") }}
-
+{{ if (eq .OS "windows") }}
 ##################################################
 ## Datadog Agent Windows Crash Detection module ##
 ##################################################


### PR DESCRIPTION
## What does this PR do?

Fixes a regression introduced by #48863 where `system-probe.yaml` was generated without a trailing newline on Linux.

**Root cause:** PR #48863 changed `pkg/config/system-probe_template.yaml` to use `{{- if (eq .OS "windows") }}` (with a leading `-`). In Go templates, the `-` trims all preceding whitespace/newlines from the rendered output. On Linux (where the Windows block is skipped), this caused the file to end without a trailing newline after the last content line (`#     enabled: true`).

**Fix:** Replace `{{- if (eq .OS "windows") }}` with `{{ if (eq .OS "windows") }}` and remove the surrounding blank lines that were added alongside it, restoring the original template whitespace behavior.

## Impact

The missing trailing newline caused `yamllint` to report `new-line-at-end-of-file` errors in the `agent-linux-install-script` unit tests ([failing job](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/1669414348)), breaking 7 tests that modify and lint `/etc/datadog-agent/system-probe.yaml`.

## Describe how you validated your changes

The change is a 3-line template whitespace fix. The rendered Linux output now ends with `#     enabled: true\n` (trailing newline restored). Windows rendering is unaffected.