### PR TITLE
Example of how I want to consume the rpath and debug split code

### DIFF
--- a/packages/installer/linux/BUILD.bazel
+++ b/packages/installer/linux/BUILD.bazel
@@ -87,9 +87,17 @@ pkg_filegroup(
     ],
 )
 
+dd_rpath_and_strip(
+    name = "stripped",
+    srcs = [
+        ":whole_distro",
+    ],
+    dbg_symbols = "symbols",
+)
+
 pkg_tar(
     name = "whole_distro_tar",
-    srcs = [":whole_distro"],
+    srcs = [":stripped"],
     compression_level = get_compression_level(),
     extension = "tar.xz",
     owner = "0.0",
@@ -206,4 +214,19 @@ pkg_files(
 pkg_install(
     name = "copy_out",
     srcs = [":all_packages"],
+)
+
+pkg_tar(
+    name = "dbg_tar",
+    srcs = [":symbols"],
+    compression_level = get_compression_level(),
+    extension = "tar.xz",
+    owner = "0.0",
+)
+
+pkg_deb(
+    name = "debian_dbg",
+    data = ":dbg_tar",
+    package_file_name = "datadog-installer-dbg_{version}-1_{arch_deb}.deb",
+    ...
 )

--- a/packages/installer/linux/BUILD.bazel
+++ b/packages/installer/linux/BUILD.bazel
@@ -228,5 +228,5 @@ pkg_deb(
     name = "debian_dbg",
     data = ":dbg_tar",
     package_file_name = "datadog-installer-dbg_{version}-1_{arch_deb}.deb",
-    ...
+    # ...
 )


### PR DESCRIPTION
### What does this PR do?

Shows an ideal use of the rule that can rewrite a tree to have rpath fixed and stripped files and an seperated output just for the symbols files.

Let's see how aligned we are.