### PR TITLE
[anomalydetection] Wire CheckSampler observer tap for core check metrics

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
@@ -277,6 +278,9 @@ type BufferedAggregator struct {
 	tagger                      tagger.Component
 	flushAndSerializeInParallel FlushAndSerializeInParallel
 
+	// observerHandle is set at startup and copied into newly created CheckSamplers.
+	observerHandle observer.Handle
+
 	// use this chan to trigger a filterList reconfiguration
 	filterListChan  chan utilstrings.Matcher
 	flushFilterList utilstrings.Matcher
@@ -517,6 +521,12 @@ func (agg *BufferedAggregator) addEvent(e event.Event) {
 	e.Tags = tb.Get()
 
 	agg.events = append(agg.events, &e)
+}
+
+// SetObserverHandle sets the observer handle for mirroring check metrics.
+// The handle is propagated to newly created CheckSamplers.
+func (agg *BufferedAggregator) SetObserverHandle(h observer.Handle) {
+	agg.observerHandle = h
 }
 
 // GetSeriesAndSketches grabs all the series & sketches from the queue and clears the queue
@@ -1001,7 +1011,7 @@ func (agg *BufferedAggregator) handleRegisterSampler(id checkid.ID) {
 		log.Debugf("Sampler with ID '%s' has already been registered, will use existing sampler", id)
 		return
 	}
-	agg.checkSamplers[id] = newCheckSampler(
+	cs := newCheckSampler(
 		pkgconfigsetup.Datadog().GetInt("check_sampler_bucket_commits_count_expiry"),
 		pkgconfigsetup.Datadog().GetBool("check_sampler_expire_metrics"),
 		pkgconfigsetup.Datadog().GetBool("check_sampler_context_metrics"),
@@ -1011,4 +1021,8 @@ func (agg *BufferedAggregator) handleRegisterSampler(id checkid.ID) {
 		id,
 		agg.tagger,
 	)
+	if agg.observerHandle != nil {
+		cs.SetObserverHandle(agg.observerHandle)
+	}
+	agg.checkSamplers[id] = cs
 }

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"time"
 
+	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
@@ -41,6 +42,7 @@ type CheckSampler struct {
 	contextResolverMetrics bool
 	logThrottling          util.SimpleThrottler
 	allowSketchBucketReset bool
+	observerHandle         observer.Handle
 }
 
 // newCheckSampler returns a newly initialized CheckSampler
@@ -68,8 +70,16 @@ func newCheckSampler(
 	}
 }
 
+// SetObserverHandle sets the observer handle for mirroring check samples.
+func (cs *CheckSampler) SetObserverHandle(h observer.Handle) {
+	cs.observerHandle = h
+}
+
 func (cs *CheckSampler) addSample(metricSample *metrics.MetricSample, tagFilterList filterlist.TagMatcher) {
 	contextKey := cs.contextResolver.trackContext(metricSample, tagFilterList)
+	if cs.observerHandle != nil {
+		cs.observerHandle.ObserveMetric(metricSample)
+	}
 	if metricSample.Mtype == metrics.DistributionType {
 		cs.sketchMap.insert(int64(metricSample.Timestamp), contextKey, metricSample.Value, metricSample.SampleRate)
 		return

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -246,13 +246,14 @@ func (d *AgentDemultiplexer) Options() AgentDemultiplexerOptions {
 	return d.options
 }
 
-// SetObserver wires an observer component into the DogStatsD metric pipeline.
+// SetObserver wires an observer component into the DogStatsD metric pipeline
+// and the BufferedAggregator → CheckSampler path (Go core checks).
 //
 // Requires both anomaly_detection.enabled and anomaly_detection.metrics.enabled to be true.
-// Every raw metric sample passing through the time-sampler workers and the
-// no-aggregation pipeline will be forwarded to the provided observer handle
-// before aggregation. The call is a no-op when either flag is off or obs is
-// nil, so default overhead is zero.
+// Every raw metric sample passing through the time-sampler workers, the
+// no-aggregation pipeline, and every CheckSampler will be forwarded to the
+// provided observer handle before aggregation. The call is a no-op when
+// either flag is off or obs is nil, so default overhead is zero.
 func (d *AgentDemultiplexer) SetObserver(obs observer.Component) {
 	if obs == nil {
 		return
@@ -269,13 +270,16 @@ func (d *AgentDemultiplexer) SetObserver(obs observer.Component) {
 
 	metricsHandle := obs.GetHandle("all-metrics")
 
+	// DogStatsD paths
 	for _, worker := range d.statsd.workers {
 		worker.sampler.observerHandle = metricsHandle
 	}
-
 	if d.statsd.noAggStreamWorker != nil {
 		d.statsd.noAggStreamWorker.observerHandle = metricsHandle
 	}
+
+	// Go core check path (BufferedAggregator → CheckSampler)
+	d.aggregator.SetObserverHandle(metricsHandle)
 }
 
 // AddAgentStartupTelemetry adds a startup event and count (in a DSD time sampler)

--- a/pkg/aggregator/observer_handle_test.go
+++ b/pkg/aggregator/observer_handle_test.go
@@ -116,6 +116,7 @@ func TestSetObserverNilIsNoop(t *testing.T) {
 
 // TestSetObserverConfigOff verifies that SetObserver does not wire the handle
 // when anomaly_detection.enabled or anomaly_detection.metrics.enabled is false.
+// Covers both the DogStatsD TimeSampler path and the BufferedAggregator/CheckSampler path.
 func TestSetObserverConfigOff(t *testing.T) {
 	opts := demuxTestOptions()
 	deps := createDemultiplexerAgentTestDeps(t)
@@ -127,8 +128,17 @@ func TestSetObserverConfigOff(t *testing.T) {
 	demux.SetObserver(comp)
 
 	for _, w := range demux.statsd.workers {
-		assert.Nil(t, w.sampler.observerHandle, "handle should not be wired when config is off")
+		assert.Nil(t, w.sampler.observerHandle, "DogStatsD worker handle should not be wired when config is off")
 	}
+	assert.Nil(t, demux.aggregator.observerHandle, "BufferedAggregator handle should not be wired when config is off")
+
+	// Verify that a CheckSampler registered after the (no-op) SetObserver call also has no handle.
+	demux.aggregator.handleRegisterSampler("check-config-off")
+	demux.aggregator.mu.Lock()
+	cs := demux.aggregator.checkSamplers["check-config-off"]
+	demux.aggregator.mu.Unlock()
+	require.NotNil(t, cs)
+	assert.Nil(t, cs.observerHandle, "CheckSampler handle should not be wired when config is off")
 }
 
 // TestCheckSamplerObserverHandle verifies that ObserveMetric is called for each

--- a/pkg/aggregator/observer_handle_test.go
+++ b/pkg/aggregator/observer_handle_test.go
@@ -130,3 +130,64 @@ func TestSetObserverConfigOff(t *testing.T) {
 		assert.Nil(t, w.sampler.observerHandle, "handle should not be wired when config is off")
 	}
 }
+
+// TestCheckSamplerObserverHandle verifies that ObserveMetric is called for each
+// sample fed to CheckSampler.addSample when an observerHandle is wired.
+func TestCheckSamplerObserverHandle(t *testing.T) {
+	store := tags.NewStore(false, "test")
+	cs := newCheckSampler(10, false, false, 0, false, store, "test-check", nooptagger.NewComponent())
+	handle := &recordingHandle{}
+	cs.SetObserverHandle(handle)
+
+	matcher := filterlist.NewNoopTagMatcher()
+
+	samples := []metrics.MetricSample{
+		{Name: "system.cpu.user", Value: 42.0, Mtype: metrics.GaugeType, Tags: []string{"host:myhost"}, SampleRate: 1, Timestamp: 1000},
+		{Name: "system.mem.used", Value: 8192.0, Mtype: metrics.GaugeType, Tags: []string{}, SampleRate: 1, Timestamp: 2000},
+	}
+
+	for i := range samples {
+		cs.addSample(&samples[i], matcher)
+	}
+
+	require.Len(t, handle.calls, 2)
+	assert.Equal(t, "system.cpu.user", handle.calls[0].name)
+	assert.Equal(t, 42.0, handle.calls[0].value)
+	assert.Equal(t, []string{"host:myhost"}, handle.calls[0].tags)
+	assert.Equal(t, int64(1000), handle.calls[0].timestamp)
+
+	assert.Equal(t, "system.mem.used", handle.calls[1].name)
+	assert.Equal(t, 8192.0, handle.calls[1].value)
+}
+
+// TestCheckSamplerObserverHandleNil verifies no panic when observerHandle is nil.
+func TestCheckSamplerObserverHandleNil(t *testing.T) {
+	store := tags.NewStore(false, "test")
+	cs := newCheckSampler(10, false, false, 0, false, store, "test-check", nooptagger.NewComponent())
+	// observerHandle is nil by default
+
+	matcher := filterlist.NewNoopTagMatcher()
+	s := metrics.MetricSample{Name: "m", Value: 1, Mtype: metrics.GaugeType, SampleRate: 1}
+	assert.NotPanics(t, func() { cs.addSample(&s, matcher) })
+}
+
+// TestBufferedAggregatorObserverHandlePropagation verifies that SetObserverHandle
+// on BufferedAggregator is propagated to CheckSamplers created afterwards.
+func TestBufferedAggregatorObserverHandlePropagation(t *testing.T) {
+	opts := demuxTestOptions()
+	deps := createDemultiplexerAgentTestDeps(t)
+	demux := initAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+
+	handle := &recordingHandle{}
+	demux.aggregator.SetObserverHandle(handle)
+
+	// Simulate a check registering its sampler
+	demux.aggregator.handleRegisterSampler("test-check-id")
+
+	demux.aggregator.mu.Lock()
+	cs, ok := demux.aggregator.checkSamplers["test-check-id"]
+	demux.aggregator.mu.Unlock()
+
+	require.True(t, ok, "sampler should have been created")
+	assert.Equal(t, handle, cs.observerHandle, "observer handle should have been propagated to CheckSampler")
+}


### PR DESCRIPTION
## What does this PR do?
  Adds an observer tap on the Go core check metrics path so anomaly detection can see metrics emitted by checks (not just DogStatsD).

  - `BufferedAggregator` gets `SetObserverHandle`, which propagates the handle to every `CheckSampler` it owns.
  - `CheckSampler.addSample` calls `ObserveMetric` when a handle is set; nil otherwise, so default overhead is one nil-check per sample.
  - `AgentDemultiplexer.SetObserver` wires the handle into the aggregator alongside the existing DogStatsD `TimeSampler` and `noAgg` paths.

  Double-gated behind `anomaly_detection.enabled` and `anomaly_detection.metrics.enabled` (both default `false`), so the default agent is unchanged.

  ## Motivation
  The Wave-2 observer metrics handle only taps DogStatsD paths (UDP/8125). Go core check metrics (`system.cpu.user`, `system.mem.*`, network checks, etc.) flow through `BufferedAggregator → CheckSampler` — a completely separate path with no observer tap until this PR.
  Without this wiring, anomaly detection has no visibility into the metrics emitted by Go checks.

  Stacks after the Wave-2 metrics-handle PR (`celian/observer-wave2-metrics-handle`); will rebase once that's merged.

  ## Describe how you validated your changes
Unit tests `pkg/aggregator/observer_handle_test.go`: tap, nil-safety, and aggregator → sampler propagation.

  Manual validation: with `anomaly_detection.enabled: true` + `anomaly_detection.metrics.enabled: true` and the system check enabled, confirmed `system.cpu.user` reaches the observer handle.


**enabled config:** 
```
anomaly_detection:
  enabled: true
  metrics:
    enabled: true
  debug:
    dump_path: /tmp/observer_metrics.json
    dump_interval: 5s

```
<details><summary>Details</summary>
<p>

```

ella.taira@COMP-L3Q3Q6QQTX datadog-agent % echo "=== 1. Observer initialization ===" && \
grep -E "\[observer\]" /tmp/dev-agent.log | head -10 | cut -c1-200 && \
echo && \
echo "=== 2. Anomaly detection gates ===" && \
grep -iE "anomaly_detection.*(enabled|metrics)" /tmp/dev-agent.log | head -10 | cut -c1-200 && \
echo && \
echo "=== 3. Periodic dump confirmation ===" && \
grep "dumped metrics" /tmp/dev-agent.log | head -5 | cut -c1-200 && \
echo && \
echo "=== 4. Distinct system.* metric names (THE proof) ===" && \
python3 -c "
import json
data = json.load(open('/tmp/observer_metrics.json'))
for n in sorted({m['name'] for m in data if m['name'].startswith('system.')}): print(n)
" | head -15 && \
echo && \
echo "=== 5. Sample counts per metric ===" && \
python3 -c "
import json
from collections import Counter
data = json.load(open('/tmp/observer_metrics.json'))
c = Counter(m['name'] for m in data)
for name, count in c.most_common(10): print(f'{count:5d} {name}')
" && \
echo && \
echo "=== 6. DogStatsD path unregressed (non-system.* metrics) ===" && \
python3 -c "
import json
data = json.load(open('/tmp/observer_metrics.json'))
names = sorted({m['name'] for m in data if not m['name'].startswith('system.')})
for n in names[:15]: print(n)
print(f'... ({len(names)} total non-system.* metrics)')
"
=== 1. Observer initialization ===
2026-05-13 13:30:38 EDT | CORE | INFO | (comp/anomalydetection/observer/impl/observer.go:517 in GetHandle) | [observer] getting handle for system-checks-hf
2026-05-13 13:30:38 EDT | CORE | INFO | (comp/anomalydetection/observer/impl/observer.go:517 in GetHandle) | [observer] getting handle for container-checks-hf
2026-05-13 13:30:38 EDT | CORE | INFO | (comp/anomalydetection/observer/impl/observer.go:517 in GetHandle) | [observer] getting handle for all-metrics
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json

=== 2. Anomaly detection gates ===
2026-05-13 13:30:38 EDT | CORE | WARN | (pkg/util/log/log.go:762 in func1) | Unknown key in config file: anomaly_detection.enabled
2026-05-13 13:30:38 EDT | CORE | WARN | (pkg/util/log/log.go:762 in func1) | Unknown key in config file: anomaly_detection.metrics.enabled
2026-05-13 13:31:38 EDT | CORE | DEBUG | (pkg/serializer/serializer.go:335 in sendMetadata) | Sending metadata payload, content: {"hostname":"dev-agent","timestamp":1778693498163543000,"agent_metadata

=== 3. Periodic dump confirmation ===
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json

=== 4. Distinct system.* metric names  ===
system.cpu.guest
system.cpu.guest.total
system.cpu.guestnice.total
system.cpu.idle
system.cpu.idle.total
system.cpu.interrupt
system.cpu.iowait
system.cpu.iowait.total
system.cpu.irq.total
system.cpu.nice.total
system.cpu.num_cores
system.cpu.softirq.total
system.cpu.steal.total
system.cpu.stolen
system.cpu.system

=== 5. Sample counts per metric ===
    9 system.disk.total
    9 system.disk.utilized
    9 system.fs.inodes.free
    9 system.disk.used
    9 system.fs.inodes.in_use
    9 system.fs.inodes.total
    9 system.disk.free
    9 system.fs.inodes.utilized
    9 system.fs.inodes.used
    9 system.disk.in_use

=== 6. DogStatsD path unregressed (non-system.* metrics) ===
my.test.metric
ntp.intake_offset
ntp.offset
... (3 total non-system.* metrics)
ella.taira@COMP-L3Q3Q6QQTX datadog-agent % 
```

</p>
</details> 

**Conversely, when disabled:** 
```
anomaly_detection:
  enabled: true
  metrics:
    enabled: false
  debug:
    dump_path: /tmp/observer_metrics.json
    dump_interval: 5s

```
<details><summary>Details</summary>
<p>


```
ella.taira@COMP-L3Q3Q6QQTX datadog-agent % echo "=== 1. Observer initialization ===" && \
grep -E "\[observer\]" /tmp/dev-agent.log | head -10 | cut -c1-200 && \
echo && \
echo "=== 2. Anomaly detection gates ===" && \
grep -iE "anomaly_detection.*(enabled|metrics)" /tmp/dev-agent.log | head -10 | cut -c1-200 && \
echo && \
echo "=== 3. Drop warning (metrics.enabled=false) ===" && \
grep "metrics.enabled=false" /tmp/dev-agent.log | head -5 | cut -c1-200 && \
echo && \
echo "=== 4. Dump file state (should be empty / no system.*) ===" && \
python3 << 'EOF'
import json, os
path = '/tmp/observer_metrics.json'
if not os.path.exists(path):
    print('No dump file written'); exit()
data = json.load(open(path))
if data is None or data == []:
    print('Dump file contains no metrics (expected when metrics.enabled=false)')
else:
    print(f'{len(data)} entries in dump')
    sys_count = sum(1 for m in data if m['name'].startswith('system.'))
    print(f'system.* count: {sys_count} (expected 0)')
EOF
=== 1. Observer initialization ===
2026-05-13 13:42:58 EDT | CORE | WARN | (comp/anomalydetection/observer/impl/observer.go:213 in NewComponent) | [observer] anomaly_detection.metrics.enabled=false: externally-ingested metrics will be 
2026-05-13 13:42:58 EDT | CORE | INFO | (comp/anomalydetection/observer/impl/observer.go:517 in GetHandle) | [observer] getting handle for system-checks-hf
2026-05-13 13:42:58 EDT | CORE | INFO | (comp/anomalydetection/observer/impl/observer.go:517 in GetHandle) | [observer] getting handle for container-checks-hf
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json
[observer] dumped metrics to /tmp/observer_metrics.json

=== 2. Anomaly detection gates ===
2026-05-13 13:42:58 EDT | CORE | WARN | (pkg/util/log/log.go:762 in func1) | Unknown key in config file: anomaly_detection.enabled
2026-05-13 13:42:58 EDT | CORE | WARN | (pkg/util/log/log.go:762 in func1) | Unknown key in config file: anomaly_detection.metrics.enabled
2026-05-13 13:42:58 EDT | CORE | WARN | (comp/anomalydetection/observer/impl/observer.go:213 in NewComponent) | [observer] anomaly_detection.metrics.enabled=false: externally-ingested metrics will be dropped at the handle factory
2026-05-13 13:42:58 EDT | CORE | DEBUG | (pkg/aggregator/demultiplexer_agent.go:267 in SetObserver) | Observer metric capture disabled (anomaly_detection.metrics.enabled=false)
2026-05-13 13:43:58 EDT | CORE | DEBUG | (pkg/serializer/serializer.go:335 in sendMetadata) | Sending metadata payload, content: {"hostname":"dev-agent","timestamp":1778694238234190000,"agent_metadata

=== 3. Drop warning (metrics.enabled=false) ===
2026-05-13 13:42:58 EDT | CORE | WARN | (comp/anomalydetection/observer/impl/observer.go:213 in NewComponent) | [observer] anomaly_detection.metrics.enabled=false: externally-ingested metrics will be dropped at the handle factory
2026-05-13 13:42:58 EDT | CORE | DEBUG | (pkg/aggregator/demultiplexer_agent.go:267 in SetObserver) | Observer metric capture disabled (anomaly_detection.metrics.enabled=false)

=== 4. Dump file state (should be empty / no system.*) ===
Dump file contains no metrics (expected when metrics.enabled=false)
ella.taira@COMP-L3Q3Q6QQTX datadog-agent % 

```


</p>
</details> 

**performance testing w AD enabled**  https://github.com/DataDog/datadog-agent/pull/50778 

  ## Additional Notes
 