### PR TITLE
healthplatform: introduce egress component, simplify forwarder to stateless Send

### DIFF
--- a/comp/README.md
+++ b/comp/README.md
@@ -333,6 +333,10 @@ Package orchestratorinterface defines the interface for the orchestrator forward
 Package healthplatform implements the "healthplatform" bundle, providing the
 health platform component for detecting and reporting agent health issues.
 
+### [comp/healthplatform/egress](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/healthplatform/egress)
+
+Package egress defines the interface for the health platform egress component.
+
 ### [comp/healthplatform/forwarder](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/healthplatform/forwarder)
 
 Package forwarder defines the interface for the health platform forwarder.

--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -12,6 +12,8 @@ go_library(
         "//comp/core/config",
         "//comp/core/diagnose/def",
         "//comp/core/log/def",
+        "//comp/healthplatform/egress/def",
+        "//comp/healthplatform/egress/fx",
         "//comp/healthplatform/forwarder/fx",
         "//comp/healthplatform/issues",
         "//comp/healthplatform/issues/admisconfig",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	egressdef "github.com/DataDog/datadog-agent/comp/healthplatform/egress/def"
+	egressfx "github.com/DataDog/datadog-agent/comp/healthplatform/egress/fx"
 	forwarderfx "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/fx"
 	issuesmod "github.com/DataDog/datadog-agent/comp/healthplatform/issues"
 
@@ -47,12 +49,15 @@ func Bundle() fxutil.BundleOptions {
 		runnerfx.Module(),
 		schedulerfx.Module(),
 		forwarderfx.Module(),
+		egressfx.Module(),
 		corefx.Module(),
 		fx.Invoke(bootstrapBuiltInHealthChecks),
 	)
 }
 
-// bootstrapBuiltInHealthChecks registers all built-in health checks at startup.
+// bootstrapBuiltInHealthChecks registers all built-in health checks at startup
+// and forces the egress component to be instantiated (its lifecycle hooks drive the
+// periodic store→intake flush).
 // Once checks run in background goroutines so they do not block OnStart;
 // periodic checks are registered with the scheduler.
 func bootstrapBuiltInHealthChecks(
@@ -61,6 +66,7 @@ func bootstrapBuiltInHealthChecks(
 	runner runnerdef.Component,
 	scheduler schedulerdef.Component,
 	store storedef.Component,
+	_ egressdef.Component,
 	lc fx.Lifecycle,
 ) {
 	if !cfg.GetBool("health_platform.enabled") {

--- a/comp/healthplatform/egress/def/BUILD.bazel
+++ b/comp/healthplatform/egress/def/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/egress/def",
+    visibility = ["//visibility:public"],
+)

--- a/comp/healthplatform/egress/def/component.go
+++ b/comp/healthplatform/egress/def/component.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package egress defines the interface for the health platform egress component.
+package egress
+
+// team: agent-health
+
+// Component is the health platform egress component interface.
+// Egress drives the periodic outbound HTTP POST to the Datadog intake:
+// on each tick it calls store.GetAllIssues(), builds a HealthReport, and
+// forwards it via forwarder.Send. It has no public methods — behaviour is
+// driven entirely by its fx lifecycle hooks.
+type Component interface{}

--- a/comp/healthplatform/egress/fx/BUILD.bazel
+++ b/comp/healthplatform/egress/fx/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/egress/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/healthplatform/egress/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/healthplatform/egress/fx/fx.go
+++ b/comp/healthplatform/egress/fx/fx.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the health platform egress component.
+package fx
+
+import (
+	egressimpl "github.com/DataDog/datadog-agent/comp/healthplatform/egress/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for the egress component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(egressimpl.New),
+	)
+}

--- a/comp/healthplatform/egress/impl/BUILD.bazel
+++ b/comp/healthplatform/egress/impl/BUILD.bazel
@@ -2,16 +2,19 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "impl",
-    srcs = ["forwarder.go"],
-    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/impl",
+    srcs = ["egress.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/egress/impl",
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface",
         "//comp/core/log/def",
+        "//comp/def",
+        "//comp/healthplatform/egress/def",
         "//comp/healthplatform/forwarder/def",
-        "//pkg/config/model",
-        "//pkg/config/utils",
-        "//pkg/util/http",
+        "//comp/healthplatform/store/def",
+        "//pkg/util/flavor",
+        "//pkg/util/pointer",
         "//pkg/version",
         "@com_github_datadog_agent_payload_v5//healthplatform",
     ],
@@ -19,13 +22,13 @@ go_library(
 
 go_test(
     name = "impl_test",
-    srcs = ["forwarder_test.go"],
+    srcs = ["egress_test.go"],
     embed = [":impl"],
     gotags = ["test"],
     deps = [
-        "//comp/core/config",
         "//comp/core/log/mock",
-        "//pkg/version",
+        "//comp/healthplatform/forwarder/def",
+        "//comp/healthplatform/store/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/healthplatform/egress/impl/egress.go
+++ b/comp/healthplatform/egress/impl/egress.go
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package egressimpl implements the health platform egress component.
+package egressimpl
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	egressdef "github.com/DataDog/datadog-agent/comp/healthplatform/egress/def"
+	forwarderdef "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+const (
+	// defaultEgressInterval is the default interval between health report submissions.
+	// Matches the previous forwarder default for backward compatibility.
+	defaultEgressInterval = 15 * time.Minute
+
+	// sendTimeout is the HTTP timeout for a single forwarder.Send call.
+	sendTimeout = 30 * time.Second
+
+	// eventType is the health report event type consumed by the intake.
+	eventType = "agent-health-issues"
+)
+
+// egress drives the periodic outbound POST to the Datadog intake.
+// On each tick it calls store.GetAllIssues(), builds a HealthReport, and
+// forwards it via forwarder.Send. When health_platform is disabled, lifecycle
+// hooks are never registered so the goroutine is never launched.
+type egress struct {
+	log         log.Component
+	interval    time.Duration
+	hostname    string
+	agentFlavor string
+	store       storedef.Component
+	forwarder   forwarderdef.Component
+
+	stopCh chan struct{}
+	doneCh chan struct{}
+}
+
+// Requires defines the dependencies for the egress component.
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+	Log       log.Component
+	Config    config.Component
+	Hostname  hostnameinterface.Component
+	Store     storedef.Component
+	Forwarder forwarderdef.Component
+}
+
+// New creates the egress component and registers its lifecycle hooks.
+// When health_platform.enabled is false, it returns a zero-value struct without
+// registering any lifecycle hooks.
+func New(reqs Requires) egressdef.Component {
+	if !reqs.Config.GetBool("health_platform.enabled") {
+		return &egress{}
+	}
+
+	hostname, err := reqs.Hostname.Get(context.Background())
+	if err != nil {
+		reqs.Log.Warn("Health platform egress: failed to get hostname: " + err.Error())
+		hostname = ""
+	}
+
+	interval := reqs.Config.GetDuration("health_platform.forwarder.interval")
+	if interval <= 0 {
+		interval = defaultEgressInterval
+	}
+
+	e := &egress{
+		log:         reqs.Log,
+		interval:    interval,
+		hostname:    hostname,
+		agentFlavor: flavor.GetFlavor(),
+		store:       reqs.Store,
+		forwarder:   reqs.Forwarder,
+		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}),
+	}
+
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: e.start,
+		OnStop:  e.stop,
+	})
+
+	return e
+}
+
+func (e *egress) start(_ context.Context) error {
+	e.log.Info(fmt.Sprintf("Starting health platform egress with %v interval", e.interval))
+	go e.run()
+	return nil
+}
+
+func (e *egress) stop(_ context.Context) error {
+	e.log.Info("Stopping health platform egress")
+	close(e.stopCh)
+	<-e.doneCh
+	return nil
+}
+
+func (e *egress) run() {
+	defer close(e.doneCh)
+
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			e.tick()
+		case <-e.stopCh:
+			return
+		}
+	}
+}
+
+func (e *egress) tick() {
+	count, issues := e.store.GetAllIssues()
+	if count == 0 {
+		e.log.Debug("Health platform egress: no issues to report, skipping tick")
+		return
+	}
+
+	report := e.buildReport(issues)
+
+	// Fresh context with a fixed timeout per send: the run loop does not carry
+	// a cancellable context, so we derive from Background rather than from an
+	// ancestor that may have already expired or been cancelled.
+	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	defer cancel()
+
+	if err := e.forwarder.Send(ctx, report); err != nil {
+		e.log.Warn(fmt.Sprintf("Health platform egress: failed to send %d issues: %v", count, err))
+		return
+	}
+
+	e.log.Info(fmt.Sprintf("Health platform egress: sent report with %d issues", count))
+}
+
+func (e *egress) buildReport(issues map[string]*healthplatform.Issue) *healthplatform.HealthReport {
+	return &healthplatform.HealthReport{
+		EventType: eventType,
+		EmittedAt: time.Now().UTC().Format(time.RFC3339),
+		Service:   e.agentFlavor,
+		Host: &healthplatform.HostInfo{
+			Hostname:     e.hostname,
+			AgentVersion: pointer.Ptr(version.AgentVersion),
+		},
+		Issues: issues,
+	}
+}

