### PR TITLE
pass schedule field to postgres check DO queries

### DIFF
--- a/comp/dataobs/queryactions/impl/BUILD.bazel
+++ b/comp/dataobs/queryactions/impl/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//comp/remote-config/rcclient/def",
         "//pkg/config/remote/data",
         "//pkg/remoteconfig/state",
+        "@com_github_robfig_cron_v3//:cron",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -241,12 +241,11 @@ func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integrati
 		// unambiguously on the receiving side.
 		queryNode := &yaml.Node{Kind: yaml.ScalarNode, Style: yaml.DoubleQuotedStyle, Value: q.Query}
 		qm := map[string]any{
-			"dbname":           q.DBName,
-			"monitor_id":       q.MonitorID,
-			"type":             q.Type,
-			"query":            queryNode,
-			"interval_seconds": q.IntervalSeconds,
-			"query_timeout":    q.TimeoutSeconds * 1000,
+			"dbname":        q.DBName,
+			"monitor_id":    q.MonitorID,
+			"type":          q.Type,
+			"query":         queryNode,
+			"query_timeout": q.TimeoutSeconds * 1000,
 			"entity": map[string]any{
 				"platform": q.Entity.Platform,
 				"account":  q.Entity.Account,
@@ -260,6 +259,9 @@ func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integrati
 				"metric_config_id": q.CustomSQLSelectFields.MetricConfigID,
 				"entity_id":        q.CustomSQLSelectFields.EntityID,
 			}
+		}
+		if q.IntervalSeconds > 0 {
+			qm["interval_seconds"] = q.IntervalSeconds
 		}
 		if q.Schedule != "" {
 			qm["schedule"] = q.Schedule

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
 )
 
@@ -70,6 +71,21 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 		if len(payload.Queries) == 0 {
 			c.collectDisable(configID, &changes)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+			continue
+		}
+
+		// Validate each query spec before paying the cost of finding the postgres config.
+		// On the first invalid query, reject the entire config — no partial scheduling.
+		var validationErr error
+		for _, q := range payload.Queries {
+			if err := validateQuerySpec(q); err != nil {
+				validationErr = err
+				break
+			}
+		}
+		if validationErr != nil {
+			c.log.Warnf("Invalid DO query spec in config %s: %v", configID, validationErr)
+			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: validationErr.Error()})
 			continue
 		}
 
@@ -217,13 +233,20 @@ func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
 func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integration.Config, instance map[string]any, remoteConfigID string) (integration.Config, error) {
 	queries := make([]map[string]any, 0, len(payload.Queries))
 	for _, q := range payload.Queries {
+		// Force the query string to be emitted as a double-quoted scalar.
+		// yaml.v3's default style selection picks a `|N` block scalar for multi-line
+		// strings, which is unparseable when the source string mixes indentation
+		// across lines (e.g. a SQL body with -- comment trailing at column 0). A
+		// double-quoted scalar preserves the content byte-for-byte and parses
+		// unambiguously on the receiving side.
+		queryNode := &yaml.Node{Kind: yaml.ScalarNode, Style: yaml.DoubleQuotedStyle, Value: q.Query}
 		qm := map[string]any{
 			"dbname":           q.DBName,
 			"monitor_id":       q.MonitorID,
 			"type":             q.Type,
-			"query":            q.Query,
+			"query":            queryNode,
 			"interval_seconds": q.IntervalSeconds,
-			"timeout_seconds":  q.TimeoutSeconds,
+			"query_timeout":    q.TimeoutSeconds * 1000,
 			"entity": map[string]any{
 				"platform": q.Entity.Platform,
 				"account":  q.Entity.Account,
@@ -237,6 +260,9 @@ func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integrati
 				"metric_config_id": q.CustomSQLSelectFields.MetricConfigID,
 				"entity_id":        q.CustomSQLSelectFields.EntityID,
 			}
+		}
+		if q.Schedule != "" {
+			qm["schedule"] = q.Schedule
 		}
 		queries = append(queries, qm)
 	}
@@ -261,4 +287,27 @@ func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integrati
 		NodeName:  baseCfg.NodeName,
 		Instances: []integration.Data{instanceYAML},
 	}, nil
