### PR TITLE
Add noisy_neighbor.pmu_metrics.* config keys

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -268,6 +268,15 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("ebpf_check.kernel_bpf_stats", false)
 	// noisy neighbor module
 	cfg.BindEnvAndSetDefault("noisy_neighbor.enabled", false)
+	// Per-PMU-event toggles. Default false because each enabled event
+	// adds non-trivial overhead.
+	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.cycles", false)
+	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.instructions", false)
+	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.llc_misses", false)
+	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.cache_references", false)
+	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.itlb_misses", false)
+	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.branch_misses", false)
+	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.cpu_migrations", false)
 
 	// settings for the entry count of the ebpfcheck
 	// control the size of the buffers used for the batch lookups of the ebpf maps

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -272,7 +272,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// adds non-trivial overhead.
 	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.cycles", false)
 	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.instructions", false)
-	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.llc_misses", false)
+	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.cache_misses", false)
 	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.cache_references", false)
 	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.itlb_misses", false)
 	cfg.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.branch_misses", false)


### PR DESCRIPTION
### What does this PR do?

Registers 7 `noisy_neighbor.pmu_metrics.*` boolean config keys in `pkg/config/setup/system_probe.go`, all defaulted to `false`:

- `noisy_neighbor.pmu_metrics.cycles`
- `noisy_neighbor.pmu_metrics.instructions`
- `noisy_neighbor.pmu_metrics.cache_misses`
- `noisy_neighbor.pmu_metrics.cache_references`
- `noisy_neighbor.pmu_metrics.itlb_misses`
- `noisy_neighbor.pmu_metrics.branch_misses`
- `noisy_neighbor.pmu_metrics.cpu_migrations`

### Motivation

We plan to support collection of these PMU events in the noisy neighbor module, but testing shows the overhead per read is non-trivial, so we are making it opt-in for now.

### Describe how you validated your changes

- `go build ./pkg/config/setup/` clean.
- `gofmt` clean.
- Naming attempts to follows the established precedent for per-feature toggle namespaces in the same file.