### PR TITLE
Host Profiler: add automatic profiler bump workflow

### DIFF
--- a/.github/chainguard/opentelemetry-ebpf-profiler.notify-datadog-agent-on-push.dispatch.sts.yaml
+++ b/.github/chainguard/opentelemetry-ebpf-profiler.notify-datadog-agent-on-push.dispatch.sts.yaml
@@ -10,4 +10,4 @@ claim_pattern:
   repository: DataDog/opentelemetry-ebpf-profiler
 
 permissions:
-  actions: write
+  contents: write

--- a/.github/chainguard/opentelemetry-ebpf-profiler.notify-datadog-agent-on-push.dispatch.sts.yaml
+++ b/.github/chainguard/opentelemetry-ebpf-profiler.notify-datadog-agent-on-push.dispatch.sts.yaml
@@ -9,5 +9,6 @@ claim_pattern:
   job_workflow_ref: DataDog/opentelemetry-ebpf-profiler/\.github/workflows/notify-datadog-agent-on-push\.yml@refs/heads/datadog
   repository: DataDog/opentelemetry-ebpf-profiler
 
+# most restrictive that still grants permissions for repository_dispatch
 permissions:
   contents: write

--- a/.github/chainguard/opentelemetry-ebpf-profiler.notify-datadog-agent-on-push.dispatch.sts.yaml
+++ b/.github/chainguard/opentelemetry-ebpf-profiler.notify-datadog-agent-on-push.dispatch.sts.yaml
@@ -1,0 +1,13 @@
+# Policy for: .github/workflows/notify-datadog-agent-on-push.yml in DataDog/opentelemetry-ebpf-profiler
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/opentelemetry-ebpf-profiler:ref:refs/heads/datadog
+
+claim_pattern:
+  event_name: push
+  ref: refs/heads/datadog
+  ref_protected: "true"
+  job_workflow_ref: DataDog/opentelemetry-ebpf-profiler/\.github/workflows/notify-datadog-agent-on-push\.yml@refs/heads/datadog
+  repository: DataDog/opentelemetry-ebpf-profiler
+
+permissions:
+  actions: write

--- a/.github/chainguard/self.update-ebpf-profiler-branch.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-ebpf-profiler-branch.create-pr.sts.yaml
@@ -4,7 +4,6 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:DataDog/datadog-agent:ref:refs/heads/main
 
 claim_pattern:
-  event_name: workflow_dispatch
   ref: refs/heads/main
   ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/update-ebpf-profiler-branch\.yml@refs/heads/main

--- a/.github/chainguard/self.update-ebpf-profiler-branch.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-ebpf-profiler-branch.create-pr.sts.yaml
@@ -1,0 +1,15 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:ref:refs/heads/main
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/update-ebpf-profiler-branch\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write
+  members: read

--- a/.github/workflows/update-ebpf-profiler-branch.yml
+++ b/.github/workflows/update-ebpf-profiler-branch.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           token: ${{ steps.octo-sts.outputs.token }}
           sign-commits: true
-          branch: update-ebpf-profiler-to-datadog-${{ github.run_id }}
+          branch: update-ebpf-profiler-to-datadog
           commit-message: "chore(deps): switch ebpf-profiler replace directive to datadog branch"
           title: "Bump opentelemetry-ebpf-profiler dependency to latest fork version"
           body: |

--- a/.github/workflows/update-ebpf-profiler-branch.yml
+++ b/.github/workflows/update-ebpf-profiler-branch.yml
@@ -1,0 +1,62 @@
+name: Update ebpf-profiler to branch
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  update-ebpf-profiler:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for dd-octo-sts OIDC token
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: .go-version
+
+      - name: Install dda
+        uses: ./.github/actions/install-dda
+        with:
+          features: legacy-tasks
+
+      - name: Update go.mod replace directive to datadog branch
+        run: sed -i "s|go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v[^ ]*|go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog|" go.mod
+
+      - name: Tidy and generate licenses
+        run: |
+          go mod tidy
+          dda inv -- -e tidy
+          dda inv -- -e install-tools
+          dda inv -- -e generate-licenses
+
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.update-ebpf-profiler-branch.create-pr
+
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        name: Create draft PR
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          sign-commits: true
+          branch: update-ebpf-profiler-to-datadog-${{ github.run_id }}
+          commit-message: "chore(deps): switch ebpf-profiler replace directive to datadog branch"
+          title: "Bump opentelemetry-ebpf-profiler dependency to latest fork version"
+          body: |
+            ### What does this PR do?
+            Bump profiler's version to match latest rebase on datadog's fork.
+
+            ### Motivation
+
+            ### Describe how you validated your changes
+
+            ### Additional Notes
+          draft: true
+          team-reviewers: |
+            profiling-full-host
+            opentelemetry-agent
+          labels: changelog/no-changelog,qa/no-code-change

--- a/.github/workflows/update-ebpf-profiler-branch.yml
+++ b/.github/workflows/update-ebpf-profiler-branch.yml
@@ -2,6 +2,8 @@ name: Update ebpf-profiler to branch
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types: [ebpf-profiler-datadog-branch-updated]
 
 permissions: {}
 


### PR DESCRIPTION
### What does this PR do?

Add an workflow to bump the profiler dependency and post a draft PR. It gets triggered by https://github.com/DataDog/opentelemetry-ebpf-profiler/pull/81

This workflow:
1. updates `go.mod` replace directive from the version slug to branch slug
2. runs:
  - `go mod tidy`
  - `dda inv tidy`
  - `dda inv install-tools` (required for next step)
  - `dda inv generate-licenses`
3. creates draft PR

### Motivation

We periodically rebase https://github.com/DataDog/opentelemetry-ebpf-profiler to keep up with upstream changes.
Every time, an associated PR in `datadog-agent` needs to be created with, most of the time, the same steps.
This workflow aims to automate as much as can be automated from that process.

### Describe how you validated your changes

Ran the commands locally and checked manually.

### Additional Notes

PRs are created as drafts because some upstream changes might require custom changes before being ready for review. This is a tradeoff to make sure not to flood teams with PRs not yet ready.