+}
+
+// validateQuerySpec validates a QuerySpec before scheduling.
+// A query is valid iff exactly one of the following holds:
+//   - schedule is non-empty and is a valid 5-field standard cron expression.
+//   - schedule is empty and interval_seconds > 0.
+//
+// When both fields are set (schedule non-empty and interval_seconds > 0), the cron
+// schedule takes precedence downstream; the query is still accepted here as valid.
+func validateQuerySpec(q QuerySpec) error {
+	if q.Schedule != "" {
+		// Validate the cron expression using the same ParseStandard parser as
+		// pkg/collector/corechecks/cluster/ksm/customresources/cronjob.go:382
+		// to guarantee identical semantics between Go validation and Python scheduling.
+		if _, err := cron.ParseStandard(q.Schedule); err != nil {
+			return fmt.Errorf("monitor_id %d: invalid cron schedule %q: %w", q.MonitorID, q.Schedule, err)
+		}
+		return nil
+	}
+	if q.IntervalSeconds <= 0 {
+		return fmt.Errorf("monitor_id %d: interval_seconds must be > 0 when schedule is unset", q.MonitorID)
+	}
+	return nil
 }

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -640,7 +640,6 @@ func TestBuildCheckConfig_PerQueryDBName(t *testing.T) {
 	assert.Equal(t, 200, q2["monitor_id"])
 }
 
-
 // TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError verifies that when a postgres
 // instance's YAML is malformed, the error message from findPostgresConfig mentions the
 // parse failure, not just "identifier not found".

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -177,7 +177,7 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 	assert.Equal(t, "run_query", q1["type"])
 	assert.Equal(t, "SELECT count(*) FROM orders", q1["query"])
 	assert.Equal(t, 60, q1["interval_seconds"])
-	assert.Equal(t, 10, q1["timeout_seconds"])
+	assert.Equal(t, 10000, q1["query_timeout"])
 
 	entity1, ok := q1["entity"].(map[string]any)
 	require.True(t, ok)
@@ -640,6 +640,7 @@ func TestBuildCheckConfig_PerQueryDBName(t *testing.T) {
 	assert.Equal(t, 200, q2["monitor_id"])
 }
 
+
 // TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError verifies that when a postgres
 // instance's YAML is malformed, the error message from findPostgresConfig mentions the
 // parse failure, not just "identifier not found".
