### PR TITLE
[CWS] Fix subreapers childs leak

### DIFF
--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -281,17 +281,33 @@ func (p *EBPFResolver) tryReparentChildrenFromProcfs(exitedEntry *model.ProcessC
 	copy(children, exitedEntry.Children)
 
 	for _, child := range children {
-		p.tryReparentEntryFromProcfs(child, exitedEntry.Pid, callpathTag, newEntryCb)
+		if child.Pid == exitedEntry.Pid {
+			// The child shares the PID with the exited entry: it is the exec
+			// continuation (pre-exec → post-exec link). Attempting to reparent
+			// it via procfs would read its real ppid (grandparent) and break
+			// the exec chain stored in the Ancestor pointer.  Skip it; the
+			// exec-chain link must be preserved.
+			continue
+		}
+		p.tryReparentEntryFromProcfs(child, exitedEntry, callpathTag, newEntryCb)
 	}
 }
 
 // tryReparentEntryFromProcfs reads the current ppid of a single entry from
 // procfs and updates its parent link. If procfs hasn't been updated yet (race)
 // or fails, the entry stays linked to the dead parent.
+// When the child is no longer visible in procfs at all (process fully reaped),
+// it is detached from exitedEntry.Children immediately so it is not re-visited
+// on subsequent reparent attempts.
 // Must be called with the lock held.
