### PR TITLE
[SLES-2826] Diagnosis Logs for AAS Restart Named Pipe Overlap Issue [Do Not Merge] 

### DIFF
--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -4,6 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package main implements the entrypoint of the `trace-agent` binary.
+// See pkg/trace/api/api.go and pipe.go for [aas-repro] diagnostic changes.
 package main
 
 import (

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/fx"
@@ -259,12 +260,18 @@ func setupMetrics(statsd statsd.Component, cfg traceconfigdef.Component, telemet
 }
 
 func stop(ag component) error {
+	stopStart := time.Now()
+	log.Infof("[aas-repro] shutdown_stop_begin pid=%d at=%s", os.Getpid(), stopStart.UTC().Format(time.RFC3339Nano))
 	ag.cancel()
+	log.Infof("[aas-repro] shutdown_context_cancelled pid=%d elapsed_ms=%d", os.Getpid(), time.Since(stopStart).Milliseconds())
 	ag.wg.Wait()
+	log.Infof("[aas-repro] shutdown_agent_wg_done pid=%d elapsed_ms=%d", os.Getpid(), time.Since(stopStart).Milliseconds())
 	if err := ag.Statsd.Flush(); err != nil {
 		log.Error("Could not flush statsd: ", err)
 	}
+	log.Infof("[aas-repro] shutdown_statsd_flushed pid=%d elapsed_ms=%d", os.Getpid(), time.Since(stopStart).Milliseconds())
 	stopAgentSidekicks(ag.config, ag.Statsd, ag.params.DisableInternalProfiling)
+	log.Infof("[aas-repro] shutdown_process_exiting pid=%d elapsed_total_ms=%d", os.Getpid(), time.Since(stopStart).Milliseconds())
 	if ag.params.CPUProfile != "" {
 		pprof.StopCPUProfile()
 	}
@@ -300,6 +307,7 @@ func handleSignal(shutdowner fx.Shutdowner, statsd ddgostatsd.ClientInterface) {
 	for signo := range sigChan {
 		switch signo {
 		case syscall.SIGINT, syscall.SIGTERM:
+			log.Infof("[aas-repro] shutdown_signal_received pid=%d signal=%d signal_name=%v at=%s", os.Getpid(), signo, signo, time.Now().UTC().Format(time.RFC3339Nano))
 			log.Infof("Received signal %d (%v)", signo, signo)
 			_ = shutdowner.Shutdown()
 			return

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -419,6 +419,11 @@ func (r *HTTPReceiver) Start() {
 		ln, err := listenPipe(pipepath, secdec, bufferSize, r.conf.MaxConnections, r.statsd)
 		if err != nil {
 			log.Errorf("[aas-repro] bind_collision pipe=%q pid=%d err=%v", pipepath, os.Getpid(), err)
+			reason := "other"
+			if strings.Contains(strings.ToLower(err.Error()), "access is denied") {
+				reason = "access_denied"
+			}
+			log.Errorf("[aas-repro] pipe_bind_failed pipe=%q pid=%d reason=%s err=%v", pipepath, os.Getpid(), reason, err)
 			r.telemetryCollector.SendStartupError(telemetry.CantStartWindowsPipeServer, err)
 			killProcess("Error creating %q named pipe: %v", pipepath, err)
 		}
@@ -457,18 +462,25 @@ func (r *HTTPReceiver) Stop() error {
 	if !r.conf.ReceiverEnabled || (r.conf.ReceiverPort == 0 && r.conf.ReceiverSocket == "" && r.conf.WindowsPipeName == "") {
 		return nil
 	}
+	shutdownStart := time.Now()
+	log.Infof("[aas-repro] shutdown_pipe_listener_closing pid=%d", os.Getpid())
 	r.exit <- struct{}{}
 	<-r.exit
+	log.Infof("[aas-repro] shutdown_pipe_listener_closed pid=%d elapsed_ms=%d", os.Getpid(), time.Since(shutdownStart).Milliseconds())
 
 	expiry := time.Now().Add(5 * time.Second) // give it 5 seconds
 	ctx, cancel := context.WithDeadline(context.Background(), expiry)
 	defer cancel()
 	if err := r.server.Shutdown(ctx); err != nil {
 		log.Warnf("Error shutting down HTTPReceiver: %v", err)
+		log.Infof("[aas-repro] shutdown_http_server_error pid=%d elapsed_ms=%d err=%v", os.Getpid(), time.Since(shutdownStart).Milliseconds(), err)
 		return err
 	}
+	log.Infof("[aas-repro] shutdown_http_server_closed pid=%d elapsed_ms=%d", os.Getpid(), time.Since(shutdownStart).Milliseconds())
 	r.wg.Wait()
+	log.Infof("[aas-repro] shutdown_buffer_flush_complete pid=%d elapsed_ms=%d", os.Getpid(), time.Since(shutdownStart).Milliseconds())
 	r.telemetryForwarder.Stop()
+	log.Infof("[aas-repro] shutdown_telemetry_forwarder_stopped pid=%d elapsed_total_ms=%d", os.Getpid(), time.Since(shutdownStart).Milliseconds())
 	return nil
 }
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -412,11 +412,17 @@ func (r *HTTPReceiver) Start() {
 		pipepath := `\\.\pipe\` + path
 		bufferSize := r.conf.PipeBufferSize
 		secdec := r.conf.PipeSecurityDescriptor
+		log.Infof("[aas-repro] bind_attempt pipe=%q pid=%d", pipepath, os.Getpid())
+		if probeExistingPipe(pipepath) {
+			log.Warnf("[aas-repro] orphan_detected pipe=%q pid=%d — a listener is already bound; this process will lose the bind race", pipepath, os.Getpid())
+		}
 		ln, err := listenPipe(pipepath, secdec, bufferSize, r.conf.MaxConnections, r.statsd)
 		if err != nil {
+			log.Errorf("[aas-repro] bind_collision pipe=%q pid=%d err=%v", pipepath, os.Getpid(), err)
 			r.telemetryCollector.SendStartupError(telemetry.CantStartWindowsPipeServer, err)
 			killProcess("Error creating %q named pipe: %v", pipepath, err)
 		}
+		log.Infof("[aas-repro] bind_success pipe=%q pid=%d", pipepath, os.Getpid())
 		go func() {
 			defer watchdog.LogOnPanic(r.statsd)
 			if err := r.server.Serve(ln); err != nil && err != http.ErrServerClosed {

--- a/pkg/trace/api/pipe.go
+++ b/pkg/trace/api/pipe.go
@@ -9,6 +9,7 @@ package api
 
 import (
 	"net"
+	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/Microsoft/go-winio"
@@ -22,4 +23,18 @@ func listenPipe(path string, secdec string, bufferSize int, maxconn int, statsd 
 		InputBufferSize:    int32(bufferSize),
 	})
 	return NewMeasuredListener(ln, "pipe_connections", maxconn, statsd), err
+}
+
+// probeExistingPipe attempts to connect to a named pipe as a client.
+// Returns true if a server is already listening on the pipe (orphan or prior owner),
+// false if no server exists or the probe times out.
+// Used by the [aas-repro] diagnostic path only.
+func probeExistingPipe(path string) bool {
+	t := 100 * time.Millisecond
+	conn, err := winio.DialPipe(path, &t)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }

--- a/pkg/trace/api/pipe_off.go
+++ b/pkg/trace/api/pipe_off.go
@@ -18,3 +18,6 @@ import (
 func listenPipe(_, _ string, _, _ int, _ statsd.ClientInterface) (net.Listener, error) {
 	return nil, errors.New("Windows named pipes are only supported on Windows operating systems")
 }
+
+// probeExistingPipe is a no-op on non-Windows; named pipe diagnostics only run on Windows.
+func probeExistingPipe(_ string) bool { return false }


### PR DESCRIPTION
Adds [aas-repro] structured log lines around the Windows named pipe bind sequence in HTTPReceiver.Start (pkg/trace/api/api.go):

- bind_attempt: logged before every listenPipe call, with pid
- orphan_detected: logged if a listener is already bound before our attempt (indicates an orphan from a prior IIS Worker Process)
- bind_collision: logged on listenPipe error, before killProcess exit
- bind_success: logged on successful bind

Also adds probeExistingPipe() in pipe.go (Windows) and a no-op stub in pipe_off.go, using winio.DialPipe with a 100ms timeout to check whether a server is already holding the pipe before we attempt to bind.

These changes are repro-only and do not ship to customers.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