--- a/comp/healthplatform/egress/impl/egress_test.go
+++ b/comp/healthplatform/egress/impl/egress_test.go
@@ -1,0 +1,208 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package egressimpl
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	forwarderdef "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+)
+
+// mockStore records GetAllIssues calls and returns preset data.
+type mockStore struct {
+	mu        sync.Mutex
+	issues    map[string]*healthplatformpayload.Issue
+	callCount atomic.Int32
+}
+
+func (m *mockStore) GetAllIssues() (int, map[string]*healthplatformpayload.Issue) {
+	m.callCount.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.issues) == 0 {
+		return 0, nil
+	}
+	cp := make(map[string]*healthplatformpayload.Issue, len(m.issues))
+	for k, v := range m.issues {
+		cp[k] = v
+	}
+	return len(cp), cp
+}
+
+func (m *mockStore) ReportIssue(_ storedef.IssueReport) error       { return nil }
+func (m *mockStore) ResolveIssue(_ string)                          {}
+func (m *mockStore) ResolveAllIssues()                              {}
+func (m *mockStore) GetIssue(_ string) *healthplatformpayload.Issue { return nil }
+func (m *mockStore) GetActiveIssueIDsByIssueType(_ string) []string { return nil }
+
+// mockForwarder records Send calls.
+type mockForwarder struct {
+	mu        sync.Mutex
+	reports   []*healthplatformpayload.HealthReport
+	sendErr   error
+	sendCount atomic.Int32
+}
+
+func (m *mockForwarder) Send(_ context.Context, report *healthplatformpayload.HealthReport) error {
+	m.sendCount.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sendErr != nil {
+		return m.sendErr
+	}
+	m.reports = append(m.reports, report)
+	return nil
+}
+
+var _ forwarderdef.Component = (*mockForwarder)(nil)
+
+func newTestEgress(t *testing.T, interval time.Duration, store *mockStore, fwd *mockForwarder) *egress {
+	t.Helper()
+	return &egress{
+		log:         logmock.New(t),
+		interval:    interval,
+		hostname:    "test-host",
+		agentFlavor: "agent",
+		store:       store,
+		forwarder:   fwd,
+		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}),
+	}
+}
+
+func TestTickSendsReport(t *testing.T) {
+	store := &mockStore{
+		issues: map[string]*healthplatformpayload.Issue{
+			"issue-1": {Id: "issue-1", Title: "Test", Severity: "high"},
+		},
+	}
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, store, fwd)
+
+	e.tick()
+
+	assert.Equal(t, int32(1), fwd.sendCount.Load())
+	fwd.mu.Lock()
+	defer fwd.mu.Unlock()
+	require.Len(t, fwd.reports, 1)
+	assert.Contains(t, fwd.reports[0].Issues, "issue-1")
+	assert.Equal(t, "test-host", fwd.reports[0].Host.Hostname)
+	assert.Equal(t, eventType, fwd.reports[0].EventType)
+}
+
+func TestTickSkipsEmptyStore(t *testing.T) {
+	store := &mockStore{}
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, store, fwd)
+
+	e.tick()
+
+	assert.Equal(t, int32(0), fwd.sendCount.Load())
+}
+
+func TestTickLogsOnForwarderError(t *testing.T) {
+	store := &mockStore{
+		issues: map[string]*healthplatformpayload.Issue{
+			"issue-1": {Id: "issue-1"},
+		},
+	}
+	fwd := &mockForwarder{sendErr: assert.AnError}
+	e := newTestEgress(t, time.Minute, store, fwd)
+
+	// Should not panic; error is logged internally.
+	e.tick()
+
+	assert.Equal(t, int32(1), fwd.sendCount.Load())
+}
+
+func TestLifecycleStartStop(t *testing.T) {
+	store := &mockStore{}
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, 50*time.Millisecond, store, fwd)
+
+	require.NoError(t, e.start(context.Background()))
+	time.Sleep(30 * time.Millisecond)
+	require.NoError(t, e.stop(context.Background()))
+}
+
+func TestTickFiresOnInterval(t *testing.T) {
+	store := &mockStore{
+		issues: map[string]*healthplatformpayload.Issue{
+			"issue-1": {Id: "issue-1"},
+		},
+	}
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, 30*time.Millisecond, store, fwd)
+
+	require.NoError(t, e.start(context.Background()))
+
+	require.Eventually(t, func() bool {
+		return fwd.sendCount.Load() >= 2
+	}, 2*time.Second, 10*time.Millisecond, "expected at least 2 ticks")
+
+	require.NoError(t, e.stop(context.Background()))
+}
+
+func TestErrorThenRecovery(t *testing.T) {
+	store := &mockStore{
+		issues: map[string]*healthplatformpayload.Issue{
+			"issue-1": {Id: "issue-1"},
+		},
+	}
+	fwd := &mockForwarder{sendErr: assert.AnError}
+	e := newTestEgress(t, 20*time.Millisecond, store, fwd)
+
+	require.NoError(t, e.start(context.Background()))
+
+	// Wait for at least one failed tick.
+	require.Eventually(t, func() bool {
+		return fwd.sendCount.Load() >= 1
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Clear the error; next tick should succeed.
+	fwd.mu.Lock()
+	fwd.sendErr = nil
+	fwd.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		fwd.mu.Lock()
+		defer fwd.mu.Unlock()
+		return len(fwd.reports) >= 1
+	}, 2*time.Second, 5*time.Millisecond, "expected successful send after error recovery")
+
+	require.NoError(t, e.stop(context.Background()))
+}
+
+func TestBuildReport(t *testing.T) {
+	store := &mockStore{}
+	fwd := &mockForwarder{}
+	e := newTestEgress(t, time.Minute, store, fwd)
+
+	issues := map[string]*healthplatformpayload.Issue{
+		"a": {Id: "a"},
+		"b": {Id: "b"},
+	}
+	report := e.buildReport(issues)
+
+	assert.Equal(t, eventType, report.EventType)
+	assert.Equal(t, "test-host", report.Host.Hostname)
+	assert.Equal(t, "agent", report.Service)
+	assert.Len(t, report.Issues, 2)
+	_, err := time.Parse(time.RFC3339, report.EmittedAt)
+	assert.NoError(t, err)
+}

