### PR TITLE
[AD] Filter discovery templates against existing config sources

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
@@ -251,13 +251,15 @@ func (cm *reconcilingConfigManager) processNewConfig(config integration.Config) 
 
 		// Publish to the cross-listener index so that subsequently
 		// reconciled services (e.g. ProcessService) can deduplicate
-		// templates against this static config.
+		// templates against this static config (must have instances).
 		//
 		// TODO: re-reconcile already-resolved services whose templates of
 		// this name would now be deduplicated. Without this, a static
 		// config that arrives after a dynamic process discovery leaves the
 		// duplicate scheduled until something else perturbs the service.
-		cm.staticConfigIndex.Add(config.Name)
+		if len(decryptedConfig.Instances) > 0 {
+			cm.staticConfigIndex.Add(config.Name)
+		}
 	}
 
 	//  4. update scheduledConfigs
@@ -310,10 +312,10 @@ func (cm *reconcilingConfigManager) processDelConfigs(configs []integration.Conf
 
 			changes.UnscheduleConfig(config)
 
-			// Update the cross-listener index. See processNewConfig for the
-			// TODO on runtime re-reconciliation of services whose templates
-			// of this name may now be (re)schedulable.
-			cm.staticConfigIndex.Remove(config.Name)
+			// Update the cross-listener index.
+			if len(config.Instances) > 0 {
+				cm.staticConfigIndex.Remove(config.Name)
+			}
 		}
 
 		//  4. update scheduledConfigs

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
@@ -594,7 +594,10 @@ func TestStaticConfigIndexDedupOnReconcile(t *testing.T) {
 		LogsConfig:    []byte("source: %%host%%"),
 		ADIdentifiers: []string{"proc-redis"},
 	}
-	staticRedis := integration.Config{Name: "redis"}
+	staticRedis := integration.Config{
+		Name:      "redis",
+		Instances: []integration.Data{integration.Data("port: 6379")},
+	}
 
 	// Startup ordering: static config arrives first, then the template,
 	// then the matching service.