@@ -666,4 +667,224 @@ func TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError(t *testing.T) {
 	require.Equal(t, state.ApplyStateError, statuses["path/cfg-badyaml"].State)
 	assert.Contains(t, statuses["path/cfg-badyaml"].Error, "YAML parse error",
 		"error message should surface the YAML parse failure, not just 'identifier not found'")
+}
+
+// --- validateQuerySpec tests ---
+
+// TestValidateQuerySpec_ValidScheduleOnly verifies that a query with a valid cron schedule
+// and no interval_seconds passes validation and flows through to the scheduled check.
+func TestValidateQuerySpec_ValidScheduleOnly(t *testing.T) {
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		NodeName:  "node1",
+		Instances: []integration.Data{integration.Data("host: localhost\ndata_observability:\n  enabled: true\n")},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-cron-only",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries: []QuerySpec{
+			{
+				MonitorID:      42,
+				Type:           "run_query",
+				Query:          "SELECT count(*) FROM orders",
+				Schedule:       "20 * * * *",
+				TimeoutSeconds: 10,
+				Entity:         EntityMetadata{Platform: "postgres", Database: "shop", Table: "orders"},
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-cron-only": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-cron-only"].State)
+	require.Len(t, changes.Schedule, 1, "should schedule the DO check")
+
+	var instance map[string]any
+	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 10, doConfig["collection_interval"], "collection_interval must always be 10")
+
+	queries, ok := doConfig["queries"].([]any)
+	require.True(t, ok)
+	require.Len(t, queries, 1)
+	q := queries[0].(map[string]any)
+	assert.Equal(t, "20 * * * *", q["schedule"], "schedule field should be injected into query YAML")
+	_, hasInterval := q["interval_seconds"]
+	assert.True(t, hasInterval, "interval_seconds should still be present in YAML for Python-side compatibility")
+}
+
+// TestValidateQuerySpec_BothScheduleAndInterval verifies that when both schedule and
+// interval_seconds are set, the config flows through (cron wins downstream in Python).
+func TestValidateQuerySpec_BothScheduleAndInterval(t *testing.T) {
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data("host: localhost\ndata_observability:\n  enabled: true\n")},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-both",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries: []QuerySpec{
+			{
+				MonitorID:       77,
+				Type:            "run_query",
+				Query:           "SELECT 1",
+				IntervalSeconds: 300,
+				Schedule:        "*/15 * * * *",
+				TimeoutSeconds:  10,
+				Entity:          EntityMetadata{Platform: "postgres", Database: "db", Table: "t"},
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-both": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-both"].State)
+	require.Len(t, changes.Schedule, 1, "should schedule the DO check when both fields are set")
+
+	var instance map[string]any
+	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 10, doConfig["collection_interval"], "collection_interval must always be 10")
+
+	queries, ok := doConfig["queries"].([]any)
+	require.True(t, ok)
+	require.Len(t, queries, 1)
+	q := queries[0].(map[string]any)
+	assert.Equal(t, "*/15 * * * *", q["schedule"], "schedule field should be injected")
+	assert.Equal(t, 300, q["interval_seconds"], "interval_seconds should also be present; Python enforces cron precedence")
+}
+
+// TestValidateQuerySpec_NeitherSetRejected verifies that a query with neither schedule nor
+// a positive interval_seconds is rejected with ApplyStateError and no check is scheduled.
+func TestValidateQuerySpec_NeitherSetRejected(t *testing.T) {
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Instances: []integration.Data{integration.Data("host: localhost\ndata_observability:\n  enabled: true\n")},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-neither",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries: []QuerySpec{
+			{
+				MonitorID:       55,
+				Type:            "run_query",
+				Query:           "SELECT 1",
+				IntervalSeconds: 0, // zero — invalid when no schedule
+				TimeoutSeconds:  10,
+				Entity:          EntityMetadata{Platform: "postgres", Database: "db", Table: "t"},
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-neither": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateError, statuses["path/cfg-neither"].State)
+	assert.Contains(t, statuses["path/cfg-neither"].Error, "interval_seconds must be > 0 when schedule is unset")
+	assert.Empty(t, changes.Schedule, "no check should be scheduled for invalid query")
+}
+
+// TestValidateQuerySpec_InvalidCronRejected verifies that a query with an invalid cron
+// expression is rejected with ApplyStateError before any postgres config lookup occurs.
+func TestValidateQuerySpec_InvalidCronRejected(t *testing.T) {
+	// No postgres configs at all — if validation fires before findPostgresConfig, this test
+	// will still report ApplyStateError (not "no matching postgres config").
+	c := newTestComponentWithAC(t, []integration.Config{})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-badcron",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries: []QuerySpec{
+			{
+				MonitorID:      33,
+				Type:           "run_query",
+				Query:          "SELECT 1",
+				Schedule:       "not-a-cron",
+				TimeoutSeconds: 10,
+				Entity:         EntityMetadata{Platform: "postgres", Database: "db", Table: "t"},
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-badcron": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateError, statuses["path/cfg-badcron"].State)
+	assert.Contains(t, statuses["path/cfg-badcron"].Error, "invalid cron schedule",
+		"error should mention the bad cron expression")
+	assert.Empty(t, changes.Schedule, "no check should be scheduled for invalid cron")
+}
+
+// TestValidateQuerySpec_ValidIntervalOnly verifies that existing behavior is preserved:
+// a query with only interval_seconds set (no schedule) flows through correctly and
+// does not inject a schedule field into the YAML.
+func TestValidateQuerySpec_ValidIntervalOnly(t *testing.T) {
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data("host: localhost\ndata_observability:\n  enabled: true\n")},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-interval-only",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries: []QuerySpec{
+			{
+				MonitorID:       99,
+				Type:            "run_query",
+				Query:           "SELECT count(*) FROM orders",
+				IntervalSeconds: 60,
+				TimeoutSeconds:  10,
+				Entity:          EntityMetadata{Platform: "postgres", Database: "shop", Table: "orders"},
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-interval-only": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-interval-only"].State)
+	require.Len(t, changes.Schedule, 1, "should schedule the DO check")
+
+	var instance map[string]any
+	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 10, doConfig["collection_interval"], "collection_interval must always be 10")
+
+	queries, ok := doConfig["queries"].([]any)
+	require.True(t, ok)
+	require.Len(t, queries, 1)
+	q := queries[0].(map[string]any)
+	assert.Equal(t, 60, q["interval_seconds"], "interval_seconds should be present")
+	_, hasSchedule := q["schedule"]
+	assert.False(t, hasSchedule, "schedule field must be absent when not set on the query")
 }

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -717,7 +717,7 @@ func TestValidateQuerySpec_ValidScheduleOnly(t *testing.T) {
 	q := queries[0].(map[string]any)
 	assert.Equal(t, "20 * * * *", q["schedule"], "schedule field should be injected into query YAML")
 	_, hasInterval := q["interval_seconds"]
-	assert.True(t, hasInterval, "interval_seconds should still be present in YAML for Python-side compatibility")
+	assert.False(t, hasInterval, "interval_seconds should be absent when not set in the RC payload")
 }
 
 // TestValidateQuerySpec_BothScheduleAndInterval verifies that when both schedule and
