### PR TITLE
Remove h2c package from pkg/network

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3203,7 +3203,6 @@ core,golang.org/x/net/html/charset,BSD-3-Clause,Copyright (c) 2009 The Go Author
 core,golang.org/x/net/http/httpguts,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/net/http/httpproxy,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/net/http2,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
-core,golang.org/x/net/http2/h2c,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/net/http2/hpack,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/net/icmp,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
 core,golang.org/x/net/idna,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved

--- a/pkg/network/protocols/http2/testutils.go
+++ b/pkg/network/protocols/http2/testutils.go
@@ -40,6 +40,9 @@ func StartH2CServer(t *testing.T, address string, isTLS bool) func() {
 	}
 	srv.Protocols.SetHTTP1(true)
 	srv.Protocols.SetUnencryptedHTTP2(true)
+	if isTLS {
+		srv.Protocols.SetHTTP2(true)
+	}
 
 	require.NoError(t, http2.ConfigureServer(srv, nil), "could not configure server")
 

--- a/pkg/network/protocols/http2/testutils.go
+++ b/pkg/network/protocols/http2/testutils.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 )
@@ -26,7 +25,7 @@ import (
 func StartH2CServer(t *testing.T, address string, isTLS bool) func() {
 	srv := &http.Server{
 		Addr: address,
-		Handler: h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			statusCode := testutil.StatusFromPath(r.URL.Path)
 			if statusCode == 0 {
 				w.WriteHeader(http.StatusOK)
@@ -35,9 +34,12 @@ func StartH2CServer(t *testing.T, address string, isTLS bool) func() {
 			}
 			defer func() { _ = r.Body.Close() }()
 			_, _ = io.Copy(w, r.Body)
-		}), &http2.Server{}),
+		}),
 		IdleTimeout: 2 * time.Second,
+		Protocols:   new(http.Protocols),
 	}
+	srv.Protocols.SetHTTP1(true)
+	srv.Protocols.SetUnencryptedHTTP2(true)
 
 	require.NoError(t, http2.ConfigureServer(srv, nil), "could not configure server")
 

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy.go
@@ -187,7 +187,7 @@ func (p *UnixTransparentProxyServer) handleConnection(unixSocketConn net.Conn) {
 	var err error
 	if p.useTLS {
 		timedContext, cancel := context.WithTimeout(context.Background(), defaultDialTimeout)
-		dialer := &tls.Dialer{Config: &tls.Config{InsecureSkipVerify: true}}
+		dialer := &tls.Dialer{Config: &tls.Config{InsecureSkipVerify: true, NextProtos: []string{"h2", "http/1.1"}}}
 		remoteConn, err = dialer.DialContext(timedContext, network, p.remoteAddr)
 		cancel()
 	} else {

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -1949,7 +1949,7 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 		Handler: nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
 			w.WriteHeader(200)
 			w.Write([]byte("test"))
-		},
+		}),
 		Protocols: new(http.Protocols),
 	}
 	http2Server.Protocols.SetHTTP1(true)

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -37,7 +37,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"golang.org/x/net/http2/hpack"
 	"golang.org/x/sys/unix"
 
@@ -1947,11 +1946,14 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 	http2TargetAddress := net.JoinHostPort(targetHost, http2Port)
 	http2Server := &nethttp.Server{
 		Addr: ":" + http2Port,
-		Handler: h2c.NewHandler(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		Handler: nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
 			w.WriteHeader(200)
 			w.Write([]byte("test"))
-		}), &http2.Server{}),
+		},
+		Protocols: new(http.Protocols),
 	}
+	http2Server.Protocols.SetHTTP1(true)
+	http2Server.Protocols.SetUnencryptedHTTP2(true)
 
 	go func() {
 		if err := http2Server.ListenAndServe(); err != nethttp.ErrServerClosed {

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -1950,7 +1950,7 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 			w.WriteHeader(200)
 			w.Write([]byte("test"))
 		}),
-		Protocols: new(http.Protocols),
+		Protocols: new(nethttp.Protocols),
 	}
 	http2Server.Protocols.SetHTTP1(true)
 	http2Server.Protocols.SetUnencryptedHTTP2(true)


### PR DESCRIPTION
### What does this PR do?
Stop using the deprecated h2c package in pkg/network.
Replace as advised on https://pkg.go.dev/golang.org/x/net/http2/h2c.

### Motivation
Follow-up of https://github.com/DataDog/datadog-agent/pull/50579 but for pkg/network which I previously missed.

### Describe how you validated your changes
CI
Only tests are affected.

### Additional Notes
See https://github.com/golang/go/issues/72039 for details.