@@ -624,7 +627,7 @@ func TestStaticConfigIndexRefcountThroughConfigMgr(t *testing.T) {
 
 	cm := newReconcilingConfigManager(&mockResolver, nil, idx)
 
-	staticRedis1 := integration.Config{Name: "redis"}
+	staticRedis1 := integration.Config{Name: "redis", Instances: []integration.Data{integration.Data("port: 6379")}}
 	staticRedis2 := integration.Config{Name: "redis", Instances: []integration.Data{integration.Data("port: 6380")}}
 
 	cm.processNewConfig(staticRedis1)
@@ -637,6 +640,30 @@ func TestStaticConfigIndexRefcountThroughConfigMgr(t *testing.T) {
 	assert.True(t, idx.Has("redis"))
 
 	cm.processDelConfigs([]integration.Config{staticRedis2})
+	assert.False(t, idx.Has("redis"))
+}
+
+// Logs-only static configs (no Instances) are not added to the
+// StaticConfigIndex. The index tracks integrations covered by a scheduled
+// non-template *check* config so that dynamic templates of the same name can
+// be deduplicated. A logs-only conf.d entry forwards logs but doesn't
+// configure a check, so it must not suppress dynamic check templates.
+func TestStaticConfigIndex_SkipsLogsOnlyConfigs(t *testing.T) {
+	mockResolver := MockSecretResolver{}
+	idx := listeners.NewStaticConfigIndex()
+
+	cm := newReconcilingConfigManager(&mockResolver, nil, idx)
+
+	logsOnly := integration.Config{
+		Name:       "redis",
+		LogsConfig: []byte(`{"source":"redis"}`),
+	}
+	cm.processNewConfig(logsOnly)
+	assert.False(t, idx.Has("redis"),
+		"logs-only static configs must not populate the static config index")
+
+	// Removing the same config should be a no-op for the index.
+	cm.processDelConfigs([]integration.Config{logsOnly})
 	assert.False(t, idx.Has("redis"))
 }
 

--- a/comp/core/autodiscovery/integration/config.go
+++ b/comp/core/autodiscovery/integration/config.go
@@ -125,7 +125,7 @@ type Config struct {
 	// template: the agent should not schedule it directly, and any matched
 	// instance is meant to discover its own config at runtime. A non-nil
 	// pointer means discovery is requested. (optional)
-	Discovery *DiscoveryConfig `json:"discovery,omitempty"` // (include in digest: false)
+	Discovery *DiscoveryConfig `json:"discovery,omitempty"` // (include in digest: true)
 }
 
 // DiscoveryConfig holds per-template configuration-discovery options.
@@ -476,6 +476,9 @@ func (c *Config) IntDigest() uint64 {
 	_, _ = h.Write([]byte(c.LogsConfig))
 	_, _ = h.Write([]byte(c.ServiceID))
 	_, _ = h.Write([]byte(strconv.FormatBool(c.IgnoreAutodiscoveryTags)))
+	if c.Discovery != nil {
+		_, _ = h.Write([]byte("discovery"))
+	}
 
 	return h.Sum64()
 }
@@ -499,6 +502,9 @@ func (c *Config) FastDigest() uint64 {
 	_, _ = h.Write([]byte(c.LogsConfig))
 	_, _ = h.Write([]byte(c.ServiceID))
 	_, _ = h.Write([]byte(strconv.FormatBool(c.IgnoreAutodiscoveryTags)))
+	if c.Discovery != nil {
+		_, _ = h.Write([]byte("discovery"))
+	}
 
 	return h.Sum64()
 }

--- a/comp/core/autodiscovery/integration/config.go
+++ b/comp/core/autodiscovery/integration/config.go
@@ -120,7 +120,16 @@ type Config struct {
 
 	// ImageName is the container image name if any
 	ImageName string `json:"image_name"` // (include in digest: false)
+
+	// Discovery indicates that this config is a configuration-discovery
+	// template: the agent should not schedule it directly, and any matched
+	// instance is meant to discover its own config at runtime. A non-nil
+	// pointer means discovery is requested. (optional)
+	Discovery *DiscoveryConfig `json:"discovery,omitempty"` // (include in digest: false)
 }
+
+// DiscoveryConfig holds per-template configuration-discovery options.
+type DiscoveryConfig struct{}
 
 // MatchingProgram is an interface for matching objects against filter rules.
 type MatchingProgram interface {
@@ -228,6 +237,12 @@ func (c *Config) String() string {
 // IsTemplate returns if the config has AD identifiers
 func (c *Config) IsTemplate() bool {
 	return len(c.ADIdentifiers) > 0 || len(c.AdvancedADIdentifiers) > 0
+}
+
+// IsDiscovery returns true if this config is a configuration-discovery
+// template (a non-nil Discovery field).
+func (c *Config) IsDiscovery() bool {
+	return c.Discovery != nil
 }
 
 // IsMatched returns true if the given object matches the filtering program of the config.

--- a/comp/core/autodiscovery/integration/config_test.go
+++ b/comp/core/autodiscovery/integration/config_test.go
@@ -254,6 +254,22 @@ func TestIsDiscovery(t *testing.T) {
 	assert.True(t, config.IsDiscovery())
 }
 
+func TestDigestIncludesDiscovery(t *testing.T) {
+	withoutDiscovery := &Config{
+		Name:       "foo",
+		InitConfig: Data(""),
+	}
+	withDiscovery := &Config{
+		Name:       "foo",
+		InitConfig: Data(""),
+		Discovery:  &DiscoveryConfig{},
+	}
+	assert.NotEqual(t, withoutDiscovery.Digest(), withDiscovery.Digest(),
+		"Discovery field must change the config digest so a discovery template and its non-discovery counterpart are distinct")
+	assert.NotEqual(t, withoutDiscovery.FastDigest(), withDiscovery.FastDigest(),
+		"Discovery field must change FastDigest as well")
+}
+
 func TestGetNameForInstance(t *testing.T) {
 	config := &Config{}
 

--- a/comp/core/autodiscovery/integration/config_test.go
+++ b/comp/core/autodiscovery/integration/config_test.go
@@ -247,6 +247,13 @@ func TestDigest(t *testing.T) {
 	assert.NotEqual(t, simpleConfig.Digest(), simpleIngoreADTagsConfig.Digest())
 }
 
+func TestIsDiscovery(t *testing.T) {
+	config := &Config{}
+	assert.False(t, config.IsDiscovery())
+	config.Discovery = &DiscoveryConfig{}
+	assert.True(t, config.IsDiscovery())
+}
+
 func TestGetNameForInstance(t *testing.T) {
 	config := &Config{}
 

--- a/comp/core/autodiscovery/listeners/common_filter.go
+++ b/comp/core/autodiscovery/listeners/common_filter.go
@@ -31,15 +31,21 @@ func filterTemplatesMatched(svc FilterableService, configs map[string]integratio
 
 // filterTemplatesDiscovery drops configuration-discovery templates that are
 // redundant with another config source for the same integration. Dropped when:
-//  1. another template for the same integration Name has matched this same service (present in configs), or
-//  2. a scheduled non-template (static) config exists for the same Name (tracked in staticIdx).
+//  1. another check template (Instances > 0) for the same integration Name has
+//     matched this same service (present in configs), or
+//  2. a scheduled non-template (static) config exists for the same Name
+//     (tracked in staticIdx).
+//
+// Logs-only sibling templates (no Instances) are ignored — discovery covers
+// metric-check configuration and shouldn't be suppressed by an integration's
+// log forwarding setup.
 func filterTemplatesDiscovery(staticIdx *StaticConfigIndex, configs map[string]integration.Config) {
 	if len(configs) == 0 {
 		return
 	}
 	nonDiscoveryNames := map[string]struct{}{}
 	for _, cfg := range configs {
-		if !cfg.IsDiscovery() {
+		if !cfg.IsDiscovery() && len(cfg.Instances) > 0 {
 			nonDiscoveryNames[cfg.Name] = struct{}{}
 		}
 	}

--- a/comp/core/autodiscovery/listeners/common_filter.go
+++ b/comp/core/autodiscovery/listeners/common_filter.go
@@ -8,6 +8,7 @@ package listeners
 import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // FilterableService is an interface for a subset of services that can use advanced filtering
@@ -24,6 +25,33 @@ func filterTemplatesMatched(svc FilterableService, configs map[string]integratio
 			if !config.IsMatched(filterableEntity) {
 				delete(configs, digest)
 			}
+		}
+	}
+}
+
+// filterTemplatesDiscovery drops configuration-discovery templates that are
+// redundant with another config source for the same integration. Dropped when:
+//  1. another template for the same integration Name has matched this same service (present in configs), or
+//  2. a scheduled non-template (static) config exists for the same Name (tracked in staticIdx).
+func filterTemplatesDiscovery(staticIdx *StaticConfigIndex, configs map[string]integration.Config) {
+	if len(configs) == 0 {
+		return
+	}
+	nonDiscoveryNames := map[string]struct{}{}
+	for _, cfg := range configs {
+		if !cfg.IsDiscovery() {
+			nonDiscoveryNames[cfg.Name] = struct{}{}
+		}
+	}
+	for digest, cfg := range configs {
+		if !cfg.IsDiscovery() {
+			continue
+		}
+		_, hasSibling := nonDiscoveryNames[cfg.Name]
+		if hasSibling || staticIdx.Has(cfg.Name) {
+			log.Debugf("Ignoring discovery template %s from %s: another config source already covers this integration",
+				cfg.Name, cfg.Source)
+			delete(configs, digest)
 		}
 	}
 }

--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -35,20 +35,22 @@ const (
 // workloadmeta store.
 type ContainerListener struct {
 	workloadmetaListener
-	globalFilter  workloadfilter.FilterBundle
-	metricsFilter workloadfilter.FilterBundle
-	logsFilter    workloadfilter.FilterBundle
-	tagger        tagger.Component
+	globalFilter      workloadfilter.FilterBundle
+	metricsFilter     workloadfilter.FilterBundle
+	logsFilter        workloadfilter.FilterBundle
+	tagger            tagger.Component
+	staticConfigIndex *StaticConfigIndex
 }
 
 // NewContainerListener returns a new ContainerListener.
 func NewContainerListener(options ServiceListernerDeps) (ServiceListener, error) {
 	const name = "ad-containerlistener"
 	l := &ContainerListener{
-		globalFilter:  options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.GlobalFilter),
-		metricsFilter: options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.MetricsFilter),
-		logsFilter:    options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.LogsFilter),
-		tagger:        options.Tagger,
+		globalFilter:      options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.GlobalFilter),
+		metricsFilter:     options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.MetricsFilter),
+		logsFilter:        options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.LogsFilter),
+		tagger:            options.Tagger,
+		staticConfigIndex: options.StaticConfigIndex,
 	}
 	filter := workloadmeta.NewFilterBuilder().
 		SetSource(workloadmeta.SourceAll).
@@ -132,13 +134,14 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 			containerImg.RawName,
 			container.Labels,
 		),
-		ports:           ports,
-		pid:             container.PID,
-		hostname:        container.Hostname,
-		metricsExcluded: l.metricsFilter.IsExcluded(filterableContainer),
-		logsExcluded:    l.logsFilter.IsExcluded(filterableContainer),
-		tagger:          l.tagger,
-		wmeta:           l.Store(),
+		ports:             ports,
+		pid:               container.PID,
+		hostname:          container.Hostname,
+		metricsExcluded:   l.metricsFilter.IsExcluded(filterableContainer),
+		logsExcluded:      l.logsFilter.IsExcluded(filterableContainer),
+		tagger:            l.tagger,
+		wmeta:             l.Store(),
+		staticConfigIndex: l.staticConfigIndex,
 	}
 
 	if pod != nil {

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -29,10 +29,11 @@ import (
 // to the workloadmeta store.
 type KubeletListener struct {
 	workloadmetaListener
-	globalFilter  workloadfilter.FilterBundle
-	metricsFilter workloadfilter.FilterBundle
-	logsFilter    workloadfilter.FilterBundle
-	tagger        tagger.Component
+	globalFilter      workloadfilter.FilterBundle
+	metricsFilter     workloadfilter.FilterBundle
+	logsFilter        workloadfilter.FilterBundle
+	tagger            tagger.Component
+	staticConfigIndex *StaticConfigIndex
 }
 
 // NewKubeletListener returns a new KubeletListener.
@@ -40,10 +41,11 @@ func NewKubeletListener(options ServiceListernerDeps) (ServiceListener, error) {
 	const name = "ad-kubeletlistener"
 
 	l := &KubeletListener{
-		globalFilter:  options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.GlobalFilter),
-		metricsFilter: options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.MetricsFilter),
-		logsFilter:    options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.LogsFilter),
-		tagger:        options.Tagger,
+		globalFilter:      options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.GlobalFilter),
+		metricsFilter:     options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.MetricsFilter),
+		logsFilter:        options.Filter.GetContainerAutodiscoveryFilters(workloadfilter.LogsFilter),
+		tagger:            options.Tagger,
+		staticConfigIndex: options.StaticConfigIndex,
 	}
 	wmetaFilter := workloadmeta.NewFilterBuilder().
 		SetSource(workloadmeta.SourceAll).