--- a/comp/healthplatform/egress/mock/BUILD.bazel
+++ b/comp/healthplatform/egress/mock/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mock",
+    srcs = ["mock.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/egress/mock",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/healthplatform/egress/def",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/healthplatform/egress/mock/mock.go
+++ b/comp/healthplatform/egress/mock/mock.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+// Package mock provides a no-op mock for the health platform egress component.
+package mock
+
+import (
+	egressdef "github.com/DataDog/datadog-agent/comp/healthplatform/egress/def"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+type mockEgress struct{}
+
+// New returns a no-op mock egress for testing.
+func New() egressdef.Component {
+	return &mockEgress{}
+}
+
+// MockModule provides a mock egress via fx.
+func MockModule() fxutil.Module {
+	return fxutil.Component(fxutil.ProvideComponentConstructor(New))
+}

--- a/comp/healthplatform/egress/noop-impl/BUILD.bazel
+++ b/comp/healthplatform/egress/noop-impl/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "noop-impl",
+    srcs = ["noop.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/egress/noop-impl",
+    visibility = ["//visibility:public"],
+    deps = ["//comp/healthplatform/egress/def"],
+)

--- a/comp/healthplatform/egress/noop-impl/noop.go
+++ b/comp/healthplatform/egress/noop-impl/noop.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package noopimpl provides a no-op implementation of the health platform egress component.
+// Used when the health platform is disabled via configuration.
+package noopimpl
+
+import (
+	egressdef "github.com/DataDog/datadog-agent/comp/healthplatform/egress/def"
+)
+
+type noopEgress struct{}
+
+// NewNoopComponent creates a no-op egress (health platform disabled).
+func NewNoopComponent() egressdef.Component {
+	return &noopEgress{}
+}

--- a/comp/healthplatform/forwarder/def/component.go
+++ b/comp/healthplatform/forwarder/def/component.go
@@ -7,20 +7,18 @@
 package forwarder
 
 import (
+	"context"
+
 	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
 )
 
 // team: agent-health
 
-// IssueProvider provides the current set of issues to report.
-type IssueProvider interface {
-	GetAllIssues() (int, map[string]*healthplatformpayload.Issue)
-}
-
-// Component is the forwarder component.
+// Component is the stateless forwarder component. It POSTs a pre-built
+// HealthReport to the Datadog intake. The periodic tick is owned by the
+// egress component; the forwarder only handles the HTTP mechanics.
 type Component interface {
-	// SetProvider wires the issue provider after construction, breaking the
-	// circular fx dependency between core and forwarder.
-	// Must be called before the first send fires (i.e. from the core lifecycle start hook).
-	SetProvider(provider IssueProvider)
+	// Send POSTs the given report to the Datadog intake.
+	// The caller is responsible for building the report and choosing when to send.
+	Send(ctx context.Context, report *healthplatformpayload.HealthReport) error
 }

--- a/comp/healthplatform/forwarder/impl/forwarder.go
+++ b/comp/healthplatform/forwarder/impl/forwarder.go
@@ -13,197 +13,53 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/healthplatform"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	compdef "github.com/DataDog/datadog-agent/comp/def"
 	forwarderdef "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/def"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const (
-	// intakeEndpointPrefix is the URL prefix for the Datadog intake endpoint
 	intakeEndpointPrefix = "https://agenthealth-intake."
-
-	// intakeEndpointPath is the API path for agent health reports
-	intakeEndpointPath = "/api/v2/agenthealth"
-
-	// defaultForwarderInterval is the default interval between health report submissions
-	defaultForwarderInterval = 15 * time.Minute
-
-	// httpTimeout is the timeout for HTTP requests
-	httpTimeout = 30 * time.Second
-
-	// eventType is the event type for health reports
-	eventType = "agent-health-issues"
+	intakeEndpointPath   = "/api/v2/agenthealth"
+	httpTimeout          = 30 * time.Second
 )
 
-// forwarder handles periodic sending of health reports to the Datadog intake
+// forwarder is a stateless HTTP client. It has no ticker or provider — the
+// egress component owns the send cadence.
 type forwarder struct {
-	cfg         pkgconfigmodel.Reader
-	intakeURL   string
-	interval    time.Duration
-	hostname    string
-	agentFlavor string
-	providerMu  sync.RWMutex
-	provider    forwarderdef.IssueProvider
-	httpClient  *http.Client
-	log         log.Component
-
-	stopCh chan struct{}
-	doneCh chan struct{}
+	cfg        pkgconfigmodel.Reader
+	intakeURL  string
+	httpClient *http.Client
+	log        log.Component
 }
 
 // Requires defines the dependencies for the forwarder.
 type Requires struct {
-	Log       log.Component
-	Config    config.Component
-	Hostname  hostnameinterface.Component
-	Lifecycle compdef.Lifecycle
+	Log    log.Component
+	Config config.Component
 }
 
-// New creates a new forwarder instance and registers its lifecycle hooks.
+// New creates a forwarder. It never registers lifecycle hooks; there is nothing
+// to clean up for a stateless HTTP client.
 func New(reqs Requires) forwarderdef.Component {
-	if !reqs.Config.GetBool("health_platform.enabled") {
-		return &forwarder{log: reqs.Log}
-	}
-
-	hostname, err := reqs.Hostname.Get(context.Background())
-	if err != nil {
-		reqs.Log.Warn("Health platform forwarder: failed to get hostname, will use empty string: " + err.Error())
-		hostname = ""
-	}
-
-	interval := reqs.Config.GetDuration("health_platform.forwarder.interval")
-	if interval <= 0 {
-		interval = defaultForwarderInterval
-	}
-
-	f := &forwarder{
-		cfg:         reqs.Config,
-		intakeURL:   buildIntakeURL(reqs.Config),
-		interval:    interval,
-		hostname:    hostname,
-		agentFlavor: flavor.GetFlavor(),
-		httpClient:  buildHTTPClient(reqs.Config),
-		log:         reqs.Log,
-		stopCh:      make(chan struct{}),
-		doneCh:      make(chan struct{}),
-	}
-
-	reqs.Lifecycle.Append(compdef.Hook{
-		OnStart: f.start,
-		OnStop:  f.stop,
-	})
-
-	return f
-}
-
-func (f *forwarder) start(_ context.Context) error {
-	f.log.Info(fmt.Sprintf("Starting health platform forwarder with %v interval to %s", f.interval, f.intakeURL))
-	go f.run()
-	return nil
-}
-
-func (f *forwarder) stop(_ context.Context) error {
-	f.log.Info("Stopping health platform forwarder")
-	close(f.stopCh)
-	<-f.doneCh
-	return nil
-}
-
-// SetProvider wires the issue provider. Safe to call concurrently with sendHealthReport.
-func (f *forwarder) SetProvider(provider forwarderdef.IssueProvider) {
-	f.providerMu.Lock()
-	defer f.providerMu.Unlock()
-	f.provider = provider
-}
-
-// buildIntakeURL constructs the intake URL based on site configuration
-func buildIntakeURL(cfg pkgconfigmodel.Reader) string {
-	baseURL := configutils.GetMainEndpoint(cfg, intakeEndpointPrefix, "dd_url")
-	return baseURL + intakeEndpointPath
-}
-
-// buildHTTPClient creates an HTTP client with agent-standard transport configuration
-func buildHTTPClient(cfg pkgconfigmodel.Reader) *http.Client {
-	return &http.Client{
-		Timeout:   httpTimeout,
-		Transport: httputils.CreateHTTPTransport(cfg),
+	return &forwarder{
+		cfg:        reqs.Config,
+		intakeURL:  buildIntakeURL(reqs.Config),
+		httpClient: buildHTTPClient(reqs.Config),
+		log:        reqs.Log,
 	}
 }
 
-// run is the main loop that sends health reports periodically
-func (f *forwarder) run() {
-	defer close(f.doneCh)
-
-	ticker := time.NewTicker(f.interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			f.sendHealthReport()
-		case <-f.stopCh:
-			return
-		}
-	}
-}
-
-// sendHealthReport collects issues and sends them to the intake endpoint
-func (f *forwarder) sendHealthReport() {
-	f.providerMu.RLock()
-	provider := f.provider
-	f.providerMu.RUnlock()
-
-	if provider == nil {
-		f.log.Warn("Health platform forwarder has no provider set, skipping report")
-		return
-	}
-	count, issues := provider.GetAllIssues()
-
-	if count == 0 {
-		f.log.Info("No health issues to report")
-		return
-	}
-
-	report := f.buildReport(issues)
-
-	if err := f.send(report); err != nil {
-		f.log.Warn(fmt.Sprintf("Failed to send health report: %v", err))
-		return
-	}
-
-	f.log.Info(fmt.Sprintf("Successfully sent health report with %d issues", count))
-}
-
-// buildReport creates a HealthReport from the current issues
-func (f *forwarder) buildReport(issues map[string]*healthplatform.Issue) *healthplatform.HealthReport {
-	return &healthplatform.HealthReport{
-		EventType: eventType,
-		EmittedAt: time.Now().UTC().Format(time.RFC3339),
-		Service:   f.agentFlavor,
-		Host: &healthplatform.HostInfo{
-			Hostname:     f.hostname,
-			AgentVersion: pointer.Ptr(version.AgentVersion),
-		},
-		Issues: issues,
-	}
-}
-
-// send marshals and sends the report to the intake endpoint
-func (f *forwarder) send(report *healthplatform.HealthReport) error {
-	// Fetch API key once and check if configured
+// Send marshals report and POSTs it to the Datadog intake.
+func (f *forwarder) Send(ctx context.Context, report *healthplatform.HealthReport) error {
 	apiKey := f.cfg.GetString("api_key")
 	if apiKey == "" {
 		return errors.New("API key not configured")
@@ -214,10 +70,10 @@ func (f *forwarder) send(report *healthplatform.HealthReport) error {
 		return fmt.Errorf("marshal report: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+	reqCtx, cancel := context.WithTimeout(ctx, httpTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, f.intakeURL, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, f.intakeURL, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -238,4 +94,16 @@ func (f *forwarder) send(report *healthplatform.HealthReport) error {
 	}
 
 	return nil
+}
+
+func buildIntakeURL(cfg pkgconfigmodel.Reader) string {
+	baseURL := configutils.GetMainEndpoint(cfg, intakeEndpointPrefix, "dd_url")
+	return baseURL + intakeEndpointPath
+}
+
+func buildHTTPClient(cfg pkgconfigmodel.Reader) *http.Client {
+	return &http.Client{
+		Timeout:   httpTimeout,
+		Transport: httputils.CreateHTTPTransport(cfg),
+	}
 }

--- a/comp/healthplatform/forwarder/impl/forwarder_test.go
+++ b/comp/healthplatform/forwarder/impl/forwarder_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,160 +21,60 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-// mockIssueProvider is a test implementation of IssueProvider
-type mockIssueProvider struct {
-	issues map[string]*healthplatform.Issue
-}
-
-func newMockIssueProvider() *mockIssueProvider {
-	return &mockIssueProvider{
-		issues: make(map[string]*healthplatform.Issue),
-	}
-}
-
-func (m *mockIssueProvider) GetAllIssues() (int, map[string]*healthplatform.Issue) {
-	count := 0
-	for _, issue := range m.issues {
-		if issue != nil {
-			count++
-		}
-	}
-	return count, m.issues
-}
-
-func (m *mockIssueProvider) addIssue(checkID string, issue *healthplatform.Issue) {
-	m.issues[checkID] = issue
-}
-
-// newTestForwarder creates a forwarder for white-box testing
-func newTestForwarder(t *testing.T, cfg config.Component, provider *mockIssueProvider, hostname string) *forwarder {
-	interval := cfg.GetDuration("health_platform.forwarder.interval")
-	if interval <= 0 {
-		interval = defaultForwarderInterval
-	}
+func newTestForwarder(t *testing.T, cfg config.Component) *forwarder {
+	t.Helper()
 	return &forwarder{
-		cfg:         cfg,
-		intakeURL:   buildIntakeURL(cfg),
-		interval:    interval,
-		hostname:    hostname,
-		agentFlavor: flavor.GetFlavor(),
-		provider:    provider,
-		httpClient:  buildHTTPClient(cfg),
-		log:         logmock.New(t),
-		stopCh:      make(chan struct{}),
-		doneCh:      make(chan struct{}),
+		cfg:        cfg,
+		intakeURL:  buildIntakeURL(cfg),
+		httpClient: buildHTTPClient(cfg),
+		log:        logmock.New(t),
 	}
 }
 
-// TestForwarderBuildReport tests report building
-func TestForwarderBuildReport(t *testing.T) {
-	cfg := config.NewMock(t)
-	cfg.SetWithoutSource("api_key", "test-api-key")
-	provider := newMockIssueProvider()
-
-	fwd := newTestForwarder(t, cfg, provider, "test-host")
-
-	// Add some test issues
-	provider.addIssue("check-1", &healthplatform.Issue{
-		Id:       "issue-1",
-		Title:    "Test Issue 1",
-		Severity: "high",
-	})
-	provider.addIssue("check-2", &healthplatform.Issue{
-		Id:       "issue-2",
-		Title:    "Test Issue 2",
-		Severity: "medium",
-	})
-
-	report := fwd.buildReport(provider.issues)
-
-	assert.Equal(t, "agent-health-issues", report.EventType)
-	assert.Equal(t, flavor.DefaultAgent, report.Service)
-	assert.Equal(t, "test-host", report.Host.Hostname)
-	assert.Equal(t, version.AgentVersion, report.Host.GetAgentVersion())
-	assert.Len(t, report.Issues, 2)
-	assert.NotEmpty(t, report.EmittedAt)
-
-	// Verify timestamp is valid RFC3339
-	_, err := time.Parse(time.RFC3339, report.EmittedAt)
-	assert.NoError(t, err)
-}
-
-// TestForwarderSend tests sending reports to a mock server
-func TestForwarderSend(t *testing.T) {
+func TestSend(t *testing.T) {
 	var receivedRequest *http.Request
 	var receivedBody []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedRequest = r
-
 		buf := make([]byte, r.ContentLength)
 		_, _ = r.Body.Read(buf)
 		receivedBody = buf
-
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	cfg := config.NewMock(t)
 	cfg.SetWithoutSource("api_key", "test-api-key")
-	provider := newMockIssueProvider()
 
-	fwd := newTestForwarder(t, cfg, provider, "test-host")
+	fwd := newTestForwarder(t, cfg)
 	fwd.intakeURL = server.URL
 
-	provider.addIssue("check-1", &healthplatform.Issue{
-		Id:       "issue-1",
-		Title:    "Test Issue",
-		Severity: "high",
-	})
+	report := &healthplatform.HealthReport{
+		EventType: "agent-health-issues",
+		EmittedAt: time.Now().UTC().Format(time.RFC3339),
+		Host:      &healthplatform.HostInfo{Hostname: "test-host"},
+		Issues: map[string]*healthplatform.Issue{
+			"issue-1": {Id: "issue-1", Title: "Test Issue", Severity: "high"},
+		},
+	}
 
-	report := fwd.buildReport(provider.issues)
-	err := fwd.send(report)
-	require.NoError(t, err)
+	require.NoError(t, fwd.Send(context.Background(), report))
 
-	// Verify request headers
 	assert.Equal(t, "application/json", receivedRequest.Header.Get("Content-Type"))
-	assert.Equal(t, "test-api-key", receivedRequest.Header.Get("DD-API-KEY")) // API key read from config at request time
+	assert.Equal(t, "test-api-key", receivedRequest.Header.Get("DD-API-KEY"))
 	assert.Equal(t, version.AgentVersion, receivedRequest.Header.Get("DD-Agent-Version"))
 	assert.Contains(t, receivedRequest.Header.Get("User-Agent"), "datadog-agent/")
 
-	// Verify body can be unmarshaled
-	var receivedReport healthplatform.HealthReport
-	err = json.Unmarshal(receivedBody, &receivedReport)
-	require.NoError(t, err)
-	assert.Equal(t, "test-host", receivedReport.Host.Hostname)
+	var decoded healthplatform.HealthReport
+	require.NoError(t, json.Unmarshal(receivedBody, &decoded))
+	assert.Equal(t, "test-host", decoded.Host.Hostname)
 }
 
-// TestForwarderSendNoIssues tests that no request is sent when there are no issues
-func TestForwarderSendNoIssues(t *testing.T) {
-	requestCount := int32(0)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&requestCount, 1)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	cfg := config.NewMock(t)
-	cfg.SetWithoutSource("api_key", "test-api-key")
-	provider := newMockIssueProvider() // No issues
-
-	fwd := newTestForwarder(t, cfg, provider, "test-host")
-	fwd.intakeURL = server.URL
-
-	fwd.sendHealthReport()
-
-	// Verify no request was sent
-	assert.Equal(t, int32(0), atomic.LoadInt32(&requestCount))
-}
-
-// TestForwarderSendError tests error handling when server returns error
-func TestForwarderSendError(t *testing.T) {
+func TestSendHTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -183,63 +82,24 @@ func TestForwarderSendError(t *testing.T) {
 
 	cfg := config.NewMock(t)
 	cfg.SetWithoutSource("api_key", "test-api-key")
-	provider := newMockIssueProvider()
 
-	fwd := newTestForwarder(t, cfg, provider, "test-host")
+	fwd := newTestForwarder(t, cfg)
 	fwd.intakeURL = server.URL
 
-	provider.addIssue("check-1", &healthplatform.Issue{
-		Id:       "issue-1",
-		Title:    "Test Issue",
-		Severity: "high",
-	})
-
-	// This should not panic - error is logged internally
-	fwd.sendHealthReport()
+	err := fwd.Send(context.Background(), &healthplatform.HealthReport{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status code: 500")
 }
 
-// TestForwarderStartStop tests the forwarder lifecycle
-func TestForwarderStartStop(t *testing.T) {
+func TestSendNoAPIKey(t *testing.T) {
 	cfg := config.NewMock(t)
-	cfg.SetWithoutSource("health_platform.forwarder.interval", 100*time.Millisecond)
-	cfg.SetWithoutSource("api_key", "test-api-key")
+	fwd := newTestForwarder(t, cfg)
 
-	provider := newMockIssueProvider()
-
-	fwd := newTestForwarder(t, cfg, provider, "test-host")
-
-	// Start the forwarder
-	require.NoError(t, fwd.start(context.Background()))
-
-	// Give it a moment to start the goroutine
-	time.Sleep(50 * time.Millisecond)
-
-	// Stop the forwarder - should complete gracefully
-	require.NoError(t, fwd.stop(context.Background()))
-}
-
-// TestForwarderSendWithoutAPIKey tests that send fails gracefully without API key
-func TestForwarderSendWithoutAPIKey(t *testing.T) {
-	cfg := config.NewMock(t)
-	// Don't set API key
-	provider := newMockIssueProvider()
-
-	fwd := newTestForwarder(t, cfg, provider, "test-host")
-
-	provider.addIssue("check-1", &healthplatform.Issue{
-		Id:       "issue-1",
-		Title:    "Test Issue",
-		Severity: "high",
-	})
-
-	report := fwd.buildReport(provider.issues)
-	err := fwd.send(report)
-
+	err := fwd.Send(context.Background(), &healthplatform.HealthReport{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "API key not configured")
 }
 
-// TestBuildIntakeURL tests URL building based on site configuration
 func TestBuildIntakeURL(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -249,15 +109,12 @@ func TestBuildIntakeURL(t *testing.T) {
 	}{
 		{
 			name:     "default site",
-			site:     "",
-			ddURL:    "",
-			expected: "https://agenthealth-intake.datadoghq.com./api/v2/agenthealth", // FQDN with trailing dot
+			expected: "https://agenthealth-intake.datadoghq.com./api/v2/agenthealth",
 		},
 		{
 			name:     "eu site",
 			site:     "datadoghq.eu",
-			ddURL:    "",
-			expected: "https://agenthealth-intake.datadoghq.eu./api/v2/agenthealth", // FQDN with trailing dot
+			expected: "https://agenthealth-intake.datadoghq.eu./api/v2/agenthealth",
 		},
 		{
 			name:     "custom dd_url overrides",
@@ -276,19 +133,7 @@ func TestBuildIntakeURL(t *testing.T) {
 			if tt.ddURL != "" {
 				cfg.SetWithoutSource("dd_url", tt.ddURL)
 			}
-
-			url := buildIntakeURL(cfg)
-			assert.Equal(t, tt.expected, url)
+			assert.Equal(t, tt.expected, buildIntakeURL(cfg))
 		})
 	}
-}
-
-// TestForwarderNewWithHostname tests that a forwarder stores the given hostname
-func TestForwarderNewWithHostname(t *testing.T) {
-	cfg := config.NewMock(t)
-	cfg.SetWithoutSource("api_key", "test-api-key")
-	provider := newMockIssueProvider()
-
-	fwd := newTestForwarder(t, cfg, provider, "test-hostname")
-	assert.Equal(t, "test-hostname", fwd.hostname)
 }

--- a/comp/healthplatform/forwarder/mock/BUILD.bazel
+++ b/comp/healthplatform/forwarder/mock/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//comp/healthplatform/forwarder/def",
         "//pkg/util/fxutil",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
     ],
 )

--- a/comp/healthplatform/forwarder/mock/mock.go
+++ b/comp/healthplatform/forwarder/mock/mock.go
@@ -9,13 +9,19 @@
 package mock
 
 import (
+	"context"
+
+	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
+
 	forwarder "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 type mockForwarder struct{}
 
-func (m *mockForwarder) SetProvider(_ forwarder.IssueProvider) {}
+func (m *mockForwarder) Send(_ context.Context, _ *healthplatformpayload.HealthReport) error {
+	return nil
+}
 
 // New returns a no-op mock forwarder for testing.
 func New() forwarder.Component {

--- a/comp/healthplatform/store/impl/BUILD.bazel
+++ b/comp/healthplatform/store/impl/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//comp/core/log/def",
         "//comp/core/telemetry/def",
         "//comp/def",
-        "//comp/healthplatform/forwarder/def",
         "//comp/healthplatform/issues",
         "//comp/healthplatform/store/def",
         "//comp/healthplatform/store/noop-impl",

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -27,7 +27,6 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
-	forwarderdef "github.com/DataDog/datadog-agent/comp/healthplatform/forwarder/def"
 	issuesmod "github.com/DataDog/datadog-agent/comp/healthplatform/issues"
 	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	noopimpl "github.com/DataDog/datadog-agent/comp/healthplatform/store/noop-impl"
@@ -43,7 +42,6 @@ type Requires struct {
 	Log       log.Component
 	Telemetry telemetry.Component
 	Hostname  hostnameinterface.Component
-	Forwarder forwarderdef.Component
 }
 
 // Provides defines the output of the health-platform component
@@ -76,9 +74,6 @@ type healthPlatformImpl struct {
 
 	// Issue module registry (combines checks + remediations)
 	issueRegistry *issuesmod.Registry
-
-	// Forwarder for sending reports to Datadog intake
-	forwarder forwarderdef.Component
 
 	// Metrics
 	metrics telemetryMetrics // Telemetry metrics for health platform
@@ -266,9 +261,6 @@ func NewComponent(reqs Requires) (Provides, error) {
 		hostnameProvider: reqs.Hostname,
 		agentFlavor:      flavor.GetFlavor(),
 
-		// Sub-components injected by fx
-		forwarder: reqs.Forwarder,
-
 		// Issue module registry
 		issueRegistry: issueRegistry,
 
@@ -323,8 +315,6 @@ func (h *healthPlatformImpl) start(_ context.Context) error {
 		h.log.Warn("Failed to load persisted issues: " + err.Error())
 	}
 
-	h.forwarder.SetProvider(h)
-
 	return nil
 }
 
@@ -339,9 +329,9 @@ func (h *healthPlatformImpl) stop(_ context.Context) error {
 // ============================================================================
 
 // ReportIssue records a new or ongoing issue. The issue is keyed by
-// report.IssueID (unique instance id). If a template is registered for
-// report.IssueType it enriches the proto (title, severity, remediation, etc.);
-// otherwise a minimal proto is built from the report fields.
+// report.IssueID (unique instance id). The template is looked up by
+// report.IssueType in the issue registry; report.Tags are appended to the
+// template's tags. The template's user-facing Source field is preserved.
 func (h *healthPlatformImpl) ReportIssue(report healthplatformdef.IssueReport) error {
 	if report.IssueID == "" {
 		return errors.New("issue id cannot be empty")
@@ -352,7 +342,7 @@ func (h *healthPlatformImpl) ReportIssue(report healthplatformdef.IssueReport) e
 
 	issue, err := h.toProto(report)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to build issue %s: %w", report.IssueType, err)
 	}
 
 	h.issuesMux.RLock()

--- a/releasenotes/notes/healthplatform-egress-component-19813e8e7ad2cc02.yaml
+++ b/releasenotes/notes/healthplatform-egress-component-19813e8e7ad2cc02.yaml
@@ -1,0 +1,9 @@
+---
+other:
+  - |
+    Internal refactoring of the health platform component: introduces an
+    ``egress`` component that owns the periodic ``store → intake`` flush loop,
+    and simplifies the ``forwarder`` component to a stateless HTTP client
+    (``Send(ctx, *HealthReport) error``). The ``SetProvider``/``IssueProvider``
+    callback workaround for the circular dependency between the store and the
+    forwarder has been removed.


### PR DESCRIPTION
### What does this PR do?

Introduces a new `egress` component that owns the periodic health-platform flush loop, and simplifies the `forwarder` component to a stateless HTTP client.

**forwarder** — now a stateless HTTP client:
- Drops `IssueProvider`/`SetProvider` callback, internal ticker, `hostname`/`agentFlavor` fields, and lifecycle hooks.
- `Requires` shrinks to `{Log, Config}`. Single public method: `Send(ctx context.Context, report *HealthReport) error`.

**egress** — new component that owns the periodic store→intake tick:
- Reads `health_platform.forwarder.interval` (default 15 min, unchanged).
- Each tick: `store.GetAllIssues()` → build `HealthReport` → `forwarder.Send`. Skips empty ticks.
- Full lifecycle start/stop with goroutine cancellation.

**store** — drops forwarder dependency:
- Removes `Forwarder forwarderdef.Component` from `Requires` and the `SetProvider` call from `start()`. No more circular-dependency workaround.

**bundle** — wires egress:
- `egressfx.Module()` added; the bootstrap `fx.Invoke` takes `egressdef.Component` to force fx instantiation.

### Motivation

The previous design mixed HTTP mechanics and send cadence in the `forwarder`, and worked around a circular dependency between `store` and `forwarder` via a `SetProvider` callback set at startup. This is PR 5 in the healthplatform refactor series (builds on #50748).

### Describe how you validated your changes

- `dda inv test --targets=./comp/healthplatform/...` — all 54 unit tests pass locally.
- New `comp/healthplatform/egress/impl` tests cover: tick→send, empty-store skip, error recovery after a failed tick, lifecycle start/stop, `buildReport` shape.
- `TestBundleStartLifecycle` exercises the full scheduler→store→egress→forwarder POST chain end-to-end.
- E2E tests successful on the CI

### Additional Notes

<details>
<summary>Full refactor plan</summary>

See `comp/healthplatform/PLAN.md` for the complete plan. This PR covers the **egress + forwarder simplification** step.

**Component split — single responsibility per component:**
- `store` — pure state owner. Receives `ReportIssue`/`ResolveIssue`, owns the in-memory issue map + persistence + lifecycle state machine, exposes queries, hosts the local HTTP `GET /health-platform/issues` endpoint, and the flare provider. No dependency on the forwarder.
- `runner` — stateless. Runs a single `HealthCheckFunc` once, forwards each emitted `IssueReport` to the store, returns the set of issue ids it reported.
- `scheduler` — schedules periodic execution. On each tick, calls `runner.Run(...)`, diffs the returned issue ids, and resolves any that disappeared.
- `egress` *(this PR)* — periodic backend egress driver. Each tick: `store.GetAllIssues()`, builds a `HealthReport`, calls `forwarder.Send(...)`.
- `forwarder` *(this PR)* — stateless HTTP client. `Send(ctx, report *HealthReport) error`. Builds the request, POSTs to Datadog intake.

**Dependency graph (no cycles):**
```
issues/registry  ◀── store
store            ◀── runner
runner           ◀── scheduler
store            ◀── scheduler
store            ◀── egress
forwarder        ◀── egress
```

</details>