### PR TITLE
bazel/sqlite3: share the libsqlite3 build with mattn/go-sqlite3

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,7 @@ common:adms --config=dd-internal
 startup --max_idle_secs=28800 # Keep the server alive for at most 8 hours of inactivity
 
 # Common options -------------------------------------------------------------------------------------------------------
+common --@rules_go//go/config:tags=libsqlite3 # Link mattn/go-sqlite3 against //deps:sqlite3 instead of compiling its bundled amalgamation
 common --@rules_python//python/config_settings:bootstrap_impl=script # https://github.com/bazel-contrib/rules_python/blob/main/BZLMOD_SUPPORT.md
 common --check_direct_dependencies=error # Escalate any bypassed `bazel_dep` to a resolution failure
 common --credential_helper_cache_duration=55m # Refresh a little earlier than the Vault OIDC token TTL (1h)

--- a/bazel/rules/go_sqlite3/BUILD.bazel
+++ b/bazel/rules/go_sqlite3/BUILD.bazel
@@ -1,0 +1,9 @@
+# Indirection so go_sqlite3_library can reference libsqlite3_dynamic via a
+# main-module label. @sqlite3 isn't visible from inside the bzlmod context of
+# the gazelle-generated github.com/mattn/go-sqlite3 repo; @@//... always
+# resolves and insulates the macro from canonical-name churn.
+alias(
+    name = "libsqlite3_dynamic",
+    actual = "@sqlite3//:libsqlite3_dynamic",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/rules/go_sqlite3/go_sqlite3_library.bzl
+++ b/bazel/rules/go_sqlite3/go_sqlite3_library.bzl
@@ -3,7 +3,9 @@
 load("@rules_go//go:def.bzl", _go_library = "go_library")
 
 def go_sqlite3_library(**kwargs):
-    """Wraps go_library so the Gazelle-generated rule for mattn/go-sqlite3
+    """Links mattn/go-sqlite3 against the shared libsqlite3 from //deps:sqlite3.
+
+    Wraps go_library so the Gazelle-generated rule for mattn/go-sqlite3
     enables cgo and pulls in @sqlite3//:libsqlite3_dynamic as a cdep.
 
     Wired in via gazelle:map_kind on github.com/mattn/go-sqlite3 (see
@@ -20,11 +22,21 @@ def go_sqlite3_library(**kwargs):
 
     Args:
       **kwargs: forwarded to go_library. cdeps is extended (not replaced) so
-        Gazelle-emitted entries are preserved.
+        Gazelle-emitted entries are preserved. clinkopts is dropped: Gazelle
+        lifts mattn's `#cgo {darwin,linux,windows,...} LDFLAGS: -lsqlite3`
+        into this attribute, and the per-OS variants (notably
+        `-L/usr/local/opt/sqlite/lib` on darwin_amd64 and
+        `-L/opt/homebrew/opt/sqlite/lib` on darwin_arm64) get the linker to
+        resolve `-lsqlite3` against the macOS SDK sysroot's `libsqlite3.tbd`
+        (Apple's system libsqlite3, built with SQLITE_OMIT_LOAD_EXTENSION).
+        The cdep's cc_import → cc_shared_library chain provides the right
+        `-L`/`-l` linker arguments for our libsqlite3 on every platform, so
+        the Gazelle-lifted entries are redundant at best and broken at worst.
     """
     kwargs["cgo"] = True
     cdeps = kwargs.pop("cdeps", [])
     label = "@@//bazel/rules/go_sqlite3:libsqlite3_dynamic"
     if label not in cdeps:
         cdeps = cdeps + [label]
+    kwargs.pop("clinkopts", None)
     _go_library(cdeps = cdeps, **kwargs)

--- a/bazel/rules/go_sqlite3/go_sqlite3_library.bzl
+++ b/bazel/rules/go_sqlite3/go_sqlite3_library.bzl
@@ -1,0 +1,30 @@
+"""go_library wrapper that links github.com/mattn/go-sqlite3 against //deps:sqlite3."""
+
+load("@rules_go//go:def.bzl", _go_library = "go_library")
+
+def go_sqlite3_library(**kwargs):
+    """Wraps go_library so the Gazelle-generated rule for mattn/go-sqlite3
+    enables cgo and pulls in @sqlite3//:libsqlite3_dynamic as a cdep.
+
+    Wired in via gazelle:map_kind on github.com/mattn/go-sqlite3 (see
+    deps/go.MODULE.bazel). The libsqlite3 Go build tag is enabled globally
+    in .bazelrc, so sqlite3_libsqlite3.go defines USE_LIBSQLITE3 and the
+    bundled amalgamation in sqlite3-binding.c is a no-op TU.
+
+    TODO(agent-build): when the agent binary is built with Bazel, its rpath
+    will point into bazel-bin/_solib_local/... and won't resolve at install
+    time. Apply the same packaging path used for cpython: pull
+    @sqlite3//:sqlite3_pkg into the binary's packaging deps and run the
+    bazel/rules/rewrite_rpath rule post-link to retarget to the install-tree
+    libsqlite3.so location.
+
+    Args:
+      **kwargs: forwarded to go_library. cdeps is extended (not replaced) so
+        Gazelle-emitted entries are preserved.
+    """
+    kwargs["cgo"] = True
+    cdeps = kwargs.pop("cdeps", [])
+    label = "@@//bazel/rules/go_sqlite3:libsqlite3_dynamic"
+    if label not in cdeps:
+        cdeps = cdeps + [label]
+    _go_library(cdeps = cdeps, **kwargs)

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -88,6 +88,20 @@ go_deps.gazelle_override(
     build_extra_args = ["-build_tags=requirefips"],
     path = "go.opentelemetry.io/collector/config/configtls",
 )
+
+# Link go-sqlite3 against the shared libsqlite3 from //deps:sqlite3 rather than
+# compiling the bundled amalgamation. The libsqlite3 build tag is enabled
+# globally in .bazelrc. The map_kind directive redirects Gazelle to emit our
+# go_sqlite3_library wrapper, which sets cgo = True and injects the
+# @sqlite3//:libsqlite3_dynamic cdep so the binding's #include <sqlite3.h> and
+# -lsqlite3 directives resolve.
+go_deps.gazelle_override(
+    build_extra_args = ["-build_tags=libsqlite3"],
+    directives = [
+        "gazelle:map_kind go_library go_sqlite3_library @@//bazel/rules/go_sqlite3:go_sqlite3_library.bzl",
+    ],
+    path = "github.com/mattn/go-sqlite3",
+)
 use_repo(
     go_deps,
     "cat_dario_mergo",

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -59,13 +59,25 @@ cc_import(
 
 # This target is meant to be used as a cdeps for go code that relies on sqlite3
 # More specifically, it's intended to avoid rebuilding the sqlite3 amalgamation
-# in github.com/mattn/go-sqlite3
+# in github.com/mattn/go-sqlite3.
+#
+# On Linux/macOS we link against the shared :sqlite3 so a single libsqlite3.so
+# / .dylib is reused across consumers (the dedup goal). On Windows we instead
+# fold the static :libsqlite3 into each consumer binary: the Windows loader
+# does not search Bazel's runfiles `_solib_x86_64/` tree for DLLs, and the
+# current set of Windows consumers is small enough (collectorv2 is the only
+# package that imports the binding, and its tests are linux-only) that
+# embedding sqlite3 statically into each Windows .exe is cheaper than wiring
+# up DLL co-location for both runfiles and the install tree.
 cc_library(
     name = "libsqlite3_dynamic",
     hdrs = _SQLITE3_PUBLIC_HEADERS,
     includes = ["."],
     visibility = ["//visibility:public"],
-    deps = [":_libsqlite3_shared"],
+    deps = select({
+        "@platforms//os:windows": [":libsqlite3"],
+        "//conditions:default": [":_libsqlite3_shared"],
+    }),
 )
 
 dd_cc_packaged(

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -27,20 +27,11 @@ cc_library(
     srcs = ["sqlite3.c"],
     hdrs = _SQLITE3_PUBLIC_HEADERS,
     includes = ["."],
-    # SQLITE_* defines mirror mattn/go-sqlite3's bundled-amalgamation build
-    # (sqlite3.go:13-23) so this shared library is feature-equivalent to the
-    # binding's default flavor.
     copts = [
         "-Wall",
-        "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1",
-        "-DSQLITE_ENABLE_FTS3",
-        "-DSQLITE_ENABLE_FTS3_PARENTHESIS",
         "-DSQLITE_ENABLE_MATH_FUNCTIONS",
-        "-DSQLITE_ENABLE_RTREE",
-        "-DSQLITE_ENABLE_UPDATE_DELETE_LIMIT",
         "-DSQLITE_OMIT_DEPRECATED",
         "-DSQLITE_THREADSAFE=1",
-        "-DSQLITE_TRACE_SIZE_LIMIT=15",
         "-O2",
     ],
     linkstatic = True,

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -1,5 +1,5 @@
 load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 
 package(
@@ -26,10 +26,20 @@ cc_library(
     srcs = ["sqlite3.c"],
     hdrs = _SQLITE3_PUBLIC_HEADERS,
     includes = ["."],
+    # SQLITE_* defines mirror mattn/go-sqlite3's bundled-amalgamation build
+    # (sqlite3.go:13-23) so this shared library is feature-equivalent to the
+    # binding's default flavor.
     copts = [
         "-Wall",
+        "-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1",
+        "-DSQLITE_ENABLE_FTS3",
+        "-DSQLITE_ENABLE_FTS3_PARENTHESIS",
         "-DSQLITE_ENABLE_MATH_FUNCTIONS",
+        "-DSQLITE_ENABLE_RTREE",
+        "-DSQLITE_ENABLE_UPDATE_DELETE_LIMIT",
+        "-DSQLITE_OMIT_DEPRECATED",
         "-DSQLITE_THREADSAFE=1",
+        "-DSQLITE_TRACE_SIZE_LIMIT=15",
         "-O2",
     ],
     linkstatic = True,
@@ -40,6 +50,22 @@ cc_shared_library(
     name = "sqlite3",
     deps = [":libsqlite3"],
     visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "_libsqlite3_shared",
+    shared_library = ":sqlite3",
+)
+
+# This target is meant to be used as a cdeps for go code that relies on sqlite3
+# More specifically, it's intended to avoid rebuilding the sqlite3 amalgamation
+# in github.com/mattn/go-sqlite3
+cc_library(
+    name = "libsqlite3_dynamic",
+    hdrs = _SQLITE3_PUBLIC_HEADERS,
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = [":_libsqlite3_shared"],
 )
 
 dd_cc_packaged(

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -1,6 +1,7 @@
 load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(
     default_package_metadata = [":license"],
@@ -80,9 +81,23 @@ cc_library(
     }),
 )
 
+pkg_files(
+    name = "sqlite3_header_pkg_files",
+    srcs = _SQLITE3_PUBLIC_HEADERS,
+    prefix = "include",
+)
+
 dd_cc_packaged(
     name = "sqlite3_pkg",
     input = ":sqlite3",
+    # Headers are shipped for builds that include go-sqlite3 consumers, so
+    # that dda-inv go builds can find sqlite3.h in the embedded/ directory.
+    # Heroku doesn't include those consumers and doesn't need the headers.
+    # Remove once all go builds are Bazel-managed.
+    installed_files = select({
+        "@@//packages/agent:heroku_flavor": [],
+        "//conditions:default": [":sqlite3_header_pkg_files"],
+    }),
     version = VERSION,
     visibility = ["//visibility:public"],
 )

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -70,10 +70,22 @@ cc_import(
 # package that imports the binding, and its tests are linux-only) that
 # embedding sqlite3 statically into each Windows .exe is cheaper than wiring
 # up DLL co-location for both runfiles and the install tree.
+#
+# macOS linkopts: go-sqlite3's sqlite3_libsqlite3.go only emits
+# "#cgo linux LDFLAGS: -lsqlite3"; it relies on the macOS linker auto-linking
+# from SDK stubs.  ld64.lld (LLVM's drop-in for Apple's ld64, used on CI)
+# does not do that, so without an explicit -lsqlite3 the linker would pick up
+# Apple's system sqlite3 (which has SQLITE_OMIT_LOAD_EXTENSION) instead of
+# ours.  The -L search path for our library is already provided by the
+# _libsqlite3_shared cc_import's CcInfo; we just need to name the library.
 cc_library(
     name = "libsqlite3_dynamic",
     hdrs = _SQLITE3_PUBLIC_HEADERS,
     includes = ["."],
+    linkopts = select({
+        "@platforms//os:macos": ["-lsqlite3"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     deps = select({
         "@platforms//os:windows": [":libsqlite3"],

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -29,10 +29,10 @@ from tasks.libs.common.constants import CONTAINER_PLATFORM_MAPPING
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import (
     REPO_PATH,
+    apply_sqlite3_build_flags,
     bin_name,
     get_build_flags,
     get_embedded_path,
-    get_sqlite3_paths,
     get_version,
     gitlab_section,
 )
@@ -146,9 +146,7 @@ def build(
     if not glibc:
         build_tags = list(set(build_tags).difference({"nvml"}))
 
-    sqlite3_lib, _ = get_sqlite3_paths(embedded_path or get_embedded_path(ctx))
-    if sqlite3_lib:
-        build_tags = list(set(build_tags) | {"libsqlite3"})
+    build_tags = apply_sqlite3_build_flags(env, build_tags, embedded_path or get_embedded_path(ctx))
 
     if not agent_bin:
         agent_bin = os.path.join(BIN_PATH, bin_name("agent"))

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -31,6 +31,8 @@ from tasks.libs.common.utils import (
     REPO_PATH,
     bin_name,
     get_build_flags,
+    get_embedded_path,
+    get_sqlite3_paths,
     get_version,
     gitlab_section,
 )
@@ -143,6 +145,10 @@ def build(
 
     if not glibc:
         build_tags = list(set(build_tags).difference({"nvml"}))
+
+    sqlite3_lib, _ = get_sqlite3_paths(embedded_path or get_embedded_path(ctx))
+    if sqlite3_lib:
+        build_tags = list(set(build_tags) | {"libsqlite3"})
 
     if not agent_bin:
         agent_bin = os.path.join(BIN_PATH, bin_name("agent"))

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -33,11 +33,15 @@ from tasks.libs.types.arch import Arch
 
 if sys.platform == "darwin":
     RTLOADER_LIB_NAME = "libdatadog-agent-rtloader.dylib"
+    SQLITE3_LIB_NAME = "libsqlite3.dylib"
 elif sys.platform == "win32":
     RTLOADER_LIB_NAME = "libdatadog-agent-rtloader.a"
+    SQLITE3_LIB_NAME = None  # linked statically on Windows
 else:
     RTLOADER_LIB_NAME = "libdatadog-agent-rtloader.so"
+    SQLITE3_LIB_NAME = "libsqlite3.so"
 RTLOADER_HEADER_NAME = "datadog_agent_rtloader.h"
+SQLITE3_HEADER_NAME = "sqlite3.h"
 
 
 @dataclass
@@ -178,6 +182,19 @@ def get_rtloader_paths(embedded_path=None, rtloader_root=None):
     return rtloader_lib, rtloader_headers, rtloader_common_headers
 
 
+def get_sqlite3_paths(embedded_path):
+    """Return (lib_dir, include_dir) if a pre-built libsqlite3 is found under embedded_path, else (None, None)."""
+    if not embedded_path or not SQLITE3_LIB_NAME:
+        return None, None
+    for libdir in ["lib", "lib64"]:
+        lib_path = os.path.join(embedded_path, libdir, SQLITE3_LIB_NAME)
+        if os.path.exists(lib_path):
+            include_dir = os.path.join(embedded_path, "include")
+            if os.path.exists(os.path.join(include_dir, SQLITE3_HEADER_NAME)):
+                return os.path.join(embedded_path, libdir), include_dir
+    return None, None
+
+
 def get_embedded_path(ctx):
     base = os.path.dirname(os.path.abspath(__file__))
     task_repo_root = os.path.abspath(os.path.join(base, "..", ".."))
@@ -259,6 +276,7 @@ def get_build_flags(
             raise Exit("unable to locate embedded path please check your setup or set --embedded-path")
 
     rtloader_lib, rtloader_headers, rtloader_common_headers = get_rtloader_paths(embedded_path, rtloader_root)
+    sqlite3_lib, sqlite3_headers = get_sqlite3_paths(embedded_path)
     # setting the install path, allowing the agent to be installed in a custom location
     if sys.platform.startswith('linux') and install_path:
         ldflags += f"-X {REPO_PATH}/pkg/config/setup.InstallPath={install_path} "
@@ -304,11 +322,20 @@ def get_build_flags(
     if sys.platform == 'win32':
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + ' -Wl,--allow-multiple-definition'
 
+    if sqlite3_lib:
+        env['DYLD_LIBRARY_PATH'] = (
+            env.get('DYLD_LIBRARY_PATH', os.environ.get('DYLD_LIBRARY_PATH', '')) + f":{sqlite3_lib}"
+        )
+        env['LD_LIBRARY_PATH'] = env.get('LD_LIBRARY_PATH', os.environ.get('LD_LIBRARY_PATH', '')) + f":{sqlite3_lib}"
+        env['CGO_LDFLAGS'] = env.get('CGO_LDFLAGS', os.environ.get('CGO_LDFLAGS', '')) + f" -L{sqlite3_lib}"
+
     extra_cgo_flags = " -Werror -Wno-deprecated-declarations"
     if rtloader_headers:
         extra_cgo_flags += f" -I{rtloader_headers}"
     if rtloader_common_headers:
         extra_cgo_flags += f" -I{rtloader_common_headers}"
+    if sqlite3_headers:
+        extra_cgo_flags += f" -I{sqlite3_headers}"
     env['CGO_CFLAGS'] = os.environ.get('CGO_CFLAGS', '') + extra_cgo_flags
 
     if sys.platform == 'linux' and os.getenv('GOOS') == "windows":

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -182,6 +182,11 @@ def get_rtloader_paths(embedded_path=None, rtloader_root=None):
     return rtloader_lib, rtloader_headers, rtloader_common_headers
 
 
+# Build tags whose presence indicates go-sqlite3 is a dependency. Used by
+# apply_sqlite3_build_flags to skip the library lookup for builds that don't need it.
+SQLITE3_DEPENDENT_BUILD_TAGS = frozenset({"trivy", "podman"})
+
+
 def get_sqlite3_paths(embedded_path):
     """Return (lib_dir, include_dir) if a pre-built libsqlite3 is found under embedded_path, else (None, None)."""
     if not embedded_path or not SQLITE3_LIB_NAME:
@@ -193,6 +198,26 @@ def get_sqlite3_paths(embedded_path):
             if os.path.exists(os.path.join(include_dir, SQLITE3_HEADER_NAME)):
                 return os.path.join(embedded_path, libdir), include_dir
     return None, None
+
+
+def apply_sqlite3_build_flags(env, build_tags, embedded_path):
+    """Inject libsqlite3 into build_tags and set CGO env vars if the pre-built library is available.
+
+    Only acts when build_tags already contains a tag from SQLITE3_DEPENDENT_BUILD_TAGS,
+    so builds that don't need sqlite3 (IoT agent, dogstatsd, …) are left unchanged.
+    Returns the (possibly updated) build_tags list.
+    """
+    if not (SQLITE3_DEPENDENT_BUILD_TAGS & set(build_tags)):
+        return build_tags
+    sqlite3_lib, sqlite3_headers = get_sqlite3_paths(embedded_path)
+    if not sqlite3_lib:
+        return build_tags
+    build_tags = list(set(build_tags) | {"libsqlite3"})
+    env['DYLD_LIBRARY_PATH'] = env.get('DYLD_LIBRARY_PATH', os.environ.get('DYLD_LIBRARY_PATH', '')) + f":{sqlite3_lib}"
+    env['LD_LIBRARY_PATH'] = env.get('LD_LIBRARY_PATH', os.environ.get('LD_LIBRARY_PATH', '')) + f":{sqlite3_lib}"
+    env['CGO_LDFLAGS'] = env.get('CGO_LDFLAGS', os.environ.get('CGO_LDFLAGS', '')) + f" -L{sqlite3_lib}"
+    env['CGO_CFLAGS'] = env.get('CGO_CFLAGS', os.environ.get('CGO_CFLAGS', '')) + f" -I{sqlite3_headers}"
+    return build_tags
 
 
 def get_embedded_path(ctx):
@@ -276,7 +301,6 @@ def get_build_flags(
             raise Exit("unable to locate embedded path please check your setup or set --embedded-path")
 
     rtloader_lib, rtloader_headers, rtloader_common_headers = get_rtloader_paths(embedded_path, rtloader_root)
-    sqlite3_lib, sqlite3_headers = get_sqlite3_paths(embedded_path)
     # setting the install path, allowing the agent to be installed in a custom location
     if sys.platform.startswith('linux') and install_path:
         ldflags += f"-X {REPO_PATH}/pkg/config/setup.InstallPath={install_path} "
@@ -322,20 +346,11 @@ def get_build_flags(
     if sys.platform == 'win32':
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + ' -Wl,--allow-multiple-definition'
 
-    if sqlite3_lib:
-        env['DYLD_LIBRARY_PATH'] = (
-            env.get('DYLD_LIBRARY_PATH', os.environ.get('DYLD_LIBRARY_PATH', '')) + f":{sqlite3_lib}"
-        )
-        env['LD_LIBRARY_PATH'] = env.get('LD_LIBRARY_PATH', os.environ.get('LD_LIBRARY_PATH', '')) + f":{sqlite3_lib}"
-        env['CGO_LDFLAGS'] = env.get('CGO_LDFLAGS', os.environ.get('CGO_LDFLAGS', '')) + f" -L{sqlite3_lib}"
-
     extra_cgo_flags = " -Werror -Wno-deprecated-declarations"
     if rtloader_headers:
         extra_cgo_flags += f" -I{rtloader_headers}"
     if rtloader_common_headers:
         extra_cgo_flags += f" -I{rtloader_common_headers}"
-    if sqlite3_headers:
-        extra_cgo_flags += f" -I{sqlite3_headers}"
     env['CGO_CFLAGS'] = os.environ.get('CGO_CFLAGS', '') + extra_cgo_flags
 
     if sys.platform == 'linux' and os.getenv('GOOS') == "windows":

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -215,7 +215,13 @@ def apply_sqlite3_build_flags(env, build_tags, embedded_path):
     build_tags = list(set(build_tags) | {"libsqlite3"})
     env['DYLD_LIBRARY_PATH'] = env.get('DYLD_LIBRARY_PATH', os.environ.get('DYLD_LIBRARY_PATH', '')) + f":{sqlite3_lib}"
     env['LD_LIBRARY_PATH'] = env.get('LD_LIBRARY_PATH', os.environ.get('LD_LIBRARY_PATH', '')) + f":{sqlite3_lib}"
-    env['CGO_LDFLAGS'] = env.get('CGO_LDFLAGS', os.environ.get('CGO_LDFLAGS', '')) + f" -L{sqlite3_lib}"
+    ldflags = f" -L{sqlite3_lib}"
+    if sys.platform == "darwin":
+        # go-sqlite3's sqlite3_libsqlite3.go only adds -lsqlite3 for Linux; on
+        # macOS we must add it explicitly so the linker binds to our library
+        # rather than auto-linking the system sqlite3 (which omits extension loading).
+        ldflags += " -lsqlite3"
+    env['CGO_LDFLAGS'] = env.get('CGO_LDFLAGS', os.environ.get('CGO_LDFLAGS', '')) + ldflags
     env['CGO_CFLAGS'] = env.get('CGO_CFLAGS', os.environ.get('CGO_CFLAGS', '')) + f" -I{sqlite3_headers}"
     return build_tags
 


### PR DESCRIPTION
### What does this PR do?

Stops compiling the SQLite amalgamation bundled with `github.com/mattn/go-sqlite3` and links the binding against the agent's existing `//deps:sqlite3` shared library instead.

Two commits:
1. Add a `go_sqlite3_library` Gazelle-emitted wrapper rule (via `map_kind`), a `:libsqlite3_dynamic` cdeps target in `deps/sqlite3.BUILD.bazel`, and the feature defines that the binding applies in its default build (cherry-picked from `sqlite3.go:13-23`). Inert on its own.
2. Enable the `libsqlite3` Go build tag globally in `.bazelrc` and wire the `gazelle_override` that redirects `go_library` to the wrapper.

### Motivation

The agent already builds `libsqlite3.so` once (`@sqlite3//:sqlite3`, consumed by cpython, rpm, openscap). go-sqlite3 was independently rebuilding the same SQLite 3.53.0 amalgamation and statically linking it into every binary that imports the binding. Removes a duplicate native build and keeps a single `.so` in the runtime artifacts.

### Describe how you validated your changes

Local Linux:
- `bazel build //pkg/util/podman:podman` — green; go-sqlite3 `GoCompilePkg` runs in ~0s (bundled amalgamation is no-op'd via `USE_LIBSQLITE3`).
- `bazel build //pkg/security/resolvers/sbom/collectorv2:collectorv2_test` — green; `ldd` confirms the binary dynamically links against `@sqlite3//:sqlite3`'s `libsqlite3.so`.
- `bazel run //:gazelle` is idempotent across both commits.

`//pkg/inventory/software:software` is darwin/ios-only and already wired in Bazel, so the macOS CI job will exercise it.

### Additional Notes

The wrapper macro carries a `TODO(agent-build)` noting that rpath fix-up (same pattern cpython uses today via `bazel/rules/rewrite_rpath`) will be needed once the agent binary is built with Bazel — the current rpath points into `bazel-bin/_solib_local/...` and won't resolve in the install tree.