### PR TITLE
[Closed] GetBulk-based device scan (banco BV customer-test build)

### DIFF
--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -105,8 +105,11 @@ func (s snmpScannerImpl) runDeviceScan(
 	callInterval time.Duration,
 	maxCallCount int,
 ) error {
-	// execute the scan
-	pdus, err := gatherPDUs(ctx, snmpConnection, callInterval, maxCallCount)
+	// Execute the scan using GetBulk-based walk.
+	// This approach never sends fabricated OIDs to devices, which:
+	// - Prevents infinite loops on devices that respond incorrectly to non-existent OIDs
+	// - Prevents crashes on devices that can't handle malformed table indices
+	pdus, err := gatherPDUsWithBulk(ctx, snmpConnection, callInterval, maxCallCount)
 	if err != nil {
 		return err
 	}
@@ -132,8 +135,13 @@ func (s snmpScannerImpl) runDeviceScan(
 	return nil
 }
 
-// gatherPDUs returns PDUs from the given SNMP device that should cover ever
+// gatherPDUs returns PDUs from the given SNMP device that should cover every
 // scalar value and at least one row of every table.
+//
+// Deprecated: This function uses SkipOIDRowsNaive which fabricates OIDs that may
+// not exist on the device. This can cause infinite loops on devices that respond
+// incorrectly to non-existent OIDs, or crashes on devices that can't handle
+// malformed table indices. Use gatherPDUsWithBulk instead.
 func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Duration, maxCallCount int) ([]*gosnmp.SnmpPDU, error) {
 	var pdus []*gosnmp.SnmpPDU
 	err := gosnmplib.ConditionalWalk(
@@ -151,4 +159,93 @@ func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Dura
 		return nil, err
 	}
 	return pdus, nil
+}
+
+const defaultBulkBatchSize = 50
+
+// gatherPDUsWithBulk returns PDUs from the given SNMP device using GetBulk operations.
+// It walks the entire MIB tree but filters results to keep only one row per column.
+//
+// Key safety properties:
+//   - Never sends fabricated OIDs to the device - only OIDs the device has returned
+//   - Cannot cause infinite loops - tracks visited OIDs
+//   - Cannot crash devices - never sends malformed table indices
+//
+// Trade-off: May be slower than gatherPDUs for devices with large tables (1000+ rows)
+// because it retrieves all rows before filtering.
+func gatherPDUsWithBulk(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Duration, maxCallCount int) ([]*gosnmp.SnmpPDU, error) {
+	var result []*gosnmp.SnmpPDU
+	seenColumns := make(map[string]bool)
+	visitedOIDs := make(map[string]bool)
+
+	// Start from the beginning of the MIB tree
+	oid := ".0.0"
+	requests := 0
+	batchSize := uint32(defaultBulkBatchSize)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+
+		if callInterval > 0 {
+			time.Sleep(callInterval)
+		}
+
+		requests++
+		if maxCallCount > 0 && requests >= maxCallCount {
+			return result, fmt.Errorf("exceeded maximum request limit (%d)", maxCallCount)
+		}
+
+		// Use GetBulk with REAL OIDs only (never fabricated)
+		response, err := snmp.GetBulk([]string{oid}, 0, batchSize)
+		if err != nil {
+			return result, fmt.Errorf("GetBulk error at OID %s: %w", oid, err)
+		}
+
+		if len(response.Variables) == 0 {
+			// No more data
+			break
+		}
+
+		var lastOID string
+
+		for _, pdu := range response.Variables {
+			// End conditions
+			if pdu.Type == gosnmp.EndOfMibView ||
+				pdu.Type == gosnmp.NoSuchObject ||
+				pdu.Type == gosnmp.NoSuchInstance {
+				return result, nil
+			}
+
+			// Cycle detection - if we've seen this OID before, we're in a loop
+			if visitedOIDs[pdu.Name] {
+				return result, fmt.Errorf("cycle detected: OID %s already visited", pdu.Name)
+			}
+			visitedOIDs[pdu.Name] = true
+
+			lastOID = pdu.Name
+
+			// Column filtering - keep first row of each "column"
+			columnSig := gosnmplib.ExtractColumnSignature(pdu.Name)
+			if !seenColumns[columnSig] {
+				seenColumns[columnSig] = true
+				pduCopy := pdu // Copy to avoid aliasing issues
+				result = append(result, &pduCopy)
+			}
+		}
+
+		// Stuck detection - if we didn't advance, something is wrong
+		if lastOID == "" || lastOID == oid {
+			return result, fmt.Errorf("walk stuck at OID %s", oid)
+		}
+
+		// Use the last OID from the batch as the starting point for the next request.
+		// This OID came directly from the device, so it's always safe to use.
+		oid = lastOID
+	}
+
+	return result, nil
 }

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
@@ -97,6 +98,10 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 	return nil
 }
 
