### PR TITLE
fix(e2e): retry msiexec on transient ERROR_INSTALL_PACKAGE_OPEN_FAILED (1619)

### DIFF
--- a/test/new-e2e/tests/windows/common/msi.go
+++ b/test/new-e2e/tests/windows/common/msi.go
@@ -7,21 +7,24 @@
 package common
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
 )
 
-// msiSuccessExitCodes are Windows Installer exit codes that indicate success
-// but require or initiated a reboot. See:
+// Windows Installer exit codes. See:
 // https://learn.microsoft.com/en-us/windows/win32/msi/error-codes
 const (
-	msiExitSuccessRebootRequired  = 3010 // ERROR_SUCCESS_REBOOT_REQUIRED
-	msiExitSuccessRebootInitiated = 1641 // ERROR_SUCCESS_REBOOT_INITIATED
+	msiExitSuccessRebootRequired    = 3010 // ERROR_SUCCESS_REBOOT_REQUIRED
+	msiExitSuccessRebootInitiated   = 1641 // ERROR_SUCCESS_REBOOT_INITIATED
+	msiExitInstallPackageOpenFailed = 1619 // ERROR_INSTALL_PACKAGE_OPEN_FAILED
 )
 
 func isMsiSuccessExitCode(err error) bool {
@@ -34,6 +37,24 @@ func isMsiSuccessExitCode(err error) bool {
 	}
 	code := exitErr.ExitStatus()
 	return code == msiExitSuccessRebootRequired || code == msiExitSuccessRebootInitiated
+}
+
+// isMsiPackageOpenFailedExitCode reports whether err is an msiexec failure with exit code
+// 1619 (ERROR_INSTALL_PACKAGE_OPEN_FAILED) — typically transient when the package is
+// fetched over the network.
+func isMsiPackageOpenFailedExitCode(err error) bool {
+	if err == nil {
+		return false
+	}
+	var exitErr *ssh.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	return exitErr.ExitStatus() == msiExitInstallPackageOpenFailed
+}
+
+func isRemoteMSIPath(p string) bool {
+	return strings.HasPrefix(p, "http://") || strings.HasPrefix(p, "https://")
 }
 
 // MsiExec runs msiexec on the VM with the provided operation and args and collects the log
@@ -54,10 +75,23 @@ func MsiExec(host *components.RemoteHost, operation string, product string, args
 	}
 	args = fmt.Sprintf(`/qn /norestart /l "%s" %s "%s" %s`, remoteLogPath, operation, product, args)
 	cmd := fmt.Sprintf(`Exit (Start-Process -Wait msiexec -PassThru -ArgumentList '%s').ExitCode`, args)
-	_, msiExecErr := host.Execute(cmd)
-	if msiExecErr != nil && isMsiSuccessExitCode(msiExecErr) {
-		msiExecErr = nil // Treat as success
-	}
+
+	_, msiExecErr := backoff.Retry(context.Background(), func() (any, error) {
+		_, err := host.Execute(cmd)
+		if err == nil || isMsiSuccessExitCode(err) {
+			return nil, nil // Treat reboot-required exit codes as success
+		}
+		// Retry transient package-open failures (exit 1619) when installing from a remote URL.
+		// We've seen S3-hosted MSIs fail to open momentarily mid-test even when the same URL
+		// succeeded earlier in the same run (e.g. WINA-2296). 1619 fires before msiexec writes
+		// any action to the log, so it's a clean signal that nothing actually started.
+		if isMsiPackageOpenFailedExitCode(err) && operation == "/i" && isRemoteMSIPath(product) {
+			fmt.Printf("msiexec /i %s failed with ERROR_INSTALL_PACKAGE_OPEN_FAILED (1619), retrying\n", product)
+			return nil, err
+		}
+		// Fail on any other error
+		return nil, backoff.Permanent(err)
+	}, backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)), backoff.WithMaxTries(3))
 	if logPath != "" {
 		err = host.GetFile(remoteLogPath, logPath)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

Adds a retry loop in `MsiExec` (`test/new-e2e/tests/windows/common/msi.go`) for transient
MSI exit code **1619** (`ERROR_INSTALL_PACKAGE_OPEN_FAILED`) when installing from a
remote URL. The retry only fires when **all three** conditions hold:

- operation is `/i` (install)
- msi path starts with `http://` or `https://`
- exit code is exactly 1619

Up to 2 retries with a constant 5s delay (3 attempts total). Any other failure is wrapped
in `backoff.Permanent` and surfaced immediately.

### Motivation

[WINA-2296](https://datadoghq.atlassian.net/browse/WINA-2296) closed today as a transient
S3 flake: a single `TestInstaller/.../Install_after_purge` failure in 30 days where
msiexec exited 1619 before writing any action to the install log. The same S3-hosted MSI
URL had succeeded 3 times earlier in the same test run, confirming a momentary
S3/network blip rather than a code bug. 1619 fires before msiexec writes anything, so
it's a clean transient signal to retry on.

Same pattern as the recent `/norestart` + 1641 handling added by #47484 — narrow the
known-transient classes that msiexec returns and retry/swallow them at the harness layer.