### PR TITLE
Fix tests and linters on AIX

### DIFF
--- a/pkg/util/hostname/container_stub.go
+++ b/pkg/util/hostname/container_stub.go
@@ -9,9 +9,9 @@ package hostname
 
 import (
 	"context"
-	"fmt"
+	"errors"
 )
 
-func fromContainer(ctx context.Context, _ string) (string, error) {
-	return "", fmt.Errorf("container support is not compiled in")
+func fromContainer(_ context.Context, _ string) (string, error) {
+	return "", errors.New("container support is not compiled in")
 }

--- a/pkg/util/port/portlist/poller_test.go
+++ b/pkg/util/port/portlist/poller_test.go
@@ -190,8 +190,8 @@ func TestSortAndDedup(t *testing.T) {
 }
 
 func TestGetList(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping test on Windows -- not implemented yet")
+	if runtime.GOOS == "windows" || runtime.GOOS == "aix" {
+		t.Skip("Skipping test on Windows/AIX -- not implemented yet")
 	}
 	var p Poller
 	pl, _, err := p.Poll()
@@ -204,8 +204,8 @@ func TestGetList(t *testing.T) {
 }
 
 func TestIgnoreLocallyBoundPorts(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping test on Windows -- not implemented yet")
+	if runtime.GOOS == "windows" || runtime.GOOS == "aix" {
+		t.Skip("Skipping test on Windows/AIX -- not implemented yet")
 	}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -227,8 +227,8 @@ func TestIgnoreLocallyBoundPorts(t *testing.T) {
 }
 
 func TestPoller(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping test on Windows -- not implemented yet")
+	if runtime.GOOS == "windows" || runtime.GOOS == "aix" {
+		t.Skip("Skipping test on Windows/AIX -- not implemented yet")
 	}
 	var p Poller
 	p.IncludeLocalhost = true
@@ -271,8 +271,8 @@ func TestPoller(t *testing.T) {
 }
 
 func TestPollerIPPopulated(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("Skipping test on macOS -- IP parsing not implemented")
+	if runtime.GOOS == "darwin" || runtime.GOOS == "aix" {
+		t.Skip("Skipping test on macOS/AIX -- IP parsing not implemented")
 	}
 	tests := []struct {
 		addr   string


### PR DESCRIPTION
### What does this PR do?

Skip four `portlist` tests on AIX and fix two linter issues in `container_stub.go`.

### Motivation

Being able to run tests and lints on AIX.

### Describe how you validated your changes

CI, local testing.

### Additional Notes