@@ -114,14 +116,15 @@ func (l *KubeletListener) createPodService(
 	entity := kubelet.PodUIDToEntityName(pod.ID)
 	taggerEntityID := common.BuildTaggerEntityID(pod.GetID())
 	svc := &WorkloadService{
-		entity:        pod,
-		tagsHash:      l.tagger.GetEntityHash(taggerEntityID, types.ChecksConfigCardinality),
-		adIdentifiers: []string{entity},
-		hosts:         map[string]string{"pod": pod.IP},
-		ports:         ports,
-		ready:         true,
-		tagger:        l.tagger,
-		wmeta:         l.Store(),
+		entity:            pod,
+		tagsHash:          l.tagger.GetEntityHash(taggerEntityID, types.ChecksConfigCardinality),
+		adIdentifiers:     []string{entity},
+		hosts:             map[string]string{"pod": pod.IP},
+		ports:             ports,
+		ready:             true,
+		tagger:            l.tagger,
+		wmeta:             l.Store(),
+		staticConfigIndex: l.staticConfigIndex,
 	}
 
 	svcID := buildSvcID(pod.GetID())
@@ -187,11 +190,12 @@ func (l *KubeletListener) createContainerService(
 
 		// Exclude non-running containers (including init containers)
 		// from metrics collection but keep them for collecting logs.
-		metricsExcluded: l.metricsFilter.IsExcluded(filterableContainer) || !container.State.Running,
-		logsExcluded:    l.logsFilter.IsExcluded(filterableContainer),
-		tagger:          l.tagger,
-		imageName:       containerImg.ShortName,
-		wmeta:           l.Store(),
+		metricsExcluded:   l.metricsFilter.IsExcluded(filterableContainer) || !container.State.Running,
+		logsExcluded:      l.logsFilter.IsExcluded(filterableContainer),
+		tagger:            l.tagger,
+		imageName:         containerImg.ShortName,
+		wmeta:             l.Store(),
+		staticConfigIndex: l.staticConfigIndex,
 	}
 
 	adIdentifier := containerName

--- a/comp/core/autodiscovery/listeners/process.go
+++ b/comp/core/autodiscovery/listeners/process.go
@@ -245,13 +245,23 @@ func (s *ProcessService) HasFilter(_ workloadfilter.Scope) bool {
 // process services: users configure single-instance process integrations via
 // conf.d, and we don't want the dynamic process listener to schedule a second
 // instance behind their back.
+//
+// Discovery templates are then dropped if any other config source has matched
+// this service for the same integration: a sibling non-discovery template, or
+// a scheduled static config.
 func (s *ProcessService) FilterTemplates(configs map[string]integration.Config) {
+	// Step 1: CEL Matching
 	filterTemplatesMatched(s, configs)
+
+	// Step 2: Static Config Deduplication
 	for digest, cfg := range configs {
 		if s.staticConfigIndex.Has(cfg.Name) {
 			delete(configs, digest)
 		}
 	}
+
+	// Step 3: Discovery Template Deduplication
+	filterTemplatesDiscovery(s.staticConfigIndex, configs)
 }
 
 // GetExtraConfig returns extra configuration associated with the service.

--- a/comp/core/autodiscovery/listeners/process_test.go
+++ b/comp/core/autodiscovery/listeners/process_test.go
@@ -541,6 +541,23 @@ func TestProcessServiceFilterTemplates_DropsDiscovery(t *testing.T) {
 		assert.Contains(t, configs, discoveryTpl.Digest(), "discovery template should be kept")
 		assert.Contains(t, configs, unrelatedTpl.Digest(), "unrelated template should be kept")
 	})
+
+	t.Run("discovery kept when sibling template has only logs config", func(t *testing.T) {
+		logsOnlySibling := integration.Config{
+			Name:          "redis",
+			ADIdentifiers: []string{string(adtypes.CelProcessIdentifier)},
+			LogsConfig:    []byte(`{"source":"redis"}`),
+		}
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest():    discoveryTpl,
+			logsOnlySibling.Digest(): logsOnlySibling,
+		}
+		mkSvc(NewStaticConfigIndex()).FilterTemplates(configs)
+		assert.Contains(t, configs, discoveryTpl.Digest(),
+			"discovery template should be kept when the sibling is logs-only")
+		assert.Contains(t, configs, logsOnlySibling.Digest(),
+			"logs-only sibling should be kept")
+	})
 }
 
 func newProcessListener(t *testing.T, tagger tagger.Component) (*ProcessListener, *testWorkloadmetaListener) {

--- a/comp/core/autodiscovery/listeners/process_test.go
+++ b/comp/core/autodiscovery/listeners/process_test.go
@@ -477,6 +477,72 @@ func TestProcessServiceFilterTemplates_DedupesStaticConfigs(t *testing.T) {
 	})
 }
 
