### PR TITLE
[observer] Test CheckSampler metrics enabled

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
@@ -277,6 +278,9 @@ type BufferedAggregator struct {
 	tagger                      tagger.Component
 	flushAndSerializeInParallel FlushAndSerializeInParallel
 
+	// observerHandle is set at startup and copied into newly created CheckSamplers.
+	observerHandle observer.Handle
+
 	// use this chan to trigger a filterList reconfiguration
 	filterListChan  chan utilstrings.Matcher
 	flushFilterList utilstrings.Matcher
@@ -517,6 +521,12 @@ func (agg *BufferedAggregator) addEvent(e event.Event) {
 	e.Tags = tb.Get()
 
 	agg.events = append(agg.events, &e)
+}
+
+// SetObserverHandle sets the observer handle for mirroring check metrics.
+// The handle is propagated to newly created CheckSamplers.
+func (agg *BufferedAggregator) SetObserverHandle(h observer.Handle) {
+	agg.observerHandle = h
 }
 
 // GetSeriesAndSketches grabs all the series & sketches from the queue and clears the queue
@@ -1001,7 +1011,7 @@ func (agg *BufferedAggregator) handleRegisterSampler(id checkid.ID) {
 		log.Debugf("Sampler with ID '%s' has already been registered, will use existing sampler", id)
 		return
 	}
-	agg.checkSamplers[id] = newCheckSampler(
+	cs := newCheckSampler(
 		pkgconfigsetup.Datadog().GetInt("check_sampler_bucket_commits_count_expiry"),
 		pkgconfigsetup.Datadog().GetBool("check_sampler_expire_metrics"),
 		pkgconfigsetup.Datadog().GetBool("check_sampler_context_metrics"),
@@ -1011,4 +1021,8 @@ func (agg *BufferedAggregator) handleRegisterSampler(id checkid.ID) {
 		id,
 		agg.tagger,
 	)
+	if agg.observerHandle != nil {
+		cs.SetObserverHandle(agg.observerHandle)
+	}
+	agg.checkSamplers[id] = cs
 }

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"time"
 
+	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
@@ -41,6 +42,7 @@ type CheckSampler struct {
 	contextResolverMetrics bool
 	logThrottling          util.SimpleThrottler
 	allowSketchBucketReset bool
+	observerHandle         observer.Handle
 }
 
 // newCheckSampler returns a newly initialized CheckSampler
@@ -68,8 +70,16 @@ func newCheckSampler(
 	}
 }
 
+// SetObserverHandle sets the observer handle for mirroring check samples.
+func (cs *CheckSampler) SetObserverHandle(h observer.Handle) {
+	cs.observerHandle = h
+}
+
 func (cs *CheckSampler) addSample(metricSample *metrics.MetricSample, tagFilterList filterlist.TagMatcher) {
 	contextKey := cs.contextResolver.trackContext(metricSample, tagFilterList)
+	if cs.observerHandle != nil {
+		cs.observerHandle.ObserveMetric(metricSample)
+	}
 	if metricSample.Mtype == metrics.DistributionType {
 		cs.sketchMap.insert(int64(metricSample.Timestamp), contextKey, metricSample.Value, metricSample.SampleRate)
 		return

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -246,13 +246,14 @@ func (d *AgentDemultiplexer) Options() AgentDemultiplexerOptions {
 	return d.options
 }
 
-// SetObserver wires an observer component into the DogStatsD metric pipeline.
+// SetObserver wires an observer component into the DogStatsD metric pipeline
+// and the BufferedAggregator → CheckSampler path (Go core checks).
 //
 // Requires both anomaly_detection.enabled and anomaly_detection.metrics.enabled to be true.
-// Every raw metric sample passing through the time-sampler workers and the
-// no-aggregation pipeline will be forwarded to the provided observer handle
-// before aggregation. The call is a no-op when either flag is off or obs is
-// nil, so default overhead is zero.
+// Every raw metric sample passing through the time-sampler workers, the
+// no-aggregation pipeline, and every CheckSampler will be forwarded to the
+// provided observer handle before aggregation. The call is a no-op when
+// either flag is off or obs is nil, so default overhead is zero.
 func (d *AgentDemultiplexer) SetObserver(obs observer.Component) {
 	if obs == nil {
 		return
@@ -269,13 +270,16 @@ func (d *AgentDemultiplexer) SetObserver(obs observer.Component) {
 
 	metricsHandle := obs.GetHandle("all-metrics")
 
+	// DogStatsD paths
 	for _, worker := range d.statsd.workers {
 		worker.sampler.observerHandle = metricsHandle
 	}
-
 	if d.statsd.noAggStreamWorker != nil {
 		d.statsd.noAggStreamWorker.observerHandle = metricsHandle
 	}
+
+	// Go core check path (BufferedAggregator → CheckSampler)
+	d.aggregator.SetObserverHandle(metricsHandle)
 }
 
 // AddAgentStartupTelemetry adds a startup event and count (in a DSD time sampler)

--- a/pkg/aggregator/observer_handle_test.go
+++ b/pkg/aggregator/observer_handle_test.go
@@ -116,6 +116,7 @@ func TestSetObserverNilIsNoop(t *testing.T) {
 
 // TestSetObserverConfigOff verifies that SetObserver does not wire the handle
 // when anomaly_detection.enabled or anomaly_detection.metrics.enabled is false.
+// Covers both the DogStatsD TimeSampler path and the BufferedAggregator/CheckSampler path.
 func TestSetObserverConfigOff(t *testing.T) {
 	opts := demuxTestOptions()
 	deps := createDemultiplexerAgentTestDeps(t)
@@ -127,8 +128,17 @@ func TestSetObserverConfigOff(t *testing.T) {
 	demux.SetObserver(comp)
 
 	for _, w := range demux.statsd.workers {
-		assert.Nil(t, w.sampler.observerHandle, "handle should not be wired when config is off")
+		assert.Nil(t, w.sampler.observerHandle, "DogStatsD worker handle should not be wired when config is off")
 	}
+	assert.Nil(t, demux.aggregator.observerHandle, "BufferedAggregator handle should not be wired when config is off")
+
+	// Verify that a CheckSampler registered after the (no-op) SetObserver call also has no handle.
+	demux.aggregator.handleRegisterSampler("check-config-off")
+	demux.aggregator.mu.Lock()
+	cs := demux.aggregator.checkSamplers["check-config-off"]
+	demux.aggregator.mu.Unlock()
+	require.NotNil(t, cs)
+	assert.Nil(t, cs.observerHandle, "CheckSampler handle should not be wired when config is off")
 }
 
 // TestCheckSamplerObserverHandle verifies that ObserveMetric is called for each

--- a/pkg/aggregator/observer_handle_test.go
+++ b/pkg/aggregator/observer_handle_test.go
@@ -130,3 +130,64 @@ func TestSetObserverConfigOff(t *testing.T) {
 		assert.Nil(t, w.sampler.observerHandle, "handle should not be wired when config is off")
 	}
 }
+
+// TestCheckSamplerObserverHandle verifies that ObserveMetric is called for each
+// sample fed to CheckSampler.addSample when an observerHandle is wired.
+func TestCheckSamplerObserverHandle(t *testing.T) {
+	store := tags.NewStore(false, "test")
+	cs := newCheckSampler(10, false, false, 0, false, store, "test-check", nooptagger.NewComponent())
+	handle := &recordingHandle{}
+	cs.SetObserverHandle(handle)
+
+	matcher := filterlist.NewNoopTagMatcher()
+
+	samples := []metrics.MetricSample{
+		{Name: "system.cpu.user", Value: 42.0, Mtype: metrics.GaugeType, Tags: []string{"host:myhost"}, SampleRate: 1, Timestamp: 1000},
+		{Name: "system.mem.used", Value: 8192.0, Mtype: metrics.GaugeType, Tags: []string{}, SampleRate: 1, Timestamp: 2000},
+	}
+
+	for i := range samples {
+		cs.addSample(&samples[i], matcher)
+	}
+
+	require.Len(t, handle.calls, 2)
+	assert.Equal(t, "system.cpu.user", handle.calls[0].name)
+	assert.Equal(t, 42.0, handle.calls[0].value)
+	assert.Equal(t, []string{"host:myhost"}, handle.calls[0].tags)
+	assert.Equal(t, int64(1000), handle.calls[0].timestamp)
+
+	assert.Equal(t, "system.mem.used", handle.calls[1].name)
+	assert.Equal(t, 8192.0, handle.calls[1].value)
+}
+
+// TestCheckSamplerObserverHandleNil verifies no panic when observerHandle is nil.
+func TestCheckSamplerObserverHandleNil(t *testing.T) {
+	store := tags.NewStore(false, "test")
+	cs := newCheckSampler(10, false, false, 0, false, store, "test-check", nooptagger.NewComponent())
+	// observerHandle is nil by default
+
+	matcher := filterlist.NewNoopTagMatcher()
+	s := metrics.MetricSample{Name: "m", Value: 1, Mtype: metrics.GaugeType, SampleRate: 1}
+	assert.NotPanics(t, func() { cs.addSample(&s, matcher) })
+}
+
+// TestBufferedAggregatorObserverHandlePropagation verifies that SetObserverHandle
+// on BufferedAggregator is propagated to CheckSamplers created afterwards.
+func TestBufferedAggregatorObserverHandlePropagation(t *testing.T) {
+	opts := demuxTestOptions()
+	deps := createDemultiplexerAgentTestDeps(t)
+	demux := initAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+
+	handle := &recordingHandle{}
+	demux.aggregator.SetObserverHandle(handle)
+
+	// Simulate a check registering its sampler
+	demux.aggregator.handleRegisterSampler("test-check-id")
+
+	demux.aggregator.mu.Lock()
+	cs, ok := demux.aggregator.checkSamplers["test-check-id"]
+	demux.aggregator.mu.Unlock()
+
+	require.True(t, ok, "sampler should have been created")
+	assert.Equal(t, handle, cs.observerHandle, "observer handle should have been propagated to CheckSampler")
+}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1699,6 +1699,10 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_origin_optout_enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)
+	
+	// TEST ONLY: enabled by default to measure overhead — do not merge
+	config.BindEnvAndSetDefault("anomaly_detection.metrics.enabled", true)
+
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — performance measurement branch

This branch enables `anomaly_detection.metrics.enabled` by **default** (`true`) on top of #50763 to measure the CPU and memory overhead of the new `CheckSampler → ObserveMetric` tap on the Go core-check metrics path when active.

The purpose is to give reviewers a CI pipeline to compare against `dogstatsd_metrics_stats_enable` and against #50594, and validate that the per-sample overhead is acceptable for core-check metrics (`system.cpu.*`, `system.mem.*`, network, etc.).

## What changed

Single addition in `pkg/config/setup/common_settings.go`:
```go
// TEST ONLY: enabled by default to measure overhead — do not merge
config.BindEnvAndSetDefault("anomaly_detection.metrics.enabled", true)
```

This activates the observer tap in `CheckSampler.addSample` for every Go core-check metric — adding one nil-check + one virtual interface dispatch per sample on the BufferedAggregator path.

## What to look at

- Benchmark jobs in CI on this branch
- Compare against a baseline run with `dogstatsd_metrics_stats_enable=true`

Stacks on top of #50763.