+// comparisonModeEnabled enables running both scan methods for comparison testing.
+// Set to true for testing, false for production.
+const comparisonModeEnabled = true
+
 func (s snmpScannerImpl) runDeviceScan(
 	ctx context.Context,
 	snmpConnection *gosnmp.GoSNMP,
@@ -105,6 +110,10 @@ func (s snmpScannerImpl) runDeviceScan(
 	callInterval time.Duration,
 	maxCallCount int,
 ) error {
+	if comparisonModeEnabled {
+		return s.runDeviceScanComparison(ctx, snmpConnection, callInterval, maxCallCount)
+	}
+
 	// Execute the scan using GetBulk-based walk.
 	// This approach never sends fabricated OIDs to devices, which:
 	// - Prevents infinite loops on devices that respond incorrectly to non-existent OIDs
@@ -132,6 +141,99 @@ func (s snmpScannerImpl) runDeviceScan(
 		}
 	}
 
+	return nil
+}
+
+// scanResult holds the results of a scan method for comparison
+type scanResult struct {
+	name     string
+	duration time.Duration
+	oidCount int
+	err      error
+}
+
+// runDeviceScanComparison runs both scan methods and prints comparison results.
+// This is for testing purposes only - it does not send data to the backend.
+func (s snmpScannerImpl) runDeviceScanComparison(
+	ctx context.Context,
+	snmpConnection *gosnmp.GoSNMP,
+	callInterval time.Duration,
+	maxCallCount int,
+) error {
+	fmt.Println("\n" + strings.Repeat("=", 60))
+	fmt.Println("SCAN COMPARISON MODE (testing only - no data sent)")
+	fmt.Println(strings.Repeat("=", 60))
+
+	var results []scanResult
+
+	// Run GetBulk-based scan FIRST (safer - won't crash devices)
+	fmt.Println("\n[1/2] Running GetBulk-based scan (new, safe approach)...")
+	bulkStart := time.Now()
+	bulkPDUs, bulkErr := gatherPDUsWithBulk(ctx, snmpConnection, callInterval, maxCallCount)
+	bulkDuration := time.Since(bulkStart)
+
+	bulkResult := scanResult{
+		name:     "GetBulk (new)",
+		duration: bulkDuration,
+		oidCount: len(bulkPDUs),
+		err:      bulkErr,
+	}
+	results = append(results, bulkResult)
+
+	if bulkErr != nil {
+		fmt.Printf("      ERROR: %v\n", bulkErr)
+	} else {
+		fmt.Printf("      Completed: %d OIDs in %v\n", len(bulkPDUs), bulkDuration)
+	}
+
+	// Run old SkipOIDRowsNaive-based scan SECOND (may crash device or loop)
+	fmt.Println("\n[2/2] Running SkipOIDRowsNaive-based scan (old approach)...")
+	fmt.Println("      WARNING: This may crash the device or cause infinite loops!")
+	oldStart := time.Now()
+	oldPDUs, oldErr := gatherPDUs(ctx, snmpConnection, callInterval, maxCallCount)
+	oldDuration := time.Since(oldStart)
+
+	oldResult := scanResult{
+		name:     "SkipOIDRowsNaive (old)",
+		duration: oldDuration,
+		oidCount: len(oldPDUs),
+		err:      oldErr,
+	}
+	results = append(results, oldResult)
+
+	if oldErr != nil {
+		fmt.Printf("      ERROR: %v\n", oldErr)
+	} else {
+		fmt.Printf("      Completed: %d OIDs in %v\n", len(oldPDUs), oldDuration)
+	}
+
+	// Print comparison summary
+	fmt.Println("\n" + strings.Repeat("-", 60))
+	fmt.Println("COMPARISON SUMMARY")
+	fmt.Println(strings.Repeat("-", 60))
+	fmt.Printf("%-25s | %-10s | %-15s | %s\n", "Method", "OIDs", "Duration", "Status")
+	fmt.Println(strings.Repeat("-", 60))
+
+	for _, r := range results {
+		status := "OK"
+		if r.err != nil {
+			status = "FAILED"
+		}
+		fmt.Printf("%-25s | %-10d | %-15v | %s\n", r.name, r.oidCount, r.duration.Round(time.Millisecond), status)
+	}
+	fmt.Println(strings.Repeat("-", 60))
+
+	// Print detailed error info if any scan failed
+	for _, r := range results {
+		if r.err != nil {
+			fmt.Printf("\n%s error details:\n  %v\n", r.name, r.err)
+		}
+	}
+
+	fmt.Println("\nNote: No scan data was sent to the backend (comparison mode).")
+	fmt.Println(strings.Repeat("=", 60) + "\n")
+
+	// Return nil even if scans failed - we want to see the comparison output
 	return nil
 }
 

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -100,7 +100,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 
 // comparisonModeEnabled enables running both scan methods for comparison testing.
 // Set to true for testing, false for production.