+func TestProcessServiceFilterTemplates_DropsDiscovery(t *testing.T) {
+	process := &workloadmeta.Process{
+		EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindProcess, ID: "1234"},
+		Pid:      1234,
+		Service:  &workloadmeta.Service{GeneratedName: "redis"},
+	}
+
+	mkSvc := func(idx *StaticConfigIndex) *ProcessService {
+		return &ProcessService{
+			process:           process,
+			pid:               1234,
+			ready:             true,
+			staticConfigIndex: idx,
+		}
+	}
+
+	discoveryTpl := integration.Config{
+		Name:          "redis",
+		ADIdentifiers: []string{string(adtypes.CelProcessIdentifier)},
+		Discovery:     &integration.DiscoveryConfig{},
+	}
+	siblingTpl := integration.Config{
+		Name:          "redis",
+		ADIdentifiers: []string{string(adtypes.CelProcessIdentifier)},
+		Instances:     []integration.Data{[]byte("port: 6379")},
+	}
+	unrelatedTpl := integration.Config{
+		Name:          "nginx",
+		ADIdentifiers: []string{string(adtypes.CelProcessIdentifier)},
+		Instances:     []integration.Data{[]byte("port: 80")},
+	}
+
+	t.Run("discovery dropped when sibling template matches same service", func(t *testing.T) {
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest(): discoveryTpl,
+			siblingTpl.Digest():   siblingTpl,
+		}
+		mkSvc(nil).FilterTemplates(configs)
+		assert.NotContains(t, configs, discoveryTpl.Digest(), "discovery template should be dropped")
+		assert.Contains(t, configs, siblingTpl.Digest(), "non-discovery sibling should be kept")
+	})
+
+	t.Run("discovery dropped when static config of same name exists", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		idx.Add("redis")
+
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest(): discoveryTpl,
+			unrelatedTpl.Digest(): unrelatedTpl,
+		}
+		mkSvc(idx).FilterTemplates(configs)
+		assert.NotContains(t, configs, discoveryTpl.Digest(), "discovery template should be dropped")
+		assert.Contains(t, configs, unrelatedTpl.Digest(), "unrelated template should be kept")
+	})
+
+	t.Run("discovery kept when no sibling and no static config", func(t *testing.T) {
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest(): discoveryTpl,
+			unrelatedTpl.Digest(): unrelatedTpl,
+		}
+		mkSvc(NewStaticConfigIndex()).FilterTemplates(configs)
+		assert.Contains(t, configs, discoveryTpl.Digest(), "discovery template should be kept")
+		assert.Contains(t, configs, unrelatedTpl.Digest(), "unrelated template should be kept")
+	})
+}
+
 func newProcessListener(t *testing.T, tagger tagger.Component) (*ProcessListener, *testWorkloadmetaListener) {
 	return newProcessListenerWithFilters(t, tagger, nil)
 }

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -27,21 +27,22 @@ import (
 // WorkloadService implements the Service interface and stores data collected from
 // workloadmeta.Store. Covers containers and kubernetes pods.
 type WorkloadService struct {
-	entity          workloadmeta.Entity
-	tagsHash        string
-	adIdentifiers   []string
-	hosts           map[string]string
-	ports           []workloadmeta.ContainerPort
-	pid             int
-	hostname        string
-	ready           bool
-	checkNames      []string
-	extraConfig     map[string]string
-	metricsExcluded bool
-	logsExcluded    bool
-	tagger          tagger.Component
-	wmeta           workloadmeta.Component
-	imageName       string
+	entity            workloadmeta.Entity
+	tagsHash          string
+	adIdentifiers     []string
+	hosts             map[string]string
+	ports             []workloadmeta.ContainerPort
+	pid               int
+	hostname          string
+	ready             bool
+	checkNames        []string
+	extraConfig       map[string]string
+	metricsExcluded   bool
+	logsExcluded      bool
+	tagger            tagger.Component
+	wmeta             workloadmeta.Component
+	imageName         string
+	staticConfigIndex *StaticConfigIndex
 }
 
 var _ Service = &WorkloadService{}
@@ -148,6 +149,11 @@ func (s *WorkloadService) FilterTemplates(configs map[string]integration.Config)
 	s.filterTemplatesEmptyOverrides(configs)
 	s.filterTemplatesOverriddenChecks(configs)
 	filterTemplatesMatched(s, configs)
+
+	// Drop discovery templates when another config source already covers
+	// the same integration for this service. Runs after AD-identifier and
+	// CEL matching so we only consider templates actually bound to this service.
+	filterTemplatesDiscovery(s.staticConfigIndex, configs)
 
 	// Container Collect All filtering should always be last
 	s.filterTemplatesContainerCollectAll(configs)

--- a/comp/core/autodiscovery/listeners/service_test.go
+++ b/comp/core/autodiscovery/listeners/service_test.go
@@ -189,6 +189,25 @@ func TestServiceFilterTemplatesDiscovery(t *testing.T) {
 		mkSvc(idx).FilterTemplates(configs)
 		assert.Contains(t, configs, discoveryTpl.Digest(), "discovery template should be kept when only an unrelated static config exists")
 	})