@@ -766,7 +766,7 @@ func TestValidateQuerySpec_BothScheduleAndInterval(t *testing.T) {
 	require.Len(t, queries, 1)
 	q := queries[0].(map[string]any)
 	assert.Equal(t, "*/15 * * * *", q["schedule"], "schedule field should be injected")
-	assert.Equal(t, 300, q["interval_seconds"], "interval_seconds should also be present; Python enforces cron precedence")
+	assert.Equal(t, 300, q["interval_seconds"], "interval_seconds should be present when set in the RC payload")
 }
 
 // TestValidateQuerySpec_NeitherSetRejected verifies that a query with neither schedule nor

--- a/comp/dataobs/queryactions/impl/types.go
+++ b/comp/dataobs/queryactions/impl/types.go
@@ -29,6 +29,7 @@ type QuerySpec struct {
 	Type                  string                 `json:"type"`
 	Query                 string                 `json:"query"`
 	IntervalSeconds       int                    `json:"interval_seconds"`
+	Schedule              string                 `json:"schedule,omitempty"`
 	TimeoutSeconds        int                    `json:"timeout_seconds"`
 	Entity                EntityMetadata         `json:"entity"`
 	CustomSQLSelectFields *CustomSQLSelectFields `json:"custom_sql_select_fields,omitempty"`

--- a/releasenotes/notes/do-queryactions-cron-schedule-261f601c3272f3ed.yaml
+++ b/releasenotes/notes/do-queryactions-cron-schedule-261f601c3272f3ed.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``comp/dataobs/queryactions`` component now supports an optional ``schedule`` field
+    on Data Observability monitor queries. The field accepts a standard 5-field cron expression
+    (e.g. ``"20 * * * *"`` for 20 minutes past every hour) and enables wall-clock-aligned
+    scheduling in place of the fixed ``interval_seconds`` cadence. When both ``schedule`` and
+    ``interval_seconds`` are set on the same query, ``schedule`` takes precedence and
+    ``interval_seconds`` is ignored. At least one of the two fields must be set; the agent
+    rejects Remote Configuration payloads containing queries where neither field is provided
+    or where the cron expression is syntactically invalid.


### PR DESCRIPTION
### What does this PR do

Adds an optional `schedule` field to Data Observability monitor queries, accepting a standard 5-field cron expression. When set, it takes precedence over `interval_seconds`. Two additional fixes are bundled: query strings are now serialised as YAML double-quoted scalars to prevent `yaml.v3` from emitting block scalars that the Python check can't re-parse, and `timeout_seconds` is converted to milliseconds (`query_timeout`) to match the postgres check's expected unit.

**Motivation**

Some Data Observability monitor queries need to run at specific times — e.g. once per hour at minute 20 — rather than on a fixed polling interval, for example to support source-to-target monitors. A cron expression gives it a precise control over when each query fires.

### Describe how you validated your changes

### Additional Notes
