### PR TITLE
Put global bazel ownership to the end of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -929,11 +929,6 @@
 /internal/third_party/kubernetes        @DataDog/container-integrations
 /internal/third_party/golang/           @DataDog/container-integrations
 
-# Temporary during Bazel migration
-# This needs to go after all other rules that may include BUILD.bazel files, it otherwise gets overridden
-/**/BUILD.bazel                         @DataDog/agent-build
-/**/*.bzl                               @DataDog/agent-build
-
 # With the introduction of go.work, dependencies bump modify go.mod and go.sum in a lot of file.
 # Which bring a lot of team in the review each time. To make it smoother we no longer consider go.mod and go.sum owned by teams.
 # Each team can individually decide to update CODEOWNERS to be requested for a review on each modification of their go.mod/sum
@@ -950,3 +945,8 @@
 
 # AI-related files
 /.claude/skills/explain-lading-config @DataDog/single-machine-performance
+
+# Temporary during Bazel migration
+# This needs to go after all other rules that may include BUILD.bazel files, it otherwise gets overridden
+/**/BUILD.bazel                         @DataDog/agent-build
+/**/*.bzl                               @DataDog/agent-build


### PR DESCRIPTION
### What does this PR do?

Moves the global bazel codeownership rules to the end of the files to make them override rules that target subtrees.

### Motivation

Discovered BUILD files under `/comp/anomalydetection/` not being assignd to agent-build.

### Describe how you validated your changes

### Additional Notes
