### PR TITLE
[AD] Extend static-config dedup to container/kubelet templates

### DIFF
--- a/comp/core/autodiscovery/integration/config.go
+++ b/comp/core/autodiscovery/integration/config.go
@@ -120,6 +120,13 @@ type Config struct {
 
 	// ImageName is the container image name if any
 	ImageName string `json:"image_name"` // (include in digest: false)
+
+	// PreferStaticConfig, when true on a dynamic AD template, causes the
+	// template to be dropped at resolution time if a non-template (static)
+	// config of the same integration Name is already scheduled. Intended for
+	// shipped auto_conf templates so they yield to user-authored conf.d
+	// configs. The flag has no meaning on a non-template static config.
+	PreferStaticConfig bool `json:"prefer_static_config"` // (include in digest: false)
 }
 
 // MatchingProgram is an interface for matching objects against filter rules.

--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -35,20 +35,22 @@ const (
 // workloadmeta store.
 type ContainerListener struct {
 	workloadmetaListener
-	globalFilter  workloadfilter.FilterBundle
-	metricsFilter workloadfilter.FilterBundle
-	logsFilter    workloadfilter.FilterBundle
-	tagger        tagger.Component
+	globalFilter      workloadfilter.FilterBundle
+	metricsFilter     workloadfilter.FilterBundle
+	logsFilter        workloadfilter.FilterBundle
+	tagger            tagger.Component
+	staticConfigIndex *StaticConfigIndex
 }
 
 // NewContainerListener returns a new ContainerListener.
 func NewContainerListener(options ServiceListernerDeps) (ServiceListener, error) {
 	const name = "ad-containerlistener"
 	l := &ContainerListener{
-		globalFilter:  options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.GlobalFilter),
-		metricsFilter: options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.MetricsFilter),
-		logsFilter:    options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.LogsFilter),
-		tagger:        options.Tagger,
+		globalFilter:      options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.GlobalFilter),
+		metricsFilter:     options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.MetricsFilter),
+		logsFilter:        options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.LogsFilter),
+		tagger:            options.Tagger,
+		staticConfigIndex: options.StaticConfigIndex,
 	}
 	filter := workloadmeta.NewFilterBuilder().
 		SetSource(workloadmeta.SourceAll).
@@ -132,13 +134,14 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 			containerImg.RawName,
 			container.Labels,
 		),
-		ports:           ports,
-		pid:             container.PID,
-		hostname:        container.Hostname,
-		metricsExcluded: l.metricsFilter.IsExcluded(filterableContainer),
-		logsExcluded:    l.logsFilter.IsExcluded(filterableContainer),
-		tagger:          l.tagger,
-		wmeta:           l.Store(),
+		ports:             ports,
+		pid:               container.PID,
+		hostname:          container.Hostname,
+		metricsExcluded:   l.metricsFilter.IsExcluded(filterableContainer),
+		logsExcluded:      l.logsFilter.IsExcluded(filterableContainer),
+		tagger:            l.tagger,
+		wmeta:             l.Store(),
+		staticConfigIndex: l.staticConfigIndex,
 	}
 
 	if pod != nil {

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -29,10 +29,11 @@ import (
 // to the workloadmeta store.
 type KubeletListener struct {
 	workloadmetaListener
-	globalFilter  workloadfilter.FilterBundle
-	metricsFilter workloadfilter.FilterBundle
-	logsFilter    workloadfilter.FilterBundle
-	tagger        tagger.Component
+	globalFilter      workloadfilter.FilterBundle
+	metricsFilter     workloadfilter.FilterBundle
+	logsFilter        workloadfilter.FilterBundle
+	tagger            tagger.Component
+	staticConfigIndex *StaticConfigIndex
 }
 
 // NewKubeletListener returns a new KubeletListener.
@@ -40,10 +41,11 @@ func NewKubeletListener(options ServiceListernerDeps) (ServiceListener, error) {
 	const name = "ad-kubeletlistener"
 
 	l := &KubeletListener{
-		globalFilter:  options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.GlobalFilter),
-		metricsFilter: options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.MetricsFilter),
-		logsFilter:    options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.LogsFilter),
-		tagger:        options.Tagger,
+		globalFilter:      options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.GlobalFilter),
+		metricsFilter:     options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.MetricsFilter),
+		logsFilter:        options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.LogsFilter),
+		tagger:            options.Tagger,
+		staticConfigIndex: options.StaticConfigIndex,
 	}
 	wmetaFilter := workloadmeta.NewFilterBuilder().
 		SetSource(workloadmeta.SourceAll).