-const comparisonModeEnabled = true
+const comparisonModeEnabled = false
 
 func (s snmpScannerImpl) runDeviceScan(
 	ctx context.Context,

--- a/comp/snmpscan/impl/devicescan_test.go
+++ b/comp/snmpscan/impl/devicescan_test.go
@@ -1,0 +1,197 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+package snmpscanimpl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractColumnSignatureIntegration(t *testing.T) {
+	// Test that ExtractColumnSignature works correctly for filtering purposes
+	// This ensures the column.go and devicescan.go integration is correct
+
+	testCases := []struct {
+		name         string
+		oids         []string
+		expectedSigs int // Expected number of unique signatures
+	}{
+		{
+			name: "scalar OIDs each get unique signature",
+			oids: []string{
+				"1.3.6.1.2.1.1.1.0",
+				"1.3.6.1.2.1.1.2.0",
+				"1.3.6.1.2.1.1.3.0",
+			},
+			expectedSigs: 3,
+		},
+		{
+			name: "same column different rows (no 1 in index) get same signature",
+			oids: []string{
+				"1.3.6.1.2.1.2.2.1.2.2",
+				"1.3.6.1.2.1.2.2.1.2.100",
+				"1.3.6.1.2.1.2.2.1.2.200",
+			},
+			expectedSigs: 1,
+		},
+		{
+			name: "different columns get different signatures",
+			oids: []string{
+				"1.3.6.1.2.1.2.2.1.2.2", // ifDescr
+				"1.3.6.1.2.1.2.2.1.3.2", // ifType
+				"1.3.6.1.2.1.2.2.1.4.2", // ifMtu
+				"1.3.6.1.2.1.2.2.1.5.2", // ifSpeed
+			},
+			expectedSigs: 4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sigs := make(map[string]bool)
+			for _, oid := range tc.oids {
+				sig := gosnmplib.ExtractColumnSignature(oid)
+				sigs[sig] = true
+			}
+			assert.Equal(t, tc.expectedSigs, len(sigs), "Expected %d unique signatures, got %d", tc.expectedSigs, len(sigs))
+		})
+	}
+}
+
+func TestGatherPDUsWithBulk_ContextCancellation(t *testing.T) {
+	// Test that the function respects context cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	snmp := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      161,
+		Community: "public",
+		Version:   gosnmp.Version2c,
+	}
+
+	_, err := gatherPDUsWithBulk(ctx, snmp, 0, 0)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestGatherPDUsWithBulk_MaxCallCount(t *testing.T) {
+	// Test that max call count is enforced
+	// This is a unit test that doesn't require actual SNMP connection
+	// since it will hit the limit before making any real calls
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	snmp := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      161,
+		Community: "public",
+		Version:   gosnmp.Version2c,
+		Timeout:   10 * time.Millisecond,
+	}
+
+	// With maxCallCount=1, it should try one GetBulk, fail to connect,
+	// and return an error (either connection error or max count error)
+	_, err := gatherPDUsWithBulk(ctx, snmp, 0, 1)
+	assert.Error(t, err)
+}
+
+func TestColumnFilteringLogic(t *testing.T) {
+	// Test the column filtering logic in isolation
+	// Simulates what gatherPDUsWithBulk does internally
+
+	pdus := []gosnmp.SnmpPDU{
+		// Scalar OIDs
+		{Name: "1.3.6.1.2.1.1.1.0", Type: gosnmp.OctetString, Value: "System Description"},
+		{Name: "1.3.6.1.2.1.1.2.0", Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.9"},
+
+		// ifTable rows - should keep only first row of each column
+		{Name: "1.3.6.1.2.1.2.2.1.2.2", Type: gosnmp.OctetString, Value: "eth0"},
+		{Name: "1.3.6.1.2.1.2.2.1.2.3", Type: gosnmp.OctetString, Value: "eth1"}, // Same column, should filter
+		{Name: "1.3.6.1.2.1.2.2.1.3.2", Type: gosnmp.Integer, Value: 6},
+		{Name: "1.3.6.1.2.1.2.2.1.3.3", Type: gosnmp.Integer, Value: 6}, // Same column, should filter
+	}
+
+	// Simulate the filtering logic from gatherPDUsWithBulk
+	seenColumns := make(map[string]bool)
+	var result []*gosnmp.SnmpPDU
+
+	for _, pdu := range pdus {
+		columnSig := gosnmplib.ExtractColumnSignature(pdu.Name)
+		if !seenColumns[columnSig] {
+			seenColumns[columnSig] = true
+			pduCopy := pdu
+			result = append(result, &pduCopy)
+		}
+	}
+
+	// Should have:
+	// 2 scalar OIDs (each unique)
+	// 1 row from ifDescr column
+	// 1 row from ifType column
+	// Total: 4
+	assert.Equal(t, 4, len(result))
+
+	// Verify the kept PDUs
+	keptOIDs := make(map[string]bool)
+	for _, pdu := range result {
+		keptOIDs[pdu.Name] = true
+	}
+
+	assert.True(t, keptOIDs["1.3.6.1.2.1.1.1.0"], "Scalar OID should be kept")
+	assert.True(t, keptOIDs["1.3.6.1.2.1.1.2.0"], "Scalar OID should be kept")
+	assert.True(t, keptOIDs["1.3.6.1.2.1.2.2.1.2.2"], "First ifDescr row should be kept")
+	assert.True(t, keptOIDs["1.3.6.1.2.1.2.2.1.3.2"], "First ifType row should be kept")
+	assert.False(t, keptOIDs["1.3.6.1.2.1.2.2.1.2.3"], "Second ifDescr row should be filtered")
+	assert.False(t, keptOIDs["1.3.6.1.2.1.2.2.1.3.3"], "Second ifType row should be filtered")
+}
+
+func TestCycleDetectionLogic(t *testing.T) {
+	// Test that cycle detection works correctly
+	visitedOIDs := make(map[string]bool)
+
+	oids := []string{
+		"1.3.6.1.2.1.1.1.0",
+		"1.3.6.1.2.1.1.2.0",
+		"1.3.6.1.2.1.1.1.0", // Repeat - cycle!
+	}
+
+	var cycleDetected bool
+	for _, oid := range oids {
+		if visitedOIDs[oid] {
+			cycleDetected = true
+			break
+		}
+		visitedOIDs[oid] = true
+	}
+
+	assert.True(t, cycleDetected, "Should detect cycle when OID is repeated")
+}
+
+func TestEndOfMibDetection(t *testing.T) {
+	// Test that end-of-MIB conditions are handled correctly
+	endConditions := []gosnmp.Asn1BER{
+		gosnmp.EndOfMibView,
+		gosnmp.NoSuchObject,
+		gosnmp.NoSuchInstance,
+	}
+
+	for _, condition := range endConditions {
+		t.Run(condition.String(), func(t *testing.T) {
+			isEnd := condition == gosnmp.EndOfMibView ||
+				condition == gosnmp.NoSuchObject ||
+				condition == gosnmp.NoSuchInstance
+			assert.True(t, isEnd, "Should recognize %s as end condition", condition)
+		})
+	}
+}

--- a/pkg/snmp/gosnmplib/column.go
+++ b/pkg/snmp/gosnmplib/column.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib
+
+import (
+	"strings"
+)
+
+// ExtractColumnSignature returns a string identifying the "column" of a table OID.
+// This is used for filtering duplicate rows when walking SNMP tables, NOT for
+// constructing new OIDs to send to devices.
+//
+// The algorithm uses the same heuristic as SkipOIDRowsNaive (finding the last ".1."
+// which typically marks the table entry), but the result is only used as a local
+// grouping key. Even if the heuristic misidentifies the column boundary, the worst
+// case is that we keep extra rows - we never send fabricated OIDs to devices.
+//
+// For scalar OIDs (ending in .0), the entire OID is returned as its own "column".
+func ExtractColumnSignature(oid string) string {
+	oid = strings.TrimLeft(oid, ".")
+
+	// Scalar OIDs (ending in .0) are their own column
+	if strings.HasSuffix(oid, ".0") {
+		return oid
+	}
+
+	// Find the last ".1." which typically marks the table entry
+	// This is the same heuristic as SkipOIDRowsNaive
+	idx := strings.LastIndex(oid, ".1.")
+	if idx == -1 {
+		// Not a table OID (no .1. found), treat entire OID as column
+		return oid
+	}
+
+	// Extract table OID (everything before .1.)
+	tableOID := oid[:idx]
+
+	// Extract the part after .1. (column number + row index)
+	rest := oid[idx+3:] // +3 to skip ".1."
+
+	// Get just the column number (first segment after .1.)
+	parts := strings.SplitN(rest, ".", 2)
+	if len(parts) == 0 {
+		return oid
+	}
+
+	// Column signature = tableOID.1.columnNumber
+	return tableOID + ".1." + parts[0]
+}

--- a/pkg/snmp/gosnmplib/column_test.go
+++ b/pkg/snmp/gosnmplib/column_test.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gosnmplib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractColumnSignature(t *testing.T) {
+	// The key property we need is CONSISTENCY: all rows from the same column
+	// should get the same signature. The exact signature value doesn't matter
+	// for filtering purposes - what matters is that grouping works correctly.
+
+	tests := []struct {
+		name     string
+		oid      string
+		expected string
+	}{
+		// Scalar OIDs (ending in .0) should return the full OID
+		{
+			name:     "scalar sysDescr",
+			oid:      "1.3.6.1.2.1.1.1.0",
+			expected: "1.3.6.1.2.1.1.1.0",
+		},
+		{
+			name:     "scalar with leading dot",
+			oid:      ".1.3.6.1.2.1.1.1.0",
+			expected: "1.3.6.1.2.1.1.1.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ExtractColumnSignature(tc.oid)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractColumnSignature_SameColumnGrouping(t *testing.T) {
+	// Test that rows from the same column get grouped together when possible.
+	// Note: The LastIndex(".1.") heuristic has limitations for simple tables where
+	// row indices contain "1" as a component. This is acceptable because:
+	// 1. We never send fabricated OIDs to devices (safety maintained)
+	// 2. Worst case is we keep extra rows (safe, just less efficient)
+
+	testCases := []struct {
+		name string
+		oids []string // All OIDs in this list should produce the same signature
+	}{
+		{
+			// For simple tables, rows that don't have "1" in the index will group correctly
+			name: "ifTable column 2 - rows without 1 in index",
+			oids: []string{
+				"1.3.6.1.2.1.2.2.1.2.2",
+				"1.3.6.1.2.1.2.2.1.2.100",
+				"1.3.6.1.2.1.2.2.1.2.200",
+			},
+		},
+		{
+			name: "ifTable column 3 - rows without 1 in index",
+			oids: []string{
+				"1.3.6.1.2.1.2.2.1.3.2",
+				"1.3.6.1.2.1.2.2.1.3.100",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.oids) < 2 {
+				t.Skip("Need at least 2 OIDs to test grouping")
+			}
+
+			firstSig := ExtractColumnSignature(tc.oids[0])
+			for _, oid := range tc.oids[1:] {
+				sig := ExtractColumnSignature(oid)
+				assert.Equal(t, firstSig, sig, "All rows from same column should have same signature. OID: %s", oid)
+			}
+		})
+	}
+}
+
+func TestExtractColumnSignature_DifferentColumnsAreDifferent(t *testing.T) {
+	// Different columns should produce different signatures
+
+	testCases := []struct {
+		name string
+		oid1 string
+		oid2 string
+	}{
+		{
+			name: "ifIndex vs ifDescr",
+			oid1: "1.3.6.1.2.1.2.2.1.1.1",
+			oid2: "1.3.6.1.2.1.2.2.1.2.1",
+		},
+		{
+			name: "ifDescr vs ifType",
+			oid1: "1.3.6.1.2.1.2.2.1.2.1",
+			oid2: "1.3.6.1.2.1.2.2.1.3.1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sig1 := ExtractColumnSignature(tc.oid1)
+			sig2 := ExtractColumnSignature(tc.oid2)
+			assert.NotEqual(t, sig1, sig2, "Different columns should have different signatures")
+		})
+	}
+}
+
+func TestExtractColumnSignature_ComplexIndexTables(t *testing.T) {
+	// For complex index tables, the heuristic groups based on the last ".1." pattern.
+	// This provides reasonable grouping for many complex tables, though not perfect.
+	// The key property is CONSISTENCY within the same grouping pattern.
+
+	t.Run("inetCidrRouteTable rows with same prefix pattern", func(t *testing.T) {
+		// These two OIDs have the same structure up to and after the last ".1."
+		// They differ only after the last ".1.X" pattern (in the 172.21.X.X part)
+		oid1 := "1.3.6.1.2.1.4.24.7.1.1.1.4.0.0.0.0.0.2.0.0.1.4.172.21.200.192"
+		oid2 := "1.3.6.1.2.1.4.24.7.1.1.1.4.0.0.0.0.0.2.0.0.1.4.172.21.211.204"
+
+		sig1 := ExtractColumnSignature(oid1)
+		sig2 := ExtractColumnSignature(oid2)
+		// Both should find last ".1." at "...0.0.1.4..." and produce same signature
+		assert.Equal(t, sig1, sig2, "Rows with same prefix pattern should have same signature")
+	})
+
+	t.Run("ipNetToPhysicalTable consistency check", func(t *testing.T) {
+		// For ipNetToPhysicalTable, the last ".1." may be in the IP portion
+		// which can cause different grouping. We verify consistency within
+		// rows that have the same ".1." position.
+		oid1 := "1.3.6.1.2.1.4.35.1.4.1000007.1.4.192.168.2.50"
+		oid2 := "1.3.6.1.2.1.4.35.1.4.1000007.1.4.192.168.2.60"
+
+		sig1 := ExtractColumnSignature(oid1)
+		sig2 := ExtractColumnSignature(oid2)
+		// Both have last ".1." at "1000007.1.4" so should match
+		assert.Equal(t, sig1, sig2, "Rows with same last .1. position should have same signature")
+	})
+}
+
+func TestExtractColumnSignature_NoTableMarker(t *testing.T) {
+	// OIDs without .1. pattern should return the full OID
+	// (treated as their own unique "column")
+
+	oid := "1.3.6.4.2.9.9.42.2.2.3.4" // No .1. pattern
+	result := ExtractColumnSignature(oid)
+	// The function finds the last .1. if any, otherwise returns the OID
+	// In this case there IS a .1. at "42.2.2" - wait no, there's no .1. here
+	// Let me check: 1.3.6.4.2.9.9.42.2.2.3.4
+	// There's no ".1." substring in this OID
+	assert.Equal(t, oid, result)
+}


### PR DESCRIPTION
## Summary

Draft PR carrying the changes from #49734 onto current `main`, with `comparisonModeEnabled` flipped to `false` so the new GetBulk path is the only codepath that runs. Built for a custom Agent that **banco BV** can test in their DEV environment against [AGENT-16184](https://datadoghq.atlassian.net/browse/AGENT-16184).

This is not a release candidate. It is the smallest delta needed to put the new scan path in a customer's hands without reintroducing the SkipOIDRowsNaive loop on every scan.

## Customer context

- **Org**: banco BV (Org ID `1300467666`, DEV org `BV-DUQ` / `1300474199`)
- **Current state**: device scan loops indefinitely, customer disabled scan, NDM rollout blocked
- **Root cause** (per [AGENT-16184](https://datadoghq.atlassian.net/browse/AGENT-16184) and [AGENT-14643](https://datadoghq.atlassian.net/browse/AGENT-14643)): Cisco devices respond to `GetNext` for the fabricated `1.3.6.1.4.1.9.9.392.1.3.21.1.1.10` with a lexicographically-lower OID `1.3.6.1.4.1.9.9.392.1.3.21.1.1.9.x` → `ConditionalWalk`'s monotonicity check trips → 0 OIDs collected
- **Test agent**: `srv-ddogduq01` in BV-DUQ

## What this changes

| Commit | Source | Purpose |
|---|---|---|
| `d6f25665` | #49734 | Add `ExtractColumnSignature` for in-memory column dedup |
| `aea21e3f` | #49734 | Add `gatherPDUsWithBulk` — GetBulk walk that never fabricates OIDs |
| `947e784f` | #49734 | Add comparison-mode scaffolding |
| `02464299` | new | **Set `comparisonModeEnabled = false`** so `runDeviceScan` goes straight through `gatherPDUsWithBulk` and the normal `sendPayload` path |

The comparison-mode code is preserved (not deleted) so future on-demand testing against a known-bad device can re-enable it with a one-line change.

## Why the flag flip matters for this customer

With `comparisonModeEnabled = true`, `runDeviceScanComparison`:
1. Runs the new GetBulk scan first (would succeed)
2. **Then runs the old SkipOIDRowsNaive scan against the same device** — i.e., the exact codepath that hangs banco's devices
3. Returns `nil` regardless of errors and **does not call `sendPayload`** — the customer would see a "scan completed" status with zero device-OID payloads, indistinguishable from their current broken state

Flipping to `false` makes the customer's test signal meaningful.

## Known caveats for the customer test

- **Memory**: `visitedOIDs` and `seenColumns` maps grow with the scanned OID count and have no upper bound. The customer's largest device walk in the ticket is ~10MB (~100k OIDs estimated). Should be fine but worth watching during the test.
- **SNMP v1**: `GetBulk` fails on v1 with `"GETBULK not supported in SNMPv1"`. The customer's affected devices are Cisco (`1.3.6.1.4.1.9` enterprise space) — v2c expected — so this should not bite. If they have any v1 devices in scope, those scans will hard-fail.
- **Scan-time inflation**: new path retrieves all rows per table and filters locally (3.15× more OIDs on large devices per [RFC](https://datadoghq.atlassian.net/wiki/spaces/II/pages/6202556953/Improvements+to+SNMP+Device+Scan)). Storage rows unchanged because the writer collapses to base OIDs.
- This is not the production fix — see [the RFC](https://datadoghq.atlassian.net/wiki/spaces/II/pages/6202556953/Improvements+to+SNMP+Device+Scan) for the issues that still need to be addressed before the new path can become the default (`MaxRepetitions`, `response.Error`, monotonicity check regression, map bounds, cancellable sleep, end-to-end tests).

## Test plan

- [ ] Build a custom Agent from this branch (or backport the four commits onto the customer's 7.77.x release branch)
- [ ] Customer runs the scan against `srv-ddogduq01` DEV in BV-DUQ
- [ ] Confirm scans complete and produce non-zero device OIDs in the backend
- [ ] Compare scan duration against the simulator baselines in the RFC

## Related

- Original PR: #49734
- RFC: [Improvements to SNMP Device Scan](https://datadoghq.atlassian.net/wiki/spaces/II/pages/6202556953/Improvements+to+SNMP+Device+Scan)
- Tickets: [AGENT-16184](https://datadoghq.atlassian.net/browse/AGENT-16184), [AGENT-14643](https://datadoghq.atlassian.net/browse/AGENT-14643)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGENT-16184]: https://datadoghq.atlassian.net/browse/AGENT-16184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENT-16184]: https://datadoghq.atlassian.net/browse/AGENT-16184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENT-14643]: https://datadoghq.atlassian.net/browse/AGENT-14643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENT-16184]: https://datadoghq.atlassian.net/browse/AGENT-16184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