-func (p *EBPFResolver) tryReparentEntryFromProcfs(child *model.ProcessCacheEntry, exitedPid uint32, callpathTag string, newEntryCb func(*model.ProcessCacheEntry, error)) {
+func (p *EBPFResolver) tryReparentEntryFromProcfs(child *model.ProcessCacheEntry, exitedEntry *model.ProcessCacheEntry, callpathTag string, newEntryCb func(*model.ProcessCacheEntry, error)) {
 	proc, err := process.NewProcess(int32(child.Pid))
 	if err != nil {
+		// The child process is gone from procfs entirely: it has been fully
+		// reaped and its exit event has been (or will be) delivered separately.
+		// Remove it from the dead parent's Children list eagerly so that future
+		// calls to tryReparentChildrenFromProcfs do not keep re-visiting it.
+		exitedEntry.RemoveChild(child)
 		return
 	}
 
@@ -301,7 +317,7 @@ func (p *EBPFResolver) tryReparentEntryFromProcfs(child *model.ProcessCacheEntry
 	}
 
 	newPPidU32 := uint32(newPPid)
-	if newPPidU32 == 0 || newPPidU32 == exitedPid {
+	if newPPidU32 == 0 || newPPidU32 == exitedEntry.Pid {
 		p.reparentFailedStats[callpathTag].Inc()
 		return
 	}
@@ -942,6 +958,15 @@ func (p *EBPFResolver) deleteEntry(pid uint32, exitTime time.Time) {
 	if entry.Ancestor != nil {
 		entry.Ancestor.RemoveChild(entry)
 	}
+
+	// Release the Children backing array.  By the time deleteEntry is called
+	// (either directly on an exit event or via DequeueExited after ~1 minute),
+	// the lazy walker in TryReparentFromProcfs has had multiple chances to
+	// reparent any remaining children.  Setting Children to nil frees the
+	// backing array and breaks the parent→child direction of the cycle so the
+	// GC can reclaim the entry as soon as its last child exits and drops its
+	// Ancestor pointer.
+	entry.Children = nil
 
 	entry.Exit(exitTime)
 	delete(p.entryCache, entry.Pid)

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -155,6 +155,13 @@ func assertChildrenConsistency(t *testing.T, resolver *EBPFResolver) {
 				"child %d's Ancestor should be %d", child.Pid, entry.Pid)
 		}
 		if entry.Ancestor != nil {
+			// Only verify bidirectionality when the ancestor is still alive in
+			// the cache. deleteEntry clears Children (to free the backing array)
+			// while intentionally preserving Ancestor pointers for field resolution,
+			// so the invariant only holds for live ancestors.
+			if resolver.entryCache[entry.Ancestor.Pid] != entry.Ancestor {
+				continue
+			}
 			found := false
 			for _, sibling := range entry.Ancestor.Children {
 				if sibling == entry {

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -46,6 +46,12 @@ func (pc *ProcessCacheEntry) RemoveChild(child *ProcessCacheEntry) {
 	pc.Children = slices.DeleteFunc(pc.Children, func(c *ProcessCacheEntry) bool {
 		return c == child
 	})
+	// slices.DeleteFunc reduces len but not cap; nil the slice when empty so
+	// the backing array can be reclaimed by the GC (important for long-lived
+	// processes such as subreapers that accumulate many transient children).
+	if len(pc.Children) == 0 {
+		pc.Children = nil
+	}
 }
 
 // HasValidLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1 or if a node has a missing parent


### PR DESCRIPTION
## What does this PR do?
Four related fixes to reduce sustained memory usage introduced by the subreaper reparenting logic (25b438f).

---

### Fix 1: preserve exec chain in `tryReparentChildrenFromProcfs`

When `TryReparentFromProcfs` walked the lineage of a fork-child `C` of a pre-exec entry `B`, it called `tryReparentChildrenFromProcfs(B)`. That function iterated over `B.Children`, which includes the exec continuation `exec-B` (same PID as `B`). `exec-B`'s procfs ppid is the grandparent, so `reparentTo()` moved `exec-B` to the grandparent — permanently breaking the exec chain. Meanwhile `C` and its siblings could never be reparented because their procfs ppid equals `B.Pid` (= `exitedPid`), so they remained stuck in `B.Children` indefinitely.

Fix: skip any child whose `Pid` equals `exitedEntry.Pid` in `tryReparentChildrenFromProcfs`. Exec continuations must not be reparented via this path; their `Ancestor` link is the exec chain and must remain intact.

---

### Fix 2: reclaim slice backing array in `RemoveChild`

`slices.DeleteFunc` shrinks the length of `Children` but never the capacity. For long-lived processes acting as subreapers (`ninja`, `make`) that accumulate large numbers of transient reparented children, the backing array grew to peak capacity and was never returned to the GC.

Fix: nil the slice after `DeleteFunc` when the length reaches zero, so the backing array is eligible for GC immediately.

---

### Fix 3: release `Children` in `deleteEntry`

When an entry was evicted from `entryCache` via `deleteEntry`, its `Children` slice was left intact, keeping a parent→child reference alive alongside the existing child→parent `Ancestor` pointer. By the time `deleteEntry` is called (direct eviction or `DequeueExited` after ~1 minute) the lazy walker has had multiple opportunities to reparent any remaining children. Any children still present are structurally stuck (exec fork-children whose procfs ppid == `exitedPid`, addressed by Fix 1) and will never be successfully reparented via this mechanism.

Fix: set `entry.Children = nil` in `deleteEntry` to release the backing array and break the parent→child cycle direction, allowing the GC to reclaim the entry as soon as its last child drops its `Ancestor` pointer.

---

### Fix 4: eagerly detach fully-reaped children in `tryReparentEntryFromProcfs`

When `tryReparentChildrenFromProcfs` iterates the children of an exited process, it calls `tryReparentEntryFromProcfs` for each child to read the child's current ppid from procfs and relink it to its new parent. If `process.NewProcess` failed (the child's PID no longer exists in `/proc`), the function returned early without touching the `Children` list — leaving the dead child pointer in `exitedEntry.Children` indefinitely.

In practice the child was eventually cleaned up (its own `deleteEntry` calls `parent.RemoveChild`), but in the meantime every subsequent invocation of `tryReparentChildrenFromProcfs` on that parent re-visited the dead child, hit the same `process.NewProcess` error, and bailed out. On a busy build server where parent processes exit faster than their children, this created repeated no-op iterations over stale entries.

Fix: change `tryReparentEntryFromProcfs` to accept `exitedEntry *model.ProcessCacheEntry` directly (instead of just its PID) and call `exitedEntry.RemoveChild(child)` immediately when the child is no longer visible in procfs. This keeps the `Children` list accurate and avoids re-visiting fully-reaped processes on future reparent attempts. The `assertChildrenConsistency` test helper is updated accordingly: the invariant "child appears in `ancestor.Children`" only holds for live ancestors — `deleteEntry` intentionally sets `Children = nil` to free the backing array while preserving the `Ancestor` pointer for field resolution.

## Motivation

Fix oom kills when deploying an agent version with the initial subreaper patch on build clusters.

## Describe how you validated your changes

## Additional Notes