@@ -114,14 +116,15 @@ func (l *KubeletListener) createPodService(
 	entity := kubelet.PodUIDToEntityName(pod.ID)
 	taggerEntityID := common.BuildTaggerEntityID(pod.GetID())
 	svc := &WorkloadService{
-		entity:        pod,
-		tagsHash:      l.tagger.GetEntityHash(taggerEntityID, types.ChecksConfigCardinality),
-		adIdentifiers: []string{entity},
-		hosts:         map[string]string{"pod": pod.IP},
-		ports:         ports,
-		ready:         true,
-		tagger:        l.tagger,
-		wmeta:         l.Store(),
+		entity:            pod,
+		tagsHash:          l.tagger.GetEntityHash(taggerEntityID, types.ChecksConfigCardinality),
+		adIdentifiers:     []string{entity},
+		hosts:             map[string]string{"pod": pod.IP},
+		ports:             ports,
+		ready:             true,
+		tagger:            l.tagger,
+		wmeta:             l.Store(),
+		staticConfigIndex: l.staticConfigIndex,
 	}
 
 	svcID := buildSvcID(pod.GetID())
@@ -187,11 +190,12 @@ func (l *KubeletListener) createContainerService(
 
 		// Exclude non-running containers (including init containers)
 		// from metrics collection but keep them for collecting logs.
-		metricsExcluded: l.metricsFilter.IsExcluded(filterableContainer) || !container.State.Running,
-		logsExcluded:    l.logsFilter.IsExcluded(filterableContainer),
-		tagger:          l.tagger,
-		imageName:       containerImg.ShortName,
-		wmeta:           l.Store(),
+		metricsExcluded:   l.metricsFilter.IsExcluded(filterableContainer) || !container.State.Running,
+		logsExcluded:      l.logsFilter.IsExcluded(filterableContainer),
+		tagger:            l.tagger,
+		imageName:         containerImg.ShortName,
+		wmeta:             l.Store(),
+		staticConfigIndex: l.staticConfigIndex,
 	}
 
 	adIdentifier := containerName

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -27,21 +27,22 @@ import (
 // WorkloadService implements the Service interface and stores data collected from
 // workloadmeta.Store. Covers containers and kubernetes pods.
 type WorkloadService struct {
-	entity          workloadmeta.Entity
-	tagsHash        string
-	adIdentifiers   []string
-	hosts           map[string]string
-	ports           []workloadmeta.ContainerPort
-	pid             int
-	hostname        string
-	ready           bool
-	checkNames      []string
-	extraConfig     map[string]string
-	metricsExcluded bool
-	logsExcluded    bool
-	tagger          tagger.Component
-	wmeta           workloadmeta.Component
-	imageName       string
+	entity            workloadmeta.Entity
+	tagsHash          string
+	adIdentifiers     []string
+	hosts             map[string]string
+	ports             []workloadmeta.ContainerPort
+	pid               int
+	hostname          string
+	ready             bool
+	checkNames        []string
+	extraConfig       map[string]string
+	metricsExcluded   bool
+	logsExcluded      bool
+	tagger            tagger.Component
+	wmeta             workloadmeta.Component
+	imageName         string
+	staticConfigIndex *StaticConfigIndex
 }
 
 var _ Service = &WorkloadService{}
@@ -149,8 +150,25 @@ func (s *WorkloadService) FilterTemplates(configs map[string]integration.Config)
 	s.filterTemplatesOverriddenChecks(configs)
 	filterTemplatesMatched(s, configs)
 
+	// Drop templates that opt in to yielding to a same-name static config.
+	s.filterTemplatesPreferStaticConfig(configs)
+
 	// Container Collect All filtering should always be last
 	s.filterTemplatesContainerCollectAll(configs)
+}
+
+// filterTemplatesPreferStaticConfig drops templates whose PreferStaticConfig
+// flag is set and whose integration Name already has a scheduled non-template
+// (static) config. Lets shipped auto_conf templates yield to user-authored
+// conf.d configs without scheduling a duplicate check.
+func (s *WorkloadService) filterTemplatesPreferStaticConfig(configs map[string]integration.Config) {
+	for digest, config := range configs {
+		if config.PreferStaticConfig && s.staticConfigIndex.Has(config.Name) {
+			log.Debugf("Ignoring template %s from %s: a static config of the same name is scheduled",
+				config.Name, config.Source)
+			delete(configs, digest)
+		}
+	}
 }
 
 // GetFilterableEntity returns the filterable entity of the service

--- a/comp/core/autodiscovery/listeners/service_test.go
+++ b/comp/core/autodiscovery/listeners/service_test.go
@@ -150,3 +150,60 @@ func TestServiceFilterTemplatesCCA(t *testing.T) {
 			filterDrops(&WorkloadService{}, noLogsTpl, logsTpl, ccaTpl))
 	})
 }