+
+	t.Run("discovery kept when sibling template has only logs config", func(t *testing.T) {
+		logsOnlySibling := integration.Config{
+			Name:          "redis",
+			Provider:      names.File,
+			ADIdentifiers: []string{"redis"},
+			LogsConfig:    []byte(`{"source":"redis"}`),
+			Source:        "file:redis/auto_conf.yaml",
+		}
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest():    discoveryTpl,
+			logsOnlySibling.Digest(): logsOnlySibling,
+		}
+		mkSvc(NewStaticConfigIndex()).FilterTemplates(configs)
+		assert.Contains(t, configs, discoveryTpl.Digest(),
+			"discovery template should be kept when the sibling is logs-only")
+		assert.Contains(t, configs, logsOnlySibling.Digest(),
+			"logs-only sibling should be kept")
+	})
 }
 
 func TestServiceFilterTemplatesCCA(t *testing.T) {

--- a/comp/core/autodiscovery/listeners/service_test.go
+++ b/comp/core/autodiscovery/listeners/service_test.go
@@ -107,6 +107,90 @@ func TestServiceFilterTemplatesOverriddenChecks(t *testing.T) {
 	})
 }
 
+func TestServiceFilterTemplatesDiscovery(t *testing.T) {
+	entity := &workloadmeta.Container{EntityID: workloadmeta.EntityID{Kind: "container", ID: "redis-1"}}
+
+	mkSvc := func(idx *StaticConfigIndex) *WorkloadService {
+		return &WorkloadService{entity: entity, staticConfigIndex: idx}
+	}
+
+	discoveryTpl := integration.Config{
+		Name:          "redis",
+		Provider:      names.File,
+		ADIdentifiers: []string{"redis"},
+		Discovery:     &integration.DiscoveryConfig{},
+		Source:        "file:redis/auto_conf.yaml",
+	}
+	siblingTpl := integration.Config{
+		Name:          "redis",
+		Provider:      names.File,
+		ADIdentifiers: []string{"redis"},
+		Instances:     []integration.Data{[]byte("port: 6379")},
+		Source:        "file:redis/auto_conf.yaml",
+	}
+	unrelatedTpl := integration.Config{
+		Name:          "nginx",
+		Provider:      names.File,
+		ADIdentifiers: []string{"nginx"},
+		Instances:     []integration.Data{[]byte("port: 80")},
+		Source:        "file:nginx/auto_conf.yaml",
+	}
+
+	containsDigests := func(configs map[string]integration.Config, want ...integration.Config) []string {
+		t.Helper()
+		got := []string{}
+		for _, c := range want {
+			if _, found := configs[c.Digest()]; found {
+				got = append(got, c.Name)
+			}
+		}
+		return got
+	}
+
+	t.Run("discovery dropped when sibling template matches same service", func(t *testing.T) {
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest(): discoveryTpl,
+			siblingTpl.Digest():   siblingTpl,
+		}
+		mkSvc(NewStaticConfigIndex()).FilterTemplates(configs)
+		assert.NotContains(t, configs, discoveryTpl.Digest(), "discovery template should be dropped")
+		assert.Contains(t, configs, siblingTpl.Digest(), "non-discovery sibling should be kept")
+	})
+
+	t.Run("discovery dropped when static config of same name exists", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		idx.Add("redis")
+
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest(): discoveryTpl,
+			unrelatedTpl.Digest(): unrelatedTpl,
+		}
+		mkSvc(idx).FilterTemplates(configs)
+		assert.NotContains(t, configs, discoveryTpl.Digest(), "discovery template should be dropped")
+		assert.Contains(t, configs, unrelatedTpl.Digest(), "unrelated template should be kept")
+	})
+
+	t.Run("discovery kept when no sibling and no static config", func(t *testing.T) {
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest(): discoveryTpl,
+			unrelatedTpl.Digest(): unrelatedTpl,
+		}
+		mkSvc(NewStaticConfigIndex()).FilterTemplates(configs)
+		assert.Equal(t, []string{"redis", "nginx"}, containsDigests(configs, discoveryTpl, unrelatedTpl))
+	})
+
+	t.Run("discovery kept when static config is for a different integration", func(t *testing.T) {
+		idx := NewStaticConfigIndex()
+		idx.Add("postgres")
+
+		configs := map[string]integration.Config{
+			discoveryTpl.Digest(): discoveryTpl,
+		}
+		mkSvc(idx).FilterTemplates(configs)
+		assert.Contains(t, configs, discoveryTpl.Digest(), "discovery template should be kept when only an unrelated static config exists")
+	})
+}
+
 func TestServiceFilterTemplatesCCA(t *testing.T) {
 	filterDrops := func(svc *WorkloadService, configs ...integration.Config) (dropped []integration.Config) {
 		return filterConfigsDropped(svc.filterTemplatesContainerCollectAll, configs...)

--- a/comp/core/autodiscovery/listeners/static_config_index.go
+++ b/comp/core/autodiscovery/listeners/static_config_index.go
@@ -8,11 +8,13 @@ package listeners
 import "sync"
 
 // StaticConfigIndex is a refcounted set of integration names that currently
-// have at least one scheduled non-template (static) config. It is shared
-// between the autodiscovery config manager (writer) and listeners that need
-// to deduplicate against static configs (reader). Reads are safe to perform
-// while the writer holds its own mutex; the index has its own RWMutex and
-// must not be locked by any caller.
+// have at least one scheduled non-template (static) *check* config — a config
+// with Instances. Logs-only static configs are intentionally excluded since
+// they do not configure a check and must not suppress dynamic check templates
+// of the same integration. It is shared between the autodiscovery config
+// manager (writer) and listeners that need to deduplicate against static
+// configs (reader). Reads are safe to perform while the writer holds its own
+// mutex; the index has its own RWMutex and must not be locked by any caller.
 //
 // A nil pointer is safe to use: Has always returns false, and Add/Remove are
 // no-ops.

--- a/comp/core/autodiscovery/providers/config_reader.go
+++ b/comp/core/autodiscovery/providers/config_reader.go
@@ -43,6 +43,7 @@ type configFormat struct {
 	DockerImages            []string                           `yaml:"docker_images,omitempty"`             // Only imported for deprecation warning
 	IgnoreAutodiscoveryTags bool                               `yaml:"ignore_autodiscovery_tags,omitempty"` // Use to ignore tags coming from autodiscovery
 	CheckTagCardinality     string                             `yaml:"check_tag_cardinality,omitempty"`     // Use to set the tag cardinality override for the check
+	Discovery               *integration.DiscoveryConfig       `yaml:"discovery,omitempty"`                 // Marks this config as a discovery template (instances are populated at runtime)
 }
 
 // ConfigFormatWrapper is a wrapper for the config format
@@ -501,6 +502,9 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, Confi
 
 	// Copy check_tag_cardinality parameter
 	conf.CheckTagCardinality = cf.CheckTagCardinality
+
+	// Copy discovery marker
+	conf.Discovery = cf.Discovery
 
 	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
 	if len(cf.DockerImages) > 0 && len(cf.ADIdentifiers) == 0 {

--- a/comp/core/autodiscovery/providers/config_reader_test.go
+++ b/comp/core/autodiscovery/providers/config_reader_test.go
@@ -119,6 +119,16 @@ func TestGetIntegrationConfig(t *testing.T) {
 	config, _, err = GetIntegrationConfigFromFile("foo", "tests/ad_with_service_id.yaml")
 	assert.Nil(t, err)
 	assert.Empty(t, config.ServiceID)
+
+	// discovery: presence of `discovery: {}` populates Config.Discovery.
+	config, _, err = GetIntegrationConfigFromFile("foo", "tests/discovery.yaml")
+	require.Nil(t, err)
+	require.NotNil(t, config.Discovery, "discovery: {} should produce a non-nil Discovery field")
+
+	// no discovery: a regular config leaves Discovery nil.
+	config, _, err = GetIntegrationConfigFromFile("foo", "tests/testcheck.yaml")
+	require.Nil(t, err)
+	assert.Nil(t, config.Discovery)
 }
 
 func TestReadConfigFiles(t *testing.T) {
@@ -127,7 +137,7 @@ func TestReadConfigFiles(t *testing.T) {
 
 	configs, errors, err := ReadConfigFiles(GetAll)
 	require.Nil(t, err)
-	require.Equal(t, 21, len(configs))
+	require.Equal(t, 22, len(configs))
 	require.Equal(t, 4, len(errors))
 
 	for _, c := range configs {
@@ -138,7 +148,7 @@ func TestReadConfigFiles(t *testing.T) {
 
 	configs, _, err = ReadConfigFiles(WithoutAdvancedAD)
 	require.Nil(t, err)
-	require.Equal(t, 19, len(configs))
+	require.Equal(t, 20, len(configs))
 
 	expectedConfig1 := integration.Config{
 		Name: "advanced_ad",

--- a/comp/core/autodiscovery/providers/file_test.go
+++ b/comp/core/autodiscovery/providers/file_test.go
@@ -82,7 +82,7 @@ func TestCollect(t *testing.T) {
 	assert.Equal(t, 0, len(get("ignored")))
 
 	// total number of configurations found
-	assert.Equal(t, 18, len(configs))
+	assert.Equal(t, 19, len(configs))
 
 	// incorrect configs get saved in the Errors map (invalid.yaml & notaconfig.yaml & ad_deprecated.yaml & null_instances.yml)
 	assert.Equal(t, 4, len(provider.Errors))

--- a/comp/core/autodiscovery/providers/tests/discovery.yaml
+++ b/comp/core/autodiscovery/providers/tests/discovery.yaml
@@ -1,0 +1,9 @@
+ad_identifiers:
+  - foo_id
+
+discovery: {}
+
+init_config:
+
+instances:
+  - foo: bar


### PR DESCRIPTION
### What does this PR do?

Adds an optional `Discovery` field on `integration.Config` to prepare for enriched integration discovery.

Also implements the necessary filtering for the Discovery feature. The discovery mechanism will be dropped if either:
1. Another template exists for the integration that is being applied to the service
2. Any other static configuration exists for the same integration

This works for both container + processes services.

### Motivation

Scaffolding for the [Configuration Discovery for Agent Integrations](https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/6671862234) mechanism.

### Describe how you validated your changes

Unit tests & CI