+
+func TestServiceFilterTemplatesPreferStaticConfig(t *testing.T) {
+	filterDrops := func(svc *WorkloadService, configs ...integration.Config) (dropped []integration.Config) {
+		return filterConfigsDropped(svc.filterTemplatesPreferStaticConfig, configs...)
+	}
+
+	yieldingTpl := integration.Config{
+		Name:               "postgres",
+		Source:             "file:/etc/datadog-agent/conf.d/postgres.d/auto_conf.yaml",
+		ADIdentifiers:      []string{"postgres"},
+		PreferStaticConfig: true,
+	}
+	nonYieldingTpl := integration.Config{
+		Name:          "postgres",
+		Source:        "file:/etc/datadog-agent/conf.d/postgres.d/auto_conf.yaml",
+		ADIdentifiers: []string{"postgres"},
+	}
+	otherYieldingTpl := integration.Config{
+		Name:               "redis",
+		Source:             "file:/etc/datadog-agent/conf.d/redis.d/auto_conf.yaml",
+		ADIdentifiers:      []string{"redis"},
+		PreferStaticConfig: true,
+	}
+	nothingDropped := []integration.Config{}
+
+	t.Run("drops yielding template when matching static is scheduled", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		idx.Add("postgres")
+		assert.Equal(t, []integration.Config{yieldingTpl},
+			filterDrops(&WorkloadService{staticConfigIndex: idx}, yieldingTpl))
+	})
+
+	t.Run("keeps template when flag is false", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		idx.Add("postgres")
+		assert.Equal(t, nothingDropped,
+			filterDrops(&WorkloadService{staticConfigIndex: idx}, nonYieldingTpl))
+	})
+
+	t.Run("keeps yielding template when no matching static", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		assert.Equal(t, nothingDropped,
+			filterDrops(&WorkloadService{staticConfigIndex: idx}, yieldingTpl))
+	})
+
+	t.Run("nil index is safe", func(t *testing.T) {
+		assert.Equal(t, nothingDropped,
+			filterDrops(&WorkloadService{staticConfigIndex: nil}, yieldingTpl))
+	})
+
+	t.Run("distinct names are independent", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		idx.Add("redis")
+		assert.Equal(t, []integration.Config{otherYieldingTpl},
+			filterDrops(&WorkloadService{staticConfigIndex: idx}, yieldingTpl, otherYieldingTpl))
+	})
+}

--- a/comp/core/autodiscovery/providers/config_reader.go
+++ b/comp/core/autodiscovery/providers/config_reader.go
@@ -43,6 +43,7 @@ type configFormat struct {
 	DockerImages            []string                           `yaml:"docker_images,omitempty"`             // Only imported for deprecation warning
 	IgnoreAutodiscoveryTags bool                               `yaml:"ignore_autodiscovery_tags,omitempty"` // Use to ignore tags coming from autodiscovery
 	CheckTagCardinality     string                             `yaml:"check_tag_cardinality,omitempty"`     // Use to set the tag cardinality override for the check
+	PreferStaticConfig      bool                               `yaml:"prefer_static_config,omitempty"`      // Dynamic template yields to a static config of the same Name
 }
 
 // ConfigFormatWrapper is a wrapper for the config format
@@ -501,6 +502,10 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, Confi
 
 	// Copy check_tag_cardinality parameter
 	conf.CheckTagCardinality = cf.CheckTagCardinality
+
+	// Copy prefer_static_config flag (auto_conf templates can opt in to
+	// yielding to a same-name static config)
+	conf.PreferStaticConfig = cf.PreferStaticConfig
 
 	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
 	if len(cf.DockerImages) > 0 && len(cf.ADIdentifiers) == 0 {


### PR DESCRIPTION
### What does this PR do?

Follow-up to PR #50250 (StaticConfigIndex for ProcessService). Adds an opt-in PreferStaticConfig flag on integration.Config so that a shipped auto_conf.yaml template can yield to a user-authored conf.d static config of the same integration Name, preventing duplicate checks. The flag is honored by WorkloadService.FilterTemplates, covering both the container listener and the kubelet (pod + container) paths.

The dedup is scoped to integration name only, mirroring the merged process path. Runtime re-reconciliation (static config arriving or leaving after a dynamic template is already scheduled) is intentionally deferred — same gap documented in the original PR.

### Motivation

### Describe how you validated your changes

### Additional Notes
