### PR TITLE
pkg/dyninst: render time.Time as RFC3339Nano with resolved timezone

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -475,6 +475,7 @@ exports_files(glob(
 # gazelle:exclude pkg/dyninst/testprogs/progs/sample/stacktraces.go
 # gazelle:exclude pkg/dyninst/testprogs/progs/sample/strings.go
 # gazelle:exclude pkg/dyninst/testprogs/progs/sample/structs.go
+# gazelle:exclude pkg/dyninst/testprogs/progs/sample/times.go
 # gazelle:exclude pkg/dyninst/testprogs/test_progs.go
 # gazelle:exclude pkg/dyninst/testprogs/test_progs_test.go
 # gazelle:exclude pkg/dyninst/uploader

--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -725,6 +725,29 @@ func (g *generator) addTypeHandler(t ir.Type) (FunctionID, bool, error) {
 		if err := structureTypeHandler(t.StructureType); err != nil {
 			return fid, needed, err
 		}
+	case *ir.GoTimeType:
+		// time.Time is special-cased: the runtime resolves the *Location
+		// pointer to a UTC offset and overwrites the captured pointer
+		// slot in place. We deliberately do not invoke
+		// structureTypeHandler here, which would chase the loc pointer
+		// (potentially recursing through Location → []zone → strings).
+		needed = true
+		offsetShift = 0
+		ops = []Op{
+			ProcessGoTimeOp{
+				WallFieldOffset:       t.WallFieldOffset,
+				ExtFieldOffset:        t.ExtFieldOffset,
+				LocFieldOffset:        t.LocFieldOffset,
+				CacheResolved:         t.CacheResolved,
+				CacheStartOffset:      t.CacheStartOffset,
+				CacheEndOffset:        t.CacheEndOffset,
+				CacheZoneOffset:       t.CacheZoneOffset,
+				ZoneOffsetFieldOffset: t.ZoneOffsetFieldOffset,
+				ZoneOffsetFieldSize:   t.ZoneOffsetFieldSize,
+			},
+			ReturnOp{},
+		}
+
 	case *ir.StructureType:
 		if err := structureTypeHandler(t); err != nil {
 			return fid, needed, err
@@ -1043,6 +1066,8 @@ func (g *generator) typeMemoryLayout(t ir.Type) ([]memoryLayoutPiece, error) {
 		case *ir.GoSliceHeaderType:
 			err = collectPieces(t.StructureType, offset)
 		case *ir.GoStringHeaderType:
+			err = collectPieces(t.StructureType, offset)
+		case *ir.GoTimeType:
 			err = collectPieces(t.StructureType, offset)
 
 		// Types that should never be stored in registers nor stack.

--- a/pkg/dyninst/compiler/instructions.go
+++ b/pkg/dyninst/compiler/instructions.go
@@ -207,6 +207,30 @@ func makeInstruction(functionID FunctionID, op Op) codeFragment {
 			bytes:  bytes,
 		}
 
+	case ProcessGoTimeOp:
+		// Layout: wall_off (u32), ext_off (u32), loc_off (u32),
+		// cache_resolved (u8), cache_start_off (u32), cache_end_off (u32),
+		// cache_zone_off (u32), zone_offset_field_off (u32),
+		// zone_offset_field_size (u32).
+		bytes := make([]byte, 0, 33)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.WallFieldOffset)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.ExtFieldOffset)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.LocFieldOffset)
+		var resolved uint8
+		if op.CacheResolved {
+			resolved = 1
+		}
+		bytes = append(bytes, resolved)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.CacheStartOffset)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.CacheEndOffset)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.CacheZoneOffset)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.ZoneOffsetFieldOffset)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.ZoneOffsetFieldSize)
+		return staticInstruction{
+			opcode: OpcodeProcessGoTime,
+			bytes:  bytes,
+		}
+
 	case ChasePointersOp:
 		return staticInstruction{
 			opcode: OpcodeChasePointers,

--- a/pkg/dyninst/compiler/opcode.go
+++ b/pkg/dyninst/compiler/opcode.go
@@ -73,6 +73,8 @@ const (
 	// the next sm_loop iteration re-enters HOP. See pkg/dyninst/irgen/trace_context.md.
 	OpcodeGoContextChainInit
 	OpcodeGoContextChainHop
+	// Time decoding.
+	OpcodeProcessGoTime
 )
 
 //revive:enable:exported

--- a/pkg/dyninst/compiler/opcode_string.go
+++ b/pkg/dyninst/compiler/opcode_string.go
@@ -57,11 +57,12 @@ func _() {
 	_ = x[OpcodeConditionLeafComplete-46]
 	_ = x[OpcodeGoContextChainInit-47]
 	_ = x[OpcodeGoContextChainHop-48]
+	_ = x[OpcodeProcessGoTime-49]
 }
 
-const _Opcode_name = "InvalidCallReturnIllegalIncrementOutputOffsetExprPrepareExprSaveExprDereferenceCfaExprReadRegisterExprDereferencePtrProcessPointerProcessSliceProcessArrayDataPrepProcessSliceDataPrepProcessSliceDataRepeatProcessStringProcessGoEmptyInterfaceProcessGoInterfaceProcessGoDictTypeProcessGoHmapProcessGoSwissMapProcessGoSwissMapGroupsChasePointersPrepareEventRootExprPushOffsetExprLoadLiteralExprReadStringExprCmpBaseExprCmpStringConditionCheckConditionBeginCallDictResolvedExprSliceBoundsCheckSwissMapSetupSwissMapAesencSwissMapHashFinishSwissMapProbeSwissMapCheckSlotCondNotCondJumpIfFalseCondJumpIfTrueExprLoadDurationConditionStateInitConditionLeafRecordConditionLeafLoadConditionCheckPreserveErrorConditionLeafCompleteGoContextChainInitGoContextChainHop"
+const _Opcode_name = "InvalidCallReturnIllegalIncrementOutputOffsetExprPrepareExprSaveExprDereferenceCfaExprReadRegisterExprDereferencePtrProcessPointerProcessSliceProcessArrayDataPrepProcessSliceDataPrepProcessSliceDataRepeatProcessStringProcessGoEmptyInterfaceProcessGoInterfaceProcessGoDictTypeProcessGoHmapProcessGoSwissMapProcessGoSwissMapGroupsChasePointersPrepareEventRootExprPushOffsetExprLoadLiteralExprReadStringExprCmpBaseExprCmpStringConditionCheckConditionBeginCallDictResolvedExprSliceBoundsCheckSwissMapSetupSwissMapAesencSwissMapHashFinishSwissMapProbeSwissMapCheckSlotCondNotCondJumpIfFalseCondJumpIfTrueExprLoadDurationConditionStateInitConditionLeafRecordConditionLeafLoadConditionCheckPreserveErrorConditionLeafCompleteGoContextChainInitGoContextChainHopProcessGoTime"
 
-var _Opcode_index = [...]uint16{0, 7, 11, 17, 24, 45, 56, 64, 82, 98, 116, 130, 142, 162, 182, 204, 217, 240, 258, 275, 288, 305, 328, 341, 357, 371, 386, 400, 411, 424, 438, 452, 468, 488, 501, 515, 533, 546, 563, 570, 585, 599, 615, 633, 652, 669, 696, 717, 735, 752}
+var _Opcode_index = [...]uint16{0, 7, 11, 17, 24, 45, 56, 64, 82, 98, 116, 130, 142, 162, 182, 204, 217, 240, 258, 275, 288, 305, 328, 341, 357, 371, 386, 400, 411, 424, 438, 452, 468, 488, 501, 515, 533, 546, 563, 570, 585, 599, 615, 633, 652, 669, 696, 717, 735, 752, 765}
 
 func (i Opcode) String() string {
 	idx := int(i) - 0

--- a/pkg/dyninst/compiler/ops.go
+++ b/pkg/dyninst/compiler/ops.go
@@ -191,6 +191,27 @@ type CallDictResolvedOp struct {
 	FallbackFunc FunctionID // shape type's ProcessType function ID
 }
 
+// ProcessGoTimeOp adjusts a captured time.Time in place. It reads the loc
+// pointer at LocFieldOffset and, when CacheResolved is true, performs one
+// userspace probe-read on the *time.Location cache fields followed by a
+// second read on cacheZone.offset. The 8 bytes at LocFieldOffset are then
+// overwritten with either the resolved offset (in seconds east of UTC,
+// sign-extended to int64) or the sentinel ir.GoTimeUnresolvedOffset
+// (INT64_MIN) when the cache miss path is taken. The op does not enqueue
+// the loc pointer for chasing.
+type ProcessGoTimeOp struct {
+	baseOp
+	WallFieldOffset       uint32
+	ExtFieldOffset        uint32
+	LocFieldOffset        uint32
+	CacheResolved         bool
+	CacheStartOffset      uint32
+	CacheEndOffset        uint32
+	CacheZoneOffset       uint32
+	ZoneOffsetFieldOffset uint32
+	ZoneOffsetFieldSize   uint32
+}
+
 type ProcessGoHmapOp struct {
 	baseOp
 	BucketsType      *ir.GoSliceDataType

--- a/pkg/dyninst/decode/time_test.go
+++ b/pkg/dyninst/decode/time_test.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package decode
+
+import (
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+// timeAsBytes extracts the in-memory representation of a time.Time as the
+// 24-byte buffer a probe would capture (wall, ext, loc). Field offsets match
+// the layout in src/time/time.go: wall at 0, ext at 8.
+func timeAsBytes(t time.Time) []byte {
+	bytes := make([]byte, unsafe.Sizeof(t))
+	*(*time.Time)(unsafe.Pointer(&bytes[0])) = t
+	return bytes
+}
+
+func TestDecodeGoTime(t *testing.T) {
+	const (
+		wallOff = 0
+		extOff  = 8
+	)
+
+	t.Run("zero", func(t *testing.T) {
+		sec, nsec, isZero := decodeGoTime(timeAsBytes(time.Time{}), wallOff, extOff)
+		require.True(t, isZero)
+		require.Zero(t, sec)
+		require.Zero(t, nsec)
+	})
+
+	t.Run("monotonic_now", func(t *testing.T) {
+		// time.Now() sets hasMonotonic.
+		want := time.Now()
+		sec, nsec, isZero := decodeGoTime(timeAsBytes(want), wallOff, extOff)
+		require.False(t, isZero)
+		require.Equal(t, want.Unix(), sec)
+		require.Equal(t, uint32(want.Nanosecond()), nsec)
+	})
+
+	t.Run("non_monotonic_unix", func(t *testing.T) {
+		// time.Unix has no monotonic reading; sec lives in ext.
+		want := time.Unix(1_700_000_000, 123_456_789)
+		sec, nsec, isZero := decodeGoTime(timeAsBytes(want), wallOff, extOff)
+		require.False(t, isZero)
+		require.Equal(t, int64(1_700_000_000), sec)
+		require.Equal(t, uint32(123_456_789), nsec)
+	})
+
+	t.Run("epoch", func(t *testing.T) {
+		want := time.Unix(0, 0)
+		sec, nsec, isZero := decodeGoTime(timeAsBytes(want), wallOff, extOff)
+		require.False(t, isZero)
+		require.Equal(t, int64(0), sec)
+		require.Equal(t, uint32(0), nsec)
+	})
+
+	t.Run("pre_unix_epoch", func(t *testing.T) {
+		// Year 1900 — well before Unix epoch, no monotonic.
+		want := time.Date(1900, 6, 15, 12, 0, 0, 0, time.UTC)
+		sec, nsec, isZero := decodeGoTime(timeAsBytes(want), wallOff, extOff)
+		require.False(t, isZero)
+		require.Equal(t, want.Unix(), sec)
+		require.Equal(t, uint32(0), nsec)
+	})
+
+	t.Run("future_pre_2157", func(t *testing.T) {
+		// Far future but inside the 33-bit monotonic range.
+		want := time.Date(2100, 1, 2, 3, 4, 5, 6, time.UTC)
+		sec, nsec, isZero := decodeGoTime(timeAsBytes(want), wallOff, extOff)
+		require.False(t, isZero)
+		require.Equal(t, want.Unix(), sec)
+		require.Equal(t, uint32(6), nsec)
+	})
+
+	t.Run("non_utc_location_decoded_as_utc_instant", func(t *testing.T) {
+		// Decoder ignores loc — the wall instant must still match.
+		want := time.Now().In(time.FixedZone("X", 3600))
+		sec, nsec, isZero := decodeGoTime(timeAsBytes(want), wallOff, extOff)
+		require.False(t, isZero)
+		require.Equal(t, want.Unix(), sec)
+		require.Equal(t, uint32(want.Nanosecond()), nsec)
+	})
+
+	t.Run("short_buffer_treated_as_zero", func(t *testing.T) {
+		_, _, isZero := decodeGoTime(make([]byte, 8), wallOff, extOff)
+		require.True(t, isZero)
+	})
+}
+
+func TestDecodeGoTimeRFC3339Format(t *testing.T) {
+	// End-to-end sanity: decode then format via the same code path the
+	// production decoder uses. We don't go through goTimeType (which needs
+	// an ir.StructureType); we just confirm the formatting choice.
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{"unix_zero", time.Unix(0, 0), "1970-01-01T00:00:00Z"},
+		{"with_nanos", time.Unix(1700000000, 123456789), "2023-11-14T22:13:20.123456789Z"},
+		{"non_utc_input", time.Unix(1700000000, 0).In(time.FixedZone("X", 3600)), "2023-11-14T22:13:20Z"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sec, nsec, isZero := decodeGoTime(timeAsBytes(tc.in), 0, 8)
+			require.False(t, isZero)
+			got := time.Unix(sec, int64(nsec)).UTC().Format(time.RFC3339Nano)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/dyninst/decode/time_test.go
+++ b/pkg/dyninst/decode/time_test.go
@@ -8,11 +8,14 @@
 package decode
 
 import (
+	"encoding/binary"
 	"testing"
 	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 )
 
 // timeAsBytes extracts the in-memory representation of a time.Time as the
@@ -93,6 +96,69 @@ func TestDecodeGoTime(t *testing.T) {
 	t.Run("short_buffer_treated_as_zero", func(t *testing.T) {
 		_, _, isZero := decodeGoTime(make([]byte, 8), wallOff, extOff)
 		require.True(t, isZero)
+	})
+}
+
+// makeTimeBuf builds a synthetic 24-byte time.Time capture buffer the way
+// BPF would after running SM_OP_PROCESS_GO_TIME: wall and ext as Go's
+// runtime would lay them out, and the high 8 bytes set to the resolved
+// offset (or the unresolved sentinel).
+func makeTimeBuf(t time.Time, offsetSlot int64) []byte {
+	buf := timeAsBytes(t)
+	binary.NativeEndian.PutUint64(buf[16:24], uint64(offsetSlot))
+	return buf
+}
+
+func TestGoTimeTypeFormat(t *testing.T) {
+	timeType := &goTimeType{GoTimeType: &ir.GoTimeType{
+		WallFieldOffset: 0,
+		ExtFieldOffset:  8,
+		LocFieldOffset:  16,
+	}}
+
+	t.Run("utc_sentinel_renders_Z", func(t *testing.T) {
+		buf := makeTimeBuf(
+			time.Unix(1700000000, 123456789),
+			ir.GoTimeUnresolvedOffset,
+		)
+		got, isZero := timeType.format(buf)
+		require.False(t, isZero)
+		require.Equal(t, "2023-11-14T22:13:20.123456789Z", got)
+	})
+
+	t.Run("positive_offset_renders_with_sign", func(t *testing.T) {
+		buf := makeTimeBuf(
+			time.Unix(1700000000, 0),
+			3600, // +01:00
+		)
+		got, isZero := timeType.format(buf)
+		require.False(t, isZero)
+		require.Equal(t, "2023-11-14T23:13:20+01:00", got)
+	})
+
+	t.Run("negative_offset_renders_with_sign", func(t *testing.T) {
+		buf := makeTimeBuf(
+			time.Unix(1700000000, 0),
+			-5*3600, // -05:00 (EST)
+		)
+		got, isZero := timeType.format(buf)
+		require.False(t, isZero)
+		require.Equal(t, "2023-11-14T17:13:20-05:00", got)
+	})
+
+	t.Run("zero_time_returns_isZero", func(t *testing.T) {
+		buf := makeTimeBuf(time.Time{}, ir.GoTimeUnresolvedOffset)
+		_, isZero := timeType.format(buf)
+		require.True(t, isZero)
+	})
+
+	t.Run("short_buffer_falls_back_to_utc", func(t *testing.T) {
+		// 16-byte buffer (no loc slot) — decoder must not panic and
+		// must default to UTC rendering.
+		buf := timeAsBytes(time.Unix(1700000000, 0))[:16]
+		got, isZero := timeType.format(buf)
+		require.False(t, isZero)
+		require.Equal(t, "2023-11-14T22:13:20Z", got)
 	})
 }
 

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -15,6 +15,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"time"
 	"unsafe"
 
 	"github.com/dustin/go-humanize"
@@ -217,6 +218,11 @@ type goStringHeaderType struct {
 }
 type goStringDataType ir.GoStringDataType
 type goMapType ir.GoMapType
+type goTimeType struct {
+	*ir.StructureType
+	wallFieldOffset uint32
+	extFieldOffset  uint32
+}
 type goHMapHeaderType struct {
 	*ir.GoHMapHeaderType
 
@@ -296,6 +302,7 @@ var (
 	_ decoderType = (*goSliceDataType)(nil)
 	_ decoderType = (*goStringHeaderType)(nil)
 	_ decoderType = (*goStringDataType)(nil)
+	_ decoderType = (*goTimeType)(nil)
 	_ decoderType = (*goMapType)(nil)
 	_ decoderType = (*goHMapHeaderType)(nil)
 	_ decoderType = (*goHMapBucketType)(nil)
@@ -431,6 +438,13 @@ func newDecoderType(
 	case *ir.TraceContextType:
 		return (*traceContextType)(s), nil
 	case *ir.StructureType:
+		// Check if this is time.Time and has the expected fields.
+		if s.Name == "time.Time" {
+			if timeType, err := newGoTimeType(s); err == nil {
+				return timeType, nil
+			}
+			// Fall through to treat as normal struct if malformed.
+		}
 		return (*structureType)(s), nil
 	case *ir.GoContextImplementationType:
 		return (*structureType)(s.StructureType), nil
@@ -1989,6 +2003,105 @@ func (s *goStringDataType) formatValueFields(
 	*encodingContext, *bytes.Buffer, []byte, *formatLimits,
 ) error {
 	return errors.New("string data is not formatted")
+}
+
+func (t *goTimeType) irType() ir.Type { return t.StructureType }
+func (t *goTimeType) encodeValueFields(
+	_ *encodingContext,
+	enc *jsontext.Encoder,
+	data []byte,
+) error {
+	unixSec, nsec, isZero := decodeGoTime(
+		data, t.wallFieldOffset, t.extFieldOffset,
+	)
+	if isZero {
+		return writeTokens(enc,
+			jsontext.String("value"),
+			jsontext.Null,
+		)
+	}
+	formatted := time.Unix(unixSec, int64(nsec)).UTC().Format(time.RFC3339Nano)
+	return writeTokens(enc,
+		jsontext.String("value"),
+		jsontext.String(formatted),
+	)
+}
+
+func (t *goTimeType) formatValueFields(
+	_ *encodingContext,
+	buf *bytes.Buffer,
+	data []byte,
+	limits *formatLimits,
+) error {
+	unixSec, nsec, isZero := decodeGoTime(
+		data, t.wallFieldOffset, t.extFieldOffset,
+	)
+	if isZero {
+		writeBoundedString(buf, limits, formatNil)
+		return nil
+	}
+	formatted := time.Unix(unixSec, int64(nsec)).UTC().Format(time.RFC3339Nano)
+	writeBoundedString(buf, limits, formatted)
+	return nil
+}
+
+// newGoTimeType creates a goTimeType from a structure type, validating that
+// it has the expected wall and ext fields.
+func newGoTimeType(s *ir.StructureType) (*goTimeType, error) {
+	wallField, err := getFieldByName(s.RawFields, "wall")
+	if err != nil {
+		return nil, err
+	}
+	extField, err := getFieldByName(s.RawFields, "ext")
+	if err != nil {
+		return nil, err
+	}
+	return &goTimeType{
+		StructureType:   s,
+		wallFieldOffset: wallField.Offset,
+		extFieldOffset:  extField.Offset,
+	}, nil
+}
+
+// decodeGoTime extracts Unix seconds and wall-clock nanoseconds from a Go
+// time.Time captured into the buffer at the given field offsets. It returns
+// isZero=true for the Go zero value (wall == 0 && ext == 0) and for buffers
+// too short to read either field.
+func decodeGoTime(
+	data []byte, wallOffset, extOffset uint32,
+) (unixSec int64, nsec uint32, isZero bool) {
+	if len(data) < int(wallOffset+8) || len(data) < int(extOffset+8) {
+		return 0, 0, true
+	}
+
+	wall := binary.NativeEndian.Uint64(data[wallOffset : wallOffset+8])
+	ext := int64(binary.NativeEndian.Uint64(data[extOffset : extOffset+8]))
+
+	if wall == 0 && ext == 0 {
+		return 0, 0, true
+	}
+
+	// Constants and arithmetic mirror time.Time.sec()/nsec() in the Go
+	// runtime (src/time/time.go).
+	const (
+		secondsPerDay  = 24 * 60 * 60
+		unixToInternal = (1969*365 + 1969/4 - 1969/100 + 1969/400) * secondsPerDay
+		internalToUnix = -unixToInternal
+		wallToInternal = (1884*365 + 1884/4 - 1884/100 + 1884/400) * secondsPerDay
+
+		hasMonotonic = uint64(1) << 63
+		nsecMask     = (uint64(1) << 30) - 1
+		nsecShift    = 30
+	)
+
+	var sec int64
+	if wall&hasMonotonic != 0 {
+		// 33-bit wall seconds since 1885, packed in bits 62..30.
+		sec = wallToInternal + int64((wall<<1)>>(nsecShift+1))
+	} else {
+		sec = ext
+	}
+	return sec + internalToUnix, uint32(wall & nsecMask), false
 }
 
 func (c *goChannelType) irType() ir.Type { return (*ir.GoChannelType)(c) }

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -219,9 +219,7 @@ type goStringHeaderType struct {
 type goStringDataType ir.GoStringDataType
 type goMapType ir.GoMapType
 type goTimeType struct {
-	*ir.StructureType
-	wallFieldOffset uint32
-	extFieldOffset  uint32
+	*ir.GoTimeType
 }
 type goHMapHeaderType struct {
 	*ir.GoHMapHeaderType
@@ -437,14 +435,9 @@ func newDecoderType(
 		return (*durationType)(s), nil
 	case *ir.TraceContextType:
 		return (*traceContextType)(s), nil
+	case *ir.GoTimeType:
+		return &goTimeType{GoTimeType: s}, nil
 	case *ir.StructureType:
-		// Check if this is time.Time and has the expected fields.
-		if s.Name == "time.Time" {
-			if timeType, err := newGoTimeType(s); err == nil {
-				return timeType, nil
-			}
-			// Fall through to treat as normal struct if malformed.
-		}
 		return (*structureType)(s), nil
 	case *ir.GoContextImplementationType:
 		return (*structureType)(s.StructureType), nil
@@ -2005,22 +1998,19 @@ func (s *goStringDataType) formatValueFields(
 	return errors.New("string data is not formatted")
 }
 
-func (t *goTimeType) irType() ir.Type { return t.StructureType }
+func (t *goTimeType) irType() ir.Type { return t.GoTimeType }
 func (t *goTimeType) encodeValueFields(
 	_ *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
-	unixSec, nsec, isZero := decodeGoTime(
-		data, t.wallFieldOffset, t.extFieldOffset,
-	)
+	formatted, isZero := t.format(data)
 	if isZero {
 		return writeTokens(enc,
 			jsontext.String("value"),
 			jsontext.Null,
 		)
 	}
-	formatted := time.Unix(unixSec, int64(nsec)).UTC().Format(time.RFC3339Nano)
 	return writeTokens(enc,
 		jsontext.String("value"),
 		jsontext.String(formatted),
@@ -2033,34 +2023,33 @@ func (t *goTimeType) formatValueFields(
 	data []byte,
 	limits *formatLimits,
 ) error {
-	unixSec, nsec, isZero := decodeGoTime(
-		data, t.wallFieldOffset, t.extFieldOffset,
-	)
+	formatted, isZero := t.format(data)
 	if isZero {
 		writeBoundedString(buf, limits, formatNil)
 		return nil
 	}
-	formatted := time.Unix(unixSec, int64(nsec)).UTC().Format(time.RFC3339Nano)
 	writeBoundedString(buf, limits, formatted)
 	return nil
 }
 
-// newGoTimeType creates a goTimeType from a structure type, validating that
-// it has the expected wall and ext fields.
-func newGoTimeType(s *ir.StructureType) (*goTimeType, error) {
-	wallField, err := getFieldByName(s.RawFields, "wall")
-	if err != nil {
-		return nil, err
+// format renders the captured time.Time as an RFC3339Nano timestamp. The
+// 8 bytes at LocFieldOffset hold either ir.GoTimeUnresolvedOffset (UTC
+// fallback) or a UTC offset in seconds written by SM_OP_PROCESS_GO_TIME.
+func (t *goTimeType) format(data []byte) (formatted string, isZero bool) {
+	unixSec, nsec, isZero := decodeGoTime(data, t.WallFieldOffset, t.ExtFieldOffset)
+	if isZero {
+		return "", true
 	}
-	extField, err := getFieldByName(s.RawFields, "ext")
-	if err != nil {
-		return nil, err
+	loc := time.UTC
+	if len(data) >= int(t.LocFieldOffset)+8 {
+		off := int64(binary.NativeEndian.Uint64(
+			data[t.LocFieldOffset : t.LocFieldOffset+8],
+		))
+		if off != ir.GoTimeUnresolvedOffset {
+			loc = time.FixedZone("", int(off))
+		}
 	}
-	return &goTimeType{
-		StructureType:   s,
-		wallFieldOffset: wallField.Offset,
-		extFieldOffset:  extField.Offset,
-	}, nil
+	return time.Unix(unixSec, int64(nsec)).In(loc).Format(time.RFC3339Nano), false
 }
 
 // decodeGoTime extracts Unix seconds and wall-clock nanoseconds from a Go
@@ -2070,7 +2059,7 @@ func newGoTimeType(s *ir.StructureType) (*goTimeType, error) {
 func decodeGoTime(
 	data []byte, wallOffset, extOffset uint32,
 ) (unixSec int64, nsec uint32, isZero bool) {
-	if len(data) < int(wallOffset+8) || len(data) < int(extOffset+8) {
+	if len(data) < int(wallOffset)+8 || len(data) < int(extOffset)+8 {
 		return 0, 0, true
 	}
 

--- a/pkg/dyninst/ebpf/stack_machine.h
+++ b/pkg/dyninst/ebpf/stack_machine.h
@@ -2365,6 +2365,107 @@ sm_swiss_map_aese(stack_machine_t* sm) {
   return 0;
 }
 
+// SM_OP_PROCESS_GO_TIME: read (wall, ext, loc) from the captured
+// time.Time at base_offset, then chase the *time.Location cache fast
+// path to resolve a UTC offset. Marked noinline so its stack frame is
+// isolated from sm_loop (BPF verifier's combined-call stack budget is
+// ~512 B). Two pairs of u32 params are packed into u64s to fit within
+// BPF's 5-argument-register limit; the kernel/verifier expose this as
+// a normal call once frames are accounted separately.
+//
+// Returns the resolved offset in seconds east of UTC, or INT64_MIN as
+// the sentinel for "could not resolve" (cache disabled, nil loc, miss,
+// or probe_read failure).
+__attribute__((noinline)) int64_t
+sm_resolve_time_offset(scratch_buf_t* buf, buf_offset_t base_offset,
+                       uint64_t wall_ext_loc_off,
+                       uint64_t cache_starts_off,
+                       uint64_t zone_off_and_size_and_flag) {
+  const int64_t sentinel = (int64_t)((uint64_t)1 << 63);
+  if (!buf) return sentinel;
+  uint8_t cache_resolved = (uint8_t)(zone_off_and_size_and_flag >> 56);
+  if (!cache_resolved) return sentinel;
+
+  uint32_t wall_off = (uint32_t)wall_ext_loc_off;
+  uint32_t ext_off = (uint32_t)(wall_ext_loc_off >> 32);
+  uint32_t loc_off = (uint32_t)cache_starts_off;
+  uint32_t cache_start_off = (uint32_t)(cache_starts_off >> 32);
+
+  buf_offset_t s = base_offset + wall_off;
+  if (!scratch_buf_bounds_check(&s, sizeof(uint64_t))) return sentinel;
+  uint64_t wall = *(uint64_t*)&((*buf)[s]);
+  s = base_offset + ext_off;
+  if (!scratch_buf_bounds_check(&s, sizeof(int64_t))) return sentinel;
+  int64_t ext = *(int64_t*)&((*buf)[s]);
+  s = base_offset + loc_off;
+  if (!scratch_buf_bounds_check(&s, sizeof(target_ptr_t))) return sentinel;
+  target_ptr_t loc_ptr = *(target_ptr_t*)&((*buf)[s]);
+  if (loc_ptr == 0) return sentinel;
+
+  // Recover Unix seconds via the same arithmetic as time.Time.sec() /
+  // time.Time.unixSec() in src/time/time.go.
+  const int64_t WALL_TO_INTERNAL = 59453308800LL;   // 1884 → year 1
+  const int64_t INTERNAL_TO_UNIX = -62135596800LL;  // year 1 → 1970
+  int64_t sec = ((wall & ((uint64_t)1 << 63)) != 0)
+      ? WALL_TO_INTERNAL + (int64_t)((wall << 1) >> 31)
+      : ext;
+  int64_t unix_sec = sec + INTERNAL_TO_UNIX;
+
+  int64_t window = 0;
+  if (bpf_probe_read_user(&window, sizeof(window),
+                          (void*)(loc_ptr + cache_start_off)) != 0) {
+    return sentinel;
+  }
+  if (unix_sec < window) return sentinel;
+
+  // The remaining params are packed in zone_off_and_size_and_flag:
+  //   bits  0..15: cache_end_off (uint16 — offsets within a Go struct
+  //                fit comfortably in 16 bits)
+  //   bits 16..31: cache_zone_off
+  //   bits 32..47: zone_offset_field_off
+  //   bits 48..55: zone_offset_field_size (1, 4, or 8)
+  //   bits 56..63: cache_resolved (1 bit, in the high byte)
+  // The irgen-side encoder asserts each value fits in its allotted
+  // width; if a future Go layout ever needs a wider offset we'll
+  // promote the encoding.
+  uint32_t cache_end_off = (uint32_t)(zone_off_and_size_and_flag & 0xFFFF);
+  uint32_t cache_zone_off = (uint32_t)((zone_off_and_size_and_flag >> 16) & 0xFFFF);
+  uint32_t zone_offset_field_off =
+      (uint32_t)((zone_off_and_size_and_flag >> 32) & 0xFFFF);
+  uint8_t zone_offset_field_size =
+      (uint8_t)((zone_off_and_size_and_flag >> 48) & 0xFF);
+
+  if (bpf_probe_read_user(&window, sizeof(window),
+                          (void*)(loc_ptr + cache_end_off)) != 0) {
+    return sentinel;
+  }
+  if (unix_sec >= window) return sentinel;
+
+  target_ptr_t cache_zone = 0;
+  if (bpf_probe_read_user(&cache_zone, sizeof(cache_zone),
+                          (void*)(loc_ptr + cache_zone_off)) != 0) {
+    return sentinel;
+  }
+  if (cache_zone == 0) return sentinel;
+
+  int64_t resolved = sentinel;
+  if (zone_offset_field_size == 8) {
+    if (bpf_probe_read_user(&resolved, 8,
+                            (void*)(cache_zone +
+                                    zone_offset_field_off)) != 0) {
+      resolved = sentinel;
+    }
+  } else if (zone_offset_field_size == 4) {
+    int32_t v = 0;
+    if (bpf_probe_read_user(&v, 4,
+                            (void*)(cache_zone +
+                                    zone_offset_field_off)) == 0) {
+      resolved = (int64_t)v;
+    }
+  }
+  return resolved;
+}
+
 static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
   global_ctx_t* ctx = (global_ctx_t*)_ctx;
   scratch_buf_t* buf = ctx->buf;
@@ -2730,6 +2831,45 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
     }
     // Jump back to a call instruction that directly preceedes this one.
     sm->pc -= 5 + 5;
+  } break;
+
+  case SM_OP_PROCESS_GO_TIME: {
+    // Decode params and pack into three u64s that fit BPF's argument
+    // registers. See sm_resolve_time_offset for the packing layout.
+    uint32_t wall_off = sm_read_program_uint32(sm);
+    uint32_t ext_off = sm_read_program_uint32(sm);
+    uint32_t loc_off = sm_read_program_uint32(sm);
+    uint8_t cache_resolved = sm_read_program_uint8(sm);
+    uint32_t cache_start_off = sm_read_program_uint32(sm);
+    uint32_t cache_end_off = sm_read_program_uint32(sm);
+    uint32_t cache_zone_off = sm_read_program_uint32(sm);
+    uint32_t zone_offset_field_off = sm_read_program_uint32(sm);
+    uint32_t zone_offset_field_size = sm_read_program_uint32(sm);
+
+    uint64_t wall_ext_loc_off =
+        (uint64_t)wall_off | ((uint64_t)ext_off << 32);
+    uint64_t cache_starts_off =
+        (uint64_t)loc_off | ((uint64_t)cache_start_off << 32);
+    uint64_t zone_packed =
+        ((uint64_t)(cache_end_off & 0xFFFF)) |
+        ((uint64_t)(cache_zone_off & 0xFFFF) << 16) |
+        ((uint64_t)(zone_offset_field_off & 0xFFFF) << 32) |
+        ((uint64_t)(zone_offset_field_size & 0xFF) << 48) |
+        ((uint64_t)(cache_resolved & 0xFF) << 56);
+
+    int64_t resolved_offset = sm_resolve_time_offset(
+        buf, sm->offset, wall_ext_loc_off, cache_starts_off, zone_packed);
+
+    // Re-bounds-check immediately before the write. The volatile read
+    // inside scratch_buf_bounds_check is what tells the verifier this
+    // offset is bounded at the point of use.
+    buf_offset_t write_slot = sm->offset + loc_off;
+    if (!scratch_buf_bounds_check(&write_slot, sizeof(int64_t))) {
+      break;
+    }
+    *(int64_t*)&((*buf)[write_slot]) = resolved_offset;
+    LOG(4, "process_go_time: loc_off=%u resolved_offset=%lld",
+        loc_off, (long long)resolved_offset);
   } break;
 
   case SM_OP_PROCESS_STRING: {

--- a/pkg/dyninst/ebpf/types.h
+++ b/pkg/dyninst/ebpf/types.h
@@ -177,6 +177,10 @@ typedef enum sm_opcode {
   // See pkg/dyninst/irgen/trace_context.md for design.
   SM_OP_GO_CONTEXT_CHAIN_INIT = 47,
   SM_OP_GO_CONTEXT_CHAIN_HOP = 48,
+  // Resolve the captured time.Time's loc pointer to a UTC offset in
+  // seconds, written in place of the loc pointer. See
+  // pkg/dyninst/compiler/ops.go: ProcessGoTimeOp.
+  SM_OP_PROCESS_GO_TIME = 49,
 } sm_opcode_t;
 
 // cmp_op_t identifies which comparison SM_OP_EXPR_CMP_BASE /

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"strconv"
@@ -54,6 +55,13 @@ import (
 
 //go:embed testdata/decoded
 var testdataFS embed.FS
+
+// beforeTests is captured at package init so the monotonic-time redactor
+// has a lower bound it can assert against: any time.Time captured by a
+// testprog probe must fall in [beforeTests, time.Now()]. The test
+// binary is loaded (and this var initialized) well before the testprog
+// is launched, so any time.Now() inside the testprog is strictly later.
+var beforeTests = time.Now()
 
 func TestDyninst(t *testing.T) {
 	dyninsttest.SkipIfKernelNotSupported(t)
@@ -287,6 +295,7 @@ func testDyninst(
 	redactors := append(defaultRedactors[:len(defaultRedactors):len(defaultRedactors)],
 		makeRedactorForManyFloats(testProgConfig.GOARCH),
 		makeRedactorForFunctionWithChangingState())
+	redactors = append(redactors, makeRedactorsForMonotonicTime(t, beforeTests)...)
 	for _, log := range testServer.getLogs() {
 		redacted := redactJSON(t, "", log.body, redactors)
 		t.Logf("Snapshot [probe=%s]: %s", log.id, string(log.body))
@@ -864,4 +873,87 @@ func makeRedactorForFunctionWithChangingState() jsonRedactor {
 		),
 		replacement(`"[per-arch-value]"`),
 	)
+}
+
+// makeRedactorsForMonotonicTime returns redactors that locate the
+// captured time.Time produced by the testprog's testTimeMonotonic probe
+// (a time.Now() value carrying a monotonic clock reading) — both in the
+// snapshot's typed `value` field and in the templated `message` string
+// — and assert each parses as an RFC3339Nano timestamp inside
+// [lower, time.Now()]. The point of the assertion is to confirm the
+// BPF + decode pipeline correctly extracts wall seconds from the packed
+// 33-bit field when hasMonotonic is set, rather than reading the
+// monotonic delta from ext (which would yield nanoseconds since process
+// start — not a wall instant). Asserted values are replaced with a
+// sentinel so the snapshot stays stable.
+//
+// monotonicNow is the field name on the testprog's timeCapture struct
+// argument; the message template renders that field as
+// "{monotonicNow: <RFC3339>}".
+func makeRedactorsForMonotonicTime(
+	t *testing.T, lower time.Time,
+) []jsonRedactor {
+	assertInWindow := func(s string) bool {
+		parsed, err := time.Parse(time.RFC3339Nano, s)
+		if !assert.NoError(t, err,
+			"captured monotonic time should parse as RFC3339Nano, got %q", s) {
+			return false
+		}
+		now := time.Now()
+		ok := assert.Falsef(t, parsed.Before(lower),
+			"captured monotonic time %s is before test start %s",
+			parsed.Format(time.RFC3339Nano), lower.Format(time.RFC3339Nano))
+		ok = assert.Falsef(t, parsed.After(now),
+			"captured monotonic time %s is after now %s",
+			parsed.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)) && ok
+		return ok
+	}
+	valueRedactor := redactor(
+		exactMatcher(
+			"/debugger/snapshot/captures/entry/arguments/c/fields/monotonicNow/value",
+		),
+		replacerFunc(func(v jsontext.Value) jsontext.Value {
+			if v.Kind() != '"' {
+				return v
+			}
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return v
+			}
+			if !assertInWindow(s) {
+				return v
+			}
+			return jsontext.Value(`"[monotonic-time]"`)
+		}),
+	)
+	// Matches "{monotonicNow: <RFC3339Nano>}" inside /message.
+	rfc3339 := `(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))`
+	re := regexp.MustCompile(`monotonicNow: ` + rfc3339)
+	messageRedactor := redactor(
+		exactMatcher(`/message`),
+		replacerFunc(func(v jsontext.Value) jsontext.Value {
+			if v.Kind() != '"' {
+				return v
+			}
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return v
+			}
+			m := re.FindStringSubmatchIndex(s)
+			if len(m) == 0 {
+				return v
+			}
+			// Captured group is at m[2]:m[3].
+			if !assertInWindow(s[m[2]:m[3]]) {
+				return v
+			}
+			replaced := s[:m[2]] + "[monotonic-time]" + s[m[3]:]
+			marshaled, err := json.Marshal(replaced)
+			if err != nil {
+				return v
+			}
+			return jsontext.Value(marshaled)
+		}),
+	)
+	return []jsonRedactor{valueRedactor, messageRedactor}
 }

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -76,6 +76,7 @@ var (
 	_ Type = (*GoHMapBucketType)(nil)
 	_ Type = (*GoSwissMapHeaderType)(nil)
 	_ Type = (*GoSwissMapGroupsType)(nil)
+	_ Type = (*GoTimeType)(nil)
 	_ Type = (*GoChannelType)(nil)
 	_ Type = (*GoEmptyInterfaceType)(nil)
 	_ Type = (*GoInterfaceType)(nil)
@@ -464,6 +465,68 @@ type GoSwissMapGroupsType struct {
 }
 
 func (GoSwissMapGroupsType) irType() {}
+
+// GoTimeType is a specialized wrapper for the standard library's time.Time
+// structure. Decoding time.Time as a generic struct would either leak the
+// private wall/ext bit layout or render an opaque blob. By recognizing the
+// type during IR generation, the decoder can emit a real RFC3339 timestamp
+// and BPF can resolve the *Location pointer to a UTC offset via the
+// Location.cacheZone fast path, avoiding any further pointer chasing.
+//
+// We deliberately only consult the one-element cache (not the full
+// tx/zone tables or the extend POSIX string), which covers the common
+// case where the program has recently formatted or compared the instant
+// in that location; values whose Location has never been exercised
+// (e.g. a freshly LoadLocation'd zone, or time.Local before initLocal
+// runs) render in UTC instead of their true offset.
+//
+// All offset/size fields are byte offsets resolved from DWARF. When
+// CacheResolved is false the BPF runtime skips the cache lookup and the
+// decoder formats in UTC; the remaining cache offset fields are unset in
+// that case.
+type GoTimeType struct {
+	*StructureType
+
+	// WallFieldOffset and ExtFieldOffset are the offsets of the wall and
+	// ext fields within the time.Time structure.
+	WallFieldOffset uint32
+	ExtFieldOffset  uint32
+	// LocFieldOffset is the offset of the loc pointer field within the
+	// time.Time structure. At runtime BPF overwrites the 8 bytes at this
+	// offset with the resolved zone offset (in seconds east of UTC) or
+	// the sentinel value GoTimeUnresolvedOffset.
+	LocFieldOffset uint32
+
+	// CacheResolved is true when irgen successfully resolved the
+	// time.Location field offsets needed for the BPF cache lookup. When
+	// false, the BPF runtime writes the unresolved sentinel and the
+	// decoder renders in UTC.
+	CacheResolved bool
+	// CacheStartOffset, CacheEndOffset, CacheZoneOffset are byte offsets
+	// within time.Location for the cacheStart, cacheEnd, cacheZone fields.
+	CacheStartOffset uint32
+	CacheEndOffset   uint32
+	CacheZoneOffset  uint32
+	// ZoneOffsetFieldOffset is the byte offset of the offset field within
+	// the time.zone structure (pointed to by cacheZone).
+	ZoneOffsetFieldOffset uint32
+	// ZoneOffsetFieldSize is the byte size of the offset field. Go's int
+	// is 8 bytes on amd64/arm64 but we record the DWARF size to avoid
+	// assumptions.
+	ZoneOffsetFieldSize uint32
+}
+
+func (GoTimeType) irType() {}
+
+// GoTimeUnresolvedOffset is the sentinel value the BPF runtime writes into
+// the loc-pointer slot of a captured time.Time when the timezone offset
+// could not be resolved (loc was nil, the Location cache was uninitialized,
+// the captured instant fell outside the cache window, or the runtime
+// failed to read the cache fields). The decoder maps this value to UTC.
+//
+// The sentinel is INT64_MIN. Real UTC offsets are bounded by ±14 hours
+// (50,400 seconds), so collisions are impossible.
+const GoTimeUnresolvedOffset = int64(-1) << 63
 
 // GoSubroutineType is a type that represents a function type in the target
 // program.

--- a/pkg/dyninst/irgen/abi.go
+++ b/pkg/dyninst/irgen/abi.go
@@ -478,6 +478,9 @@ func registerAssign(
 		}
 		return pieces, true, nil
 
+	case *ir.GoTimeType:
+		return registerAssign(typ.StructureType, regs, abi)
+
 	case *ir.ArrayType:
 		if !typ.HasCount {
 			return nil, false, fmt.Errorf(

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -1821,6 +1821,7 @@ func (p *typeQueueProcessor) drainQueue() error {
 			*ir.GoEmptyInterfaceType,
 			*ir.GoStringDataType,
 			*ir.GoSubroutineType,
+			*ir.GoTimeType,
 			*ir.UnresolvedPointeeType,
 			*ir.VoidPointerType:
 
@@ -3729,7 +3730,11 @@ func completeGoTypes(tc *typeCatalog, minID, maxID ir.TypeID) error {
 					return err
 				}
 			case reflect.Struct:
-				// Nothing to do.
+				if t.Name == "time.Time" {
+					if err := completeGoTimeType(tc, t); err != nil {
+						return err
+					}
+				}
 			default:
 				return fmt.Errorf(
 					"unexpected Go kind for structure type %q: %v",
@@ -3797,6 +3802,103 @@ func completeGoMapType(tc *typeCatalog, t *ir.GoMapType) error {
 			t.Name, t.HeaderType.GetName(), t.HeaderType,
 		)
 	}
+}
+
+// completeGoTimeType converts a time.Time StructureType into a GoTimeType
+// and, when possible, resolves the time.Location cache fields so the BPF
+// program can write the captured instant's UTC offset in place of the loc
+// pointer. The function is best-effort: if any expected field is missing
+// (e.g. a future Go version reshuffles internals) the type is left as a
+// plain StructureType and the decoder falls back to UTC-only rendering.
+func completeGoTimeType(tc *typeCatalog, st *ir.StructureType) error {
+	wall, err := field(tc, st, "wall")
+	if err != nil {
+		return nil
+	}
+	ext, err := field(tc, st, "ext")
+	if err != nil {
+		return nil
+	}
+	loc, err := field(tc, st, "loc")
+	if err != nil {
+		return nil
+	}
+
+	timeType := &ir.GoTimeType{
+		StructureType:   st,
+		WallFieldOffset: wall.Offset,
+		ExtFieldOffset:  ext.Offset,
+		LocFieldOffset:  loc.Offset,
+	}
+
+	// Try to resolve the time.Location pointee so the BPF runtime can
+	// chase the cache fast path. Failure is non-fatal: the decoder
+	// renders in UTC when CacheResolved is false.
+	if loc, ok := tryResolveTimeLocation(tc, loc.Type); ok {
+		timeType.CacheResolved = true
+		timeType.CacheStartOffset = loc.cacheStartOffset
+		timeType.CacheEndOffset = loc.cacheEndOffset
+		timeType.CacheZoneOffset = loc.cacheZoneOffset
+		timeType.ZoneOffsetFieldOffset = loc.zoneOffsetFieldOffset
+		timeType.ZoneOffsetFieldSize = loc.zoneOffsetFieldSize
+	}
+
+	tc.typesByID[st.ID] = timeType
+	return nil
+}
+
+type resolvedTimeLocation struct {
+	cacheStartOffset      uint32
+	cacheEndOffset        uint32
+	cacheZoneOffset       uint32
+	zoneOffsetFieldOffset uint32
+	zoneOffsetFieldSize   uint32
+}
+
+func tryResolveTimeLocation(
+	tc *typeCatalog, locFieldType ir.Type,
+) (resolvedTimeLocation, bool) {
+	loc, err := resolvePointeeType[*ir.StructureType](tc, locFieldType)
+	if err != nil {
+		return resolvedTimeLocation{}, false
+	}
+	cacheStart, err := field(tc, loc, "cacheStart")
+	if err != nil {
+		return resolvedTimeLocation{}, false
+	}
+	cacheEnd, err := field(tc, loc, "cacheEnd")
+	if err != nil {
+		return resolvedTimeLocation{}, false
+	}
+	cacheZone, err := field(tc, loc, "cacheZone")
+	if err != nil {
+		return resolvedTimeLocation{}, false
+	}
+	zone, err := resolvePointeeType[*ir.StructureType](tc, cacheZone.Type)
+	if err != nil {
+		return resolvedTimeLocation{}, false
+	}
+	zoneOffset, err := field(tc, zone, "offset")
+	if err != nil {
+		return resolvedTimeLocation{}, false
+	}
+	// The BPF opcode encoding packs cache_end/cache_zone/zone_offset
+	// offsets into 16-bit fields to fit within BPF's argument-register
+	// budget. time.Location and time.zone are tiny so this is generous,
+	// but bail out (degrading to UTC rendering) if a future Go layout
+	// outgrows it.
+	if cacheEnd.Offset > 0xFFFF ||
+		cacheZone.Offset > 0xFFFF ||
+		zoneOffset.Offset > 0xFFFF {
+		return resolvedTimeLocation{}, false
+	}
+	return resolvedTimeLocation{
+		cacheStartOffset:      cacheStart.Offset,
+		cacheEndOffset:        cacheEnd.Offset,
+		cacheZoneOffset:       cacheZone.Offset,
+		zoneOffsetFieldOffset: zoneOffset.Offset,
+		zoneOffsetFieldSize:   zoneOffset.Type.GetByteSize(),
+	}, true
 }
 
 func completeSwissMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -679,10 +679,10 @@ Types:
       ByteSize: 8
       Pointee: 726 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 153
+      ID: 159
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 152 GoSliceDataType []os.Signal.array
+      Pointee: 158 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -708,15 +708,15 @@ Types:
       ByteSize: 8
       Pointee: 476 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 162
+      ID: 161
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []time.zone.array
+      Pointee: 160 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 164
+      ID: 163
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 163 GoSliceDataType []time.zoneTrans.array
+      Pointee: 162 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1036
       Name: '*[]uint16.array'
@@ -2879,19 +2879,19 @@ Types:
       ByteSize: 8
       Pointee: 185 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 156
+      ID: 153
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 82944
       GoKind: 22
-      Pointee: 157 StructureType time.zone
+      Pointee: 154 StructureType time.zone
     - __kind: PointerType
-      ID: 159
+      ID: 156
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 83008
       GoKind: 22
-      Pointee: 160 StructureType time.zoneTrans
+      Pointee: 157 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 101
       Name: '*uint'
@@ -3010,7 +3010,7 @@ Types:
       GoRuntimeType: 118464
       GoKind: 18
     - __kind: GoChannelType
-      ID: 154
+      ID: 164
       Name: <-chan time.Time
       GoRuntimeType: 120576
       GoKind: 18
@@ -4407,9 +4407,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 152 GoSliceDataType []os.Signal.array
+      Data: 158 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 152
+      ID: 158
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4465,7 +4465,7 @@ Types:
       ByteSize: 16
       Element: 475 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 152
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 103616
@@ -4473,22 +4473,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType *time.zone
+          Type: 153 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 161 GoSliceDataType []time.zone.array
+      Data: 160 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 160
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 157 StructureType time.zone
+      Element: 154 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 155
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 103680
@@ -4496,20 +4496,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 159 PointerType *time.zoneTrans
+          Type: 156 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 163 GoSliceDataType []time.zoneTrans.array
+      Data: 162 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 163
+      ID: 162
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 160 StructureType time.zoneTrans
+      Element: 157 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 536
       Name: '[]uint16'
@@ -5305,7 +5305,7 @@ Types:
           Type: 130 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 132 StructureType time.Time
+          Type: 132 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -6183,7 +6183,7 @@ Types:
           Type: 506 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 132 StructureType time.Time
+          Type: 132 GoTimeType time.Time
     - __kind: StructureType
       ID: 534
       Name: crypto/x509.CertPool
@@ -6251,10 +6251,10 @@ Types:
           Type: 395 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 132 StructureType time.Time
+          Type: 132 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 132 StructureType time.Time
+          Type: 132 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 400 BaseType crypto/x509.KeyUsage
@@ -12656,10 +12656,10 @@ Types:
           Type: 12 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 155 GoSliceHeaderType []time.zone
+          Type: 152 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 158 GoSliceHeaderType []time.zoneTrans
+          Type: 155 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 12 GoStringHeaderType string
@@ -12671,7 +12671,7 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 156 PointerType *time.zone
+          Type: 153 PointerType *time.zone
     - __kind: StructureType
       ID: 224
       Name: time.ParseError
@@ -12694,7 +12694,7 @@ Types:
         - Name: Message
           Offset: 64
           Type: 12 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 132
       Name: time.Time
       ByteSize: 24
@@ -12710,6 +12710,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 133 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 131
       Name: time.Timer
@@ -12719,7 +12727,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 154 GoChannelType <-chan time.Time
+          Type: 164 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -12743,7 +12751,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 157
+      ID: 154
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 296256
@@ -12759,7 +12767,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 160
+      ID: 157
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 340992

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -772,10 +772,10 @@ Types:
       ByteSize: 8
       Pointee: 729 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 162
+      ID: 168
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []os.Signal.array
+      Pointee: 167 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -801,15 +801,15 @@ Types:
       ByteSize: 8
       Pointee: 494 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 171
+      ID: 170
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []time.zone.array
+      Pointee: 169 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 173
+      ID: 172
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType []time.zoneTrans.array
+      Pointee: 171 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1139
       Name: '*[]uint16.array'
@@ -3147,19 +3147,19 @@ Types:
       ByteSize: 8
       Pointee: 194 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 165
+      ID: 162
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 92160
       GoKind: 22
-      Pointee: 166 StructureType time.zone
+      Pointee: 163 StructureType time.zone
     - __kind: PointerType
-      ID: 168
+      ID: 165
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 92224
       GoKind: 22
-      Pointee: 169 StructureType time.zoneTrans
+      Pointee: 166 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 106
       Name: '*uint'
@@ -3264,7 +3264,7 @@ Types:
       GoRuntimeType: 132480
       GoKind: 18
     - __kind: GoChannelType
-      ID: 163
+      ID: 173
       Name: <-chan time.Time
       GoRuntimeType: 134528
       GoKind: 18
@@ -4759,9 +4759,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 161 GoSliceDataType []os.Signal.array
+      Data: 167 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 167
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4817,7 +4817,7 @@ Types:
       ByteSize: 16
       Element: 493 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 161
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 115072
@@ -4825,22 +4825,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *time.zone
+          Type: 162 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 170 GoSliceDataType []time.zone.array
+      Data: 169 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 169
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 166 StructureType time.zone
+      Element: 163 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 164
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 115136
@@ -4848,20 +4848,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *time.zoneTrans
+          Type: 165 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 172 GoSliceDataType []time.zoneTrans.array
+      Data: 171 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 171
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 169 StructureType time.zoneTrans
+      Element: 166 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 555
       Name: '[]uint16'
@@ -5218,7 +5218,7 @@ Types:
           Type: 135 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 137 StructureType time.Time
+          Type: 137 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -6191,7 +6191,7 @@ Types:
           Type: 525 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 137 StructureType time.Time
+          Type: 137 GoTimeType time.Time
     - __kind: StructureType
       ID: 553
       Name: crypto/x509.CertPool
@@ -6259,10 +6259,10 @@ Types:
           Type: 406 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 137 StructureType time.Time
+          Type: 137 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 137 StructureType time.Time
+          Type: 137 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 411 BaseType crypto/x509.KeyUsage
@@ -14167,10 +14167,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 164 GoSliceHeaderType []time.zone
+          Type: 161 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 167 GoSliceHeaderType []time.zoneTrans
+          Type: 164 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -14182,7 +14182,7 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 165 PointerType *time.zone
+          Type: 162 PointerType *time.zone
     - __kind: StructureType
       ID: 234
       Name: time.ParseError
@@ -14205,7 +14205,7 @@ Types:
         - Name: Message
           Offset: 64
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 137
       Name: time.Time
       ByteSize: 24
@@ -14221,6 +14221,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 138 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 136
       Name: time.Timer
@@ -14230,7 +14238,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 163 GoChannelType <-chan time.Time
+          Type: 173 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -14254,7 +14262,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 166
+      ID: 163
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 343424
@@ -14270,7 +14278,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 169
+      ID: 166
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 375488

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -805,10 +805,10 @@ Types:
       ByteSize: 8
       Pointee: 836 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 167
+      ID: 173
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []os.Signal.array
+      Pointee: 172 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -844,15 +844,15 @@ Types:
       ByteSize: 8
       Pointee: 603 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 176
+      ID: 175
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []time.zone.array
+      Pointee: 174 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 178
+      ID: 177
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []time.zoneTrans.array
+      Pointee: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1245
       Name: '*[]uint16.array'
@@ -3332,19 +3332,19 @@ Types:
       ByteSize: 8
       Pointee: 199 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 170
+      ID: 167
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 93728
       GoKind: 22
-      Pointee: 171 StructureType time.zone
+      Pointee: 168 StructureType time.zone
     - __kind: PointerType
-      ID: 173
+      ID: 170
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 93792
       GoKind: 22
-      Pointee: 174 StructureType time.zoneTrans
+      Pointee: 171 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 108
       Name: '*uint'
@@ -3456,7 +3456,7 @@ Types:
       GoRuntimeType: 135008
       GoKind: 18
     - __kind: GoChannelType
-      ID: 168
+      ID: 178
       Name: <-chan time.Time
       GoRuntimeType: 136992
       GoKind: 18
@@ -5107,9 +5107,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 166 GoSliceDataType []os.Signal.array
+      Data: 172 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 172
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -5207,7 +5207,7 @@ Types:
       ByteSize: 16
       Element: 602 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 166
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 116640
@@ -5215,22 +5215,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *time.zone
+          Type: 167 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 175 GoSliceDataType []time.zone.array
+      Data: 174 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 174
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 171 StructureType time.zone
+      Element: 168 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 169
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 116704
@@ -5238,20 +5238,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *time.zoneTrans
+          Type: 170 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 177 GoSliceDataType []time.zoneTrans.array
+      Data: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 176
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 174 StructureType time.zoneTrans
+      Element: 171 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 662
       Name: '[]uint16'
@@ -5631,7 +5631,7 @@ Types:
           Type: 137 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -6597,7 +6597,7 @@ Types:
           Type: 632 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
     - __kind: StructureType
       ID: 660
       Name: crypto/x509.CertPool
@@ -6665,10 +6665,10 @@ Types:
           Type: 515 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 520 BaseType crypto/x509.KeyUsage
@@ -15800,10 +15800,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 169 GoSliceHeaderType []time.zone
+          Type: 166 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 172 GoSliceHeaderType []time.zoneTrans
+          Type: 169 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -15815,7 +15815,7 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 170 PointerType *time.zone
+          Type: 167 PointerType *time.zone
     - __kind: StructureType
       ID: 242
       Name: time.ParseError
@@ -15838,7 +15838,7 @@ Types:
         - Name: Message
           Offset: 64
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 139
       Name: time.Time
       ByteSize: 24
@@ -15854,6 +15854,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 140 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 138
       Name: time.Timer
@@ -15863,7 +15871,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 168 GoChannelType <-chan time.Time
+          Type: 178 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -15887,7 +15895,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 171
+      ID: 168
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 347360
@@ -15903,7 +15911,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 174
+      ID: 171
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 381920

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.26rc1.yaml
@@ -805,10 +805,10 @@ Types:
       ByteSize: 8
       Pointee: 866 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 177
+      ID: 183
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []os.Signal.array
+      Pointee: 182 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -844,15 +844,15 @@ Types:
       ByteSize: 8
       Pointee: 632 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 186
+      ID: 185
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []time.zone.array
+      Pointee: 184 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 188
+      ID: 187
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []time.zoneTrans.array
+      Pointee: 186 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1272
       Name: '*[]uint16.array'
@@ -3386,19 +3386,19 @@ Types:
       ByteSize: 8
       Pointee: 212 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 180
+      ID: 177
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 98176
       GoKind: 22
-      Pointee: 181 StructureType time.zone
+      Pointee: 178 StructureType time.zone
     - __kind: PointerType
-      ID: 183
+      ID: 180
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 98240
       GoKind: 22
-      Pointee: 184 StructureType time.zoneTrans
+      Pointee: 181 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 113
       Name: '*uint'
@@ -3510,7 +3510,7 @@ Types:
       GoRuntimeType: 140640
       GoKind: 18
     - __kind: GoChannelType
-      ID: 178
+      ID: 188
       Name: <-chan time.Time
       GoRuntimeType: 144096
       GoKind: 18
@@ -5179,9 +5179,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 176 GoSliceDataType []os.Signal.array
+      Data: 182 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 182
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -5279,7 +5279,7 @@ Types:
       ByteSize: 16
       Element: 631 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 176
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 122176
@@ -5287,22 +5287,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 180 PointerType *time.zone
+          Type: 177 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 185 GoSliceDataType []time.zone.array
+      Data: 184 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 184
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 181 StructureType time.zone
+      Element: 178 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 182
+      ID: 179
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 122240
@@ -5310,20 +5310,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 183 PointerType *time.zoneTrans
+          Type: 180 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 187 GoSliceDataType []time.zoneTrans.array
+      Data: 186 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 186
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 184 StructureType time.zoneTrans
+      Element: 181 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 690
       Name: '[]uint16'
@@ -5727,7 +5727,7 @@ Types:
           Type: 147 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 149 StructureType time.Time
+          Type: 149 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -6715,7 +6715,7 @@ Types:
           Type: 659 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 149 StructureType time.Time
+          Type: 149 GoTimeType time.Time
     - __kind: StructureType
       ID: 688
       Name: crypto/x509.CertPool
@@ -6783,10 +6783,10 @@ Types:
           Type: 544 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 149 StructureType time.Time
+          Type: 149 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 149 StructureType time.Time
+          Type: 149 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 549 BaseType crypto/x509.KeyUsage
@@ -16217,10 +16217,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 179 GoSliceHeaderType []time.zone
+          Type: 176 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 182 GoSliceHeaderType []time.zoneTrans
+          Type: 179 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -16232,7 +16232,7 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 180 PointerType *time.zone
+          Type: 177 PointerType *time.zone
     - __kind: StructureType
       ID: 257
       Name: time.ParseError
@@ -16255,7 +16255,7 @@ Types:
         - Name: Message
           Offset: 64
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 149
       Name: time.Time
       ByteSize: 24
@@ -16271,6 +16271,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 150 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 148
       Name: time.Timer
@@ -16280,7 +16288,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 178 GoChannelType <-chan time.Time
+          Type: 188 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -16304,7 +16312,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 181
+      ID: 178
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 361824
@@ -16320,7 +16328,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 184
+      ID: 181
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 399264

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -666,10 +666,10 @@ Types:
       ByteSize: 8
       Pointee: 726 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 153
+      ID: 159
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 152 GoSliceDataType []os.Signal.array
+      Pointee: 158 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -695,15 +695,15 @@ Types:
       ByteSize: 8
       Pointee: 476 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 162
+      ID: 161
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []time.zone.array
+      Pointee: 160 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 164
+      ID: 163
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 163 GoSliceDataType []time.zoneTrans.array
+      Pointee: 162 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1036
       Name: '*[]uint16.array'
@@ -2866,19 +2866,19 @@ Types:
       ByteSize: 8
       Pointee: 185 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 156
+      ID: 153
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 83008
       GoKind: 22
-      Pointee: 157 StructureType time.zone
+      Pointee: 154 StructureType time.zone
     - __kind: PointerType
-      ID: 159
+      ID: 156
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 83072
       GoKind: 22
-      Pointee: 160 StructureType time.zoneTrans
+      Pointee: 157 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 101
       Name: '*uint'
@@ -2997,7 +2997,7 @@ Types:
       GoRuntimeType: 118592
       GoKind: 18
     - __kind: GoChannelType
-      ID: 154
+      ID: 164
       Name: <-chan time.Time
       GoRuntimeType: 120704
       GoKind: 18
@@ -4394,9 +4394,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 152 GoSliceDataType []os.Signal.array
+      Data: 158 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 152
+      ID: 158
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4452,7 +4452,7 @@ Types:
       ByteSize: 16
       Element: 475 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 152
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 103680
@@ -4460,22 +4460,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType *time.zone
+          Type: 153 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 161 GoSliceDataType []time.zone.array
+      Data: 160 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 160
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 157 StructureType time.zone
+      Element: 154 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 155
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 103744
@@ -4483,20 +4483,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 159 PointerType *time.zoneTrans
+          Type: 156 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 163 GoSliceDataType []time.zoneTrans.array
+      Data: 162 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 163
+      ID: 162
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 160 StructureType time.zoneTrans
+      Element: 157 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 536
       Name: '[]uint16'
@@ -5292,7 +5292,7 @@ Types:
           Type: 130 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 132 StructureType time.Time
+          Type: 132 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -6170,7 +6170,7 @@ Types:
           Type: 506 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 132 StructureType time.Time
+          Type: 132 GoTimeType time.Time
     - __kind: StructureType
       ID: 534
       Name: crypto/x509.CertPool
@@ -6238,10 +6238,10 @@ Types:
           Type: 395 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 132 StructureType time.Time
+          Type: 132 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 132 StructureType time.Time
+          Type: 132 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 400 BaseType crypto/x509.KeyUsage
@@ -12643,10 +12643,10 @@ Types:
           Type: 12 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 155 GoSliceHeaderType []time.zone
+          Type: 152 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 158 GoSliceHeaderType []time.zoneTrans
+          Type: 155 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 12 GoStringHeaderType string
@@ -12658,7 +12658,7 @@ Types:
           Type: 16 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 156 PointerType *time.zone
+          Type: 153 PointerType *time.zone
     - __kind: StructureType
       ID: 224
       Name: time.ParseError
@@ -12681,7 +12681,7 @@ Types:
         - Name: Message
           Offset: 64
           Type: 12 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 132
       Name: time.Time
       ByteSize: 24
@@ -12697,6 +12697,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 133 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 131
       Name: time.Timer
@@ -12706,7 +12714,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 154 GoChannelType <-chan time.Time
+          Type: 164 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -12730,7 +12738,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 157
+      ID: 154
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 296480
@@ -12746,7 +12754,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 160
+      ID: 157
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 341408

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -767,10 +767,10 @@ Types:
       ByteSize: 8
       Pointee: 729 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 162
+      ID: 168
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []os.Signal.array
+      Pointee: 167 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -796,15 +796,15 @@ Types:
       ByteSize: 8
       Pointee: 494 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 171
+      ID: 170
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []time.zone.array
+      Pointee: 169 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 173
+      ID: 172
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType []time.zoneTrans.array
+      Pointee: 171 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1139
       Name: '*[]uint16.array'
@@ -3142,19 +3142,19 @@ Types:
       ByteSize: 8
       Pointee: 194 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 165
+      ID: 162
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 92032
       GoKind: 22
-      Pointee: 166 StructureType time.zone
+      Pointee: 163 StructureType time.zone
     - __kind: PointerType
-      ID: 168
+      ID: 165
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 92096
       GoKind: 22
-      Pointee: 169 StructureType time.zoneTrans
+      Pointee: 166 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 106
       Name: '*uint'
@@ -3259,7 +3259,7 @@ Types:
       GoRuntimeType: 132160
       GoKind: 18
     - __kind: GoChannelType
-      ID: 163
+      ID: 173
       Name: <-chan time.Time
       GoRuntimeType: 134208
       GoKind: 18
@@ -4754,9 +4754,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 161 GoSliceDataType []os.Signal.array
+      Data: 167 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 167
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4812,7 +4812,7 @@ Types:
       ByteSize: 16
       Element: 493 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 161
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 114816
@@ -4820,22 +4820,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *time.zone
+          Type: 162 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 170 GoSliceDataType []time.zone.array
+      Data: 169 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 169
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 166 StructureType time.zone
+      Element: 163 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 164
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 114880
@@ -4843,20 +4843,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *time.zoneTrans
+          Type: 165 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 172 GoSliceDataType []time.zoneTrans.array
+      Data: 171 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 171
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 169 StructureType time.zoneTrans
+      Element: 166 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 555
       Name: '[]uint16'
@@ -5213,7 +5213,7 @@ Types:
           Type: 135 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 137 StructureType time.Time
+          Type: 137 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -6186,7 +6186,7 @@ Types:
           Type: 525 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 137 StructureType time.Time
+          Type: 137 GoTimeType time.Time
     - __kind: StructureType
       ID: 553
       Name: crypto/x509.CertPool
@@ -6254,10 +6254,10 @@ Types:
           Type: 406 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 137 StructureType time.Time
+          Type: 137 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 137 StructureType time.Time
+          Type: 137 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 411 BaseType crypto/x509.KeyUsage
@@ -14162,10 +14162,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 164 GoSliceHeaderType []time.zone
+          Type: 161 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 167 GoSliceHeaderType []time.zoneTrans
+          Type: 164 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -14177,7 +14177,7 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 165 PointerType *time.zone
+          Type: 162 PointerType *time.zone
     - __kind: StructureType
       ID: 234
       Name: time.ParseError
@@ -14200,7 +14200,7 @@ Types:
         - Name: Message
           Offset: 64
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 137
       Name: time.Time
       ByteSize: 24
@@ -14216,6 +14216,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 138 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 136
       Name: time.Timer
@@ -14225,7 +14233,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 163 GoChannelType <-chan time.Time
+          Type: 173 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -14249,7 +14257,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 166
+      ID: 163
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 342720
@@ -14265,7 +14273,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 169
+      ID: 166
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 374784

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -790,10 +790,10 @@ Types:
       ByteSize: 8
       Pointee: 836 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 167
+      ID: 173
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []os.Signal.array
+      Pointee: 172 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -829,15 +829,15 @@ Types:
       ByteSize: 8
       Pointee: 603 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 176
+      ID: 175
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []time.zone.array
+      Pointee: 174 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 178
+      ID: 177
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []time.zoneTrans.array
+      Pointee: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1245
       Name: '*[]uint16.array'
@@ -3317,19 +3317,19 @@ Types:
       ByteSize: 8
       Pointee: 199 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 170
+      ID: 167
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 93632
       GoKind: 22
-      Pointee: 171 StructureType time.zone
+      Pointee: 168 StructureType time.zone
     - __kind: PointerType
-      ID: 173
+      ID: 170
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 93696
       GoKind: 22
-      Pointee: 174 StructureType time.zoneTrans
+      Pointee: 171 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 108
       Name: '*uint'
@@ -3441,7 +3441,7 @@ Types:
       GoRuntimeType: 134720
       GoKind: 18
     - __kind: GoChannelType
-      ID: 168
+      ID: 178
       Name: <-chan time.Time
       GoRuntimeType: 136704
       GoKind: 18
@@ -5092,9 +5092,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 166 GoSliceDataType []os.Signal.array
+      Data: 172 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 172
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -5192,7 +5192,7 @@ Types:
       ByteSize: 16
       Element: 602 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 166
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 116416
@@ -5200,22 +5200,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *time.zone
+          Type: 167 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 175 GoSliceDataType []time.zone.array
+      Data: 174 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 174
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 171 StructureType time.zone
+      Element: 168 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 169
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 116480
@@ -5223,20 +5223,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *time.zoneTrans
+          Type: 170 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 177 GoSliceDataType []time.zoneTrans.array
+      Data: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 176
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 174 StructureType time.zoneTrans
+      Element: 171 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 662
       Name: '[]uint16'
@@ -5616,7 +5616,7 @@ Types:
           Type: 137 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -6582,7 +6582,7 @@ Types:
           Type: 632 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
     - __kind: StructureType
       ID: 660
       Name: crypto/x509.CertPool
@@ -6650,10 +6650,10 @@ Types:
           Type: 515 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 520 BaseType crypto/x509.KeyUsage
@@ -15785,10 +15785,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 169 GoSliceHeaderType []time.zone
+          Type: 166 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 172 GoSliceHeaderType []time.zoneTrans
+          Type: 169 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -15800,7 +15800,7 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 170 PointerType *time.zone
+          Type: 167 PointerType *time.zone
     - __kind: StructureType
       ID: 242
       Name: time.ParseError
@@ -15823,7 +15823,7 @@ Types:
         - Name: Message
           Offset: 64
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 139
       Name: time.Time
       ByteSize: 24
@@ -15839,6 +15839,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 140 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 138
       Name: time.Timer
@@ -15848,7 +15856,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 168 GoChannelType <-chan time.Time
+          Type: 178 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -15872,7 +15880,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 171
+      ID: 168
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 346688
@@ -15888,7 +15896,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 174
+      ID: 171
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 381248

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.26rc1.yaml
@@ -790,10 +790,10 @@ Types:
       ByteSize: 8
       Pointee: 865 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 177
+      ID: 183
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []os.Signal.array
+      Pointee: 182 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -829,15 +829,15 @@ Types:
       ByteSize: 8
       Pointee: 632 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 186
+      ID: 185
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []time.zone.array
+      Pointee: 184 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 188
+      ID: 187
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []time.zoneTrans.array
+      Pointee: 186 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1271
       Name: '*[]uint16.array'
@@ -3371,19 +3371,19 @@ Types:
       ByteSize: 8
       Pointee: 212 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 180
+      ID: 177
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 98016
       GoKind: 22
-      Pointee: 181 StructureType time.zone
+      Pointee: 178 StructureType time.zone
     - __kind: PointerType
-      ID: 183
+      ID: 180
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 98080
       GoKind: 22
-      Pointee: 184 StructureType time.zoneTrans
+      Pointee: 181 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 113
       Name: '*uint'
@@ -3495,7 +3495,7 @@ Types:
       GoRuntimeType: 140288
       GoKind: 18
     - __kind: GoChannelType
-      ID: 178
+      ID: 188
       Name: <-chan time.Time
       GoRuntimeType: 143744
       GoKind: 18
@@ -5164,9 +5164,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 176 GoSliceDataType []os.Signal.array
+      Data: 182 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 182
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -5264,7 +5264,7 @@ Types:
       ByteSize: 16
       Element: 631 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 176
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 121888
@@ -5272,22 +5272,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 180 PointerType *time.zone
+          Type: 177 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 185 GoSliceDataType []time.zone.array
+      Data: 184 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 184
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 181 StructureType time.zone
+      Element: 178 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 182
+      ID: 179
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 121952
@@ -5295,20 +5295,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 183 PointerType *time.zoneTrans
+          Type: 180 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 187 GoSliceDataType []time.zoneTrans.array
+      Data: 186 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 186
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 184 StructureType time.zoneTrans
+      Element: 181 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 689
       Name: '[]uint16'
@@ -5712,7 +5712,7 @@ Types:
           Type: 147 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 149 StructureType time.Time
+          Type: 149 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -6700,7 +6700,7 @@ Types:
           Type: 460 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 149 StructureType time.Time
+          Type: 149 GoTimeType time.Time
     - __kind: StructureType
       ID: 687
       Name: crypto/x509.CertPool
@@ -6768,10 +6768,10 @@ Types:
           Type: 544 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 149 StructureType time.Time
+          Type: 149 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 149 StructureType time.Time
+          Type: 149 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 549 BaseType crypto/x509.KeyUsage
@@ -16178,10 +16178,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 179 GoSliceHeaderType []time.zone
+          Type: 176 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 182 GoSliceHeaderType []time.zoneTrans
+          Type: 179 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -16193,7 +16193,7 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 180 PointerType *time.zone
+          Type: 177 PointerType *time.zone
     - __kind: StructureType
       ID: 257
       Name: time.ParseError
@@ -16216,7 +16216,7 @@ Types:
         - Name: Message
           Offset: 64
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 149
       Name: time.Time
       ByteSize: 24
@@ -16232,6 +16232,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 150 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 148
       Name: time.Timer
@@ -16241,7 +16249,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 178 GoChannelType <-chan time.Time
+          Type: 188 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -16265,7 +16273,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 181
+      ID: 178
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 361088
@@ -16281,7 +16289,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 184
+      ID: 181
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 398528

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -119,7 +119,7 @@ Types:
       ID: 926
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 629 PointerType *crypto/x509.Certificate
+      Pointee: 639 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 681
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -164,30 +164,30 @@ Types:
       ByteSize: 8
       Pointee: 937 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 666
+      ID: 676
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 665 GoSliceDataType []float64.array
+      Pointee: 675 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 199
+      ID: 205
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 204 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 207
+      ID: 213
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 212 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 943
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 942 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 190
+      ID: 196
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []os.Signal.array
+      Pointee: 195 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -196,20 +196,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 664
+      ID: 674
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 663 GoSliceDataType []string.array
+      Pointee: 673 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 677
+      ID: 215
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 676 GoSliceDataType []time.zone.array
+      Pointee: 214 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 679
+      ID: 217
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 678 GoSliceDataType []time.zoneTrans.array
+      Pointee: 216 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 930
       Name: '*[]uint8'
@@ -228,17 +228,17 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 877728
       GoKind: 22
-      Pointee: 450 GoSliceHeaderType archive/tar.headerError
+      Pointee: 460 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 451 GoSliceDataType archive/tar.headerError.array
+      Pointee: 461 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 845
       Name: '*archive/zip.checksumReader'
@@ -285,10 +285,10 @@ Types:
       ByteSize: 8
       Pointee: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 203
+      ID: 209
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 915
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -305,10 +305,10 @@ Types:
       ByteSize: 8
       Pointee: 165 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 634
+      ID: 644
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 635 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 159
       Name: '*bucket<string,interface {}>'
@@ -334,24 +334,24 @@ Types:
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 864096
       GoKind: 22
-      Pointee: 254 BaseType compress/flate.CorruptInputError
+      Pointee: 264 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 864192
       GoKind: 22
-      Pointee: 255 GoStringHeaderType compress/flate.InternalError
+      Pointee: 265 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 257
+      ID: 267
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 256 GoStringDataType compress/flate.InternalError.str
+      Pointee: 266 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 877
       Name: '*compress/flate.decompressor'
@@ -381,12 +381,12 @@ Types:
       GoKind: 22
       Pointee: 113 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1121792
       GoKind: 22
-      Pointee: 556 StructureType context.deadlineExceededError
+      Pointee: 566 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 944
       Name: '*context.emptyCtx'
@@ -430,40 +430,40 @@ Types:
       GoKind: 22
       Pointee: 121 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863136
       GoKind: 22
-      Pointee: 251 BaseType crypto/aes.KeySizeError
+      Pointee: 261 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 385
+      ID: 395
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863328
       GoKind: 22
-      Pointee: 252 BaseType crypto/des.KeySizeError
+      Pointee: 262 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863616
       GoKind: 22
-      Pointee: 253 BaseType crypto/rc4.KeySizeError
+      Pointee: 263 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 325
+      ID: 335
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 852768
       GoKind: 22
-      Pointee: 228 BaseType crypto/tls.AlertError
+      Pointee: 238 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1017024
       GoKind: 22
-      Pointee: 515 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 525 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 907
       Name: '*crypto/tls.Conn'
@@ -479,206 +479,206 @@ Types:
       GoKind: 22
       Pointee: 797 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 323
+      ID: 333
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 852576
       GoKind: 22
-      Pointee: 324 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 334 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 321
+      ID: 331
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 852480
       GoKind: 22
-      Pointee: 322 StructureType crypto/tls.RecordHeaderError
+      Pointee: 332 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1015360
       GoKind: 22
-      Pointee: 482 BaseType crypto/tls.alert
+      Pointee: 492 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1263456
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 631 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 629
+      ID: 639
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1952864
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 640 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 862944
       GoKind: 22
-      Pointee: 381 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 391 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 862464
       GoKind: 22
-      Pointee: 375 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 385 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 376
+      ID: 386
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 862560
       GoKind: 22
-      Pointee: 377 StructureType crypto/x509.HostnameError
+      Pointee: 387 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 862368
       GoKind: 22
-      Pointee: 250 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 260 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 528
+      ID: 538
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1027520
       GoKind: 22
-      Pointee: 529 StructureType crypto/x509.SystemRootsError
+      Pointee: 539 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 863040
       GoKind: 22
-      Pointee: 383 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 393 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 862848
       GoKind: 22
-      Pointee: 379 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 389 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 441
+      ID: 451
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 873504
       GoKind: 22
-      Pointee: 442 StructureType encoding/asn1.StructuralError
+      Pointee: 452 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 873696
       GoKind: 22
-      Pointee: 446 StructureType encoding/asn1.SyntaxError
+      Pointee: 456 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 873600
       GoKind: 22
-      Pointee: 444 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 454 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 326
+      ID: 336
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 852864
       GoKind: 22
-      Pointee: 229 BaseType encoding/base64.CorruptInputError
+      Pointee: 239 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 861312
       GoKind: 22
-      Pointee: 249 BaseType encoding/hex.InvalidByteError
+      Pointee: 259 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 343
+      ID: 353
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 856416
       GoKind: 22
-      Pointee: 344 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 354 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 526
+      ID: 536
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1022272
       GoKind: 22
-      Pointee: 527 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 537 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 856032
       GoKind: 22
-      Pointee: 336 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 346 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 341
+      ID: 351
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 856320
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 352 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 856224
       GoKind: 22
-      Pointee: 340 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 350 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 856128
       GoKind: 22
-      Pointee: 338 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 348 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 856800
       GoKind: 22
-      Pointee: 346 StructureType encoding/json.jsonError
+      Pointee: 356 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 871296
       GoKind: 22
-      Pointee: 437 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 447 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 871200
       GoKind: 22
-      Pointee: 435 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 445 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 871392
       GoKind: 22
-      Pointee: 259 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 269 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 261
+      ID: 271
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 260 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 270 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 439
+      ID: 449
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 871488
       GoKind: 22
-      Pointee: 440 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 450 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -687,19 +687,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 309
+      ID: 319
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 847968
       GoKind: 22
-      Pointee: 310 UnresolvedPointeeType errors.errorString
+      Pointee: 320 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1008320
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType errors.joinError
+      Pointee: 512 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -715,26 +715,26 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 485
+      ID: 495
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 998336
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType fmt.wrapError
+      Pointee: 496 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 487
+      ID: 497
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 998464
       GoKind: 22
-      Pointee: 488 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 498 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 860832
       GoKind: 22
-      Pointee: 367 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 377 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 748
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -743,83 +743,83 @@ Types:
       GoKind: 22
       Pointee: 749 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 858048
       GoKind: 22
-      Pointee: 349 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 359 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 858144
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 361 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 857856
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 660 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 354
+      ID: 364
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 858432
       GoKind: 22
-      Pointee: 355 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 365 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 857952
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 662 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 352
+      ID: 362
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 858240
       GoKind: 22
-      Pointee: 243 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 253 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 245
+      ID: 255
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 244 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 254 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 347
+      ID: 357
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 857760
       GoKind: 22
-      Pointee: 240 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 250 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 242
+      ID: 252
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 241 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 251 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 858336
       GoKind: 22
-      Pointee: 246 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 256 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 248
+      ID: 258
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 247 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 257 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 391
+      ID: 401
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 865152
       GoKind: 22
-      Pointee: 392 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 402 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 739
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
@@ -877,12 +877,12 @@ Types:
       GoKind: 22
       Pointee: 689 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 209
+      ID: 219
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1130112
       GoKind: 22
-      Pointee: 210 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 220 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 174
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
@@ -898,12 +898,12 @@ Types:
       GoKind: 22
       Pointee: 755 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 596
+      ID: 606
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1151360
       GoKind: 22
-      Pointee: 597 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 607 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 690
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
@@ -940,143 +940,143 @@ Types:
       GoKind: 22
       Pointee: 826 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 867360
       GoKind: 22
-      Pointee: 394 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 404 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 400
+      ID: 410
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 868416
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 411 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 868128
       GoKind: 22
-      Pointee: 258 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 268 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 868320
       GoKind: 22
-      Pointee: 399 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 409 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 396
+      ID: 406
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 868224
       GoKind: 22
-      Pointee: 397 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 407 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 869760
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 419 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 869952
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 423 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 869856
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 421 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 869664
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 417 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 668
+      ID: 678
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 667 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 677 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 870336
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 431 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 870048
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 425 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 870240
       GoKind: 22
-      Pointee: 419 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 429 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 870144
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 427 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 870432
       GoKind: 22
-      Pointee: 423 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 433 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 870720
       GoKind: 22
-      Pointee: 429 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 439 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 870816
       GoKind: 22
-      Pointee: 431 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 441 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 870624
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 437 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 870528
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 435 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 871008
       GoKind: 22
-      Pointee: 433 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 443 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 764
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1106,12 +1106,12 @@ Types:
       GoKind: 22
       Pointee: 763 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 859584
       GoKind: 22
-      Pointee: 357 StructureType github.com/cihub/seelog.baseError
+      Pointee: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 741
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1120,12 +1120,12 @@ Types:
       GoKind: 22
       Pointee: 742 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 358
+      ID: 368
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 859680
       GoKind: 22
-      Pointee: 359 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 369 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 731
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1148,12 +1148,12 @@ Types:
       GoKind: 22
       Pointee: 738 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 859872
       GoKind: 22
-      Pointee: 363 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 373 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 735
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1169,19 +1169,19 @@ Types:
       GoKind: 22
       Pointee: 757 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 859776
       GoKind: 22
-      Pointee: 361 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 371 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 22
-      Pointee: 365 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 375 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 843
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1197,289 +1197,289 @@ Types:
       GoKind: 22
       Pointee: 863 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 624
+      ID: 634
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1281056
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 635 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 540
+      ID: 550
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1046080
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 551 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 538
+      ID: 548
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1045952
       GoKind: 22
-      Pointee: 539 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 549 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 542
+      ID: 552
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1050432
       GoKind: 22
-      Pointee: 543 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 553 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 544
+      ID: 554
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1050560
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 555 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 534
+      ID: 544
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1035072
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 545 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 861504
       GoKind: 22
-      Pointee: 370 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 380 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 598
+      ID: 608
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1158528
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 609 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 584
+      ID: 594
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1143424
       GoKind: 22
-      Pointee: 585 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1143040
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 589 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 520
+      ID: 530
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1019968
       GoKind: 22
-      Pointee: 521 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 531 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 590
+      ID: 600
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1143808
       GoKind: 22
-      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 519
+      ID: 529
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1019840
       GoKind: 22
-      Pointee: 484 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 494 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 582
+      ID: 592
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1143296
       GoKind: 22
-      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 580
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1143168
       GoKind: 22
-      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 588
+      ID: 598
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1143680
       GoKind: 22
-      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 599 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1143552
       GoKind: 22
-      Pointee: 587 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 594
+      ID: 604
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1144192
       GoKind: 22
-      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 524
+      ID: 534
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1020224
       GoKind: 22
-      Pointee: 525 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 535 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1020096
       GoKind: 22
-      Pointee: 523 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 533 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 592
+      ID: 602
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1144064
       GoKind: 22
-      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 603 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 888960
       GoKind: 22
-      Pointee: 266 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 276 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 268
+      ID: 278
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 277 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 637
+      ID: 647
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1508416
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 648 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 548
+      ID: 558
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1065408
       GoKind: 22
-      Pointee: 549 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 559 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 890208
       GoKind: 22
-      Pointee: 269 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 279 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 606
+      ID: 616
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1196672
       GoKind: 22
-      Pointee: 607 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 617 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 890496
       GoKind: 22
-      Pointee: 468 StructureType golang.org/x/net/http2.connError
+      Pointee: 478 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 890400
       GoKind: 22
-      Pointee: 273 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 283 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 275
+      ID: 285
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 284 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 890688
       GoKind: 22
-      Pointee: 279 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 289 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 281
+      ID: 291
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 280 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 290 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 469
+      ID: 479
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 890592
       GoKind: 22
-      Pointee: 276 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 286 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 278
+      ID: 288
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 287 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 465
+      ID: 475
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 890304
       GoKind: 22
-      Pointee: 270 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 280 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 272
+      ID: 282
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 281 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 890784
       GoKind: 22
-      Pointee: 472 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 482 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 473
+      ID: 483
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 890880
       GoKind: 22
-      Pointee: 282 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 292 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 884640
       GoKind: 22
-      Pointee: 460 StructureType google.golang.org/grpc.dropError
+      Pointee: 470 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1193600
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 615 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1288576
       GoKind: 22
-      Pointee: 627 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 637 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 887232
       GoKind: 22
-      Pointee: 462 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 472 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 868
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1488,12 +1488,12 @@ Types:
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 546
+      ID: 556
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1059648
       GoKind: 22
-      Pointee: 547 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 557 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 852
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1502,54 +1502,54 @@ Types:
       GoKind: 22
       Pointee: 853 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 876384
       GoKind: 22
-      Pointee: 448 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 458 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 536
+      ID: 546
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1039296
       GoKind: 22
-      Pointee: 537 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 547 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 602
+      ID: 612
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1162752
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 613 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1162496
       GoKind: 22
-      Pointee: 601 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 611 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 453
+      ID: 463
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 878688
       GoKind: 22
-      Pointee: 454 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 464 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 455
+      ID: 465
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 878784
       GoKind: 22
-      Pointee: 456 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 466 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 868512
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 413 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 130
       Name: '*hash<context.canceler,struct {}>'
@@ -1561,10 +1561,10 @@ Types:
       ByteSize: 8
       Pointee: 745 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 201
+      ID: 207
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 202 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 208 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 913
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
@@ -1581,10 +1581,10 @@ Types:
       ByteSize: 8
       Pointee: 163 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 632
+      ID: 642
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 633 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 643 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 157
       Name: '*hash<string,interface {}>'
@@ -1596,12 +1596,12 @@ Types:
       ByteSize: 8
       Pointee: 153 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 891648
       GoKind: 22
-      Pointee: 475 UnresolvedPointeeType html/template.Error
+      Pointee: 485 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 95
       Name: '*int'
@@ -1638,19 +1638,19 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 861888
       GoKind: 22
-      Pointee: 372 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 382 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 576
+      ID: 586
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1138816
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 587 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 905
       Name: '*internal/poll.FD'
@@ -1659,19 +1659,19 @@ Types:
       GoKind: 22
       Pointee: 906 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 574
+      ID: 584
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1138688
       GoKind: 22
-      Pointee: 575 StructureType internal/poll.errNetClosing
+      Pointee: 585 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 311
+      ID: 321
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 848352
       GoKind: 22
-      Pointee: 312 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 322 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 870
       Name: '*io.PipeReader'
@@ -1701,19 +1701,19 @@ Types:
       GoKind: 22
       Pointee: 842 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1137920
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType io/fs.PathError
+      Pointee: 583 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 864768
       GoKind: 22
-      Pointee: 390 StructureType math/big.ErrNaN
+      Pointee: 400 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 920
       Name: '*mime/multipart.FileHeader'
@@ -1743,19 +1743,19 @@ Types:
       GoKind: 22
       Pointee: 857 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 558
+      ID: 568
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1122944
       GoKind: 22
-      Pointee: 559 UnresolvedPointeeType net.AddrError
+      Pointee: 569 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1256576
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType net.DNSError
+      Pointee: 622 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 881
       Name: '*net.IPConn'
@@ -1764,19 +1764,19 @@ Types:
       GoKind: 22
       Pointee: 882 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 609
+      ID: 619
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1256256
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType net.OpError
+      Pointee: 620 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 560
+      ID: 570
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1123072
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType net.ParseError
+      Pointee: 571 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 889
       Name: '*net.TCPConn'
@@ -1799,24 +1799,24 @@ Types:
       GoKind: 22
       Pointee: 888 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1122176
       GoKind: 22
-      Pointee: 552 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 562 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 553 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 563 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 489
+      ID: 499
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 999360
       GoKind: 22
-      Pointee: 490 StructureType net.canceledError
+      Pointee: 500 StructureType net.canceledError
     - __kind: PointerType
       ID: 879
       Name: '*net.conn'
@@ -1825,12 +1825,12 @@ Types:
       GoKind: 22
       Pointee: 880 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1744096
       GoKind: 22
-      Pointee: 656 StructureType net.dialResult·1
+      Pointee: 666 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 895
       Name: '*net.netFD'
@@ -1839,12 +1839,12 @@ Types:
       GoKind: 22
       Pointee: 896 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 283
+      ID: 293
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 284 UnresolvedPointeeType net.notFoundError
+      Pointee: 294 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 945
       Name: '*net.onlyValuesCtx'
@@ -1853,12 +1853,12 @@ Types:
       GoKind: 22
       Pointee: 946 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 285
+      ID: 295
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 841824
       GoKind: 22
-      Pointee: 286 StructureType net.result·2
+      Pointee: 296 StructureType net.result·2
     - __kind: PointerType
       ID: 885
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1874,33 +1874,33 @@ Types:
       GoKind: 22
       Pointee: 884 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1123712
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType net.temporaryError
+      Pointee: 573 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1256896
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType net.timeoutError
+      Pointee: 624 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 291
+      ID: 301
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 844416
       GoKind: 22
-      Pointee: 292 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 302 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 491
+      ID: 501
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1002688
       GoKind: 22
-      Pointee: 492 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 502 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 105
       Name: '*net/http.Request'
@@ -1958,26 +1958,26 @@ Types:
       GoKind: 22
       Pointee: 820 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 293
+      ID: 303
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 844608
       GoKind: 22
-      Pointee: 212 BaseType net/http.http2ConnectionError
+      Pointee: 222 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 294
+      ID: 304
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 844704
       GoKind: 22
-      Pointee: 295 StructureType net/http.http2GoAwayError
+      Pointee: 305 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1257856
       GoKind: 22
-      Pointee: 616 StructureType net/http.http2StreamError
+      Pointee: 626 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 849
       Name: '*net/http.http2clientStream'
@@ -1986,31 +1986,31 @@ Types:
       GoKind: 22
       Pointee: 850 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 300
+      ID: 310
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 845568
       GoKind: 22
-      Pointee: 301 StructureType net/http.http2connError
+      Pointee: 311 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 297
+      ID: 307
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 845088
       GoKind: 22
-      Pointee: 216 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 226 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 218
+      ID: 228
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 217 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 227 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 845184
       GoKind: 22
-      Pointee: 299 StructureType net/http.http2goAwayFlowError
+      Pointee: 309 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 813
       Name: '*net/http.http2gzipReader'
@@ -2019,36 +2019,36 @@ Types:
       GoKind: 22
       Pointee: 814 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 303
+      ID: 313
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 22
-      Pointee: 222 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 232 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 224
+      ID: 234
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 223 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 233 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 302
+      ID: 312
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 22
-      Pointee: 219 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 229 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 221
+      ID: 231
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 220 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 230 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 566
+      ID: 576
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1127936
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 577 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 809
       Name: '*net/http.http2missingBody'
@@ -2064,24 +2064,24 @@ Types:
       GoKind: 22
       Pointee: 822 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 497
+      ID: 507
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1004736
       GoKind: 22
-      Pointee: 498 StructureType net/http.http2noCachedConnError
+      Pointee: 508 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 296
+      ID: 306
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 844992
       GoKind: 22
-      Pointee: 213 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 223 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 215
+      ID: 225
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 214 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 224 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 817
       Name: '*net/http.http2requestBody'
@@ -2125,12 +2125,12 @@ Types:
       GoKind: 22
       Pointee: 840 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 493
+      ID: 503
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1004352
       GoKind: 22
-      Pointee: 494 StructureType net/http.nothingWrittenError
+      Pointee: 504 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 801
       Name: '*net/http.pattern'
@@ -2153,12 +2153,12 @@ Types:
       GoKind: 22
       Pointee: 838 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 304
+      ID: 314
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 845952
       GoKind: 22
-      Pointee: 305 StructureType net/http.requestBodyReadError
+      Pointee: 315 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 729
       Name: '*net/http.response'
@@ -2174,40 +2174,40 @@ Types:
       GoKind: 22
       Pointee: 941 StructureType net/http.segment
     - __kind: PointerType
-      ID: 289
+      ID: 299
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 844320
       GoKind: 22
-      Pointee: 290 StructureType net/http.statusError
+      Pointee: 300 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1259296
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 628 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1127808
       GoKind: 22
-      Pointee: 565 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 575 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 495
+      ID: 505
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1004480
       GoKind: 22
-      Pointee: 496 StructureType net/http.transportReadFromServerError
+      Pointee: 506 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 287
+      ID: 297
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 843552
       GoKind: 22
-      Pointee: 288 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 298 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 831
       Name: '*net/http/httputil.failureToReadBody'
@@ -2216,69 +2216,69 @@ Types:
       GoKind: 22
       Pointee: 832 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 317
+      ID: 327
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 318 StructureType net/netip.parseAddrError
+      Pointee: 328 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 315
+      ID: 325
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 316 StructureType net/netip.parsePrefixError
+      Pointee: 326 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 854112
       GoKind: 22
-      Pointee: 331 UnresolvedPointeeType net/textproto.Error
+      Pointee: 341 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 329
+      ID: 339
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 854016
       GoKind: 22
-      Pointee: 236 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 246 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 238
+      ID: 248
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 237 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 247 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 622
+      ID: 632
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1263936
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net/url.Error
+      Pointee: 633 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 852960
       GoKind: 22
-      Pointee: 230 GoStringHeaderType net/url.EscapeError
+      Pointee: 240 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 232
+      ID: 242
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 231 GoStringDataType net/url.EscapeError.str
+      Pointee: 241 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 853056
       GoKind: 22
-      Pointee: 233 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 243 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 235
+      ID: 245
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 234 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 244 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 790
       Name: '*net/url.URL'
@@ -2301,12 +2301,12 @@ Types:
       GoKind: 22
       Pointee: 902 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 499
+      ID: 509
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1006656
       GoKind: 22
-      Pointee: 500 UnresolvedPointeeType os.LinkError
+      Pointee: 510 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 145
       Name: '*os.Signal'
@@ -2315,12 +2315,12 @@ Types:
       GoKind: 22
       Pointee: 146 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1128448
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType os.SyscallError
+      Pointee: 579 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 899
       Name: '*os.fileWithoutReadFrom'
@@ -2336,26 +2336,26 @@ Types:
       GoKind: 22
       Pointee: 898 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 530
+      ID: 540
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1029824
       GoKind: 22
-      Pointee: 531 UnresolvedPointeeType os/exec.Error
+      Pointee: 541 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2004032
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 670 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 532
+      ID: 542
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1029952
       GoKind: 22
-      Pointee: 533 StructureType os/exec.wrappedError
+      Pointee: 543 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 122
       Name: '*os/signal.signalCtx'
@@ -2364,52 +2364,52 @@ Types:
       GoKind: 22
       Pointee: 123 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 458
+      ID: 468
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 882720
       GoKind: 22
-      Pointee: 263 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 273 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 265
+      ID: 275
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 274 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 882624
       GoKind: 22
-      Pointee: 262 BaseType os/user.UnknownUserIdError
+      Pointee: 272 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 313
+      ID: 323
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 849216
       GoKind: 22
-      Pointee: 314 UnresolvedPointeeType reflect.ValueError
+      Pointee: 324 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 868992
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 415 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1011264
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 517 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1013184
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 522 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2425,12 +2425,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1011392
       GoKind: 22
-      Pointee: 509 StructureType runtime.boundsError
+      Pointee: 519 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -2446,24 +2446,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 570
+      ID: 580
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1136768
       GoKind: 22
-      Pointee: 571 StructureType runtime.errorAddressString
+      Pointee: 581 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1011008
       GoKind: 22
-      Pointee: 476 GoStringHeaderType runtime.errorString
+      Pointee: 486 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 477 GoStringDataType runtime.errorString.str
+      Pointee: 487 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -2486,17 +2486,17 @@ Types:
       GoKind: 22
       Pointee: 135 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 510
+      ID: 520
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1012928
       GoKind: 22
-      Pointee: 479 GoStringHeaderType runtime.plainError
+      Pointee: 489 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 481
+      ID: 491
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 480 GoStringDataType runtime.plainError.str
+      Pointee: 490 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2519,12 +2519,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1010624
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType strconv.NumError
+      Pointee: 514 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -2650,12 +2650,12 @@ Types:
       GoKind: 22
       Pointee: 834 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 619
+      ID: 629
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1262816
       GoKind: 22
-      Pointee: 608 BaseType syscall.Errno
+      Pointee: 618 BaseType syscall.Errno
     - __kind: PointerType
       ID: 686
       Name: '*syscall.Signal'
@@ -2664,12 +2664,12 @@ Types:
       GoKind: 22
       Pointee: 685 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1069248
       GoKind: 22
-      Pointee: 551 StructureType text/template.ExecError
+      Pointee: 561 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 140
       Name: '*time.Location'
@@ -2678,12 +2678,12 @@ Types:
       GoKind: 22
       Pointee: 141 StructureType time.Location
     - __kind: PointerType
-      ID: 307
+      ID: 317
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 846816
       GoKind: 22
-      Pointee: 308 UnresolvedPointeeType time.ParseError
+      Pointee: 318 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 137
       Name: '*time.Timer'
@@ -2692,31 +2692,31 @@ Types:
       GoKind: 22
       Pointee: 138 StructureType time.Timer
     - __kind: PointerType
-      ID: 306
+      ID: 316
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 846720
       GoKind: 22
-      Pointee: 225 GoStringHeaderType time.fileSizeError
+      Pointee: 235 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 227
+      ID: 237
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 226 GoStringDataType time.fileSizeError.str
+      Pointee: 236 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 671
+      ID: 190
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370880
       GoKind: 22
-      Pointee: 672 StructureType time.zone
+      Pointee: 191 StructureType time.zone
     - __kind: PointerType
-      ID: 674
+      ID: 193
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 370944
       GoKind: 22
-      Pointee: 675 StructureType time.zoneTrans
+      Pointee: 194 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -2760,47 +2760,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 319
+      ID: 329
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 851616
       GoKind: 22
-      Pointee: 320 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 330 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 332
+      ID: 342
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 854496
       GoKind: 22
-      Pointee: 333 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 343 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 334
+      ID: 344
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 854592
       GoKind: 22
-      Pointee: 239 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 249 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 516
+      ID: 526
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1018432
       GoKind: 22
-      Pointee: 517 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 527 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1018560
       GoKind: 22
-      Pointee: 483 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 493 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 798
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: GoChannelType
-      ID: 669
+      ID: 679
       Name: <-chan time.Time
       GoRuntimeType: 558496
       GoKind: 18
@@ -2969,7 +2969,7 @@ Types:
       HasCount: true
       Element: 12 BaseType uint64
     - __kind: ArrayType
-      ID: 643
+      ID: 653
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 652960
@@ -3026,7 +3026,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 629 PointerType *crypto/x509.Certificate
+      Element: 639 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 680
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3132,11 +3132,11 @@ Types:
       ByteSize: 32
       Element: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 221
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 921
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
@@ -3150,31 +3150,31 @@ Types:
       ByteSize: 336
       Element: 783 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 203
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 165 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 662
+      ID: 672
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 635 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 201
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
       Element: 160 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 199
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
       Element: 155 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 648
+      ID: 658
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 468736
@@ -3189,9 +3189,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 665 GoSliceDataType []float64.array
+      Data: 675 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 675
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3212,9 +3212,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 198 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 204 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 204
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3235,9 +3235,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 206 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 212 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 212
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3257,7 +3257,7 @@ Types:
       HasCount: true
       Element: 767 BaseType github.com/cihub/seelog.LogLevel
     - __kind: ArrayType
-      ID: 191
+      ID: 197
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -3302,9 +3302,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 189 GoSliceDataType []os.Signal.array
+      Data: 195 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 195
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3314,7 +3314,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 647
+      ID: 657
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -3329,15 +3329,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 663 GoSliceDataType []string.array
+      Data: 673 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 663
+      ID: 673
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 670
+      ID: 189
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463104
@@ -3345,22 +3345,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 671 PointerType *time.zone
+          Type: 190 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 676 GoSliceDataType []time.zone.array
+      Data: 214 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 676
+      ID: 214
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 672 StructureType time.zone
+      Element: 191 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 673
+      ID: 192
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463168
@@ -3368,20 +3368,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 674 PointerType *time.zoneTrans
+          Type: 193 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 678 GoSliceDataType []time.zoneTrans.array
+      Data: 216 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 678
+      ID: 216
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 675 StructureType time.zoneTrans
+      Element: 194 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3429,12 +3429,12 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 208
+      ID: 218
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 209 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 219 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
       ID: 917
       Name: '[]val<[]*mime/multipart.FileHeader>'
@@ -3448,7 +3448,7 @@ Types:
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 647 GoSliceHeaderType []string
+      Element: 657 GoSliceHeaderType []string
     - __kind: ArrayType
       ID: 768
       Name: '[]val<bool>'
@@ -3457,28 +3457,28 @@ Types:
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 196
+      ID: 202
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 661
+      ID: 671
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 654 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 194
+      ID: 200
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 128 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 192
+      ID: 198
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -3491,7 +3491,7 @@ Types:
       HasCount: true
       Element: 187 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 450
+      ID: 460
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 877824
@@ -3506,9 +3506,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 451 GoSliceDataType archive/tar.headerError.array
+      Data: 461 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 451
+      ID: 461
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3574,7 +3574,7 @@ Types:
       KeyType: 767 BaseType github.com/cihub/seelog.LogLevel
       ValueType: 6 BaseType bool
     - __kind: GoHMapBucketType
-      ID: 204
+      ID: 210
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
@@ -3583,15 +3583,15 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 208 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 218 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 209 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 219 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 916
       Name: bucket<string,[]*mime/multipart.FileHeader>
@@ -3602,7 +3602,7 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
           Type: 917 ArrayType []val<[]*mime/multipart.FileHeader>
@@ -3621,7 +3621,7 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
           Type: 788 ArrayType []val<[]string>
@@ -3629,7 +3629,7 @@ Types:
           Offset: 328
           Type: 782 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 647 GoSliceHeaderType []string
+      ValueType: 657 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
       ID: 165
       Name: bucket<string,float64>
@@ -3640,17 +3640,17 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 196 ArrayType []val<float64>
+          Type: 202 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
           Type: 164 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 635
+      ID: 645
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
@@ -3659,15 +3659,15 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 661 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 671 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 634 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 654 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 160
       Name: bucket<string,interface {}>
@@ -3678,10 +3678,10 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 194 ArrayType []val<interface {}>
+          Type: 200 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
           Type: 159 PointerType *bucket<string,interface {}>
@@ -3697,10 +3697,10 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 192 ArrayType []val<string>
+          Type: 198 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 154 PointerType *bucket<string,string>
@@ -3737,13 +3737,13 @@ Types:
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: BaseType
-      ID: 254
+      ID: 264
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 781152
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 255
+      ID: 265
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 781248
@@ -3751,13 +3751,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 257 PointerType *compress/flate.InternalError.str
+          Type: 267 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 256 GoStringDataType compress/flate.InternalError.str
+      Data: 266 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 256
+      ID: 266
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3841,7 +3841,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 556
+      ID: 566
       Name: context.deadlineExceededError
       GoRuntimeType: 1305824
       GoKind: 25
@@ -3885,7 +3885,7 @@ Types:
           Type: 137 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3931,31 +3931,31 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 251
+      ID: 261
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 780864
       GoKind: 2
     - __kind: BaseType
-      ID: 252
+      ID: 262
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 780960
       GoKind: 2
     - __kind: BaseType
-      ID: 253
+      ID: 263
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 781056
       GoKind: 2
     - __kind: BaseType
-      ID: 228
+      ID: 238
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 778656
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 515
+      ID: 525
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4024,11 +4024,11 @@ Types:
       GoRuntimeType: 778464
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 324
+      ID: 334
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 322
+      ID: 332
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1636960
@@ -4039,26 +4039,26 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 643 ArrayType [5]uint8
+          Type: 653 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 644 GoInterfaceType net.Conn
+          Type: 654 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 482
+      ID: 492
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 967520
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 631
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 640
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 381
+      ID: 391
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1639840
@@ -4066,21 +4066,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 629 PointerType *crypto/x509.Certificate
+          Type: 639 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 653 BaseType crypto/x509.InvalidReason
+          Type: 663 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 375
+      ID: 385
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1097088
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 377
+      ID: 387
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1436640
@@ -4088,24 +4088,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 629 PointerType *crypto/x509.Certificate
+          Type: 639 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 250
+      ID: 260
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 780672
       GoKind: 2
     - __kind: BaseType
-      ID: 653
+      ID: 663
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 546464
       GoKind: 2
     - __kind: StructureType
-      ID: 529
+      ID: 539
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1399808
@@ -4115,13 +4115,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 383
+      ID: 393
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1097344
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 379
+      ID: 389
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1639648
@@ -4129,15 +4129,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 629 PointerType *crypto/x509.Certificate
+          Type: 639 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 629 PointerType *crypto/x509.Certificate
+          Type: 639 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 442
+      ID: 452
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1276896
@@ -4147,7 +4147,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 446
+      ID: 456
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1277056
@@ -4157,47 +4157,47 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 444
+      ID: 454
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 229
+      ID: 239
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 778752
       GoKind: 6
     - __kind: BaseType
-      ID: 249
+      ID: 259
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 780480
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 344
+      ID: 354
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 527
+      ID: 537
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 336
+      ID: 346
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 352
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 340
+      ID: 350
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 338
+      ID: 348
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 346
+      ID: 356
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1266976
@@ -4207,15 +4207,15 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 437
+      ID: 447
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 435
+      ID: 445
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 259
+      ID: 269
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 782688
@@ -4223,18 +4223,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 261 PointerType *encoding/xml.UnmarshalError.str
+          Type: 271 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 260 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 270 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 260
+      ID: 270
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 440
+      ID: 450
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4251,11 +4251,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 310
+      ID: 320
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 512
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4271,11 +4271,11 @@ Types:
       GoRuntimeType: 543264
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 496
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 488
+      ID: 498
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4309,7 +4309,7 @@ Types:
       GoRuntimeType: 982976
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 367
+      ID: 377
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4319,7 +4319,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 349
+      ID: 359
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1638112
@@ -4327,7 +4327,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 645 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 655 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -4335,25 +4335,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 361
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 660
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 355
+      ID: 365
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1095680
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 662
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 243
+      ID: 253
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 779808
@@ -4361,18 +4361,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 245 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 255 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 244 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 254 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 244
+      ID: 254
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 645
+      ID: 655
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2126592
@@ -4380,13 +4380,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 646 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 656 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 13 GoStringHeaderType string
@@ -4395,7 +4395,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 648 GoSliceHeaderType []float64
+          Type: 658 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4404,13 +4404,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 649 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 659 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 651 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 661 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 13 GoStringHeaderType string
@@ -4421,13 +4421,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 646
+      ID: 656
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 544992
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 240
+      ID: 250
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 779712
@@ -4435,18 +4435,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 242 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 252 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 241 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 251 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 241
+      ID: 251
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 246
+      ID: 256
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 779904
@@ -4454,18 +4454,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 248 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 258 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 247 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 257 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 247
+      ID: 257
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 392
+      ID: 402
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
@@ -4681,16 +4681,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 200 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 206 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 205 GoMapType map[string]interface {}
+          Type: 211 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 689
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 210
+      ID: 220
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1822272
@@ -4771,7 +4771,7 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 597
+      ID: 607
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4823,29 +4823,29 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 394
+      ID: 404
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 401
+      ID: 411
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1099136
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 258
+      ID: 268
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 782016
       GoKind: 2
     - __kind: StructureType
-      ID: 399
+      ID: 409
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1099008
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 397
+      ID: 407
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1437600
@@ -4858,7 +4858,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 409
+      ID: 419
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1438240
@@ -4871,7 +4871,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 413
+      ID: 423
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1641376
@@ -4887,7 +4887,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1275456
@@ -4897,7 +4897,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 407
+      ID: 417
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1275136
@@ -4907,14 +4907,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 631
+      ID: 641
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1158784
       GoKind: 21
-      HeaderType: 633 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 643 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 654
+      ID: 664
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1033152
@@ -4929,15 +4929,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 667 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 677 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 667
+      ID: 677
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 421
+      ID: 431
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1438560
@@ -4945,12 +4945,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 631 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 641 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 631 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 641 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 415
+      ID: 425
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1275616
@@ -4960,7 +4960,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 419
+      ID: 429
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1641568
@@ -4971,12 +4971,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 654 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 654 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 417
+      ID: 427
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1438400
@@ -4989,7 +4989,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 423
+      ID: 433
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1275776
@@ -4997,9 +4997,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
     - __kind: StructureType
-      ID: 429
+      ID: 439
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1438880
@@ -5012,7 +5012,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 431
+      ID: 441
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1276096
@@ -5022,7 +5022,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 427
+      ID: 437
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1438720
@@ -5035,7 +5035,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1275936
@@ -5045,7 +5045,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 433
+      ID: 443
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1439040
@@ -5080,7 +5080,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 357
+      ID: 367
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1268256
@@ -5094,7 +5094,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 359
+      ID: 369
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1268416
@@ -5102,7 +5102,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 357 StructureType github.com/cihub/seelog.baseError
+          Type: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 732
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -5125,7 +5125,7 @@ Types:
           Offset: 8
           Type: 743 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 363
+      ID: 373
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1268736
@@ -5133,7 +5133,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 357 StructureType github.com/cihub/seelog.baseError
+          Type: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 736
       Name: github.com/cihub/seelog.splitDispatcher
@@ -5149,7 +5149,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 361
+      ID: 371
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1268576
@@ -5157,9 +5157,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 357 StructureType github.com/cihub/seelog.baseError
+          Type: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 365
+      ID: 375
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1268896
@@ -5167,7 +5167,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 357 StructureType github.com/cihub/seelog.baseError
+          Type: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 860
       Name: github.com/cihub/seelog/archive.Reader
@@ -5196,42 +5196,42 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 635
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 551
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 539
+      ID: 549
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 543
+      ID: 553
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 555
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 545
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 370
+      ID: 380
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1269856
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 609
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 585
+      ID: 595
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1755968
@@ -5247,11 +5247,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 589
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 521
+      ID: 531
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1544224
@@ -5264,7 +5264,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 591
+      ID: 601
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1756416
@@ -5280,13 +5280,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 484
+      ID: 494
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 968192
       GoKind: 8
     - __kind: StructureType
-      ID: 583
+      ID: 593
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1755744
@@ -5302,13 +5302,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 657
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 779328
       GoKind: 8
     - __kind: StructureType
-      ID: 581
+      ID: 591
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1755520
@@ -5316,15 +5316,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 657 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 667 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 657 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 667 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 589
+      ID: 599
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1672448
@@ -5337,7 +5337,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1756192
@@ -5353,7 +5353,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 595
+      ID: 605
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1473280
@@ -5363,19 +5363,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 525
+      ID: 535
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1217984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 523
+      ID: 533
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1217856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 593
+      ID: 603
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1672640
@@ -5388,7 +5388,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 276
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 784608
@@ -5396,22 +5396,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 278 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 267 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 277 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 277
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 648
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 549
+      ID: 559
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1291296
@@ -5421,19 +5421,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 269
+      ID: 279
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 785184
       GoKind: 10
     - __kind: BaseType
-      ID: 636
+      ID: 646
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 980288
       GoKind: 10
     - __kind: StructureType
-      ID: 607
+      ID: 617
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1789792
@@ -5444,12 +5444,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 636 BaseType golang.org/x/net/http2.ErrCode
+          Type: 646 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 468
+      ID: 478
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1445760
@@ -5457,12 +5457,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 636 BaseType golang.org/x/net/http2.ErrCode
+          Type: 646 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 283
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 785376
@@ -5470,18 +5470,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 285 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 274 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 284 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 284
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 279
+      ID: 289
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 785568
@@ -5489,18 +5489,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 281 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 291 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 280 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 290 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 280
+      ID: 290
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 286
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 785472
@@ -5508,18 +5508,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 288 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 277 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 287 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 287
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 280
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 785280
@@ -5527,18 +5527,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 282 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 271 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 281 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 281
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 472
+      ID: 482
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1291936
@@ -5548,13 +5548,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 282
+      ID: 292
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 785664
       GoKind: 2
     - __kind: StructureType
-      ID: 460
+      ID: 470
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1286976
@@ -5564,11 +5564,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 615
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 627
+      ID: 637
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1816672
@@ -5584,7 +5584,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 462
+      ID: 472
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1445280
@@ -5601,7 +5601,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 547
+      ID: 557
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1406848
@@ -5615,25 +5615,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 448
+      ID: 458
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 537
+      ID: 547
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 613
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 601
+      ID: 611
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1354144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 454
+      ID: 464
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1280256
@@ -5643,7 +5643,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 456
+      ID: 466
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1280416
@@ -5653,7 +5653,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 413
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -5725,7 +5725,7 @@ Types:
       BucketType: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
       BucketsType: 769 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
     - __kind: GoHMapHeaderType
-      ID: 202
+      ID: 208
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -5746,18 +5746,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
-      BucketType: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 211 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 221 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
       ID: 914
       Name: hash<string,[]*mime/multipart.FileHeader>
@@ -5859,9 +5859,9 @@ Types:
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
       BucketType: 165 GoHMapBucketType bucket<string,float64>
-      BucketsType: 197 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 203 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 633
+      ID: 643
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -5882,18 +5882,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 634 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 634 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
-      BucketType: 635 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 662 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 672 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 158
       Name: hash<string,interface {}>
@@ -5927,7 +5927,7 @@ Types:
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
       BucketType: 160 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 195 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 201 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 153
       Name: hash<string,string>
@@ -5961,9 +5961,9 @@ Types:
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
       BucketType: 155 GoHMapBucketType bucket<string,string>
-      BucketsType: 193 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 199 GoSliceDataType []bucket<string,string>.array
     - __kind: UnresolvedPointeeType
-      ID: 475
+      ID: 485
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -6010,7 +6010,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 372
+      ID: 382
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -6036,7 +6036,7 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 587
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6044,13 +6044,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 575
+      ID: 585
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1323104
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 312
+      ID: 322
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6198,7 +6198,7 @@ Types:
           Offset: 0
           Type: 851 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 583
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoMapType
@@ -6216,12 +6216,12 @@ Types:
       GoKind: 21
       HeaderType: 745 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 200
+      ID: 206
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 21
-      HeaderType: 202 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 208 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 912
       Name: map[string][]*mime/multipart.FileHeader
@@ -6244,7 +6244,7 @@ Types:
       GoKind: 21
       HeaderType: 163 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 205
+      ID: 211
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896352
@@ -6258,7 +6258,7 @@ Types:
       GoKind: 21
       HeaderType: 153 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 390
+      ID: 400
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1272256
@@ -6302,11 +6302,11 @@ Types:
           Offset: 8
           Type: 861 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 559
+      ID: 569
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 644
+      ID: 654
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1434880
@@ -6319,7 +6319,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 622
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6327,11 +6327,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 620
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 571
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6347,7 +6347,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 552
+      ID: 562
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1090688
@@ -6355,18 +6355,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 554 PointerType *net.UnknownNetworkError.str
+          Type: 564 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 553 GoStringDataType net.UnknownNetworkError.str
+      Data: 563 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 553
+      ID: 563
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 490
+      ID: 500
       Name: net.canceledError
       GoRuntimeType: 1215808
       GoKind: 25
@@ -6376,7 +6376,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 656
+      ID: 666
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2016256
@@ -6384,7 +6384,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 644 GoInterfaceType net.Conn
+          Type: 654 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -6411,7 +6411,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 284
+      ID: 294
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6428,7 +6428,7 @@ Types:
           Offset: 16
           Type: 111 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 286
+      ID: 296
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1631584
@@ -6436,7 +6436,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 639 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 649 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -6470,11 +6470,11 @@ Types:
           Offset: 0
           Type: 889 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 573
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 624
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6524,11 +6524,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 292
+      ID: 302
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 492
+      ID: 502
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6580,7 +6580,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6625,7 +6625,7 @@ Types:
           Type: 801 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 151 GoMapType map[string]string
@@ -6662,7 +6662,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6735,19 +6735,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 212
+      ID: 222
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 776256
       GoKind: 10
     - __kind: BaseType
-      ID: 628
+      ID: 638
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 964832
       GoKind: 10
     - __kind: StructureType
-      ID: 295
+      ID: 305
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1633120
@@ -6758,12 +6758,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 628 BaseType net/http.http2ErrCode
+          Type: 638 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 616
+      ID: 626
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1806176
@@ -6774,7 +6774,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 628 BaseType net/http.http2ErrCode
+          Type: 638 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
@@ -6783,7 +6783,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 301
+      ID: 311
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1435360
@@ -6791,12 +6791,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 628 BaseType net/http.http2ErrCode
+          Type: 638 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 216
+      ID: 226
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 776448
@@ -6804,18 +6804,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 218 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 228 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 217 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 227 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 217
+      ID: 227
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 299
+      ID: 309
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1091968
       GoKind: 25
@@ -6825,7 +6825,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 222
+      ID: 232
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 776640
@@ -6833,18 +6833,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 224 PointerType *net/http.http2headerFieldNameError.str
+          Type: 234 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 223 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 233 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 223
+      ID: 233
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 219
+      ID: 229
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 776544
@@ -6852,18 +6852,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 221 PointerType *net/http.http2headerFieldValueError.str
+          Type: 231 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 220 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 230 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 220
+      ID: 230
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 577
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -6879,13 +6879,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 498
+      ID: 508
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1216448
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 213
+      ID: 223
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 776352
@@ -6893,13 +6893,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 215 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 225 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 214 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 224 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 214
+      ID: 224
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -6942,7 +6942,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 494
+      ID: 504
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1392128
@@ -6982,7 +6982,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 305
+      ID: 315
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1260096
@@ -7057,7 +7057,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 775 StructureType sync/atomic.Bool
@@ -7093,7 +7093,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 290
+      ID: 300
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1435200
@@ -7106,17 +7106,17 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 628
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 565
+      ID: 575
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1310304
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 496
+      ID: 506
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1392288
@@ -7126,7 +7126,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 288
+      ID: 298
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7136,7 +7136,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 318
+      ID: 328
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1636384
@@ -7152,7 +7152,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 316
+      ID: 326
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1435680
@@ -7165,11 +7165,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 331
+      ID: 341
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 236
+      ID: 246
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 779040
@@ -7177,22 +7177,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 238 PointerType *net/textproto.ProtocolError.str
+          Type: 248 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 237 GoStringDataType net/textproto.ProtocolError.str
+      Data: 247 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 237
+      ID: 247
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 633
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 230
+      ID: 240
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 778848
@@ -7200,18 +7200,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 232 PointerType *net/url.EscapeError.str
+          Type: 242 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 231 GoStringDataType net/url.EscapeError.str
+      Data: 241 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 231
+      ID: 241
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 233
+      ID: 243
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 778944
@@ -7219,13 +7219,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 235 PointerType *net/url.InvalidHostError.str
+          Type: 245 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 234 GoStringDataType net/url.InvalidHostError.str
+      Data: 244 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 234
+      ID: 244
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7285,7 +7285,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 500
+      ID: 510
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7302,7 +7302,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 579
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7344,15 +7344,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 531
+      ID: 541
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 670
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 533
+      ID: 543
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1544608
@@ -7386,7 +7386,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 273
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 783840
@@ -7394,36 +7394,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *os/user.UnknownGroupIdError.str
+          Type: 275 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 264 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 274 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 274
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 262
+      ID: 272
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 783744
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 314
+      ID: 324
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 415
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 517
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 522
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7435,7 +7435,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 509
+      ID: 519
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1795616
@@ -7452,9 +7452,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 658 BaseType runtime.boundsErrorCode
+          Type: 668 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 658
+      ID: 668
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 543456
@@ -7474,7 +7474,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 571
+      ID: 581
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1667072
@@ -7487,7 +7487,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 476
+      ID: 486
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 966080
@@ -7495,13 +7495,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 478 PointerType *runtime.errorString.str
+          Type: 488 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 477 GoStringDataType runtime.errorString.str
+      Data: 487 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 477
+      ID: 487
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8127,7 +8127,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 479
+      ID: 489
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 966656
@@ -8135,13 +8135,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 481 PointerType *runtime.plainError.str
+          Type: 491 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 480 GoStringDataType runtime.plainError.str
+      Data: 490 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 480
+      ID: 490
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8223,7 +8223,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 514
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8588,7 +8588,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 608
+      ID: 618
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1217088
@@ -8600,7 +8600,7 @@ Types:
       GoRuntimeType: 966848
       GoKind: 2
     - __kind: StructureType
-      ID: 551
+      ID: 561
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1548832
@@ -8630,10 +8630,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 670 GoSliceHeaderType []time.zone
+          Type: 189 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 673 GoSliceHeaderType []time.zoneTrans
+          Type: 192 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -8645,12 +8645,12 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 671 PointerType *time.zone
+          Type: 190 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 308
+      ID: 318
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 139
       Name: time.Time
       ByteSize: 24
@@ -8666,6 +8666,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 140 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 138
       Name: time.Timer
@@ -8675,12 +8683,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 669 GoChannelType <-chan time.Time
+          Type: 679 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 225
+      ID: 235
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 776736
@@ -8688,18 +8696,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 227 PointerType *time.fileSizeError.str
+          Type: 237 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 226 GoStringDataType time.fileSizeError.str
+      Data: 236 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 226
+      ID: 236
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 672
+      ID: 191
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1457920
@@ -8715,7 +8723,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 675
+      ID: 194
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1663616
@@ -8776,7 +8784,7 @@ Types:
       GoRuntimeType: 543392
       GoKind: 26
     - __kind: StructureType
-      ID: 639
+      ID: 649
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1967232
@@ -8787,10 +8795,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 640 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 650 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 641 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 651 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -8805,18 +8813,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 642 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 652 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 642
+      ID: 652
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 967136
       GoKind: 9
     - __kind: StructureType
-      ID: 640
+      ID: 650
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1825088
@@ -8841,17 +8849,17 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 320
+      ID: 330
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 641
+      ID: 651
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 544288
       GoKind: 8
     - __kind: StructureType
-      ID: 333
+      ID: 343
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1265056
@@ -8861,13 +8869,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 239
+      ID: 249
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 779136
       GoKind: 2
     - __kind: StructureType
-      ID: 517
+      ID: 527
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1544032
@@ -8880,7 +8888,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 483
+      ID: 493
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 968000

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -120,7 +120,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 665 PointerType *crypto/x509.Certificate
+      Pointee: 675 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 723
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -144,10 +144,10 @@ Types:
       ByteSize: 8
       Pointee: 789 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 229
+      ID: 235
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 230 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 236 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 970
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -164,10 +164,10 @@ Types:
       ByteSize: 8
       Pointee: 170 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 670
+      ID: 680
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 671 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 164
       Name: '**table<string,interface {}>'
@@ -210,30 +210,30 @@ Types:
       ByteSize: 8
       Pointee: 998 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 708
+      ID: 718
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 707 GoSliceDataType []float64.array
+      Pointee: 717 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 225
+      ID: 231
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 230 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 233
+      ID: 239
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1004
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1003 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 199
+      ID: 205
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []os.Signal.array
+      Pointee: 204 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -242,20 +242,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 706
+      ID: 716
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 705 GoSliceDataType []string.array
+      Pointee: 715 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 719
+      ID: 241
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 718 GoSliceDataType []time.zone.array
+      Pointee: 240 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 721
+      ID: 243
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 720 GoSliceDataType []time.zoneTrans.array
+      Pointee: 242 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 991
       Name: '*[]uint8'
@@ -274,17 +274,17 @@ Types:
       ByteSize: 8
       Pointee: 186 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 485
+      ID: 495
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 945920
       GoKind: 22
-      Pointee: 486 GoSliceHeaderType archive/tar.headerError
+      Pointee: 496 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 487 GoSliceDataType archive/tar.headerError.array
+      Pointee: 497 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 898
       Name: '*archive/zip.checksumReader'
@@ -335,24 +335,24 @@ Types:
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 423
+      ID: 433
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 931520
       GoKind: 22
-      Pointee: 287 BaseType compress/flate.CorruptInputError
+      Pointee: 297 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 931616
       GoKind: 22
-      Pointee: 288 GoStringHeaderType compress/flate.InternalError
+      Pointee: 298 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 290
+      ID: 300
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType compress/flate.InternalError.str
+      Pointee: 299 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 932
       Name: '*compress/flate.decompressor'
@@ -382,12 +382,12 @@ Types:
       GoKind: 22
       Pointee: 118 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1203520
       GoKind: 22
-      Pointee: 592 StructureType context.deadlineExceededError
+      Pointee: 602 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1005
       Name: '*context.emptyCtx'
@@ -431,47 +431,47 @@ Types:
       GoKind: 22
       Pointee: 126 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 419
+      ID: 429
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930272
       GoKind: 22
-      Pointee: 283 BaseType crypto/aes.KeySizeError
+      Pointee: 293 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930464
       GoKind: 22
-      Pointee: 284 BaseType crypto/des.KeySizeError
+      Pointee: 294 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 421
+      ID: 431
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930752
       GoKind: 22
-      Pointee: 285 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 295 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 931040
       GoKind: 22
-      Pointee: 286 BaseType crypto/rc4.KeySizeError
+      Pointee: 296 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 358
+      ID: 368
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 260 BaseType crypto/tls.AlertError
+      Pointee: 270 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1056128
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 561 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 962
       Name: '*crypto/tls.Conn'
@@ -487,206 +487,206 @@ Types:
       GoKind: 22
       Pointee: 850 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 919808
       GoKind: 22
-      Pointee: 357 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 367 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 354
+      ID: 364
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 355 StructureType crypto/tls.RecordHeaderError
+      Pointee: 365 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1054464
       GoKind: 22
-      Pointee: 518 BaseType crypto/tls.alert
+      Pointee: 528 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 656
+      ID: 666
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1438272
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 667 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 665
+      ID: 675
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2082688
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 676 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 930080
       GoKind: 22
-      Pointee: 416 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 426 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 409
+      ID: 419
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 929600
       GoKind: 22
-      Pointee: 410 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 420 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 411
+      ID: 421
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 929696
       GoKind: 22
-      Pointee: 412 StructureType crypto/x509.HostnameError
+      Pointee: 422 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 929504
       GoKind: 22
-      Pointee: 282 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 292 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1065728
       GoKind: 22
-      Pointee: 565 StructureType crypto/x509.SystemRootsError
+      Pointee: 575 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 930176
       GoKind: 22
-      Pointee: 418 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 428 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 413
+      ID: 423
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 929984
       GoKind: 22
-      Pointee: 414 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 424 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 477
+      ID: 487
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 941600
       GoKind: 22
-      Pointee: 478 StructureType encoding/asn1.StructuralError
+      Pointee: 488 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 481
+      ID: 491
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941792
       GoKind: 22
-      Pointee: 482 StructureType encoding/asn1.SyntaxError
+      Pointee: 492 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 479
+      ID: 489
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 941696
       GoKind: 22
-      Pointee: 480 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 490 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 920096
       GoKind: 22
-      Pointee: 261 BaseType encoding/base64.CorruptInputError
+      Pointee: 271 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 928352
       GoKind: 22
-      Pointee: 281 BaseType encoding/hex.InvalidByteError
+      Pointee: 291 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 376
+      ID: 386
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 387 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1061248
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 573 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923072
       GoKind: 22
-      Pointee: 369 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 379 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 923360
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 385 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 372
+      ID: 382
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923264
       GoKind: 22
-      Pointee: 373 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 383 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 370
+      ID: 380
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 923168
       GoKind: 22
-      Pointee: 371 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 381 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 923840
       GoKind: 22
-      Pointee: 379 StructureType encoding/json.jsonError
+      Pointee: 389 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 472
+      ID: 482
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 938816
       GoKind: 22
-      Pointee: 473 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 483 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 938720
       GoKind: 22
-      Pointee: 471 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 481 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 938912
       GoKind: 22
-      Pointee: 292 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 302 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 294
+      ID: 304
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 293 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 303 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 475
+      ID: 485
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 939008
       GoKind: 22
-      Pointee: 476 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 486 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -695,19 +695,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 342
+      ID: 352
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 915296
       GoKind: 22
-      Pointee: 343 UnresolvedPointeeType errors.errorString
+      Pointee: 353 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 537
+      ID: 547
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1047424
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType errors.joinError
+      Pointee: 548 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -723,26 +723,26 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 521
+      ID: 531
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1037184
       GoKind: 22
-      Pointee: 522 UnresolvedPointeeType fmt.wrapError
+      Pointee: 532 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1037312
       GoKind: 22
-      Pointee: 524 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 534 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 399
+      ID: 409
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927872
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 410 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 790
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -751,83 +751,83 @@ Types:
       GoKind: 22
       Pointee: 791 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 925088
       GoKind: 22
-      Pointee: 382 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 392 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 383
+      ID: 393
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 925184
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 394 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 685
+      ID: 695
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 924896
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 696 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 925472
       GoKind: 22
-      Pointee: 388 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 398 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 687
+      ID: 697
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 924992
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 698 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 385
+      ID: 395
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 925280
       GoKind: 22
-      Pointee: 275 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 285 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 277
+      ID: 287
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 276 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 286 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 924800
       GoKind: 22
-      Pointee: 272 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 282 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 274
+      ID: 284
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 273 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 283 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 925376
       GoKind: 22
-      Pointee: 278 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 288 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 280
+      ID: 290
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 279 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 427
+      ID: 437
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 932672
       GoKind: 22
-      Pointee: 428 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 438 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 781
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
@@ -885,12 +885,12 @@ Types:
       GoKind: 22
       Pointee: 731 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 240
+      ID: 250
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1211584
       GoKind: 22
-      Pointee: 241 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 251 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 179
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
@@ -906,12 +906,12 @@ Types:
       GoKind: 22
       Pointee: 797 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 632
+      ID: 642
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1232576
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 643 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 732
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
@@ -948,143 +948,143 @@ Types:
       GoKind: 22
       Pointee: 879 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 429
+      ID: 439
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 934880
       GoKind: 22
-      Pointee: 430 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 440 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 935936
       GoKind: 22
-      Pointee: 437 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 447 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 935648
       GoKind: 22
-      Pointee: 291 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 301 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 935840
       GoKind: 22
-      Pointee: 435 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 445 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 433 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 443 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 444
+      ID: 454
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 937280
       GoKind: 22
-      Pointee: 445 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 455 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 448
+      ID: 458
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 937472
       GoKind: 22
-      Pointee: 449 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 459 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 446
+      ID: 456
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 447 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 457 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 442
+      ID: 452
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 937184
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 453 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 710
+      ID: 720
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 709 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 456
+      ID: 466
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 937856
       GoKind: 22
-      Pointee: 457 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 467 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 937568
       GoKind: 22
-      Pointee: 451 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 461 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 454
+      ID: 464
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 937760
       GoKind: 22
-      Pointee: 455 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 465 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 937664
       GoKind: 22
-      Pointee: 453 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 463 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 458
+      ID: 468
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 937952
       GoKind: 22
-      Pointee: 459 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 938240
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 475 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 467 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 477 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 462
+      ID: 472
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 938144
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 473 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 460
+      ID: 470
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 938048
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 471 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 938528
       GoKind: 22
-      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 806
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1114,12 +1114,12 @@ Types:
       GoKind: 22
       Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 926624
       GoKind: 22
-      Pointee: 390 StructureType github.com/cihub/seelog.baseError
+      Pointee: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 783
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1128,12 +1128,12 @@ Types:
       GoKind: 22
       Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 391
+      ID: 401
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 926720
       GoKind: 22
-      Pointee: 392 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 402 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 773
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1156,12 +1156,12 @@ Types:
       GoKind: 22
       Pointee: 780 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 396 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 406 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 777
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1177,19 +1177,19 @@ Types:
       GoKind: 22
       Pointee: 799 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 394 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 404 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 927008
       GoKind: 22
-      Pointee: 398 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 408 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 896
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1205,289 +1205,289 @@ Types:
       GoKind: 22
       Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 660
+      ID: 670
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1456672
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 671 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 576
+      ID: 586
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1083648
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 587 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 574
+      ID: 584
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1083520
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 585 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1088000
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 589 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 580
+      ID: 590
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1088128
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 591 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 570
+      ID: 580
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1072640
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 581 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 928544
       GoKind: 22
-      Pointee: 403 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 413 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 634
+      ID: 644
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1240768
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 645 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1224512
       GoKind: 22
-      Pointee: 621 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 631 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 614
+      ID: 624
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1224128
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 625 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 556
+      ID: 566
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1059072
       GoKind: 22
-      Pointee: 557 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 567 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1224896
       GoKind: 22
-      Pointee: 627 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 637 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1058944
       GoKind: 22
-      Pointee: 520 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 530 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1224384
       GoKind: 22
-      Pointee: 619 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 629 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 616
+      ID: 626
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1224256
       GoKind: 22
-      Pointee: 617 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 627 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 624
+      ID: 634
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1224768
       GoKind: 22
-      Pointee: 625 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 635 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 622
+      ID: 632
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1224640
       GoKind: 22
-      Pointee: 623 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 633 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 630
+      ID: 640
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1225280
       GoKind: 22
-      Pointee: 631 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 560
+      ID: 570
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1059328
       GoKind: 22
-      Pointee: 561 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 571 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 558
+      ID: 568
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1059200
       GoKind: 22
-      Pointee: 559 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 569 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 628
+      ID: 638
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1225152
       GoKind: 22
-      Pointee: 629 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 639 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 499
+      ID: 509
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 957344
       GoKind: 22
-      Pointee: 299 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 309 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 301
+      ID: 311
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 300 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 310 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 673
+      ID: 683
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1692704
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 684 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 584
+      ID: 594
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1102848
       GoKind: 22
-      Pointee: 585 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 595 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 958592
       GoKind: 22
-      Pointee: 302 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 312 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 642
+      ID: 652
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1278912
       GoKind: 22
-      Pointee: 643 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 653 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 958880
       GoKind: 22
-      Pointee: 504 StructureType golang.org/x/net/http2.connError
+      Pointee: 514 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 958784
       GoKind: 22
-      Pointee: 306 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 316 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 308
+      ID: 318
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 317 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 959072
       GoKind: 22
-      Pointee: 312 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 314
+      ID: 324
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 313 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 323 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 958976
       GoKind: 22
-      Pointee: 309 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 319 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 311
+      ID: 321
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 310 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 320 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 958688
       GoKind: 22
-      Pointee: 303 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 313 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 305
+      ID: 315
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 304 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 314 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 959168
       GoKind: 22
-      Pointee: 508 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 518 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 509
+      ID: 519
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 959264
       GoKind: 22
-      Pointee: 315 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 325 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 495
+      ID: 505
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 953024
       GoKind: 22
-      Pointee: 496 StructureType google.golang.org/grpc.dropError
+      Pointee: 506 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1275968
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 651 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 662
+      ID: 672
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1464192
       GoKind: 22
-      Pointee: 663 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 673 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 497
+      ID: 507
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 955616
       GoKind: 22
-      Pointee: 498 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 508 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 921
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1496,12 +1496,12 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 582
+      ID: 592
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1097088
       GoKind: 22
-      Pointee: 583 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 593 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 905
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1510,61 +1510,61 @@ Types:
       GoKind: 22
       Pointee: 906 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 483
+      ID: 493
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 944576
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 494 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1077248
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 583 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1244864
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 649 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 636
+      ID: 646
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1244608
       GoKind: 22
-      Pointee: 637 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 647 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 489
+      ID: 499
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 946880
       GoKind: 22
-      Pointee: 490 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 500 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 491
+      ID: 501
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 946976
       GoKind: 22
-      Pointee: 492 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 502 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 936032
       GoKind: 22
-      Pointee: 439 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 449 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 510
+      ID: 520
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 960032
       GoKind: 22
-      Pointee: 511 UnresolvedPointeeType html/template.Error
+      Pointee: 521 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -1601,26 +1601,26 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 929120
       GoKind: 22
-      Pointee: 407 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 417 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 929024
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 415 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 612
+      ID: 622
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1219648
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 623 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 960
       Name: '*internal/poll.FD'
@@ -1629,19 +1629,19 @@ Types:
       GoKind: 22
       Pointee: 961 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1219520
       GoKind: 22
-      Pointee: 611 StructureType internal/poll.errNetClosing
+      Pointee: 621 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 915680
       GoKind: 22
-      Pointee: 345 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 355 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 925
       Name: '*io.PipeReader'
@@ -1671,12 +1671,12 @@ Types:
       GoKind: 22
       Pointee: 895 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1218752
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType io/fs.PathError
+      Pointee: 619 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 137
       Name: '*map<context.canceler,struct {}>'
@@ -1688,10 +1688,10 @@ Types:
       ByteSize: 8
       Pointee: 787 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 227
+      ID: 233
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 228 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 234 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 968
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1708,10 +1708,10 @@ Types:
       ByteSize: 8
       Pointee: 168 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 668
+      ID: 678
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 669 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 162
       Name: '*map<string,interface {}>'
@@ -1723,12 +1723,12 @@ Types:
       ByteSize: 8
       Pointee: 158 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 425
+      ID: 435
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 932288
       GoKind: 22
-      Pointee: 426 StructureType math/big.ErrNaN
+      Pointee: 436 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 980
       Name: '*mime/multipart.FileHeader'
@@ -1758,19 +1758,19 @@ Types:
       GoKind: 22
       Pointee: 910 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 594
+      ID: 604
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1204672
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType net.AddrError
+      Pointee: 605 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 647
+      ID: 657
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1431392
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType net.DNSError
+      Pointee: 658 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 936
       Name: '*net.IPConn'
@@ -1779,19 +1779,19 @@ Types:
       GoKind: 22
       Pointee: 937 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 645
+      ID: 655
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1431072
       GoKind: 22
-      Pointee: 646 UnresolvedPointeeType net.OpError
+      Pointee: 656 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 596
+      ID: 606
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1204800
       GoKind: 22
-      Pointee: 597 UnresolvedPointeeType net.ParseError
+      Pointee: 607 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 944
       Name: '*net.TCPConn'
@@ -1814,24 +1814,24 @@ Types:
       GoKind: 22
       Pointee: 943 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1203904
       GoKind: 22
-      Pointee: 588 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 598 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 590
+      ID: 600
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 589 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 599 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 525
+      ID: 535
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1038208
       GoKind: 22
-      Pointee: 526 StructureType net.canceledError
+      Pointee: 536 StructureType net.canceledError
     - __kind: PointerType
       ID: 934
       Name: '*net.conn'
@@ -1840,12 +1840,12 @@ Types:
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 691
+      ID: 701
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1865472
       GoKind: 22
-      Pointee: 692 StructureType net.dialResult·1
+      Pointee: 702 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 950
       Name: '*net.netFD'
@@ -1854,12 +1854,12 @@ Types:
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 316
+      ID: 326
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 908288
       GoKind: 22
-      Pointee: 317 UnresolvedPointeeType net.notFoundError
+      Pointee: 327 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1006
       Name: '*net.onlyValuesCtx'
@@ -1868,12 +1868,12 @@ Types:
       GoKind: 22
       Pointee: 1007 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 318
+      ID: 328
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908960
       GoKind: 22
-      Pointee: 319 StructureType net.result·2
+      Pointee: 329 StructureType net.result·2
     - __kind: PointerType
       ID: 940
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1889,33 +1889,33 @@ Types:
       GoKind: 22
       Pointee: 939 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 598
+      ID: 608
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1205440
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType net.temporaryError
+      Pointee: 609 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1431712
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType net.timeoutError
+      Pointee: 660 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 324
+      ID: 334
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 911552
       GoKind: 22
-      Pointee: 325 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 335 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 527
+      ID: 537
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1041664
       GoKind: 22
-      Pointee: 528 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 538 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -1973,26 +1973,26 @@ Types:
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 326
+      ID: 336
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 244 BaseType net/http.http2ConnectionError
+      Pointee: 254 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 911840
       GoKind: 22
-      Pointee: 328 StructureType net/http.http2GoAwayError
+      Pointee: 338 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1432672
       GoKind: 22
-      Pointee: 652 StructureType net/http.http2StreamError
+      Pointee: 662 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 902
       Name: '*net/http.http2clientStream'
@@ -2001,31 +2001,31 @@ Types:
       GoKind: 22
       Pointee: 903 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 333
+      ID: 343
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 912896
       GoKind: 22
-      Pointee: 334 StructureType net/http.http2connError
+      Pointee: 344 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 912320
       GoKind: 22
-      Pointee: 248 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 258 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 250
+      ID: 260
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 249 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 259 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 912416
       GoKind: 22
-      Pointee: 332 StructureType net/http.http2goAwayFlowError
+      Pointee: 342 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 866
       Name: '*net/http.http2gzipReader'
@@ -2034,36 +2034,36 @@ Types:
       GoKind: 22
       Pointee: 867 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 913088
       GoKind: 22
-      Pointee: 254 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 264 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 256
+      ID: 266
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 255 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 265 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 912992
       GoKind: 22
-      Pointee: 251 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 261 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 253
+      ID: 263
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 252 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 262 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 602
+      ID: 612
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1209408
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 613 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 862
       Name: '*net/http.http2missingBody'
@@ -2079,24 +2079,24 @@ Types:
       GoKind: 22
       Pointee: 875 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 533
+      ID: 543
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1043968
       GoKind: 22
-      Pointee: 534 StructureType net/http.http2noCachedConnError
+      Pointee: 544 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 329
+      ID: 339
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 912224
       GoKind: 22
-      Pointee: 245 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 255 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 247
+      ID: 257
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 246 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 256 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 870
       Name: '*net/http.http2requestBody'
@@ -2140,12 +2140,12 @@ Types:
       GoKind: 22
       Pointee: 893 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1043584
       GoKind: 22
-      Pointee: 530 StructureType net/http.nothingWrittenError
+      Pointee: 540 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 854
       Name: '*net/http.pattern'
@@ -2168,12 +2168,12 @@ Types:
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 913280
       GoKind: 22
-      Pointee: 338 StructureType net/http.requestBodyReadError
+      Pointee: 348 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 771
       Name: '*net/http.response'
@@ -2189,33 +2189,33 @@ Types:
       GoKind: 22
       Pointee: 1002 StructureType net/http.segment
     - __kind: PointerType
-      ID: 322
+      ID: 332
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 911456
       GoKind: 22
-      Pointee: 323 StructureType net/http.statusError
+      Pointee: 333 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 653
+      ID: 663
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1434112
       GoKind: 22
-      Pointee: 654 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 664 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1209280
       GoKind: 22
-      Pointee: 601 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 611 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 531
+      ID: 541
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1043712
       GoKind: 22
-      Pointee: 532 StructureType net/http.transportReadFromServerError
+      Pointee: 542 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 923
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2224,12 +2224,12 @@ Types:
       GoKind: 22
       Pointee: 924 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 320
+      ID: 330
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 321 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 331 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 884
       Name: '*net/http/httputil.failureToReadBody'
@@ -2238,69 +2238,69 @@ Types:
       GoKind: 22
       Pointee: 885 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 351 StructureType net/netip.parseAddrError
+      Pointee: 361 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 917984
       GoKind: 22
-      Pointee: 349 StructureType net/netip.parsePrefixError
+      Pointee: 359 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 363
+      ID: 373
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 921344
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType net/textproto.Error
+      Pointee: 374 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 921248
       GoKind: 22
-      Pointee: 268 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 278 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 270
+      ID: 280
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 269 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 279 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 658
+      ID: 668
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1438752
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType net/url.Error
+      Pointee: 669 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 920192
       GoKind: 22
-      Pointee: 262 GoStringHeaderType net/url.EscapeError
+      Pointee: 272 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 264
+      ID: 274
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 263 GoStringDataType net/url.EscapeError.str
+      Pointee: 273 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 265 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 275 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 267
+      ID: 277
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 266 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 276 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 843
       Name: '*net/url.URL'
@@ -2326,10 +2326,10 @@ Types:
       ByteSize: 8
       Pointee: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 236
+      ID: 246
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 237 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 974
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2341,25 +2341,25 @@ Types:
       ByteSize: 8
       Pointee: 838 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 218
+      ID: 224
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 219 StructureType noalg.map.group[string]float64
+      Pointee: 225 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 699
+      ID: 709
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 700 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 210
+      ID: 216
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 211 StructureType noalg.map.group[string]interface {}
+      Pointee: 217 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 202
+      ID: 208
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[string]string
+      Pointee: 209 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 956
       Name: '*os.File'
@@ -2368,12 +2368,12 @@ Types:
       GoKind: 22
       Pointee: 957 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 535
+      ID: 545
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1045888
       GoKind: 22
-      Pointee: 536 UnresolvedPointeeType os.LinkError
+      Pointee: 546 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 150
       Name: '*os.Signal'
@@ -2382,12 +2382,12 @@ Types:
       GoKind: 22
       Pointee: 151 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1209920
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType os.SyscallError
+      Pointee: 615 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 954
       Name: '*os.fileWithoutReadFrom'
@@ -2403,26 +2403,26 @@ Types:
       GoKind: 22
       Pointee: 953 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 566
+      ID: 576
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1067776
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType os/exec.Error
+      Pointee: 577 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 695
+      ID: 705
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2133152
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 706 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1067904
       GoKind: 22
-      Pointee: 569 StructureType os/exec.wrappedError
+      Pointee: 579 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 127
       Name: '*os/signal.signalCtx'
@@ -2431,52 +2431,52 @@ Types:
       GoKind: 22
       Pointee: 128 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 951104
       GoKind: 22
-      Pointee: 296 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 306 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 297 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 307 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 493
+      ID: 503
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 951008
       GoKind: 22
-      Pointee: 295 BaseType os/user.UnknownUserIdError
+      Pointee: 305 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 916448
       GoKind: 22
-      Pointee: 347 UnresolvedPointeeType reflect.ValueError
+      Pointee: 357 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 440
+      ID: 450
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 936512
       GoKind: 22
-      Pointee: 441 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 451 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 543
+      ID: 553
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1050496
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 554 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 547
+      ID: 557
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1052288
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 558 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2492,12 +2492,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 545
+      ID: 555
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1050624
       GoKind: 22
-      Pointee: 546 StructureType runtime.boundsError
+      Pointee: 556 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -2513,24 +2513,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 606
+      ID: 616
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1218112
       GoKind: 22
-      Pointee: 607 StructureType runtime.errorAddressString
+      Pointee: 617 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 541
+      ID: 551
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1050112
       GoKind: 22
-      Pointee: 512 GoStringHeaderType runtime.errorString
+      Pointee: 522 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 513 GoStringDataType runtime.errorString.str
+      Pointee: 523 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2546,17 +2546,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 542
+      ID: 552
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1050240
       GoKind: 22
-      Pointee: 515 GoStringHeaderType runtime.plainError
+      Pointee: 525 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 516 GoStringDataType runtime.plainError.str
+      Pointee: 526 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2586,12 +2586,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1049728
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType strconv.NumError
+      Pointee: 550 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -2717,12 +2717,12 @@ Types:
       GoKind: 22
       Pointee: 887 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1437632
       GoKind: 22
-      Pointee: 644 BaseType syscall.Errno
+      Pointee: 654 BaseType syscall.Errno
     - __kind: PointerType
       ID: 728
       Name: '*syscall.Signal'
@@ -2741,10 +2741,10 @@ Types:
       ByteSize: 8
       Pointee: 808 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 230
+      ID: 236
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 234 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 244 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 971
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2759,29 +2759,29 @@ Types:
       ID: 170
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 216 StructureType table<string,float64>
+      Pointee: 222 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 671
+      ID: 681
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 697 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 707 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 165
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 208 StructureType table<string,interface {}>
+      Pointee: 214 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 160
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 200 StructureType table<string,string>
+      Pointee: 206 StructureType table<string,string>
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1106688
       GoKind: 22
-      Pointee: 587 StructureType text/template.ExecError
+      Pointee: 597 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 145
       Name: '*time.Location'
@@ -2790,12 +2790,12 @@ Types:
       GoKind: 22
       Pointee: 146 StructureType time.Location
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 914144
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType time.ParseError
+      Pointee: 351 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 142
       Name: '*time.Timer'
@@ -2804,31 +2804,31 @@ Types:
       GoKind: 22
       Pointee: 143 StructureType time.Timer
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 914048
       GoKind: 22
-      Pointee: 257 GoStringHeaderType time.fileSizeError
+      Pointee: 267 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 259
+      ID: 269
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 258 GoStringDataType time.fileSizeError.str
+      Pointee: 268 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 713
+      ID: 199
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 714 StructureType time.zone
+      Pointee: 200 StructureType time.zone
     - __kind: PointerType
-      ID: 716
+      ID: 202
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396704
       GoKind: 22
-      Pointee: 717 StructureType time.zoneTrans
+      Pointee: 203 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -2872,47 +2872,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 352
+      ID: 362
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 353 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 363 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 365
+      ID: 375
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 921536
       GoKind: 22
-      Pointee: 366 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 376 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 367
+      ID: 377
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 921632
       GoKind: 22
-      Pointee: 271 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 281 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1057664
       GoKind: 22
-      Pointee: 553 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 563 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1057792
       GoKind: 22
-      Pointee: 519 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 529 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 851
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: GoChannelType
-      ID: 711
+      ID: 721
       Name: <-chan time.Time
       GoRuntimeType: 606688
       GoKind: 18
@@ -3097,7 +3097,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 679
+      ID: 689
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 709056
@@ -3145,7 +3145,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 665 PointerType *crypto/x509.Certificate
+      Element: 675 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 722
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3205,11 +3205,11 @@ Types:
       ByteSize: 8
       Element: 789 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 252
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 230 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 236 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 981
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3223,25 +3223,25 @@ Types:
       ByteSize: 8
       Element: 830 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 228
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 170 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 703
+      ID: 713
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 671 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 220
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 165 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 212
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3293,7 +3293,7 @@ Types:
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 684
+      ID: 694
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 497920
@@ -3308,9 +3308,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 707 GoSliceDataType []float64.array
+      Data: 717 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 707
+      ID: 717
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3331,9 +3331,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 224 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 230 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 230
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3354,9 +3354,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 232 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 238
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3397,11 +3397,11 @@ Types:
       ByteSize: 24
       Element: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 253
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 237 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 982
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3415,29 +3415,29 @@ Types:
       ByteSize: 328
       Element: 838 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 229
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 219 StructureType noalg.map.group[string]float64
+      Element: 225 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 704
+      ID: 714
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 700 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 221
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 211 StructureType noalg.map.group[string]interface {}
+      Element: 217 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 213
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 203 StructureType noalg.map.group[string]string
+      Element: 209 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 149
       Name: '[]os.Signal'
@@ -3454,9 +3454,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 198 GoSliceDataType []os.Signal.array
+      Data: 204 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 204
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3466,7 +3466,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 683
+      ID: 693
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -3481,15 +3481,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 705 GoSliceDataType []string.array
+      Data: 715 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 705
+      ID: 715
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 712
+      ID: 198
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 491072
@@ -3497,22 +3497,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 713 PointerType *time.zone
+          Type: 199 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 718 GoSliceDataType []time.zone.array
+      Data: 240 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 718
+      ID: 240
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 714 StructureType time.zone
+      Element: 200 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 715
+      ID: 201
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491136
@@ -3520,20 +3520,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 716 PointerType *time.zoneTrans
+          Type: 202 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 720 GoSliceDataType []time.zoneTrans.array
+      Data: 242 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 720
+      ID: 242
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 717 StructureType time.zoneTrans
+      Element: 203 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3581,7 +3581,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 486
+      ID: 496
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 946016
@@ -3596,9 +3596,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 487 GoSliceDataType archive/tar.headerError.array
+      Data: 497 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 497
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3656,13 +3656,13 @@ Types:
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: BaseType
-      ID: 287
+      ID: 297
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 846720
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 298
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 846816
@@ -3670,13 +3670,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *compress/flate.InternalError.str
+          Type: 300 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType compress/flate.InternalError.str
+      Data: 299 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 299
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3760,7 +3760,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 592
+      ID: 602
       Name: context.deadlineExceededError
       GoRuntimeType: 1481312
       GoKind: 25
@@ -3804,7 +3804,7 @@ Types:
           Type: 142 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 144 StructureType time.Time
+          Type: 144 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3850,37 +3850,37 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 283
+      ID: 293
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846336
       GoKind: 2
     - __kind: BaseType
-      ID: 284
+      ID: 294
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846432
       GoKind: 2
     - __kind: BaseType
-      ID: 285
+      ID: 295
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846528
       GoKind: 2
     - __kind: BaseType
-      ID: 286
+      ID: 296
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846624
       GoKind: 2
     - __kind: BaseType
-      ID: 260
+      ID: 270
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 844128
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 561
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3949,11 +3949,11 @@ Types:
       GoRuntimeType: 843936
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 357
+      ID: 367
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 355
+      ID: 365
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1755616
@@ -3964,26 +3964,26 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 679 ArrayType [5]uint8
+          Type: 689 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 680 GoInterfaceType net.Conn
+          Type: 690 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 518
+      ID: 528
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1004896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 667
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 676
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 416
+      ID: 426
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1757728
@@ -3991,21 +3991,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 665 PointerType *crypto/x509.Certificate
+          Type: 675 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 689 BaseType crypto/x509.InvalidReason
+          Type: 699 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 410
+      ID: 420
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1134656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 412
+      ID: 422
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1620832
@@ -4013,24 +4013,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 665 PointerType *crypto/x509.Certificate
+          Type: 675 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 282
+      ID: 292
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 846144
       GoKind: 2
     - __kind: BaseType
-      ID: 689
+      ID: 699
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 594528
       GoKind: 2
     - __kind: StructureType
-      ID: 565
+      ID: 575
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1580992
@@ -4040,13 +4040,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 418
+      ID: 428
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1134912
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 414
+      ID: 424
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1757536
@@ -4054,15 +4054,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 665 PointerType *crypto/x509.Certificate
+          Type: 675 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 665 PointerType *crypto/x509.Certificate
+          Type: 675 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 478
+      ID: 488
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1452512
@@ -4072,7 +4072,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 482
+      ID: 492
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1452672
@@ -4082,47 +4082,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 480
+      ID: 490
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 261
+      ID: 271
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 844224
       GoKind: 6
     - __kind: BaseType
-      ID: 281
+      ID: 291
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 845952
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 387
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 573
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 369
+      ID: 379
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 385
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 373
+      ID: 383
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 371
+      ID: 381
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 379
+      ID: 389
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1441792
@@ -4132,15 +4132,15 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 473
+      ID: 483
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 471
+      ID: 481
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 292
+      ID: 302
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 848256
@@ -4148,18 +4148,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 294 PointerType *encoding/xml.UnmarshalError.str
+          Type: 304 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 293 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 303 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 293
+      ID: 303
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 476
+      ID: 486
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4176,11 +4176,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 343
+      ID: 353
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 548
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4196,11 +4196,11 @@ Types:
       GoRuntimeType: 591328
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 522
+      ID: 532
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 524
+      ID: 534
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4234,7 +4234,7 @@ Types:
       GoRuntimeType: 1020736
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 410
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4244,7 +4244,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 382
+      ID: 392
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1756576
@@ -4252,7 +4252,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 681 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 691 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4260,25 +4260,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 394
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 696
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 388
+      ID: 398
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1133376
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 698
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 275
+      ID: 285
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 845280
@@ -4286,18 +4286,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 277 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 287 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 276 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 286 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 276
+      ID: 286
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 681
+      ID: 691
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2264000
@@ -4305,13 +4305,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 682 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 692 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4320,7 +4320,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 684 GoSliceHeaderType []float64
+          Type: 694 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4329,13 +4329,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 685 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 695 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 687 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 697 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4346,13 +4346,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 682
+      ID: 692
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 593056
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 272
+      ID: 282
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 845184
@@ -4360,18 +4360,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 274 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 284 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 273 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 283 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 273
+      ID: 283
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 278
+      ID: 288
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 845376
@@ -4379,18 +4379,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 280 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 290 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 279 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 279
+      ID: 289
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 428
+      ID: 438
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
@@ -4606,16 +4606,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 226 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 232 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 231 GoMapType map[string]interface {}
+          Type: 237 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 731
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 241
+      ID: 251
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1947392
@@ -4696,7 +4696,7 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 643
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4748,29 +4748,29 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 430
+      ID: 440
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 437
+      ID: 447
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1136576
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 291
+      ID: 301
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 2
     - __kind: StructureType
-      ID: 435
+      ID: 445
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1136448
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 433
+      ID: 443
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1621632
@@ -4783,7 +4783,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 445
+      ID: 455
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1622272
@@ -4796,7 +4796,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 449
+      ID: 459
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1759264
@@ -4812,7 +4812,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 447
+      ID: 457
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1451072
@@ -4822,7 +4822,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 443
+      ID: 453
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1450752
@@ -4832,14 +4832,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 667
+      ID: 677
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1523392
       GoKind: 21
-      HeaderType: 669 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 690
+      ID: 700
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1070976
@@ -4854,15 +4854,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 709 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 709
+      ID: 719
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 457
+      ID: 467
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1622592
@@ -4870,12 +4870,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 667 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 667 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 451
+      ID: 461
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1451232
@@ -4885,7 +4885,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 455
+      ID: 465
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1759456
@@ -4896,12 +4896,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 690 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 690 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 453
+      ID: 463
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1622432
@@ -4914,7 +4914,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 459
+      ID: 469
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1451392
@@ -4922,9 +4922,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 144 StructureType time.Time
+          Type: 144 GoTimeType time.Time
     - __kind: StructureType
-      ID: 465
+      ID: 475
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1622912
@@ -4937,7 +4937,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 467
+      ID: 477
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1451712
@@ -4947,7 +4947,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 463
+      ID: 473
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1622752
@@ -4960,7 +4960,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 461
+      ID: 471
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1451552
@@ -4970,7 +4970,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 469
+      ID: 479
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1623072
@@ -5005,7 +5005,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 390
+      ID: 400
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1443072
@@ -5019,7 +5019,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 392
+      ID: 402
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1443232
@@ -5027,7 +5027,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 390 StructureType github.com/cihub/seelog.baseError
+          Type: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 774
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -5050,7 +5050,7 @@ Types:
           Offset: 8
           Type: 785 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 396
+      ID: 406
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1443552
@@ -5058,7 +5058,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 390 StructureType github.com/cihub/seelog.baseError
+          Type: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 778
       Name: github.com/cihub/seelog.splitDispatcher
@@ -5074,7 +5074,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 394
+      ID: 404
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1443392
@@ -5082,9 +5082,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 390 StructureType github.com/cihub/seelog.baseError
+          Type: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 398
+      ID: 408
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1443712
@@ -5092,7 +5092,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 390 StructureType github.com/cihub/seelog.baseError
+          Type: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 913
       Name: github.com/cihub/seelog/archive.Reader
@@ -5121,42 +5121,42 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 671
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 587
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 585
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 589
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 591
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 581
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 403
+      ID: 413
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1444672
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 645
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 621
+      ID: 631
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1878240
@@ -5172,11 +5172,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 625
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 567
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1729280
@@ -5189,7 +5189,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 627
+      ID: 637
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1878688
@@ -5205,13 +5205,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 520
+      ID: 530
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1005568
       GoKind: 8
     - __kind: StructureType
-      ID: 619
+      ID: 629
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1878016
@@ -5227,13 +5227,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 693
+      ID: 703
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 844800
       GoKind: 8
     - __kind: StructureType
-      ID: 617
+      ID: 627
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1877792
@@ -5241,15 +5241,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 693 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 693 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 625
+      ID: 635
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1789952
@@ -5262,7 +5262,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 623
+      ID: 633
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1878464
@@ -5278,7 +5278,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 631
+      ID: 641
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1657568
@@ -5288,19 +5288,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 561
+      ID: 571
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1301376
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 559
+      ID: 569
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1301248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 629
+      ID: 639
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1790144
@@ -5313,7 +5313,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 299
+      ID: 309
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 850176
@@ -5321,22 +5321,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 301 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 311 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 300 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 310 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 300
+      ID: 310
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 684
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 585
+      ID: 595
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1466912
@@ -5346,19 +5346,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 302
+      ID: 312
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 850752
       GoKind: 10
     - __kind: BaseType
-      ID: 672
+      ID: 682
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1017760
       GoKind: 10
     - __kind: StructureType
-      ID: 643
+      ID: 653
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1912512
@@ -5369,12 +5369,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 672 BaseType golang.org/x/net/http2.ErrCode
+          Type: 682 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 504
+      ID: 514
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1629792
@@ -5382,12 +5382,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 672 BaseType golang.org/x/net/http2.ErrCode
+          Type: 682 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 316
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850944
@@ -5395,18 +5395,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 318 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 317 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 317
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 312
+      ID: 322
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 851136
@@ -5414,18 +5414,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 314 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 324 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 313 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 323 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 313
+      ID: 323
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 309
+      ID: 319
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 851040
@@ -5433,18 +5433,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 311 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 321 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 310 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 320 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 310
+      ID: 320
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 303
+      ID: 313
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850848
@@ -5452,18 +5452,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 305 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 315 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 304 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 314 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 304
+      ID: 314
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 508
+      ID: 518
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1467552
@@ -5473,13 +5473,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 315
+      ID: 325
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 851232
       GoKind: 2
     - __kind: StructureType
-      ID: 496
+      ID: 506
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1462592
@@ -5489,11 +5489,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 651
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 663
+      ID: 673
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1941792
@@ -5509,7 +5509,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 498
+      ID: 508
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1629312
@@ -5526,7 +5526,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 583
+      ID: 593
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1588672
@@ -5540,25 +5540,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 494
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 583
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 649
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 637
+      ID: 647
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1532992
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 490
+      ID: 500
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1455872
@@ -5568,7 +5568,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 492
+      ID: 502
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1456032
@@ -5578,7 +5578,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 439
+      ID: 449
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5610,19 +5610,19 @@ Types:
       GroupType: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 816 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 235
+      ID: 245
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 236 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 246 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 237 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 973
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5652,63 +5652,63 @@ Types:
       GroupType: 838 StructureType noalg.map.group[string][]string
       GroupSliceType: 842 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 217
+      ID: 223
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 218 PointerType *noalg.map.group[string]float64
+          Type: 224 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 219 StructureType noalg.map.group[string]float64
-      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 225 StructureType noalg.map.group[string]float64
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 698
+      ID: 708
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 699 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 709 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 700 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 704 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 714 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 209
+      ID: 215
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 210 PointerType *noalg.map.group[string]interface {}
+          Type: 216 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 211 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 215 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 217 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 207
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[string]string
+          Type: 208 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[string]string
-      GroupSliceType: 207 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 209 StructureType noalg.map.group[string]string
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 511
+      ID: 521
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5755,7 +5755,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 407
+      ID: 417
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5781,11 +5781,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 415
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 623
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5793,13 +5793,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 611
+      ID: 621
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1498592
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 345
+      ID: 355
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5960,7 +5960,7 @@ Types:
           Offset: 0
           Type: 904 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 619
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6028,7 +6028,7 @@ Types:
       TablePtrSliceType: 815 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 228
+      ID: 234
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6041,7 +6041,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 229 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 235 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6057,8 +6057,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 237 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 969
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6153,10 +6153,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 222 GoSliceDataType []*table<string,float64>.array
-      GroupType: 219 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 228 GoSliceDataType []*table<string,float64>.array
+      GroupType: 225 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 669
+      ID: 679
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6169,7 +6169,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 670 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 680 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6185,8 +6185,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 703 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 700 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 713 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 163
       Name: map<string,interface {}>
@@ -6217,8 +6217,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 214 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 211 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 220 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 217 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 158
       Name: map<string,string>
@@ -6249,8 +6249,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 206 GoSliceDataType []*table<string,string>.array
-      GroupType: 203 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
+      GroupType: 209 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 136
       Name: map[context.canceler]struct {}
@@ -6266,12 +6266,12 @@ Types:
       GoKind: 21
       HeaderType: 787 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 226
+      ID: 232
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1153728
       GoKind: 21
-      HeaderType: 228 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 234 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 967
       Name: map[string][]*mime/multipart.FileHeader
@@ -6294,7 +6294,7 @@ Types:
       GoKind: 21
       HeaderType: 168 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 231
+      ID: 237
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1146944
@@ -6308,7 +6308,7 @@ Types:
       GoKind: 21
       HeaderType: 158 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 426
+      ID: 436
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1447872
@@ -6352,11 +6352,11 @@ Types:
           Offset: 8
           Type: 914 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 605
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 680
+      ID: 690
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1618912
@@ -6369,7 +6369,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 658
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6377,11 +6377,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 646
+      ID: 656
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 597
+      ID: 607
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6397,7 +6397,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 588
+      ID: 598
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1128128
@@ -6405,18 +6405,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 590 PointerType *net.UnknownNetworkError.str
+          Type: 600 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 589 GoStringDataType net.UnknownNetworkError.str
+      Data: 599 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 589
+      ID: 599
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 526
+      ID: 536
       Name: net.canceledError
       GoRuntimeType: 1298944
       GoKind: 25
@@ -6426,7 +6426,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 692
+      ID: 702
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2147840
@@ -6434,7 +6434,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 680 GoInterfaceType net.Conn
+          Type: 690 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -6461,7 +6461,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 317
+      ID: 327
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6478,7 +6478,7 @@ Types:
           Offset: 16
           Type: 116 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 319
+      ID: 329
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1750816
@@ -6486,7 +6486,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 675 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 685 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6520,11 +6520,11 @@ Types:
           Offset: 0
           Type: 944 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 609
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 660
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6574,11 +6574,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 325
+      ID: 335
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 528
+      ID: 538
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6630,7 +6630,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6675,7 +6675,7 @@ Types:
           Type: 854 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 156 GoMapType map[string]string
@@ -6712,7 +6712,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6785,19 +6785,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 244
+      ID: 254
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 841728
       GoKind: 10
     - __kind: BaseType
-      ID: 664
+      ID: 674
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1002208
       GoKind: 10
     - __kind: StructureType
-      ID: 328
+      ID: 338
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1752544
@@ -6808,12 +6808,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 664 BaseType net/http.http2ErrCode
+          Type: 674 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 652
+      ID: 662
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1932064
@@ -6824,7 +6824,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 664 BaseType net/http.http2ErrCode
+          Type: 674 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
@@ -6833,7 +6833,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 334
+      ID: 344
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1619392
@@ -6841,12 +6841,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 664 BaseType net/http.http2ErrCode
+          Type: 674 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 248
+      ID: 258
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841920
@@ -6854,18 +6854,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 250 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 260 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 249 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 259 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 249
+      ID: 259
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 332
+      ID: 342
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1129408
       GoKind: 25
@@ -6875,7 +6875,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 254
+      ID: 264
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 842112
@@ -6883,18 +6883,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 256 PointerType *net/http.http2headerFieldNameError.str
+          Type: 266 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 255 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 265 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 255
+      ID: 265
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 251
+      ID: 261
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 842016
@@ -6902,18 +6902,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 253 PointerType *net/http.http2headerFieldValueError.str
+          Type: 263 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 252 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 262 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 252
+      ID: 262
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 613
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -6929,13 +6929,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 534
+      ID: 544
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1299584
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 245
+      ID: 255
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841824
@@ -6943,13 +6943,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 247 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 257 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 246 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 256 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 246
+      ID: 256
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -6992,7 +6992,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 530
+      ID: 540
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1572832
@@ -7032,7 +7032,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 338
+      ID: 348
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1434912
@@ -7107,7 +7107,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 822 StructureType sync/atomic.Bool
@@ -7143,7 +7143,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 323
+      ID: 333
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1619232
@@ -7156,17 +7156,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 654
+      ID: 664
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 601
+      ID: 611
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1485952
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 532
+      ID: 542
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1572992
@@ -7184,12 +7184,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 680 GoInterfaceType net.Conn
+          Type: 690 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 680 GoInterfaceType net.Conn
+          Type: 690 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 321
+      ID: 331
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7199,7 +7199,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 351
+      ID: 361
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1755232
@@ -7215,7 +7215,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 349
+      ID: 359
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1619872
@@ -7228,11 +7228,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 374
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 268
+      ID: 278
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 844512
@@ -7240,22 +7240,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 270 PointerType *net/textproto.ProtocolError.str
+          Type: 280 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 269 GoStringDataType net/textproto.ProtocolError.str
+      Data: 279 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 269
+      ID: 279
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 669
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 262
+      ID: 272
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 844320
@@ -7263,18 +7263,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 264 PointerType *net/url.EscapeError.str
+          Type: 274 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 263 GoStringDataType net/url.EscapeError.str
+      Data: 273 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 263
+      ID: 273
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 265
+      ID: 275
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 844416
@@ -7282,13 +7282,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 267 PointerType *net/url.InvalidHostError.str
+          Type: 277 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 266 GoStringDataType net/url.InvalidHostError.str
+      Data: 276 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 266
+      ID: 276
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7362,14 +7362,14 @@ Types:
       HasCount: true
       Element: 813 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 238
+      ID: 248
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 239 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 249 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 976
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7389,41 +7389,41 @@ Types:
       HasCount: true
       Element: 840 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 220
+      ID: 226
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 221 StructureType noalg.struct { key string; elem float64 }
+      Element: 227 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 701
+      ID: 711
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 771936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 702 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 712 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 212
+      ID: 218
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem interface {} }
+      Element: 219 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 204
+      ID: 210
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 205 StructureType noalg.struct { key string; elem string }
+      Element: 211 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 191
       Name: noalg.map.group[context.canceler]struct {}
@@ -7451,7 +7451,7 @@ Types:
           Offset: 8
           Type: 812 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 237
+      ID: 247
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1327872
@@ -7462,7 +7462,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 238 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 248 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 975
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7490,7 +7490,7 @@ Types:
           Offset: 8
           Type: 839 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 219
+      ID: 225
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1327616
@@ -7501,9 +7501,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 220 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 226 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 700
+      ID: 710
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1376640
@@ -7514,9 +7514,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 701 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 711 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 211
+      ID: 217
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1309568
@@ -7527,9 +7527,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 218 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 203
+      ID: 209
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1314432
@@ -7540,7 +7540,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 204 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 193
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7568,7 +7568,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 239
+      ID: 249
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1327744
@@ -7579,7 +7579,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 240 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 250 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 977
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7605,9 +7605,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 221
+      ID: 227
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1327488
@@ -7620,7 +7620,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 702
+      ID: 712
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1376512
@@ -7631,9 +7631,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 690 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 213
+      ID: 219
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1309440
@@ -7646,7 +7646,7 @@ Types:
           Offset: 16
           Type: 135 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 205
+      ID: 211
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1314304
@@ -7663,7 +7663,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 536
+      ID: 546
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7680,7 +7680,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 615
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7722,15 +7722,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 577
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 706
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 569
+      ID: 579
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1729664
@@ -7764,7 +7764,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 296
+      ID: 306
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 849408
@@ -7772,36 +7772,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 298 PointerType *os/user.UnknownGroupIdError.str
+          Type: 308 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 297 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 307 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 297
+      ID: 307
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 295
+      ID: 305
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 849312
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 347
+      ID: 357
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 441
+      ID: 451
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 554
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 558
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7813,7 +7813,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 546
+      ID: 556
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1920352
@@ -7830,9 +7830,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 694 BaseType runtime.boundsErrorCode
+          Type: 704 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 694
+      ID: 704
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 591520
@@ -7852,7 +7852,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 607
+      ID: 617
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1784768
@@ -7865,7 +7865,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 512
+      ID: 522
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1003456
@@ -7873,13 +7873,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 514 PointerType *runtime.errorString.str
+          Type: 524 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 513 GoStringDataType runtime.errorString.str
+      Data: 523 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 513
+      ID: 523
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8535,7 +8535,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 515
+      ID: 525
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1003552
@@ -8543,13 +8543,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 517 PointerType *runtime.plainError.str
+          Type: 527 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 516 GoStringDataType runtime.plainError.str
+      Data: 526 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 516
+      ID: 526
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8635,7 +8635,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 550
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9006,7 +9006,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 644
+      ID: 654
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1300480
@@ -9066,7 +9066,7 @@ Types:
           Offset: 16
           Type: 809 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 234
+      ID: 244
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9088,7 +9088,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 235 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 245 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 972
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9138,7 +9138,7 @@ Types:
           Offset: 16
           Type: 836 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 216
+      ID: 222
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9160,9 +9160,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 217 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 223 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 697
+      ID: 707
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9184,9 +9184,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 698 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 708 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 208
+      ID: 214
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9208,9 +9208,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 209 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 215 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 200
+      ID: 206
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9232,9 +9232,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<string,string>
+          Type: 207 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1733888
@@ -9264,10 +9264,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 712 GoSliceHeaderType []time.zone
+          Type: 198 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 715 GoSliceHeaderType []time.zoneTrans
+          Type: 201 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9279,12 +9279,12 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 713 PointerType *time.zone
+          Type: 199 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 351
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 144
       Name: time.Time
       ByteSize: 24
@@ -9300,6 +9300,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 145 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 143
       Name: time.Timer
@@ -9309,12 +9317,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 711 GoChannelType <-chan time.Time
+          Type: 721 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 257
+      ID: 267
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 842208
@@ -9322,18 +9330,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 259 PointerType *time.fileSizeError.str
+          Type: 269 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 258 GoStringDataType time.fileSizeError.str
+      Data: 268 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 258
+      ID: 268
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 714
+      ID: 200
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1642592
@@ -9349,7 +9357,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 717
+      ID: 203
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1781504
@@ -9410,7 +9418,7 @@ Types:
       GoRuntimeType: 591456
       GoKind: 26
     - __kind: StructureType
-      ID: 675
+      ID: 685
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2096736
@@ -9421,10 +9429,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 676 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 686 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 677 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 687 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9439,18 +9447,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 678 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 688 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 678
+      ID: 688
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1004512
       GoKind: 9
     - __kind: StructureType
-      ID: 676
+      ID: 686
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1949952
@@ -9475,17 +9483,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 353
+      ID: 363
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 677
+      ID: 687
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 592352
       GoKind: 8
     - __kind: StructureType
-      ID: 366
+      ID: 376
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1439872
@@ -9495,13 +9503,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 271
+      ID: 281
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 844608
       GoKind: 2
     - __kind: StructureType
-      ID: 553
+      ID: 563
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1729088
@@ -9514,7 +9522,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 519
+      ID: 529
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1005376

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -120,7 +120,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 684 PointerType *crypto/x509.Certificate
+      Pointee: 694 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 742
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -150,10 +150,10 @@ Types:
       ByteSize: 8
       Pointee: 808 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 234
+      ID: 240
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 235 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 241 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 989
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -170,10 +170,10 @@ Types:
       ByteSize: 8
       Pointee: 172 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 689
+      ID: 699
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 690 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 166
       Name: '**table<string,interface {}>'
@@ -221,30 +221,30 @@ Types:
       ByteSize: 8
       Pointee: 1018 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 727
+      ID: 737
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 726 GoSliceDataType []float64.array
+      Pointee: 736 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 230
+      ID: 236
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 235 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 238
+      ID: 244
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1024
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1023 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 204
+      ID: 210
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []os.Signal.array
+      Pointee: 209 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -253,20 +253,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 725
+      ID: 735
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 724 GoSliceDataType []string.array
+      Pointee: 734 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 738
+      ID: 246
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 737 GoSliceDataType []time.zone.array
+      Pointee: 245 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 740
+      ID: 248
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 739 GoSliceDataType []time.zoneTrans.array
+      Pointee: 247 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1011
       Name: '*[]uint8'
@@ -285,17 +285,17 @@ Types:
       ByteSize: 8
       Pointee: 188 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 950624
       GoKind: 22
-      Pointee: 499 GoSliceHeaderType archive/tar.headerError
+      Pointee: 509 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 500 GoSliceDataType archive/tar.headerError.array
+      Pointee: 510 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 915
       Name: '*archive/zip.checksumReader'
@@ -346,24 +346,24 @@ Types:
       GoKind: 22
       Pointee: 117 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 936224
       GoKind: 22
-      Pointee: 295 BaseType compress/flate.CorruptInputError
+      Pointee: 305 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 437
+      ID: 447
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 936320
       GoKind: 22
-      Pointee: 296 GoStringHeaderType compress/flate.InternalError
+      Pointee: 306 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 297 GoStringDataType compress/flate.InternalError.str
+      Pointee: 307 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 951
       Name: '*compress/flate.decompressor'
@@ -393,12 +393,12 @@ Types:
       GoKind: 22
       Pointee: 120 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1207520
       GoKind: 22
-      Pointee: 609 StructureType context.deadlineExceededError
+      Pointee: 619 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1025
       Name: '*context.emptyCtx'
@@ -442,54 +442,54 @@ Types:
       GoKind: 22
       Pointee: 128 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 934976
       GoKind: 22
-      Pointee: 291 BaseType crypto/aes.KeySizeError
+      Pointee: 301 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 433
+      ID: 443
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935168
       GoKind: 22
-      Pointee: 292 BaseType crypto/des.KeySizeError
+      Pointee: 302 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935456
       GoKind: 22
-      Pointee: 293 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 303 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 587
+      ID: 597
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1080032
       GoKind: 22
-      Pointee: 588 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 598 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 435
+      ID: 445
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 294 BaseType crypto/rc4.KeySizeError
+      Pointee: 304 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 370
+      ID: 380
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 265 BaseType crypto/tls.AlertError
+      Pointee: 275 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 563
+      ID: 573
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1060448
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 574 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 981
       Name: '*crypto/tls.Conn'
@@ -505,213 +505,213 @@ Types:
       GoKind: 22
       Pointee: 869 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 367 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 377 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 924320
       GoKind: 22
-      Pointee: 365 StructureType crypto/tls.RecordHeaderError
+      Pointee: 375 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1058784
       GoKind: 22
-      Pointee: 531 BaseType crypto/tls.alert
+      Pointee: 541 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 924512
       GoKind: 22
-      Pointee: 369 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 379 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 673
+      ID: 683
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1442944
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 684 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 684
+      ID: 694
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2089664
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 695 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 934784
       GoKind: 22
-      Pointee: 429 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 439 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 934304
       GoKind: 22
-      Pointee: 423 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 433 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 934400
       GoKind: 22
-      Pointee: 425 StructureType crypto/x509.HostnameError
+      Pointee: 435 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 421
+      ID: 431
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 934208
       GoKind: 22
-      Pointee: 290 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 300 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 579
+      ID: 589
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1070304
       GoKind: 22
-      Pointee: 580 StructureType crypto/x509.SystemRootsError
+      Pointee: 590 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 934880
       GoKind: 22
-      Pointee: 431 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 441 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 934688
       GoKind: 22
-      Pointee: 427 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 437 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 946304
       GoKind: 22
-      Pointee: 491 StructureType encoding/asn1.StructuralError
+      Pointee: 501 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 946496
       GoKind: 22
-      Pointee: 495 StructureType encoding/asn1.SyntaxError
+      Pointee: 505 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 946400
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 503 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 924800
       GoKind: 22
-      Pointee: 266 BaseType encoding/base64.CorruptInputError
+      Pointee: 276 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 413
+      ID: 423
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 932960
       GoKind: 22
-      Pointee: 286 BaseType encoding/hex.InvalidByteError
+      Pointee: 296 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 928160
       GoKind: 22
-      Pointee: 389 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 399 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 575
+      ID: 585
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1065568
       GoKind: 22
-      Pointee: 576 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 586 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 381 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 391 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 928064
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 397 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 927968
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 395 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 927872
       GoKind: 22
-      Pointee: 383 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 393 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 928544
       GoKind: 22
-      Pointee: 391 StructureType encoding/json.jsonError
+      Pointee: 401 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 485
+      ID: 495
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 943520
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 496 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 483
+      ID: 493
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 943424
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 494 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 487
+      ID: 497
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 943616
       GoKind: 22
-      Pointee: 300 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 310 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 302
+      ID: 312
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 301 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 311 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 943712
       GoKind: 22
-      Pointee: 489 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 499 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -720,19 +720,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 919616
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType errors.errorString
+      Pointee: 361 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1051744
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType errors.joinError
+      Pointee: 561 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -748,26 +748,26 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 534
+      ID: 544
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1041376
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType fmt.wrapError
+      Pointee: 545 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 536
+      ID: 546
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1041504
       GoKind: 22
-      Pointee: 537 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 547 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 411
+      ID: 421
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932480
       GoKind: 22
-      Pointee: 412 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 809
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -776,83 +776,83 @@ Types:
       GoKind: 22
       Pointee: 810 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 929792
       GoKind: 22
-      Pointee: 394 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 404 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 929888
       GoKind: 22
-      Pointee: 396 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 406 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 704
+      ID: 714
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 929600
       GoKind: 22
-      Pointee: 705 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 399
+      ID: 409
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 930176
       GoKind: 22
-      Pointee: 400 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 410 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 706
+      ID: 716
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 929696
       GoKind: 22
-      Pointee: 707 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 717 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 929984
       GoKind: 22
-      Pointee: 280 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 290 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 282
+      ID: 292
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 291 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 392
+      ID: 402
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 929504
       GoKind: 22
-      Pointee: 277 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 287 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 279
+      ID: 289
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 288 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 930080
       GoKind: 22
-      Pointee: 283 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 293 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 285
+      ID: 295
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 294 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 440
+      ID: 450
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 441 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 451 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 800
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
@@ -910,12 +910,12 @@ Types:
       GoKind: 22
       Pointee: 750 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 245
+      ID: 255
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1215456
       GoKind: 22
-      Pointee: 246 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 256 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 181
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
@@ -931,12 +931,12 @@ Types:
       GoKind: 22
       Pointee: 816 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1236448
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 660 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 751
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
@@ -973,143 +973,143 @@ Types:
       GoKind: 22
       Pointee: 898 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 442
+      ID: 452
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 939584
       GoKind: 22
-      Pointee: 443 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 453 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 940640
       GoKind: 22
-      Pointee: 450 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 444
+      ID: 454
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 940352
       GoKind: 22
-      Pointee: 299 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 309 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 940544
       GoKind: 22
-      Pointee: 448 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 458 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 940448
       GoKind: 22
-      Pointee: 446 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 456 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 468 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 942176
       GoKind: 22
-      Pointee: 462 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 472 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 942080
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 470 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 455
+      ID: 465
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 941888
       GoKind: 22
-      Pointee: 456 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 466 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 729
+      ID: 739
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 728 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 469
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 942560
       GoKind: 22
-      Pointee: 470 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 942272
       GoKind: 22
-      Pointee: 464 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 474 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 942464
       GoKind: 22
-      Pointee: 468 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 465
+      ID: 475
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 942368
       GoKind: 22
-      Pointee: 466 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 476 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 942656
       GoKind: 22
-      Pointee: 472 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 477
+      ID: 487
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 942944
       GoKind: 22
-      Pointee: 478 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 479
+      ID: 489
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 943040
       GoKind: 22
-      Pointee: 480 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 475
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 942848
       GoKind: 22
-      Pointee: 476 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 473
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 942752
       GoKind: 22
-      Pointee: 474 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 481
+      ID: 491
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 943232
       GoKind: 22
-      Pointee: 482 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 825
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1139,12 +1139,12 @@ Types:
       GoKind: 22
       Pointee: 824 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 931328
       GoKind: 22
-      Pointee: 402 StructureType github.com/cihub/seelog.baseError
+      Pointee: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 802
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1153,12 +1153,12 @@ Types:
       GoKind: 22
       Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 403
+      ID: 413
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 931424
       GoKind: 22
-      Pointee: 404 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 414 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 792
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1181,12 +1181,12 @@ Types:
       GoKind: 22
       Pointee: 799 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 407
+      ID: 417
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 931616
       GoKind: 22
-      Pointee: 408 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 418 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 796
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1202,19 +1202,19 @@ Types:
       GoKind: 22
       Pointee: 818 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 405
+      ID: 415
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 931520
       GoKind: 22
-      Pointee: 406 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 416 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 409
+      ID: 419
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 931712
       GoKind: 22
-      Pointee: 410 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 420 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 913
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1230,289 +1230,289 @@ Types:
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 677
+      ID: 687
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1461024
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 688 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1088352
       GoKind: 22
-      Pointee: 594 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 604 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1088224
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 602 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 595
+      ID: 605
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1092704
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 606 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 597
+      ID: 607
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1092832
       GoKind: 22
-      Pointee: 598 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 608 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 585
+      ID: 595
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1077216
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 596 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 933152
       GoKind: 22
-      Pointee: 415 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 425 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1244896
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 662 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 637
+      ID: 647
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1228384
       GoKind: 22
-      Pointee: 638 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 631
+      ID: 641
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1228000
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 642 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 569
+      ID: 579
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1063392
       GoKind: 22
-      Pointee: 570 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 643
+      ID: 653
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1228768
       GoKind: 22
-      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1063264
       GoKind: 22
-      Pointee: 533 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 543 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 635
+      ID: 645
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1228256
       GoKind: 22
-      Pointee: 636 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 633
+      ID: 643
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1228128
       GoKind: 22
-      Pointee: 634 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 641
+      ID: 651
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1228640
       GoKind: 22
-      Pointee: 642 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 652 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 639
+      ID: 649
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1228512
       GoKind: 22
-      Pointee: 640 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 650 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 647
+      ID: 657
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1229152
       GoKind: 22
-      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 573
+      ID: 583
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1063648
       GoKind: 22
-      Pointee: 574 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 584 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 571
+      ID: 581
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1063520
       GoKind: 22
-      Pointee: 572 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 582 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 645
+      ID: 655
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1229024
       GoKind: 22
-      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 512
+      ID: 522
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 962048
       GoKind: 22
-      Pointee: 307 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 317 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 309
+      ID: 319
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 318 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 692
+      ID: 702
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1697984
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 703 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 601
+      ID: 611
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1107552
       GoKind: 22
-      Pointee: 602 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 612 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 963296
       GoKind: 22
-      Pointee: 310 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 320 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1283168
       GoKind: 22
-      Pointee: 660 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 670 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 516
+      ID: 526
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 963584
       GoKind: 22
-      Pointee: 517 StructureType golang.org/x/net/http2.connError
+      Pointee: 527 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 515
+      ID: 525
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 963488
       GoKind: 22
-      Pointee: 314 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 324 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 316
+      ID: 326
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 315 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 325 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 519
+      ID: 529
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 963776
       GoKind: 22
-      Pointee: 320 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 330 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 322
+      ID: 332
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 321 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 331 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 963680
       GoKind: 22
-      Pointee: 317 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 327 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 319
+      ID: 329
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 318 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 328 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 963392
       GoKind: 22
-      Pointee: 311 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 321 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 313
+      ID: 323
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 312 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 322 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 520
+      ID: 530
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 963872
       GoKind: 22
-      Pointee: 521 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 531 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 963968
       GoKind: 22
-      Pointee: 323 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 333 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 957728
       GoKind: 22
-      Pointee: 509 StructureType google.golang.org/grpc.dropError
+      Pointee: 519 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1280224
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 668 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 679
+      ID: 689
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1468544
       GoKind: 22
-      Pointee: 680 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 690 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 510
+      ID: 520
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 960320
       GoKind: 22
-      Pointee: 511 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 521 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 940
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1521,12 +1521,12 @@ Types:
       GoKind: 22
       Pointee: 941 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 599
+      ID: 609
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1101792
       GoKind: 22
-      Pointee: 600 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 610 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 924
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1535,61 +1535,61 @@ Types:
       GoKind: 22
       Pointee: 925 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 949280
       GoKind: 22
-      Pointee: 497 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 507 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 589
+      ID: 599
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1081952
       GoKind: 22
-      Pointee: 590 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 600 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1249120
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 666 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 653
+      ID: 663
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1248864
       GoKind: 22
-      Pointee: 654 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 664 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 951584
       GoKind: 22
-      Pointee: 503 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 513 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 504
+      ID: 514
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 951680
       GoKind: 22
-      Pointee: 505 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 515 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 451
+      ID: 461
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 940736
       GoKind: 22
-      Pointee: 452 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 462 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 964736
       GoKind: 22
-      Pointee: 524 UnresolvedPointeeType html/template.Error
+      Pointee: 534 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -1626,33 +1626,33 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
-      ID: 681
+      ID: 691
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2263680
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType internal/abi.Type
+      Pointee: 692 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 419
+      ID: 429
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 933824
       GoKind: 22
-      Pointee: 420 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 430 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 933728
       GoKind: 22
-      Pointee: 418 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 428 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 629
+      ID: 639
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1223520
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 640 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 979
       Name: '*internal/poll.FD'
@@ -1661,38 +1661,38 @@ Types:
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 627
+      ID: 637
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1223392
       GoKind: 22
-      Pointee: 628 StructureType internal/poll.errNetClosing
+      Pointee: 638 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 352
+      ID: 362
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 353 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 363 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 933632
       GoKind: 22
-      Pointee: 287 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 297 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 289
+      ID: 299
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 298 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1069280
       GoKind: 22
-      Pointee: 578 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 588 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 944
       Name: '*io.PipeReader'
@@ -1722,12 +1722,12 @@ Types:
       GoKind: 22
       Pointee: 912 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 625
+      ID: 635
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1222368
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType io/fs.PathError
+      Pointee: 636 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 139
       Name: '*map<context.canceler,struct {}>'
@@ -1739,10 +1739,10 @@ Types:
       ByteSize: 8
       Pointee: 806 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 232
+      ID: 238
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 233 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 239 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 987
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1759,10 +1759,10 @@ Types:
       ByteSize: 8
       Pointee: 170 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 687
+      ID: 697
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 688 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 164
       Name: '*map<string,interface {}>'
@@ -1774,12 +1774,12 @@ Types:
       ByteSize: 8
       Pointee: 160 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 936992
       GoKind: 22
-      Pointee: 439 StructureType math/big.ErrNaN
+      Pointee: 449 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 999
       Name: '*mime/multipart.FileHeader'
@@ -1809,19 +1809,19 @@ Types:
       GoKind: 22
       Pointee: 929 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1208672
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType net.AddrError
+      Pointee: 622 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 664
+      ID: 674
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1435264
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType net.DNSError
+      Pointee: 675 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 955
       Name: '*net.IPConn'
@@ -1830,19 +1830,19 @@ Types:
       GoKind: 22
       Pointee: 956 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 662
+      ID: 672
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1434944
       GoKind: 22
-      Pointee: 663 UnresolvedPointeeType net.OpError
+      Pointee: 673 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1208800
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType net.ParseError
+      Pointee: 624 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 963
       Name: '*net.TCPConn'
@@ -1865,24 +1865,24 @@ Types:
       GoKind: 22
       Pointee: 962 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1207904
       GoKind: 22
-      Pointee: 605 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 615 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 607
+      ID: 617
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 606 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 616 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 538
+      ID: 548
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1042400
       GoKind: 22
-      Pointee: 539 StructureType net.canceledError
+      Pointee: 549 StructureType net.canceledError
     - __kind: PointerType
       ID: 953
       Name: '*net.conn'
@@ -1891,12 +1891,12 @@ Types:
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 710
+      ID: 720
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1874720
       GoKind: 22
-      Pointee: 711 StructureType net.dialResult·1
+      Pointee: 721 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 969
       Name: '*net.netFD'
@@ -1905,12 +1905,12 @@ Types:
       GoKind: 22
       Pointee: 970 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 324
+      ID: 334
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 912608
       GoKind: 22
-      Pointee: 325 UnresolvedPointeeType net.notFoundError
+      Pointee: 335 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1026
       Name: '*net.onlyValuesCtx'
@@ -1919,12 +1919,12 @@ Types:
       GoKind: 22
       Pointee: 1027 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 326
+      ID: 336
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 913280
       GoKind: 22
-      Pointee: 327 StructureType net.result·2
+      Pointee: 337 StructureType net.result·2
     - __kind: PointerType
       ID: 959
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1940,33 +1940,33 @@ Types:
       GoKind: 22
       Pointee: 958 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1209440
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType net.temporaryError
+      Pointee: 626 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 666
+      ID: 676
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1435584
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType net.timeoutError
+      Pointee: 677 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 332
+      ID: 342
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 915872
       GoKind: 22
-      Pointee: 333 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 343 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 540
+      ID: 550
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1045856
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 551 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 112
       Name: '*net/http.Request'
@@ -2024,26 +2024,26 @@ Types:
       GoKind: 22
       Pointee: 892 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 334
+      ID: 344
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 916064
       GoKind: 22
-      Pointee: 249 BaseType net/http.http2ConnectionError
+      Pointee: 259 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 916160
       GoKind: 22
-      Pointee: 336 StructureType net/http.http2GoAwayError
+      Pointee: 346 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 668
+      ID: 678
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1436544
       GoKind: 22
-      Pointee: 669 StructureType net/http.http2StreamError
+      Pointee: 679 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 921
       Name: '*net/http.http2clientStream'
@@ -2052,31 +2052,31 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 341
+      ID: 351
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 342 StructureType net/http.http2connError
+      Pointee: 352 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916640
       GoKind: 22
-      Pointee: 253 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 263 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 255
+      ID: 265
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 254 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 916736
       GoKind: 22
-      Pointee: 340 StructureType net/http.http2goAwayFlowError
+      Pointee: 350 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 885
       Name: '*net/http.http2gzipReader'
@@ -2085,36 +2085,36 @@ Types:
       GoKind: 22
       Pointee: 886 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 917408
       GoKind: 22
-      Pointee: 259 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 269 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 261
+      ID: 271
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 260 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 270 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 343
+      ID: 353
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 917312
       GoKind: 22
-      Pointee: 256 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 266 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 258
+      ID: 268
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 257 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 267 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 619
+      ID: 629
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1213280
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 630 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 881
       Name: '*net/http.http2missingBody'
@@ -2130,24 +2130,24 @@ Types:
       GoKind: 22
       Pointee: 894 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 546
+      ID: 556
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1048160
       GoKind: 22
-      Pointee: 547 StructureType net/http.http2noCachedConnError
+      Pointee: 557 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 250 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 260 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 252
+      ID: 262
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 251 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 261 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 889
       Name: '*net/http.http2requestBody'
@@ -2191,12 +2191,12 @@ Types:
       GoKind: 22
       Pointee: 910 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 542
+      ID: 552
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1047776
       GoKind: 22
-      Pointee: 543 StructureType net/http.nothingWrittenError
+      Pointee: 553 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 873
       Name: '*net/http.pattern'
@@ -2219,12 +2219,12 @@ Types:
       GoKind: 22
       Pointee: 918 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 346 StructureType net/http.requestBodyReadError
+      Pointee: 356 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 790
       Name: '*net/http.response'
@@ -2240,33 +2240,33 @@ Types:
       GoKind: 22
       Pointee: 1022 StructureType net/http.segment
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 915776
       GoKind: 22
-      Pointee: 331 StructureType net/http.statusError
+      Pointee: 341 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 670
+      ID: 680
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1438144
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 681 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1213152
       GoKind: 22
-      Pointee: 618 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 628 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 544
+      ID: 554
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1047904
       GoKind: 22
-      Pointee: 545 StructureType net/http.transportReadFromServerError
+      Pointee: 555 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 942
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2275,12 +2275,12 @@ Types:
       GoKind: 22
       Pointee: 943 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 329 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 339 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 903
       Name: '*net/http/httputil.failureToReadBody'
@@ -2289,69 +2289,69 @@ Types:
       GoKind: 22
       Pointee: 904 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 922688
       GoKind: 22
-      Pointee: 361 StructureType net/netip.parseAddrError
+      Pointee: 371 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 358
+      ID: 368
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 922592
       GoKind: 22
-      Pointee: 359 StructureType net/netip.parsePrefixError
+      Pointee: 369 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 926048
       GoKind: 22
-      Pointee: 376 UnresolvedPointeeType net/textproto.Error
+      Pointee: 386 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 925952
       GoKind: 22
-      Pointee: 273 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 283 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 275
+      ID: 285
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 284 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 675
+      ID: 685
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1443264
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType net/url.Error
+      Pointee: 686 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 372
+      ID: 382
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 924896
       GoKind: 22
-      Pointee: 267 GoStringHeaderType net/url.EscapeError
+      Pointee: 277 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 269
+      ID: 279
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType net/url.EscapeError.str
+      Pointee: 278 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 924992
       GoKind: 22
-      Pointee: 270 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 280 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 272
+      ID: 282
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 281 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 862
       Name: '*net/url.URL'
@@ -2377,10 +2377,10 @@ Types:
       ByteSize: 8
       Pointee: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 241
+      ID: 251
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 242 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 993
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2392,25 +2392,25 @@ Types:
       ByteSize: 8
       Pointee: 857 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 223
+      ID: 229
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 224 StructureType noalg.map.group[string]float64
+      Pointee: 230 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 718
+      ID: 728
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 719 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 215
+      ID: 221
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 216 StructureType noalg.map.group[string]interface {}
+      Pointee: 222 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 207
+      ID: 213
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 208 StructureType noalg.map.group[string]string
+      Pointee: 214 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 975
       Name: '*os.File'
@@ -2419,12 +2419,12 @@ Types:
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 548
+      ID: 558
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1050208
       GoKind: 22
-      Pointee: 549 UnresolvedPointeeType os.LinkError
+      Pointee: 559 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 152
       Name: '*os.Signal'
@@ -2433,12 +2433,12 @@ Types:
       GoKind: 22
       Pointee: 153 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 621
+      ID: 631
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1213664
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType os.SyscallError
+      Pointee: 632 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 973
       Name: '*os.fileWithoutReadFrom'
@@ -2454,26 +2454,26 @@ Types:
       GoKind: 22
       Pointee: 972 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 581
+      ID: 591
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1072352
       GoKind: 22
-      Pointee: 582 UnresolvedPointeeType os/exec.Error
+      Pointee: 592 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 714
+      ID: 724
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2141408
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 725 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 583
+      ID: 593
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1072480
       GoKind: 22
-      Pointee: 584 StructureType os/exec.wrappedError
+      Pointee: 594 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 129
       Name: '*os/signal.signalCtx'
@@ -2482,52 +2482,52 @@ Types:
       GoKind: 22
       Pointee: 130 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 955808
       GoKind: 22
-      Pointee: 304 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 314 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 306
+      ID: 316
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 305 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 315 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 955712
       GoKind: 22
-      Pointee: 303 BaseType os/user.UnknownUserIdError
+      Pointee: 313 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 354
+      ID: 364
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 920768
       GoKind: 22
-      Pointee: 355 UnresolvedPointeeType reflect.ValueError
+      Pointee: 365 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 453
+      ID: 463
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 941216
       GoKind: 22
-      Pointee: 454 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 464 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 556
+      ID: 566
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1054816
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 567 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 560
+      ID: 570
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1056608
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 571 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2543,12 +2543,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 558
+      ID: 568
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1054944
       GoKind: 22
-      Pointee: 559 StructureType runtime.boundsError
+      Pointee: 569 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -2564,24 +2564,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 623
+      ID: 633
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1221856
       GoKind: 22
-      Pointee: 624 StructureType runtime.errorAddressString
+      Pointee: 634 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1054432
       GoKind: 22
-      Pointee: 525 GoStringHeaderType runtime.errorString
+      Pointee: 535 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 527
+      ID: 537
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 526 GoStringDataType runtime.errorString.str
+      Pointee: 536 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2604,17 +2604,17 @@ Types:
       GoKind: 22
       Pointee: 190 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1054560
       GoKind: 22
-      Pointee: 528 GoStringHeaderType runtime.plainError
+      Pointee: 538 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 530
+      ID: 540
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 529 GoStringDataType runtime.plainError.str
+      Pointee: 539 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2630,12 +2630,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 922304
       GoKind: 22
-      Pointee: 357 StructureType runtime.synctestDeadlockError
+      Pointee: 367 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -2651,12 +2651,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1054048
       GoKind: 22
-      Pointee: 553 UnresolvedPointeeType strconv.NumError
+      Pointee: 563 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -2782,12 +2782,12 @@ Types:
       GoKind: 22
       Pointee: 906 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 672
+      ID: 682
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1442144
       GoKind: 22
-      Pointee: 661 BaseType syscall.Errno
+      Pointee: 671 BaseType syscall.Errno
     - __kind: PointerType
       ID: 747
       Name: '*syscall.Signal'
@@ -2806,10 +2806,10 @@ Types:
       ByteSize: 8
       Pointee: 827 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 235
+      ID: 241
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 239 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 249 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 990
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2824,29 +2824,29 @@ Types:
       ID: 172
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 221 StructureType table<string,float64>
+      Pointee: 227 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 690
+      ID: 700
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 716 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 726 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 167
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 213 StructureType table<string,interface {}>
+      Pointee: 219 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 162
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 205 StructureType table<string,string>
+      Pointee: 211 StructureType table<string,string>
     - __kind: PointerType
-      ID: 603
+      ID: 613
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1111392
       GoKind: 22
-      Pointee: 604 StructureType text/template.ExecError
+      Pointee: 614 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 147
       Name: '*time.Location'
@@ -2855,12 +2855,12 @@ Types:
       GoKind: 22
       Pointee: 148 StructureType time.Location
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 918464
       GoKind: 22
-      Pointee: 349 UnresolvedPointeeType time.ParseError
+      Pointee: 359 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 144
       Name: '*time.Timer'
@@ -2869,31 +2869,31 @@ Types:
       GoKind: 22
       Pointee: 145 StructureType time.Timer
     - __kind: PointerType
-      ID: 347
+      ID: 357
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 918368
       GoKind: 22
-      Pointee: 262 GoStringHeaderType time.fileSizeError
+      Pointee: 272 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 264
+      ID: 274
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 263 GoStringDataType time.fileSizeError.str
+      Pointee: 273 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 732
+      ID: 204
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399456
       GoKind: 22
-      Pointee: 733 StructureType time.zone
+      Pointee: 205 StructureType time.zone
     - __kind: PointerType
-      ID: 735
+      ID: 207
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399520
       GoKind: 22
-      Pointee: 736 StructureType time.zoneTrans
+      Pointee: 208 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -2937,47 +2937,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 363 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 373 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 926240
       GoKind: 22
-      Pointee: 378 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 388 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 379
+      ID: 389
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 926336
       GoKind: 22
-      Pointee: 276 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 286 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1061984
       GoKind: 22
-      Pointee: 566 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 576 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1062112
       GoKind: 22
-      Pointee: 532 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 542 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 870
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
     - __kind: GoChannelType
-      ID: 730
+      ID: 740
       Name: <-chan time.Time
       GoRuntimeType: 610528
       GoKind: 18
@@ -3155,7 +3155,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 698
+      ID: 708
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 712672
@@ -3203,7 +3203,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 684 PointerType *crypto/x509.Certificate
+      Element: 694 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 741
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3286,11 +3286,11 @@ Types:
       ByteSize: 8
       Element: 808 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 257
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 235 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 241 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 1000
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3304,25 +3304,25 @@ Types:
       ByteSize: 8
       Element: 849 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 233
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 172 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 722
+      ID: 732
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 690 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 225
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 167 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 217
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3374,7 +3374,7 @@ Types:
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 703
+      ID: 713
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 501184
@@ -3389,9 +3389,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 726 GoSliceDataType []float64.array
+      Data: 736 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 726
+      ID: 736
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3412,9 +3412,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 235 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 235
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3435,9 +3435,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 237 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 243
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3478,11 +3478,11 @@ Types:
       ByteSize: 24
       Element: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 258
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 242 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 1001
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3496,29 +3496,29 @@ Types:
       ByteSize: 328
       Element: 857 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 234
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 224 StructureType noalg.map.group[string]float64
+      Element: 230 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 723
+      ID: 733
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 719 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 226
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 216 StructureType noalg.map.group[string]interface {}
+      Element: 222 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 218
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 208 StructureType noalg.map.group[string]string
+      Element: 214 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 151
       Name: '[]os.Signal'
@@ -3535,9 +3535,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 203 GoSliceDataType []os.Signal.array
+      Data: 209 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 209
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3547,7 +3547,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 702
+      ID: 712
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -3562,15 +3562,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 724 GoSliceDataType []string.array
+      Data: 734 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 724
+      ID: 734
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 731
+      ID: 203
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494336
@@ -3578,22 +3578,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 732 PointerType *time.zone
+          Type: 204 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 737 GoSliceDataType []time.zone.array
+      Data: 245 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 737
+      ID: 245
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 733 StructureType time.zone
+      Element: 205 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 734
+      ID: 206
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494400
@@ -3601,20 +3601,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 735 PointerType *time.zoneTrans
+          Type: 207 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 739 GoSliceDataType []time.zoneTrans.array
+      Data: 247 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 739
+      ID: 247
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 736 StructureType time.zoneTrans
+      Element: 208 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3662,7 +3662,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 499
+      ID: 509
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 950720
@@ -3677,9 +3677,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 500 GoSliceDataType archive/tar.headerError.array
+      Data: 510 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 510
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3737,13 +3737,13 @@ Types:
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: BaseType
-      ID: 295
+      ID: 305
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 850176
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 296
+      ID: 306
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 850272
@@ -3751,13 +3751,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 298 PointerType *compress/flate.InternalError.str
+          Type: 308 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 297 GoStringDataType compress/flate.InternalError.str
+      Data: 307 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 297
+      ID: 307
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3841,7 +3841,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 609
+      ID: 619
       Name: context.deadlineExceededError
       GoRuntimeType: 1485856
       GoKind: 25
@@ -3885,7 +3885,7 @@ Types:
           Type: 144 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 146 StructureType time.Time
+          Type: 146 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3931,43 +3931,43 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 291
+      ID: 301
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849792
       GoKind: 2
     - __kind: BaseType
-      ID: 292
+      ID: 302
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849888
       GoKind: 2
     - __kind: BaseType
-      ID: 293
+      ID: 303
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849984
       GoKind: 2
     - __kind: StructureType
-      ID: 588
+      ID: 598
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1309728
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 294
+      ID: 304
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 850080
       GoKind: 2
     - __kind: BaseType
-      ID: 265
+      ID: 275
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 847488
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 574
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4039,11 +4039,11 @@ Types:
       GoRuntimeType: 847200
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 367
+      ID: 377
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 365
+      ID: 375
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1762624
@@ -4054,10 +4054,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 698 ArrayType [5]uint8
+          Type: 708 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 699 GoInterfaceType net.Conn
+          Type: 709 GoInterfaceType net.Conn
     - __kind: BaseType
       ID: 1013
       Name: crypto/tls.SignatureScheme
@@ -4065,25 +4065,25 @@ Types:
       GoRuntimeType: 847296
       GoKind: 9
     - __kind: BaseType
-      ID: 531
+      ID: 541
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1009312
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 369
+      ID: 379
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 684
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 695
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 429
+      ID: 439
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1764736
@@ -4091,21 +4091,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 684 PointerType *crypto/x509.Certificate
+          Type: 694 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 708 BaseType crypto/x509.InvalidReason
+          Type: 718 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 423
+      ID: 433
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1139520
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1625568
@@ -4113,24 +4113,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 684 PointerType *crypto/x509.Certificate
+          Type: 694 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 290
+      ID: 300
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 849600
       GoKind: 2
     - __kind: BaseType
-      ID: 708
+      ID: 718
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 598368
       GoKind: 2
     - __kind: StructureType
-      ID: 580
+      ID: 590
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1586336
@@ -4140,13 +4140,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 431
+      ID: 441
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1139776
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 427
+      ID: 437
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1764544
@@ -4154,15 +4154,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 684 PointerType *crypto/x509.Certificate
+          Type: 694 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 684 PointerType *crypto/x509.Certificate
+          Type: 694 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1456864
@@ -4172,7 +4172,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 495
+      ID: 505
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1457024
@@ -4182,47 +4182,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 503
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 266
+      ID: 276
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 6
     - __kind: BaseType
-      ID: 286
+      ID: 296
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 849312
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 389
+      ID: 399
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 576
+      ID: 586
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 381
+      ID: 391
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 397
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 395
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 383
+      ID: 393
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 391
+      ID: 401
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1446304
@@ -4232,15 +4232,15 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 496
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 494
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 300
+      ID: 310
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 851712
@@ -4248,18 +4248,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 302 PointerType *encoding/xml.UnmarshalError.str
+          Type: 312 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 301 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 311 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 301
+      ID: 311
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 489
+      ID: 499
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4276,11 +4276,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 361
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 561
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4296,11 +4296,11 @@ Types:
       GoRuntimeType: 595168
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 545
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 537
+      ID: 547
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4334,7 +4334,7 @@ Types:
       GoRuntimeType: 1025152
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 412
+      ID: 422
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4344,7 +4344,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 394
+      ID: 404
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1763584
@@ -4352,7 +4352,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 700 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 710 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4360,25 +4360,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 396
+      ID: 406
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 705
+      ID: 715
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 400
+      ID: 410
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1138240
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 707
+      ID: 717
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 290
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 848640
@@ -4386,18 +4386,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 292 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 281 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 291 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 291
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 700
+      ID: 710
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2271296
@@ -4405,13 +4405,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 701 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 711 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4420,7 +4420,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 703 GoSliceHeaderType []float64
+          Type: 713 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4429,13 +4429,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 704 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 714 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 706 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 716 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4446,13 +4446,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 701
+      ID: 711
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 596896
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 287
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 848544
@@ -4460,18 +4460,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 289 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 278 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 288 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 288
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 293
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 848736
@@ -4479,18 +4479,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 295 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 294 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 294
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 441
+      ID: 451
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
@@ -4706,16 +4706,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 231 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 237 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 236 GoMapType map[string]interface {}
+          Type: 242 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 750
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 246
+      ID: 256
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1955872
@@ -4796,7 +4796,7 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 660
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4848,29 +4848,29 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 443
+      ID: 453
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 450
+      ID: 460
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1141440
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 299
+      ID: 309
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 851040
       GoKind: 2
     - __kind: StructureType
-      ID: 448
+      ID: 458
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1141312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 446
+      ID: 456
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1626368
@@ -4883,7 +4883,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 458
+      ID: 468
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1627008
@@ -4896,7 +4896,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 462
+      ID: 472
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1766272
@@ -4912,7 +4912,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 460
+      ID: 470
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1455424
@@ -4922,7 +4922,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 456
+      ID: 466
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1455104
@@ -4932,14 +4932,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 686
+      ID: 696
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1528736
       GoKind: 21
-      HeaderType: 688 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 709
+      ID: 719
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1075552
@@ -4954,15 +4954,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 728 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 728
+      ID: 738
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 470
+      ID: 480
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1627328
@@ -4970,12 +4970,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 686 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 686 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 464
+      ID: 474
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1455584
@@ -4985,7 +4985,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 468
+      ID: 478
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1766464
@@ -4996,12 +4996,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 709 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 709 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 466
+      ID: 476
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1627168
@@ -5014,7 +5014,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 472
+      ID: 482
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1455744
@@ -5022,9 +5022,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 146 StructureType time.Time
+          Type: 146 GoTimeType time.Time
     - __kind: StructureType
-      ID: 478
+      ID: 488
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1627648
@@ -5037,7 +5037,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 480
+      ID: 490
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1456064
@@ -5047,7 +5047,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 476
+      ID: 486
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1627488
@@ -5060,7 +5060,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 474
+      ID: 484
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1455904
@@ -5070,7 +5070,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 482
+      ID: 492
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1627808
@@ -5105,7 +5105,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 402
+      ID: 412
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1447584
@@ -5119,7 +5119,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 404
+      ID: 414
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1447744
@@ -5127,7 +5127,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 402 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 793
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -5150,7 +5150,7 @@ Types:
           Offset: 8
           Type: 804 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 408
+      ID: 418
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1448064
@@ -5158,7 +5158,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 402 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 797
       Name: github.com/cihub/seelog.splitDispatcher
@@ -5174,7 +5174,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 406
+      ID: 416
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1447904
@@ -5182,9 +5182,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 402 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 410
+      ID: 420
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1448224
@@ -5192,7 +5192,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 402 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 932
       Name: github.com/cihub/seelog/archive.Reader
@@ -5221,42 +5221,42 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 688
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 594
+      ID: 604
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 602
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 606
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 598
+      ID: 608
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 596
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 415
+      ID: 425
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1449184
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 662
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 648
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1887040
@@ -5272,11 +5272,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 642
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 570
+      ID: 580
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1734944
@@ -5289,7 +5289,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 644
+      ID: 654
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1887488
@@ -5305,13 +5305,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 533
+      ID: 543
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1009984
       GoKind: 8
     - __kind: StructureType
-      ID: 636
+      ID: 646
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1886816
@@ -5327,13 +5327,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 712
+      ID: 722
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 848160
       GoKind: 8
     - __kind: StructureType
-      ID: 634
+      ID: 644
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1886592
@@ -5341,15 +5341,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 712 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 712 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 642
+      ID: 652
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1797920
@@ -5362,7 +5362,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 640
+      ID: 650
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1887264
@@ -5378,7 +5378,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 648
+      ID: 658
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1662656
@@ -5388,19 +5388,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 574
+      ID: 584
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1305888
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 572
+      ID: 582
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1305760
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 646
+      ID: 656
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1798112
@@ -5413,7 +5413,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 317
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 853632
@@ -5421,22 +5421,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 319 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 318 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 318
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 703
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 602
+      ID: 612
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1471264
@@ -5446,19 +5446,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 310
+      ID: 320
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 854208
       GoKind: 10
     - __kind: BaseType
-      ID: 691
+      ID: 701
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1022176
       GoKind: 10
     - __kind: StructureType
-      ID: 660
+      ID: 670
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1920640
@@ -5469,12 +5469,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 691 BaseType golang.org/x/net/http2.ErrCode
+          Type: 701 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 517
+      ID: 527
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1634528
@@ -5482,12 +5482,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 691 BaseType golang.org/x/net/http2.ErrCode
+          Type: 701 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 314
+      ID: 324
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 854400
@@ -5495,18 +5495,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 316 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 326 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 315 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 325 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 315
+      ID: 325
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 320
+      ID: 330
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 854592
@@ -5514,18 +5514,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 322 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 332 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 321 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 331 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 321
+      ID: 331
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 317
+      ID: 327
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 854496
@@ -5533,18 +5533,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 319 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 329 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 318 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 328 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 318
+      ID: 328
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 311
+      ID: 321
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 854304
@@ -5552,18 +5552,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 313 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 323 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 312 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 322 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 312
+      ID: 322
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 521
+      ID: 531
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1471904
@@ -5573,13 +5573,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 323
+      ID: 333
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 854688
       GoKind: 2
     - __kind: StructureType
-      ID: 509
+      ID: 519
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1466944
@@ -5589,11 +5589,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 668
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 680
+      ID: 690
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1949792
@@ -5609,7 +5609,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 511
+      ID: 521
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1634048
@@ -5626,7 +5626,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 600
+      ID: 610
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1593856
@@ -5640,25 +5640,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 497
+      ID: 507
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 590
+      ID: 600
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 666
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 654
+      ID: 664
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1538336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 503
+      ID: 513
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1460224
@@ -5668,7 +5668,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 505
+      ID: 515
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1460384
@@ -5678,7 +5678,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 452
+      ID: 462
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5710,19 +5710,19 @@ Types:
       GroupType: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 835 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 240
+      ID: 250
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 241 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 251 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 242 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 248 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 992
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5752,63 +5752,63 @@ Types:
       GroupType: 857 StructureType noalg.map.group[string][]string
       GroupSliceType: 861 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 222
+      ID: 228
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 223 PointerType *noalg.map.group[string]float64
+          Type: 229 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 224 StructureType noalg.map.group[string]float64
-      GroupSliceType: 228 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 230 StructureType noalg.map.group[string]float64
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 717
+      ID: 727
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 718 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 728 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 719 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 723 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 733 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 214
+      ID: 220
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 215 PointerType *noalg.map.group[string]interface {}
+          Type: 221 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 216 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 220 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 222 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 226 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 206
+      ID: 212
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 207 PointerType *noalg.map.group[string]string
+          Type: 213 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 208 StructureType noalg.map.group[string]string
-      GroupSliceType: 212 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 214 StructureType noalg.map.group[string]string
+      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 524
+      ID: 534
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5855,11 +5855,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 692
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 420
+      ID: 430
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5885,11 +5885,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 418
+      ID: 428
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 640
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5897,13 +5897,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 638
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1503936
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 353
+      ID: 363
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5984,7 +5984,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 297
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 849504
@@ -5992,18 +5992,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 299 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 288 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 298 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 298
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 578
+      ID: 588
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1585376
@@ -6011,7 +6011,7 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 681 PointerType *internal/abi.Type
+          Type: 691 PointerType *internal/abi.Type
     - __kind: StructureType
       ID: 135
       Name: internal/sync.Mutex
@@ -6093,7 +6093,7 @@ Types:
           Offset: 0
           Type: 923 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 636
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6167,7 +6167,7 @@ Types:
       TablePtrSliceType: 834 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 233
+      ID: 239
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6180,7 +6180,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 234 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 240 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6199,8 +6199,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 247 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 242 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 988
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6304,10 +6304,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 227 GoSliceDataType []*table<string,float64>.array
-      GroupType: 224 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 233 GoSliceDataType []*table<string,float64>.array
+      GroupType: 230 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 688
+      ID: 698
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6320,7 +6320,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 689 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 699 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6339,8 +6339,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 722 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 719 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 732 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 165
       Name: map<string,interface {}>
@@ -6374,8 +6374,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 219 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 216 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 225 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 222 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 160
       Name: map<string,string>
@@ -6409,8 +6409,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 211 GoSliceDataType []*table<string,string>.array
-      GroupType: 208 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 217 GoSliceDataType []*table<string,string>.array
+      GroupType: 214 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 138
       Name: map[context.canceler]struct {}
@@ -6426,12 +6426,12 @@ Types:
       GoKind: 21
       HeaderType: 806 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 231
+      ID: 237
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1158336
       GoKind: 21
-      HeaderType: 233 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 239 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 986
       Name: map[string][]*mime/multipart.FileHeader
@@ -6454,7 +6454,7 @@ Types:
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 236
+      ID: 242
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1151808
@@ -6468,7 +6468,7 @@ Types:
       GoKind: 21
       HeaderType: 160 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 439
+      ID: 449
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1452064
@@ -6512,11 +6512,11 @@ Types:
           Offset: 8
           Type: 933 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 622
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 699
+      ID: 709
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1623168
@@ -6529,7 +6529,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 675
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6537,11 +6537,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 663
+      ID: 673
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 624
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6557,7 +6557,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 605
+      ID: 615
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1132992
@@ -6565,18 +6565,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 607 PointerType *net.UnknownNetworkError.str
+          Type: 617 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 606 GoStringDataType net.UnknownNetworkError.str
+      Data: 616 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 606
+      ID: 616
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 539
+      ID: 549
       Name: net.canceledError
       GoRuntimeType: 1303456
       GoKind: 25
@@ -6586,7 +6586,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 711
+      ID: 721
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2154688
@@ -6594,7 +6594,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 699 GoInterfaceType net.Conn
+          Type: 709 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -6621,7 +6621,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 325
+      ID: 335
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6638,7 +6638,7 @@ Types:
           Offset: 16
           Type: 118 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 327
+      ID: 337
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1757824
@@ -6646,7 +6646,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 694 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 704 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6680,11 +6680,11 @@ Types:
           Offset: 0
           Type: 963 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 626
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 677
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6734,11 +6734,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 333
+      ID: 343
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 551
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6790,7 +6790,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6835,7 +6835,7 @@ Types:
           Type: 873 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 158 GoMapType map[string]string
@@ -6872,7 +6872,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6945,19 +6945,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 249
+      ID: 259
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 845184
       GoKind: 10
     - __kind: BaseType
-      ID: 683
+      ID: 693
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1006528
       GoKind: 10
     - __kind: StructureType
-      ID: 336
+      ID: 346
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1759552
@@ -6968,12 +6968,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 683 BaseType net/http.http2ErrCode
+          Type: 693 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 669
+      ID: 679
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1939296
@@ -6984,7 +6984,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 683 BaseType net/http.http2ErrCode
+          Type: 693 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
@@ -6993,7 +6993,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 342
+      ID: 352
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1623648
@@ -7001,12 +7001,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 683 BaseType net/http.http2ErrCode
+          Type: 693 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 253
+      ID: 263
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 845376
@@ -7014,18 +7014,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 255 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 265 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 254 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 254
+      ID: 264
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 340
+      ID: 350
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1134272
       GoKind: 25
@@ -7035,7 +7035,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 259
+      ID: 269
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 845568
@@ -7043,18 +7043,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 261 PointerType *net/http.http2headerFieldNameError.str
+          Type: 271 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 260 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 270 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 260
+      ID: 270
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 256
+      ID: 266
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 845472
@@ -7062,18 +7062,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 258 PointerType *net/http.http2headerFieldValueError.str
+          Type: 268 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 257 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 267 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 257
+      ID: 267
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 630
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -7089,13 +7089,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 547
+      ID: 557
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1304096
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 250
+      ID: 260
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 845280
@@ -7103,13 +7103,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 252 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 262 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 251 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 261 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 251
+      ID: 261
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7152,7 +7152,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 543
+      ID: 553
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1578016
@@ -7192,7 +7192,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 346
+      ID: 356
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1438944
@@ -7267,7 +7267,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 841 StructureType sync/atomic.Bool
@@ -7306,7 +7306,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 331
+      ID: 341
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1623488
@@ -7319,17 +7319,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 681
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 618
+      ID: 628
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1490496
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 545
+      ID: 555
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1578176
@@ -7347,12 +7347,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 699 GoInterfaceType net.Conn
+          Type: 709 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 699 GoInterfaceType net.Conn
+          Type: 709 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 329
+      ID: 339
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7362,7 +7362,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 361
+      ID: 371
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1762240
@@ -7378,7 +7378,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 359
+      ID: 369
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1624608
@@ -7391,11 +7391,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 376
+      ID: 386
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 283
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 847872
@@ -7403,22 +7403,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *net/textproto.ProtocolError.str
+          Type: 285 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType net/textproto.ProtocolError.str
+      Data: 284 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 284
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 686
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 277
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 847680
@@ -7426,18 +7426,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *net/url.EscapeError.str
+          Type: 279 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType net/url.EscapeError.str
+      Data: 278 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 278
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 280
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 847776
@@ -7445,13 +7445,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *net/url.InvalidHostError.str
+          Type: 282 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 271 GoStringDataType net/url.InvalidHostError.str
+      Data: 281 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 281
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7525,14 +7525,14 @@ Types:
       HasCount: true
       Element: 832 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 243
+      ID: 253
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 244 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 254 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 995
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7552,41 +7552,41 @@ Types:
       HasCount: true
       Element: 859 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 225
+      ID: 231
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 226 StructureType noalg.struct { key string; elem float64 }
+      Element: 232 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 720
+      ID: 730
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 776960
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 721 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 731 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 217
+      ID: 223
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 218 StructureType noalg.struct { key string; elem interface {} }
+      Element: 224 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 209
+      ID: 215
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 210 StructureType noalg.struct { key string; elem string }
+      Element: 216 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 196
       Name: noalg.map.group[context.canceler]struct {}
@@ -7614,7 +7614,7 @@ Types:
           Offset: 8
           Type: 831 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 242
+      ID: 252
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1332000
@@ -7625,7 +7625,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 243 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 253 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 994
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7653,7 +7653,7 @@ Types:
           Offset: 8
           Type: 858 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 224
+      ID: 230
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1331744
@@ -7664,9 +7664,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 225 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 231 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 719
+      ID: 729
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1380896
@@ -7677,9 +7677,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 720 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 730 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 216
+      ID: 222
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1314080
@@ -7690,9 +7690,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 217 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 223 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 208
+      ID: 214
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1319072
@@ -7703,7 +7703,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 209 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 215 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 198
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7731,7 +7731,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 244
+      ID: 254
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1331872
@@ -7742,7 +7742,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 245 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 255 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 996
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7768,9 +7768,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 226
+      ID: 232
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1331616
@@ -7783,7 +7783,7 @@ Types:
           Offset: 16
           Type: 17 BaseType float64
     - __kind: StructureType
-      ID: 721
+      ID: 731
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1380768
@@ -7794,9 +7794,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 709 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 218
+      ID: 224
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1313952
@@ -7809,7 +7809,7 @@ Types:
           Offset: 16
           Type: 137 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 210
+      ID: 216
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1318944
@@ -7826,7 +7826,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 549
+      ID: 559
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7843,7 +7843,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 632
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7885,15 +7885,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 582
+      ID: 592
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 725
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 584
+      ID: 594
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1735328
@@ -7927,7 +7927,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 304
+      ID: 314
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 852864
@@ -7935,36 +7935,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 306 PointerType *os/user.UnknownGroupIdError.str
+          Type: 316 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 305 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 315 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 305
+      ID: 315
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 303
+      ID: 313
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 852768
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 355
+      ID: 365
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 454
+      ID: 464
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 567
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 571
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7976,7 +7976,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 559
+      ID: 569
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1928032
@@ -7993,9 +7993,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 713 BaseType runtime.boundsErrorCode
+          Type: 723 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 713
+      ID: 723
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 595360
@@ -8015,7 +8015,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 624
+      ID: 634
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1792928
@@ -8028,7 +8028,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 525
+      ID: 535
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1007776
@@ -8036,13 +8036,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 527 PointerType *runtime.errorString.str
+          Type: 537 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 526 GoStringDataType runtime.errorString.str
+      Data: 536 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 526
+      ID: 536
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8705,7 +8705,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 528
+      ID: 538
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1007872
@@ -8713,13 +8713,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 530 PointerType *runtime.plainError.str
+          Type: 540 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 529 GoStringDataType runtime.plainError.str
+      Data: 539 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 529
+      ID: 539
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8760,7 +8760,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 357
+      ID: 367
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1624288
@@ -8818,7 +8818,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 553
+      ID: 563
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9189,7 +9189,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 661
+      ID: 671
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1304992
@@ -9249,7 +9249,7 @@ Types:
           Offset: 16
           Type: 828 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 239
+      ID: 249
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9271,7 +9271,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 240 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 250 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 991
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9321,7 +9321,7 @@ Types:
           Offset: 16
           Type: 855 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 221
+      ID: 227
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9343,9 +9343,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 222 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 228 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 716
+      ID: 726
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9367,9 +9367,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 717 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 727 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 213
+      ID: 219
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9391,9 +9391,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 214 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 220 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 205
+      ID: 211
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9415,9 +9415,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 206 GoSwissMapGroupsType groupReference<string,string>
+          Type: 212 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 604
+      ID: 614
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1739552
@@ -9447,10 +9447,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 731 GoSliceHeaderType []time.zone
+          Type: 203 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 734 GoSliceHeaderType []time.zoneTrans
+          Type: 206 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9462,12 +9462,12 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 732 PointerType *time.zone
+          Type: 204 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 349
+      ID: 359
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 146
       Name: time.Time
       ByteSize: 24
@@ -9483,6 +9483,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 147 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 145
       Name: time.Timer
@@ -9492,12 +9500,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 730 GoChannelType <-chan time.Time
+          Type: 740 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 262
+      ID: 272
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 845664
@@ -9505,18 +9513,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 264 PointerType *time.fileSizeError.str
+          Type: 274 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 263 GoStringDataType time.fileSizeError.str
+      Data: 273 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 263
+      ID: 273
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 733
+      ID: 205
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1647488
@@ -9532,7 +9540,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 736
+      ID: 208
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1789472
@@ -9593,7 +9601,7 @@ Types:
       GoRuntimeType: 595296
       GoKind: 26
     - __kind: StructureType
-      ID: 694
+      ID: 704
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2104032
@@ -9604,10 +9612,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 695 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 696 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 706 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9622,18 +9630,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 697 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 697
+      ID: 707
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1008928
       GoKind: 9
     - __kind: StructureType
-      ID: 695
+      ID: 705
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1958944
@@ -9658,17 +9666,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 363
+      ID: 373
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 696
+      ID: 706
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 596192
       GoKind: 8
     - __kind: StructureType
-      ID: 378
+      ID: 388
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1444384
@@ -9678,13 +9686,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 276
+      ID: 286
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 847968
       GoKind: 2
     - __kind: StructureType
-      ID: 566
+      ID: 576
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1734752
@@ -9697,7 +9705,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 532
+      ID: 542
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1009792

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.26rc1.yaml
@@ -120,7 +120,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 694 PointerType *crypto/x509.Certificate
+      Pointee: 704 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 752
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -150,10 +150,10 @@ Types:
       ByteSize: 8
       Pointee: 818 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 244
+      ID: 250
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 245 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 251 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 999
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -170,10 +170,10 @@ Types:
       ByteSize: 8
       Pointee: 182 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 699
+      ID: 709
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 710 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 176
       Name: '**table<string,interface {}>'
@@ -221,30 +221,30 @@ Types:
       ByteSize: 8
       Pointee: 1028 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 737
+      ID: 747
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 736 GoSliceDataType []float64.array
+      Pointee: 746 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 240
+      ID: 246
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 245 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 248
+      ID: 254
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 253 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1034
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1033 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 214
+      ID: 220
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []os.Signal.array
+      Pointee: 219 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -253,20 +253,20 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 735
+      ID: 745
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 734 GoSliceDataType []string.array
+      Pointee: 744 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 748
+      ID: 256
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 747 GoSliceDataType []time.zone.array
+      Pointee: 255 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 750
+      ID: 258
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 749 GoSliceDataType []time.zoneTrans.array
+      Pointee: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1021
       Name: '*[]uint8'
@@ -285,17 +285,17 @@ Types:
       ByteSize: 8
       Pointee: 198 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 960224
       GoKind: 22
-      Pointee: 509 GoSliceHeaderType archive/tar.headerError
+      Pointee: 519 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 510 GoSliceDataType archive/tar.headerError.array
+      Pointee: 520 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 921
       Name: '*archive/zip.checksumReader'
@@ -353,24 +353,24 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 392
+      ID: 402
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 935360
       GoKind: 22
-      Pointee: 290 BaseType compress/flate.CorruptInputError
+      Pointee: 300 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 935456
       GoKind: 22
-      Pointee: 291 GoStringHeaderType compress/flate.InternalError
+      Pointee: 301 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 293
+      ID: 303
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 292 GoStringDataType compress/flate.InternalError.str
+      Pointee: 302 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 961
       Name: '*compress/flate.decompressor'
@@ -407,12 +407,12 @@ Types:
       GoKind: 22
       Pointee: 128 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1215872
       GoKind: 22
-      Pointee: 619 StructureType context.deadlineExceededError
+      Pointee: 629 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1035
       Name: '*context.emptyCtx'
@@ -456,54 +456,54 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945152
       GoKind: 22
-      Pointee: 309 BaseType crypto/aes.KeySizeError
+      Pointee: 319 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945344
       GoKind: 22
-      Pointee: 310 BaseType crypto/des.KeySizeError
+      Pointee: 320 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 451
+      ID: 461
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945632
       GoKind: 22
-      Pointee: 311 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 321 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 597
+      ID: 607
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1089024
       GoKind: 22
-      Pointee: 598 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 608 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945920
       GoKind: 22
-      Pointee: 312 BaseType crypto/rc4.KeySizeError
+      Pointee: 322 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 933440
       GoKind: 22
-      Pointee: 279 BaseType crypto/tls.AlertError
+      Pointee: 289 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 573
+      ID: 583
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1070080
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 584 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 991
       Name: '*crypto/tls.Conn'
@@ -519,187 +519,187 @@ Types:
       GoKind: 22
       Pointee: 879 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 933536
       GoKind: 22
-      Pointee: 383 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 393 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 379
+      ID: 389
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 933344
       GoKind: 22
-      Pointee: 380 StructureType crypto/tls.RecordHeaderError
+      Pointee: 390 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1068416
       GoKind: 22
-      Pointee: 541 BaseType crypto/tls.alert
+      Pointee: 551 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 933632
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 395 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 683
+      ID: 693
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1453376
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 694 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 694
+      ID: 704
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2079168
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 705 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 944768
       GoKind: 22
-      Pointee: 446 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 456 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 439
+      ID: 449
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 943808
       GoKind: 22
-      Pointee: 440 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 450 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 441
+      ID: 451
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 944288
       GoKind: 22
-      Pointee: 442 StructureType crypto/x509.HostnameError
+      Pointee: 452 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 943712
       GoKind: 22
-      Pointee: 308 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 318 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 589
+      ID: 599
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1080064
       GoKind: 22
-      Pointee: 590 StructureType crypto/x509.SystemRootsError
+      Pointee: 600 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 944864
       GoKind: 22
-      Pointee: 448 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 458 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 944672
       GoKind: 22
-      Pointee: 444 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 454 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 955616
       GoKind: 22
-      Pointee: 501 StructureType encoding/asn1.StructuralError
+      Pointee: 511 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 504
+      ID: 514
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 955808
       GoKind: 22
-      Pointee: 505 StructureType encoding/asn1.SyntaxError
+      Pointee: 515 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 955712
       GoKind: 22
-      Pointee: 503 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 513 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 933824
       GoKind: 22
-      Pointee: 280 BaseType encoding/base64.CorruptInputError
+      Pointee: 290 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 942464
       GoKind: 22
-      Pointee: 304 BaseType encoding/hex.InvalidByteError
+      Pointee: 314 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 405
+      ID: 415
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 937664
       GoKind: 22
-      Pointee: 406 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 416 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 585
+      ID: 595
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1075200
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 596 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 937280
       GoKind: 22
-      Pointee: 398 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 408 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 403
+      ID: 413
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 937568
       GoKind: 22
-      Pointee: 404 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 414 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 937472
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 412 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 399
+      ID: 409
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 407
+      ID: 417
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 938048
       GoKind: 22
-      Pointee: 408 StructureType encoding/json.jsonError
+      Pointee: 418 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 953024
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 509 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -708,19 +708,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 928352
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType errors.errorString
+      Pointee: 375 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 560
+      ID: 570
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1061248
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType errors.joinError
+      Pointee: 571 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -736,26 +736,26 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 544
+      ID: 554
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1050624
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType fmt.wrapError
+      Pointee: 555 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 546
+      ID: 556
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1050752
       GoKind: 22
-      Pointee: 547 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 557 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 429 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 439 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 819
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -764,83 +764,83 @@ Types:
       GoKind: 22
       Pointee: 820 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 939296
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 421 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 939392
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 423 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 714
+      ID: 724
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 939104
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 725 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 939680
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 427 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 716
+      ID: 726
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 939200
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 727 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 939488
       GoKind: 22
-      Pointee: 298 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 308 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 300
+      ID: 310
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 299 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 309 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 409
+      ID: 419
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 939008
       GoKind: 22
-      Pointee: 295 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 305 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 297
+      ID: 307
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 296 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 939584
       GoKind: 22
-      Pointee: 301 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 311 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 303
+      ID: 313
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 302 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 312 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 455
+      ID: 465
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 947072
       GoKind: 22
-      Pointee: 456 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 466 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 810
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
@@ -898,12 +898,12 @@ Types:
       GoKind: 22
       Pointee: 760 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 255
+      ID: 265
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1223552
       GoKind: 22
-      Pointee: 256 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 266 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 191
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
@@ -919,12 +919,12 @@ Types:
       GoKind: 22
       Pointee: 826 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1245696
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 670 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 761
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
@@ -961,143 +961,143 @@ Types:
       GoKind: 22
       Pointee: 904 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 949280
       GoKind: 22
-      Pointee: 458 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 468 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 950336
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 475 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 950048
       GoKind: 22
-      Pointee: 313 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 323 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 462
+      ID: 472
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 950240
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 473 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 460
+      ID: 470
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 950144
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 471 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 472
+      ID: 482
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 951680
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 483 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 476
+      ID: 486
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 951872
       GoKind: 22
-      Pointee: 477 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 487 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 951776
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 485 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 951584
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 481 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 739
+      ID: 749
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 748 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 484
+      ID: 494
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 952256
       GoKind: 22
-      Pointee: 485 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 495 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 951968
       GoKind: 22
-      Pointee: 479 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 489 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 482
+      ID: 492
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 952160
       GoKind: 22
-      Pointee: 483 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 493 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 480
+      ID: 490
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 952064
       GoKind: 22
-      Pointee: 481 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 491 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 952352
       GoKind: 22
-      Pointee: 487 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 497 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 952640
       GoKind: 22
-      Pointee: 493 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 503 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 952736
       GoKind: 22
-      Pointee: 495 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 505 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 952544
       GoKind: 22
-      Pointee: 491 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 501 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 952448
       GoKind: 22
-      Pointee: 489 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 499 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 952928
       GoKind: 22
-      Pointee: 497 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 507 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 835
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1127,12 +1127,12 @@ Types:
       GoKind: 22
       Pointee: 834 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 940832
       GoKind: 22
-      Pointee: 419 StructureType github.com/cihub/seelog.baseError
+      Pointee: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 812
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1141,12 +1141,12 @@ Types:
       GoKind: 22
       Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 940928
       GoKind: 22
-      Pointee: 421 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 431 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 802
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1169,12 +1169,12 @@ Types:
       GoKind: 22
       Pointee: 809 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 941120
       GoKind: 22
-      Pointee: 425 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 435 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 806
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1190,19 +1190,19 @@ Types:
       GoKind: 22
       Pointee: 828 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 941024
       GoKind: 22
-      Pointee: 423 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 433 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 941216
       GoKind: 22
-      Pointee: 427 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 437 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 919
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1218,289 +1218,289 @@ Types:
       GoKind: 22
       Pointee: 945 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 687
+      ID: 697
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1472416
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 698 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 603
+      ID: 613
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1097344
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 614 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 601
+      ID: 611
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1097216
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 612 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 605
+      ID: 615
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1101696
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 616 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 607
+      ID: 617
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1101824
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 618 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 595
+      ID: 605
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1086208
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 606 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 942656
       GoKind: 22
-      Pointee: 432 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 442 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 661
+      ID: 671
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1254400
       GoKind: 22
-      Pointee: 662 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 672 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 647
+      ID: 657
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1237760
       GoKind: 22
-      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 641
+      ID: 651
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1237376
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 652 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 579
+      ID: 589
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1073024
       GoKind: 22
-      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 653
+      ID: 663
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1238144
       GoKind: 22
-      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1072896
       GoKind: 22
-      Pointee: 543 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 553 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 645
+      ID: 655
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1237632
       GoKind: 22
-      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 643
+      ID: 653
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1237504
       GoKind: 22
-      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1238016
       GoKind: 22
-      Pointee: 652 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1237888
       GoKind: 22
-      Pointee: 650 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1238528
       GoKind: 22
-      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 583
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1073280
       GoKind: 22
-      Pointee: 584 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 581
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1073152
       GoKind: 22
-      Pointee: 582 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1238400
       GoKind: 22
-      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 971648
       GoKind: 22
-      Pointee: 318 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 328 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 320
+      ID: 330
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 329 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 702
+      ID: 712
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1715328
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 713 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1116544
       GoKind: 22
-      Pointee: 612 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 622 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 972896
       GoKind: 22
-      Pointee: 321 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 331 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 669
+      ID: 679
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1293056
       GoKind: 22
-      Pointee: 670 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 680 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 526
+      ID: 536
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 973184
       GoKind: 22
-      Pointee: 527 StructureType golang.org/x/net/http2.connError
+      Pointee: 537 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 525
+      ID: 535
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 973088
       GoKind: 22
-      Pointee: 325 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 335 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 336 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 973376
       GoKind: 22
-      Pointee: 331 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 341 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 333
+      ID: 343
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 342 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 528
+      ID: 538
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 973280
       GoKind: 22
-      Pointee: 328 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 338 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 339 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 524
+      ID: 534
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 972992
       GoKind: 22
-      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 332 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 324
+      ID: 334
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 333 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 530
+      ID: 540
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 973472
       GoKind: 22
-      Pointee: 531 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 541 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 532
+      ID: 542
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 973568
       GoKind: 22
-      Pointee: 334 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 344 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 967328
       GoKind: 22
-      Pointee: 519 StructureType google.golang.org/grpc.dropError
+      Pointee: 529 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 667
+      ID: 677
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1290112
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 678 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 689
+      ID: 699
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1479936
       GoKind: 22
-      Pointee: 690 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 700 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 520
+      ID: 530
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 969920
       GoKind: 22
-      Pointee: 521 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 531 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 950
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1509,12 +1509,12 @@ Types:
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 609
+      ID: 619
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1110784
       GoKind: 22
-      Pointee: 610 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 620 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 934
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1523,61 +1523,61 @@ Types:
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 958880
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 517 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 599
+      ID: 609
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1090944
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 610 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 665
+      ID: 675
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1259136
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 676 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 663
+      ID: 673
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1258880
       GoKind: 22
-      Pointee: 664 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 674 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 512
+      ID: 522
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 961184
       GoKind: 22
-      Pointee: 513 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 523 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 961280
       GoKind: 22
-      Pointee: 515 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 525 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 950432
       GoKind: 22
-      Pointee: 467 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 477 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 533
+      ID: 543
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 974336
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType html/template.Error
+      Pointee: 544 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 106
       Name: '*int'
@@ -1614,33 +1614,33 @@ Types:
       GoKind: 22
       Pointee: 22 BaseType int8
     - __kind: PointerType
-      ID: 691
+      ID: 701
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2273344
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType internal/abi.Type
+      Pointee: 702 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 943328
       GoKind: 22
-      Pointee: 437 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 447 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 943232
       GoKind: 22
-      Pointee: 435 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 445 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 639
+      ID: 649
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1232000
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 650 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 989
       Name: '*internal/poll.FD'
@@ -1649,19 +1649,19 @@ Types:
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 637
+      ID: 647
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1231872
       GoKind: 22
-      Pointee: 638 StructureType internal/poll.errNetClosing
+      Pointee: 648 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 928736
       GoKind: 22
-      Pointee: 367 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 377 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -1670,31 +1670,31 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 433
+      ID: 443
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 943136
       GoKind: 22
-      Pointee: 305 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 315 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 307
+      ID: 317
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 316 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 587
+      ID: 597
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1078912
       GoKind: 22
-      Pointee: 588 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 598 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 376
+      ID: 386
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 932384
       GoKind: 22
-      Pointee: 278 BaseType internal/strconv.Error
+      Pointee: 288 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 954
       Name: '*io.PipeReader'
@@ -1724,12 +1724,12 @@ Types:
       GoKind: 22
       Pointee: 918 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 635
+      ID: 645
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1230848
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType io/fs.PathError
+      Pointee: 646 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 145
       Name: '*map<context.canceler,struct {}>'
@@ -1741,10 +1741,10 @@ Types:
       ByteSize: 8
       Pointee: 816 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 242
+      ID: 248
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 243 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 249 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 997
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1761,10 +1761,10 @@ Types:
       ByteSize: 8
       Pointee: 180 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 697
+      ID: 707
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 708 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 174
       Name: '*map<string,interface {}>'
@@ -1776,12 +1776,12 @@ Types:
       ByteSize: 8
       Pointee: 170 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 453
+      ID: 463
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 946688
       GoKind: 22
-      Pointee: 454 StructureType math/big.ErrNaN
+      Pointee: 464 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 1009
       Name: '*mime/multipart.FileHeader'
@@ -1811,19 +1811,19 @@ Types:
       GoKind: 22
       Pointee: 939 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 621
+      ID: 631
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1217024
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType net.AddrError
+      Pointee: 632 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 674
+      ID: 684
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1446176
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType net.DNSError
+      Pointee: 685 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 965
       Name: '*net.IPConn'
@@ -1832,19 +1832,19 @@ Types:
       GoKind: 22
       Pointee: 966 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 672
+      ID: 682
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1445856
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType net.OpError
+      Pointee: 683 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 623
+      ID: 633
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1217152
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType net.ParseError
+      Pointee: 634 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 973
       Name: '*net.TCPConn'
@@ -1867,24 +1867,24 @@ Types:
       GoKind: 22
       Pointee: 972 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1216256
       GoKind: 22
-      Pointee: 615 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 625 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 616 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 626 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 548
+      ID: 558
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1051648
       GoKind: 22
-      Pointee: 549 StructureType net.canceledError
+      Pointee: 559 StructureType net.canceledError
     - __kind: PointerType
       ID: 963
       Name: '*net.conn'
@@ -1893,12 +1893,12 @@ Types:
       GoKind: 22
       Pointee: 964 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 720
+      ID: 730
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1893376
       GoKind: 22
-      Pointee: 721 StructureType net.dialResult·1
+      Pointee: 731 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 979
       Name: '*net.netFD'
@@ -1907,12 +1907,12 @@ Types:
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 921152
       GoKind: 22
-      Pointee: 336 UnresolvedPointeeType net.notFoundError
+      Pointee: 346 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1036
       Name: '*net.onlyValuesCtx'
@@ -1921,12 +1921,12 @@ Types:
       GoKind: 22
       Pointee: 1037 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 921824
       GoKind: 22
-      Pointee: 338 StructureType net.result·2
+      Pointee: 348 StructureType net.result·2
     - __kind: PointerType
       ID: 969
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1942,33 +1942,33 @@ Types:
       GoKind: 22
       Pointee: 968 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 625
+      ID: 635
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1217792
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType net.temporaryError
+      Pointee: 636 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 676
+      ID: 686
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1446496
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType net.timeoutError
+      Pointee: 687 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 343
+      ID: 353
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 344 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 354 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1055360
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 561 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 118
       Name: '*net/http.Request'
@@ -2026,26 +2026,26 @@ Types:
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 924608
       GoKind: 22
-      Pointee: 259 BaseType net/http.http2ConnectionError
+      Pointee: 269 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 347 StructureType net/http.http2GoAwayError
+      Pointee: 357 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 678
+      ID: 688
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1447296
       GoKind: 22
-      Pointee: 679 StructureType net/http.http2StreamError
+      Pointee: 689 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 927
       Name: '*net/http.http2clientStream'
@@ -2054,31 +2054,31 @@ Types:
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 352
+      ID: 362
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 925760
       GoKind: 22
-      Pointee: 353 StructureType net/http.http2connError
+      Pointee: 363 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 349
+      ID: 359
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 925184
       GoKind: 22
-      Pointee: 263 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 273 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 265
+      ID: 275
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 274 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 925280
       GoKind: 22
-      Pointee: 351 StructureType net/http.http2goAwayFlowError
+      Pointee: 361 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 929
       Name: '*net/http.http2gzipReader'
@@ -2087,36 +2087,36 @@ Types:
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 925952
       GoKind: 22
-      Pointee: 269 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 279 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 271
+      ID: 281
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 270 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 280 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 354
+      ID: 364
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 925856
       GoKind: 22
-      Pointee: 266 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 276 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 268
+      ID: 278
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 277 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 629
+      ID: 639
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1221376
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 640 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 891
       Name: '*net/http.http2missingBody'
@@ -2132,24 +2132,24 @@ Types:
       GoKind: 22
       Pointee: 900 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 556
+      ID: 566
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1057536
       GoKind: 22
-      Pointee: 557 StructureType net/http.http2noCachedConnError
+      Pointee: 567 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 925088
       GoKind: 22
-      Pointee: 260 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 270 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 262
+      ID: 272
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 261 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 271 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 897
       Name: '*net/http.http2requestBody'
@@ -2193,12 +2193,12 @@ Types:
       GoKind: 22
       Pointee: 916 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1057280
       GoKind: 22
-      Pointee: 553 StructureType net/http.nothingWrittenError
+      Pointee: 563 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 883
       Name: '*net/http.pattern'
@@ -2221,12 +2221,12 @@ Types:
       GoKind: 22
       Pointee: 924 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 926144
       GoKind: 22
-      Pointee: 357 StructureType net/http.requestBodyReadError
+      Pointee: 367 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 800
       Name: '*net/http.response'
@@ -2242,33 +2242,33 @@ Types:
       GoKind: 22
       Pointee: 1032 StructureType net/http.segment
     - __kind: PointerType
-      ID: 341
+      ID: 351
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 924320
       GoKind: 22
-      Pointee: 342 StructureType net/http.statusError
+      Pointee: 352 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 680
+      ID: 690
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1448736
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 691 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 627
+      ID: 637
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1221248
       GoKind: 22
-      Pointee: 628 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 638 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1057408
       GoKind: 22
-      Pointee: 555 StructureType net/http.transportReadFromServerError
+      Pointee: 565 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 952
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2277,12 +2277,12 @@ Types:
       GoKind: 22
       Pointee: 953 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 923552
       GoKind: 22
-      Pointee: 340 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 350 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 909
       Name: '*net/http/httputil.failureToReadBody'
@@ -2291,69 +2291,69 @@ Types:
       GoKind: 22
       Pointee: 910 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 931616
       GoKind: 22
-      Pointee: 375 StructureType net/netip.parseAddrError
+      Pointee: 385 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 372
+      ID: 382
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 931520
       GoKind: 22
-      Pointee: 373 StructureType net/netip.parsePrefixError
+      Pointee: 383 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 935072
       GoKind: 22
-      Pointee: 391 UnresolvedPointeeType net/textproto.Error
+      Pointee: 401 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 934976
       GoKind: 22
-      Pointee: 287 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 297 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 289
+      ID: 299
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 298 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 685
+      ID: 695
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1453696
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType net/url.Error
+      Pointee: 696 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 933920
       GoKind: 22
-      Pointee: 281 GoStringHeaderType net/url.EscapeError
+      Pointee: 291 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 283
+      ID: 293
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 282 GoStringDataType net/url.EscapeError.str
+      Pointee: 292 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 934016
       GoKind: 22
-      Pointee: 284 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 294 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 286
+      ID: 296
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 295 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 872
       Name: '*net/url.URL'
@@ -2379,10 +2379,10 @@ Types:
       ByteSize: 8
       Pointee: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 251
+      ID: 261
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 1003
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2394,25 +2394,25 @@ Types:
       ByteSize: 8
       Pointee: 867 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 233
+      ID: 239
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 234 StructureType noalg.map.group[string]float64
+      Pointee: 240 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 728
+      ID: 738
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 225
+      ID: 231
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 226 StructureType noalg.map.group[string]interface {}
+      Pointee: 232 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 217
+      ID: 223
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 218 StructureType noalg.map.group[string]string
+      Pointee: 224 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 985
       Name: '*os.File'
@@ -2421,12 +2421,12 @@ Types:
       GoKind: 22
       Pointee: 986 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 558
+      ID: 568
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1059712
       GoKind: 22
-      Pointee: 559 UnresolvedPointeeType os.LinkError
+      Pointee: 569 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 163
       Name: '*os.Signal'
@@ -2435,12 +2435,12 @@ Types:
       GoKind: 22
       Pointee: 164 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 631
+      ID: 641
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1221760
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType os.SyscallError
+      Pointee: 642 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 983
       Name: '*os.fileWithoutReadFrom'
@@ -2456,26 +2456,26 @@ Types:
       GoKind: 22
       Pointee: 982 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1081856
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType os/exec.Error
+      Pointee: 602 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 724
+      ID: 734
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2163264
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 735 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1081984
       GoKind: 22
-      Pointee: 594 StructureType os/exec.wrappedError
+      Pointee: 604 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 137
       Name: '*os/signal.signalCtx'
@@ -2484,64 +2484,64 @@ Types:
       GoKind: 22
       Pointee: 138 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 358
+      ID: 368
       Name: '*os/signal.signalError'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 272 GoStringHeaderType os/signal.signalError
+      Pointee: 282 GoStringHeaderType os/signal.signalError
     - __kind: PointerType
-      ID: 274
+      ID: 284
       Name: '*os/signal.signalError.str'
       ByteSize: 8
-      Pointee: 273 GoStringDataType os/signal.signalError.str
+      Pointee: 283 GoStringDataType os/signal.signalError.str
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 965408
       GoKind: 22
-      Pointee: 315 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 325 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 317
+      ID: 327
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 316 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 326 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 516
+      ID: 526
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 965312
       GoKind: 22
-      Pointee: 314 BaseType os/user.UnknownUserIdError
+      Pointee: 324 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 929504
       GoKind: 22
-      Pointee: 369 UnresolvedPointeeType reflect.ValueError
+      Pointee: 379 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 950912
       GoKind: 22
-      Pointee: 469 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 479 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 566
+      ID: 576
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1065600
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 577 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 570
+      ID: 580
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1066240
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 581 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -2557,12 +2557,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1065728
       GoKind: 22
-      Pointee: 569 StructureType runtime.boundsError
+      Pointee: 579 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -2578,24 +2578,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 633
+      ID: 643
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1230336
       GoKind: 22
-      Pointee: 634 StructureType runtime.errorAddressString
+      Pointee: 644 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1063936
       GoKind: 22
-      Pointee: 535 GoStringHeaderType runtime.errorString
+      Pointee: 545 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 537
+      ID: 547
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType runtime.errorString.str
+      Pointee: 546 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -2618,17 +2618,17 @@ Types:
       GoKind: 22
       Pointee: 200 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1064064
       GoKind: 22
-      Pointee: 538 GoStringHeaderType runtime.plainError
+      Pointee: 548 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 540
+      ID: 550
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 539 GoStringDataType runtime.plainError.str
+      Pointee: 549 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -2644,12 +2644,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 370
+      ID: 380
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 931232
       GoKind: 22
-      Pointee: 371 StructureType runtime.synctestDeadlockError
+      Pointee: 381 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -2672,12 +2672,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1063552
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType strconv.NumError
+      Pointee: 573 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -2803,12 +2803,12 @@ Types:
       GoKind: 22
       Pointee: 912 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 682
+      ID: 692
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1452576
       GoKind: 22
-      Pointee: 671 BaseType syscall.Errno
+      Pointee: 681 BaseType syscall.Errno
     - __kind: PointerType
       ID: 757
       Name: '*syscall.Signal'
@@ -2827,10 +2827,10 @@ Types:
       ByteSize: 8
       Pointee: 837 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 245
+      ID: 251
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 249 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 259 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 1000
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2845,29 +2845,29 @@ Types:
       ID: 182
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 231 StructureType table<string,float64>
+      Pointee: 237 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 700
+      ID: 710
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 726 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 736 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 223 StructureType table<string,interface {}>
+      Pointee: 229 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 172
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 215 StructureType table<string,string>
+      Pointee: 221 StructureType table<string,string>
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1120384
       GoKind: 22
-      Pointee: 614 StructureType text/template.ExecError
+      Pointee: 624 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 158
       Name: '*time.Location'
@@ -2876,12 +2876,12 @@ Types:
       GoKind: 22
       Pointee: 159 StructureType time.Location
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 363 UnresolvedPointeeType time.ParseError
+      Pointee: 373 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 155
       Name: '*time.Timer'
@@ -2890,38 +2890,38 @@ Types:
       GoKind: 22
       Pointee: 156 StructureType time.Timer
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 927008
       GoKind: 22
-      Pointee: 275 GoStringHeaderType time.fileSizeError
+      Pointee: 285 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 277
+      ID: 287
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 276 GoStringDataType time.fileSizeError.str
+      Pointee: 286 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 927104
       GoKind: 22
-      Pointee: 361 UnresolvedPointeeType time.parseDurationError
+      Pointee: 371 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 742
+      ID: 214
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 404672
       GoKind: 22
-      Pointee: 743 StructureType time.zone
+      Pointee: 215 StructureType time.zone
     - __kind: PointerType
-      ID: 745
+      ID: 217
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 404736
       GoKind: 22
-      Pointee: 746 StructureType time.zoneTrans
+      Pointee: 218 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -2965,47 +2965,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 932480
       GoKind: 22
-      Pointee: 378 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 388 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 394
+      ID: 404
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 395 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 405 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 396
+      ID: 406
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 935840
       GoKind: 22
-      Pointee: 294 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 304 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 575
+      ID: 585
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1071616
       GoKind: 22
-      Pointee: 576 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 586 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1071744
       GoKind: 22
-      Pointee: 542 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 552 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 880
       Name: <-chan struct {}
       GoRuntimeType: 613696
       GoKind: 18
     - __kind: GoChannelType
-      ID: 740
+      ID: 750
       Name: <-chan time.Time
       GoRuntimeType: 619392
       GoKind: 18
@@ -3183,7 +3183,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 708
+      ID: 718
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 719968
@@ -3231,7 +3231,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 694 PointerType *crypto/x509.Certificate
+      Element: 704 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 751
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3314,11 +3314,11 @@ Types:
       ByteSize: 8
       Element: 818 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 267
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 245 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 251 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 1010
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3332,25 +3332,25 @@ Types:
       ByteSize: 8
       Element: 859 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 243
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 182 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 732
+      ID: 742
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 710 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 235
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 177 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 227
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3402,7 +3402,7 @@ Types:
       ByteSize: 24
       Element: 41 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 713
+      ID: 723
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 507296
@@ -3417,9 +3417,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 736 GoSliceDataType []float64.array
+      Data: 746 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 736
+      ID: 746
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3440,9 +3440,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 239 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 245 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 245
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3463,9 +3463,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 253 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 253
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3506,11 +3506,11 @@ Types:
       ByteSize: 24
       Element: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 268
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 1011
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3524,29 +3524,29 @@ Types:
       ByteSize: 328
       Element: 867 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 244
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 234 StructureType noalg.map.group[string]float64
+      Element: 240 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 733
+      ID: 743
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 236
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 226 StructureType noalg.map.group[string]interface {}
+      Element: 232 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 228
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 218 StructureType noalg.map.group[string]string
+      Element: 224 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 162
       Name: '[]os.Signal'
@@ -3563,9 +3563,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType []os.Signal.array
+      Data: 219 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 219
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3575,7 +3575,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 712
+      ID: 722
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 507552
@@ -3590,15 +3590,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 734 GoSliceDataType []string.array
+      Data: 744 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 734
+      ID: 744
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 741
+      ID: 213
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 500384
@@ -3606,22 +3606,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 742 PointerType *time.zone
+          Type: 214 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 747 GoSliceDataType []time.zone.array
+      Data: 255 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 747
+      ID: 255
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 743 StructureType time.zone
+      Element: 215 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 744
+      ID: 216
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 500448
@@ -3629,20 +3629,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 745 PointerType *time.zoneTrans
+          Type: 217 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 749 GoSliceDataType []time.zoneTrans.array
+      Data: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 749
+      ID: 257
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 746 StructureType time.zoneTrans
+      Element: 218 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 41
       Name: '[]uint8'
@@ -3690,7 +3690,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 509
+      ID: 519
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 960320
@@ -3705,9 +3705,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 510 GoSliceDataType archive/tar.headerError.array
+      Data: 520 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 510
+      ID: 520
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3765,13 +3765,13 @@ Types:
       GoRuntimeType: 600960
       GoKind: 15
     - __kind: BaseType
-      ID: 290
+      ID: 300
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 855168
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 291
+      ID: 301
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 855264
@@ -3779,13 +3779,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 293 PointerType *compress/flate.InternalError.str
+          Type: 303 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 292 GoStringDataType compress/flate.InternalError.str
+      Data: 302 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 292
+      ID: 302
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3893,7 +3893,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 619
+      ID: 629
       Name: context.deadlineExceededError
       GoRuntimeType: 1497376
       GoKind: 25
@@ -3937,7 +3937,7 @@ Types:
           Type: 155 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 157 StructureType time.Time
+          Type: 157 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3983,43 +3983,43 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 309
+      ID: 319
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 857280
       GoKind: 2
     - __kind: BaseType
-      ID: 310
+      ID: 320
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 857376
       GoKind: 2
     - __kind: BaseType
-      ID: 311
+      ID: 321
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 857472
       GoKind: 2
     - __kind: StructureType
-      ID: 598
+      ID: 608
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1320512
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 312
+      ID: 322
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 857568
       GoKind: 2
     - __kind: BaseType
-      ID: 279
+      ID: 289
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 854688
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 584
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4091,11 +4091,11 @@ Types:
       GoRuntimeType: 854400
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 383
+      ID: 393
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 380
+      ID: 390
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1780352
@@ -4106,10 +4106,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 708 ArrayType [5]uint8
+          Type: 718 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 709 GoInterfaceType net.Conn
+          Type: 719 GoInterfaceType net.Conn
     - __kind: BaseType
       ID: 1023
       Name: crypto/tls.SignatureScheme
@@ -4117,25 +4117,25 @@ Types:
       GoRuntimeType: 854496
       GoKind: 9
     - __kind: BaseType
-      ID: 541
+      ID: 551
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1018752
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 395
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 694
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 705
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 446
+      ID: 456
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1782464
@@ -4143,21 +4143,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 704 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 718 BaseType crypto/x509.InvalidReason
+          Type: 728 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 440
+      ID: 450
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1148704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 442
+      ID: 452
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1641248
@@ -4165,24 +4165,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 704 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 308
+      ID: 318
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 856992
       GoKind: 2
     - __kind: BaseType
-      ID: 718
+      ID: 728
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 604288
       GoKind: 2
     - __kind: StructureType
-      ID: 590
+      ID: 600
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1600896
@@ -4192,13 +4192,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 448
+      ID: 458
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1148960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 444
+      ID: 454
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1782272
@@ -4206,15 +4206,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 704 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 704 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 501
+      ID: 511
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1468256
@@ -4224,7 +4224,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 505
+      ID: 515
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1468416
@@ -4234,47 +4234,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 503
+      ID: 513
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 280
+      ID: 290
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 854784
       GoKind: 6
     - __kind: BaseType
-      ID: 304
+      ID: 314
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 856704
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 406
+      ID: 416
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 596
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 398
+      ID: 408
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 404
+      ID: 414
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 412
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 410
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 408
+      ID: 418
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1457376
@@ -4284,7 +4284,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 509
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4301,11 +4301,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 375
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 571
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4321,11 +4321,11 @@ Types:
       GoRuntimeType: 601152
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 555
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 547
+      ID: 557
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4359,7 +4359,7 @@ Types:
       GoRuntimeType: 1034688
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 429
+      ID: 439
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4369,7 +4369,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1781312
@@ -4377,7 +4377,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 710 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 720 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4385,25 +4385,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 423
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 725
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 417
+      ID: 427
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1147296
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 727
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 298
+      ID: 308
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 856032
@@ -4411,18 +4411,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 300 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 310 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 299 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 309 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 299
+      ID: 309
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 710
+      ID: 720
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2294304
@@ -4430,13 +4430,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 711 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 721 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4445,7 +4445,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 713 GoSliceHeaderType []float64
+          Type: 723 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4454,13 +4454,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 714 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 724 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 716 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 726 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4471,13 +4471,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 711
+      ID: 721
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 602816
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 295
+      ID: 305
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 855936
@@ -4485,18 +4485,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 297 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 307 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 296 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 296
+      ID: 306
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 301
+      ID: 311
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 856128
@@ -4504,18 +4504,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 303 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 313 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 302 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 312 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 302
+      ID: 312
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 456
+      ID: 466
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
@@ -4731,16 +4731,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 241 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 247 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 246 GoMapType map[string]interface {}
+          Type: 252 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 760
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 256
+      ID: 266
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1975136
@@ -4821,7 +4821,7 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 670
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4873,29 +4873,29 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 458
+      ID: 468
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 465
+      ID: 475
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1150368
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 313
+      ID: 323
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 858336
       GoKind: 2
     - __kind: StructureType
-      ID: 463
+      ID: 473
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1150240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 461
+      ID: 471
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1642368
@@ -4908,7 +4908,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 473
+      ID: 483
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1643008
@@ -4921,7 +4921,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 477
+      ID: 487
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1784384
@@ -4937,7 +4937,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 475
+      ID: 485
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1466816
@@ -4947,7 +4947,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 471
+      ID: 481
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1466496
@@ -4957,14 +4957,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 696
+      ID: 706
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1542496
       GoKind: 21
-      HeaderType: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 708 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 719
+      ID: 729
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1085056
@@ -4979,15 +4979,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 748 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 738
+      ID: 748
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 485
+      ID: 495
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1643328
@@ -4995,12 +4995,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 706 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 706 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 479
+      ID: 489
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1466976
@@ -5010,7 +5010,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 483
+      ID: 493
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1784576
@@ -5021,12 +5021,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 481
+      ID: 491
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1643168
@@ -5039,7 +5039,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 487
+      ID: 497
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1467136
@@ -5047,9 +5047,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 157 StructureType time.Time
+          Type: 157 GoTimeType time.Time
     - __kind: StructureType
-      ID: 493
+      ID: 503
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1643648
@@ -5062,7 +5062,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 495
+      ID: 505
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1467456
@@ -5072,7 +5072,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1643488
@@ -5085,7 +5085,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 489
+      ID: 499
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1467296
@@ -5095,7 +5095,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 497
+      ID: 507
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1643808
@@ -5130,7 +5130,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 419
+      ID: 429
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1458656
@@ -5144,7 +5144,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 421
+      ID: 431
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1458816
@@ -5152,7 +5152,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 419 StructureType github.com/cihub/seelog.baseError
+          Type: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 803
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -5175,7 +5175,7 @@ Types:
           Offset: 8
           Type: 814 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1459136
@@ -5183,7 +5183,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 419 StructureType github.com/cihub/seelog.baseError
+          Type: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 807
       Name: github.com/cihub/seelog.splitDispatcher
@@ -5199,7 +5199,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 423
+      ID: 433
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1458976
@@ -5207,9 +5207,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 419 StructureType github.com/cihub/seelog.baseError
+          Type: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 427
+      ID: 437
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1459296
@@ -5217,7 +5217,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 419 StructureType github.com/cihub/seelog.baseError
+          Type: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 942
       Name: github.com/cihub/seelog/archive.Reader
@@ -5246,42 +5246,42 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 698
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 614
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 612
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 616
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 618
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 606
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 432
+      ID: 442
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1460256
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 662
+      ID: 672
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 648
+      ID: 658
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1905920
@@ -5297,11 +5297,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 652
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 590
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1752672
@@ -5314,7 +5314,7 @@ Types:
           Offset: 1
           Type: 22 BaseType int8
     - __kind: StructureType
-      ID: 654
+      ID: 664
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1906368
@@ -5330,13 +5330,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 543
+      ID: 553
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1019424
       GoKind: 8
     - __kind: StructureType
-      ID: 646
+      ID: 656
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1905696
@@ -5352,13 +5352,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 722
+      ID: 732
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 855552
       GoKind: 8
     - __kind: StructureType
-      ID: 644
+      ID: 654
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1905472
@@ -5366,15 +5366,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 732 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 732 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 652
+      ID: 662
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1816768
@@ -5387,7 +5387,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 650
+      ID: 660
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1906144
@@ -5403,7 +5403,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 658
+      ID: 668
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1678656
@@ -5413,19 +5413,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 584
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1316416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 582
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1316288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 656
+      ID: 666
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1816960
@@ -5438,7 +5438,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 318
+      ID: 328
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 860832
@@ -5446,22 +5446,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 320 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 330 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 329 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 319
+      ID: 329
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 713
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 612
+      ID: 622
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1482656
@@ -5471,19 +5471,19 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 321
+      ID: 331
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 861408
       GoKind: 10
     - __kind: BaseType
-      ID: 701
+      ID: 711
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1031712
       GoKind: 10
     - __kind: StructureType
-      ID: 670
+      ID: 680
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1939072
@@ -5494,12 +5494,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 701 BaseType golang.org/x/net/http2.ErrCode
+          Type: 711 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 527
+      ID: 537
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1650528
@@ -5507,12 +5507,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 701 BaseType golang.org/x/net/http2.ErrCode
+          Type: 711 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 335
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 861600
@@ -5520,18 +5520,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 337 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 336 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 336
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 341
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 861792
@@ -5539,18 +5539,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 343 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 342 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 342
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 338
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 861696
@@ -5558,18 +5558,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 340 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 339 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 339
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 332
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 861504
@@ -5577,18 +5577,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 334 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 333 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 333
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 531
+      ID: 541
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1483296
@@ -5598,13 +5598,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 334
+      ID: 344
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 861888
       GoKind: 2
     - __kind: StructureType
-      ID: 519
+      ID: 529
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1478336
@@ -5614,11 +5614,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 678
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 690
+      ID: 700
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1969312
@@ -5634,7 +5634,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 521
+      ID: 531
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1650048
@@ -5651,7 +5651,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 610
+      ID: 620
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1608736
@@ -5665,25 +5665,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 517
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 610
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 676
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 664
+      ID: 674
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1552256
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 513
+      ID: 523
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1471616
@@ -5693,7 +5693,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 515
+      ID: 525
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1471776
@@ -5703,7 +5703,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 467
+      ID: 477
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5735,19 +5735,19 @@ Types:
       GroupType: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 845 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 250
+      ID: 260
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 251 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 261 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 268 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 1002
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5777,63 +5777,63 @@ Types:
       GroupType: 867 StructureType noalg.map.group[string][]string
       GroupSliceType: 871 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 232
+      ID: 238
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 233 PointerType *noalg.map.group[string]float64
+          Type: 239 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 234 StructureType noalg.map.group[string]float64
-      GroupSliceType: 238 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 240 StructureType noalg.map.group[string]float64
+      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 727
+      ID: 737
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 728 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 738 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 733 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 743 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 224
+      ID: 230
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 225 PointerType *noalg.map.group[string]interface {}
+          Type: 231 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 226 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 230 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 232 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 216
+      ID: 222
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 217 PointerType *noalg.map.group[string]string
+          Type: 223 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 218 StructureType noalg.map.group[string]string
-      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 224 StructureType noalg.map.group[string]string
+      GroupSliceType: 228 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 544
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5880,17 +5880,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 723
+      ID: 733
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 603712
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 702
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 437
+      ID: 447
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5916,11 +5916,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 435
+      ID: 445
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 650
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5928,13 +5928,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 648
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1516256
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 367
+      ID: 377
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6006,7 +6006,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 305
+      ID: 315
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 856896
@@ -6014,18 +6014,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 317 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 306 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 316 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 316
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 588
+      ID: 598
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1599936
@@ -6033,9 +6033,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 691 PointerType *internal/abi.Type
+          Type: 701 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 278
+      ID: 288
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 854208
@@ -6121,7 +6121,7 @@ Types:
           Offset: 0
           Type: 933 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 646
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6195,7 +6195,7 @@ Types:
       TablePtrSliceType: 844 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 243
+      ID: 249
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6208,7 +6208,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 244 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 250 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6227,8 +6227,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 267 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 998
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6332,10 +6332,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 237 GoSliceDataType []*table<string,float64>.array
-      GroupType: 234 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 243 GoSliceDataType []*table<string,float64>.array
+      GroupType: 240 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 698
+      ID: 708
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6348,7 +6348,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 699 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 709 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6367,8 +6367,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 732 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 742 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 175
       Name: map<string,interface {}>
@@ -6402,8 +6402,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 229 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 226 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 232 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 170
       Name: map<string,string>
@@ -6437,8 +6437,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 221 GoSliceDataType []*table<string,string>.array
-      GroupType: 218 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 227 GoSliceDataType []*table<string,string>.array
+      GroupType: 224 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 144
       Name: map[context.canceler]struct {}
@@ -6454,12 +6454,12 @@ Types:
       GoKind: 21
       HeaderType: 816 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 241
+      ID: 247
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1167264
       GoKind: 21
-      HeaderType: 243 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 249 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 996
       Name: map[string][]*mime/multipart.FileHeader
@@ -6482,7 +6482,7 @@ Types:
       GoKind: 21
       HeaderType: 180 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 246
+      ID: 252
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1160736
@@ -6496,7 +6496,7 @@ Types:
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 454
+      ID: 464
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1463456
@@ -6540,11 +6540,11 @@ Types:
           Offset: 8
           Type: 943 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 632
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 709
+      ID: 719
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1638528
@@ -6557,7 +6557,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 685
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6565,11 +6565,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 683
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 634
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6585,7 +6585,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 615
+      ID: 625
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1141792
@@ -6593,18 +6593,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 617 PointerType *net.UnknownNetworkError.str
+          Type: 627 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 616 GoStringDataType net.UnknownNetworkError.str
+      Data: 626 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 616
+      ID: 626
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 549
+      ID: 559
       Name: net.canceledError
       GoRuntimeType: 1313856
       GoKind: 25
@@ -6614,7 +6614,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 721
+      ID: 731
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2176544
@@ -6622,7 +6622,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 709 GoInterfaceType net.Conn
+          Type: 719 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -6649,7 +6649,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 336
+      ID: 346
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6666,7 +6666,7 @@ Types:
           Offset: 16
           Type: 124 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 338
+      ID: 348
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1775168
@@ -6674,7 +6674,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 704 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 714 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6708,11 +6708,11 @@ Types:
           Offset: 0
           Type: 973 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 636
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 687
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6762,11 +6762,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 344
+      ID: 354
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 561
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6818,7 +6818,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6863,7 +6863,7 @@ Types:
           Type: 883 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 168 GoMapType map[string]string
@@ -6900,7 +6900,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6973,19 +6973,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 259
+      ID: 269
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 852192
       GoKind: 10
     - __kind: BaseType
-      ID: 693
+      ID: 703
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1015968
       GoKind: 10
     - __kind: StructureType
-      ID: 347
+      ID: 357
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1776896
@@ -6996,12 +6996,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 703 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 679
+      ID: 689
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1957536
@@ -7012,7 +7012,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 703 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
@@ -7021,7 +7021,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 353
+      ID: 363
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1639008
@@ -7029,12 +7029,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 703 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 273
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 852384
@@ -7042,18 +7042,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 275 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 274 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 274
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 351
+      ID: 361
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1143072
       GoKind: 25
@@ -7063,7 +7063,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 269
+      ID: 279
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 852576
@@ -7071,18 +7071,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 271 PointerType *net/http.http2headerFieldNameError.str
+          Type: 281 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 270 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 280 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 270
+      ID: 280
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 276
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 852480
@@ -7090,18 +7090,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *net/http.http2headerFieldValueError.str
+          Type: 278 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 267 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 277 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 277
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 640
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -7117,13 +7117,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 557
+      ID: 567
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1314752
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 260
+      ID: 270
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 852288
@@ -7131,13 +7131,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 262 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 272 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 261 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 271 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 261
+      ID: 271
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7180,7 +7180,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 553
+      ID: 563
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1592096
@@ -7220,7 +7220,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 357
+      ID: 367
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1449536
@@ -7295,7 +7295,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 150 StructureType sync/atomic.Bool
@@ -7334,7 +7334,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 342
+      ID: 352
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1638848
@@ -7347,17 +7347,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 691
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 638
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1501856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 555
+      ID: 565
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1592256
@@ -7375,12 +7375,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 709 GoInterfaceType net.Conn
+          Type: 719 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 709 GoInterfaceType net.Conn
+          Type: 719 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 340
+      ID: 350
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7390,7 +7390,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 375
+      ID: 385
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1779968
@@ -7406,7 +7406,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 373
+      ID: 383
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1640128
@@ -7419,11 +7419,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 391
+      ID: 401
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 297
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 855072
@@ -7431,22 +7431,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *net/textproto.ProtocolError.str
+          Type: 299 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 288 GoStringDataType net/textproto.ProtocolError.str
+      Data: 298 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 298
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 696
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 281
+      ID: 291
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 854880
@@ -7454,18 +7454,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 283 PointerType *net/url.EscapeError.str
+          Type: 293 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 282 GoStringDataType net/url.EscapeError.str
+      Data: 292 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 282
+      ID: 292
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 294
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 854976
@@ -7473,13 +7473,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *net/url.InvalidHostError.str
+          Type: 296 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 285 GoStringDataType net/url.InvalidHostError.str
+      Data: 295 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 295
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7553,14 +7553,14 @@ Types:
       HasCount: true
       Element: 842 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 253
+      ID: 263
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 723008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 254 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 264 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 1005
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7580,41 +7580,41 @@ Types:
       HasCount: true
       Element: 869 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 235
+      ID: 241
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 722912
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 236 StructureType noalg.struct { key string; elem float64 }
+      Element: 242 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 730
+      ID: 740
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 784160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 731 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 741 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 227
+      ID: 233
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 699136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 228 StructureType noalg.struct { key string; elem interface {} }
+      Element: 234 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 219
+      ID: 225
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 712864
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 220 StructureType noalg.struct { key string; elem string }
+      Element: 226 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 206
       Name: noalg.map.group[context.canceler]struct {}
@@ -7642,7 +7642,7 @@ Types:
           Offset: 8
           Type: 841 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 252
+      ID: 262
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1343168
@@ -7653,7 +7653,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 253 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 263 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 1004
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7681,7 +7681,7 @@ Types:
           Offset: 8
           Type: 868 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 234
+      ID: 240
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1342912
@@ -7692,9 +7692,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 235 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 241 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 729
+      ID: 739
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1391680
@@ -7705,9 +7705,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 730 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 740 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 226
+      ID: 232
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1324864
@@ -7718,9 +7718,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 227 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 233 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 218
+      ID: 224
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1329984
@@ -7731,7 +7731,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 219 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 225 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 208
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7759,7 +7759,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 254
+      ID: 264
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1343040
@@ -7770,7 +7770,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 255 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 265 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 1006
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7796,9 +7796,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 236
+      ID: 242
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1342784
@@ -7811,7 +7811,7 @@ Types:
           Offset: 16
           Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 731
+      ID: 741
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1391552
@@ -7822,9 +7822,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 228
+      ID: 234
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1324736
@@ -7837,7 +7837,7 @@ Types:
           Offset: 16
           Type: 143 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 220
+      ID: 226
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1329856
@@ -7854,7 +7854,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 559
+      ID: 569
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7871,7 +7871,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 642
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7913,15 +7913,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 602
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 735
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 594
+      ID: 604
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1753056
@@ -7955,7 +7955,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 272
+      ID: 282
       Name: os/signal.signalError
       ByteSize: 16
       GoRuntimeType: 852672
@@ -7963,18 +7963,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 274 PointerType *os/signal.signalError.str
+          Type: 284 PointerType *os/signal.signalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 273 GoStringDataType os/signal.signalError.str
+      Data: 283 GoStringDataType os/signal.signalError.str
     - __kind: GoStringDataType
-      ID: 273
+      ID: 283
       Name: os/signal.signalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 315
+      ID: 325
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 860064
@@ -7982,36 +7982,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 317 PointerType *os/user.UnknownGroupIdError.str
+          Type: 327 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 316 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 326 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 316
+      ID: 326
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 314
+      ID: 324
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 369
+      ID: 379
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 469
+      ID: 479
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 577
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 581
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -8023,7 +8023,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 569
+      ID: 579
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1946464
@@ -8040,7 +8040,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 723 BaseType internal/abi.BoundsErrorCode
+          Type: 733 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -8056,7 +8056,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 634
+      ID: 644
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1811200
@@ -8069,7 +8069,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 545
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1017216
@@ -8077,13 +8077,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *runtime.errorString.str
+          Type: 547 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 536 GoStringDataType runtime.errorString.str
+      Data: 546 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 546
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8768,7 +8768,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 538
+      ID: 548
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1017312
@@ -8776,13 +8776,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 540 PointerType *runtime.plainError.str
+          Type: 550 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 539 GoStringDataType runtime.plainError.str
+      Data: 549 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 539
+      ID: 549
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8823,7 +8823,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 371
+      ID: 381
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1639808
@@ -8895,7 +8895,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 573
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9282,7 +9282,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 671
+      ID: 681
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1315520
@@ -9342,7 +9342,7 @@ Types:
           Offset: 16
           Type: 838 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 249
+      ID: 259
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9364,7 +9364,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 250 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 260 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 1001
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9414,7 +9414,7 @@ Types:
           Offset: 16
           Type: 865 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 231
+      ID: 237
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9436,9 +9436,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 232 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 238 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 726
+      ID: 736
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9460,9 +9460,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 727 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 737 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 223
+      ID: 229
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9484,9 +9484,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 224 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 230 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 215
+      ID: 221
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9508,9 +9508,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 216 GoSwissMapGroupsType groupReference<string,string>
+          Type: 222 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 614
+      ID: 624
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1757280
@@ -9540,10 +9540,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 741 GoSliceHeaderType []time.zone
+          Type: 213 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 744 GoSliceHeaderType []time.zoneTrans
+          Type: 216 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9555,12 +9555,12 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 742 PointerType *time.zone
+          Type: 214 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 363
+      ID: 373
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 157
       Name: time.Time
       ByteSize: 24
@@ -9576,6 +9576,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 158 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 156
       Name: time.Timer
@@ -9585,12 +9593,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 740 GoChannelType <-chan time.Time
+          Type: 750 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 275
+      ID: 285
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 852768
@@ -9598,22 +9606,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 277 PointerType *time.fileSizeError.str
+          Type: 287 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 276 GoStringDataType time.fileSizeError.str
+      Data: 286 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 276
+      ID: 286
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 361
+      ID: 371
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 743
+      ID: 215
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1663104
@@ -9629,7 +9637,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 746
+      ID: 218
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1807744
@@ -9690,7 +9698,7 @@ Types:
       GoRuntimeType: 601280
       GoKind: 26
     - __kind: StructureType
-      ID: 704
+      ID: 714
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2125600
@@ -9701,10 +9709,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 715 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 706 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 716 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9719,18 +9727,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 717 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 707
+      ID: 717
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1018368
       GoKind: 9
     - __kind: StructureType
-      ID: 705
+      ID: 715
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1978208
@@ -9755,17 +9763,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 378
+      ID: 388
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 706
+      ID: 716
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 602112
       GoKind: 8
     - __kind: StructureType
-      ID: 395
+      ID: 405
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1455456
@@ -9775,13 +9783,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 294
+      ID: 304
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 855360
       GoKind: 2
     - __kind: StructureType
-      ID: 576
+      ID: 586
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1752480
@@ -9794,7 +9802,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 542
+      ID: 552
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1019232

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -119,7 +119,7 @@ Types:
       ID: 926
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 629 PointerType *crypto/x509.Certificate
+      Pointee: 639 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 681
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -164,30 +164,30 @@ Types:
       ByteSize: 8
       Pointee: 937 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 666
+      ID: 676
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 665 GoSliceDataType []float64.array
+      Pointee: 675 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 199
+      ID: 205
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 204 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 207
+      ID: 213
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 212 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 943
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 942 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 190
+      ID: 196
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []os.Signal.array
+      Pointee: 195 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -196,20 +196,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 664
+      ID: 674
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 663 GoSliceDataType []string.array
+      Pointee: 673 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 677
+      ID: 215
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 676 GoSliceDataType []time.zone.array
+      Pointee: 214 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 679
+      ID: 217
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 678 GoSliceDataType []time.zoneTrans.array
+      Pointee: 216 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 930
       Name: '*[]uint8'
@@ -228,17 +228,17 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 877856
       GoKind: 22
-      Pointee: 450 GoSliceHeaderType archive/tar.headerError
+      Pointee: 460 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 451 GoSliceDataType archive/tar.headerError.array
+      Pointee: 461 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 845
       Name: '*archive/zip.checksumReader'
@@ -285,10 +285,10 @@ Types:
       ByteSize: 8
       Pointee: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 203
+      ID: 209
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 915
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -305,10 +305,10 @@ Types:
       ByteSize: 8
       Pointee: 165 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 634
+      ID: 644
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 635 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 159
       Name: '*bucket<string,interface {}>'
@@ -334,24 +334,24 @@ Types:
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 864224
       GoKind: 22
-      Pointee: 254 BaseType compress/flate.CorruptInputError
+      Pointee: 264 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 864320
       GoKind: 22
-      Pointee: 255 GoStringHeaderType compress/flate.InternalError
+      Pointee: 265 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 257
+      ID: 267
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 256 GoStringDataType compress/flate.InternalError.str
+      Pointee: 266 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 877
       Name: '*compress/flate.decompressor'
@@ -381,12 +381,12 @@ Types:
       GoKind: 22
       Pointee: 113 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1122016
       GoKind: 22
-      Pointee: 556 StructureType context.deadlineExceededError
+      Pointee: 566 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 944
       Name: '*context.emptyCtx'
@@ -430,40 +430,40 @@ Types:
       GoKind: 22
       Pointee: 121 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863264
       GoKind: 22
-      Pointee: 251 BaseType crypto/aes.KeySizeError
+      Pointee: 261 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 385
+      ID: 395
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863456
       GoKind: 22
-      Pointee: 252 BaseType crypto/des.KeySizeError
+      Pointee: 262 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863744
       GoKind: 22
-      Pointee: 253 BaseType crypto/rc4.KeySizeError
+      Pointee: 263 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 325
+      ID: 335
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 852896
       GoKind: 22
-      Pointee: 228 BaseType crypto/tls.AlertError
+      Pointee: 238 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1017248
       GoKind: 22
-      Pointee: 515 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 525 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 907
       Name: '*crypto/tls.Conn'
@@ -479,206 +479,206 @@ Types:
       GoKind: 22
       Pointee: 797 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 323
+      ID: 333
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 852704
       GoKind: 22
-      Pointee: 324 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 334 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 321
+      ID: 331
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 852608
       GoKind: 22
-      Pointee: 322 StructureType crypto/tls.RecordHeaderError
+      Pointee: 332 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1015584
       GoKind: 22
-      Pointee: 482 BaseType crypto/tls.alert
+      Pointee: 492 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1263680
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 631 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 629
+      ID: 639
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1953440
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 640 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 863072
       GoKind: 22
-      Pointee: 381 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 391 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 862592
       GoKind: 22
-      Pointee: 375 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 385 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 376
+      ID: 386
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 862688
       GoKind: 22
-      Pointee: 377 StructureType crypto/x509.HostnameError
+      Pointee: 387 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 862496
       GoKind: 22
-      Pointee: 250 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 260 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 528
+      ID: 538
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1027744
       GoKind: 22
-      Pointee: 529 StructureType crypto/x509.SystemRootsError
+      Pointee: 539 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 863168
       GoKind: 22
-      Pointee: 383 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 393 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 862976
       GoKind: 22
-      Pointee: 379 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 389 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 441
+      ID: 451
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 873632
       GoKind: 22
-      Pointee: 442 StructureType encoding/asn1.StructuralError
+      Pointee: 452 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 873824
       GoKind: 22
-      Pointee: 446 StructureType encoding/asn1.SyntaxError
+      Pointee: 456 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 873728
       GoKind: 22
-      Pointee: 444 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 454 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 326
+      ID: 336
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 852992
       GoKind: 22
-      Pointee: 229 BaseType encoding/base64.CorruptInputError
+      Pointee: 239 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 861440
       GoKind: 22
-      Pointee: 249 BaseType encoding/hex.InvalidByteError
+      Pointee: 259 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 343
+      ID: 353
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 856544
       GoKind: 22
-      Pointee: 344 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 354 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 526
+      ID: 536
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1022496
       GoKind: 22
-      Pointee: 527 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 537 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 856160
       GoKind: 22
-      Pointee: 336 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 346 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 341
+      ID: 351
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 856448
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 352 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 856352
       GoKind: 22
-      Pointee: 340 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 350 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 856256
       GoKind: 22
-      Pointee: 338 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 348 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 856928
       GoKind: 22
-      Pointee: 346 StructureType encoding/json.jsonError
+      Pointee: 356 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 871424
       GoKind: 22
-      Pointee: 437 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 447 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 871328
       GoKind: 22
-      Pointee: 435 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 445 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 871520
       GoKind: 22
-      Pointee: 259 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 269 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 261
+      ID: 271
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 260 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 270 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 439
+      ID: 449
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 871616
       GoKind: 22
-      Pointee: 440 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 450 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -687,19 +687,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 309
+      ID: 319
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 848096
       GoKind: 22
-      Pointee: 310 UnresolvedPointeeType errors.errorString
+      Pointee: 320 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1008544
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType errors.joinError
+      Pointee: 512 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -715,26 +715,26 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 485
+      ID: 495
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 998560
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType fmt.wrapError
+      Pointee: 496 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 487
+      ID: 497
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 998688
       GoKind: 22
-      Pointee: 488 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 498 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 860960
       GoKind: 22
-      Pointee: 367 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 377 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 748
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -743,83 +743,83 @@ Types:
       GoKind: 22
       Pointee: 749 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 858176
       GoKind: 22
-      Pointee: 349 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 359 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 858272
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 361 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 857984
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 660 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 354
+      ID: 364
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 858560
       GoKind: 22
-      Pointee: 355 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 365 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 858080
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 662 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 352
+      ID: 362
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 858368
       GoKind: 22
-      Pointee: 243 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 253 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 245
+      ID: 255
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 244 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 254 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 347
+      ID: 357
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 857888
       GoKind: 22
-      Pointee: 240 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 250 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 242
+      ID: 252
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 241 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 251 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 858464
       GoKind: 22
-      Pointee: 246 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 256 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 248
+      ID: 258
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 247 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 257 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 391
+      ID: 401
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 865280
       GoKind: 22
-      Pointee: 392 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 402 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 739
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
@@ -877,12 +877,12 @@ Types:
       GoKind: 22
       Pointee: 689 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 209
+      ID: 219
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1130336
       GoKind: 22
-      Pointee: 210 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 220 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 174
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
@@ -898,12 +898,12 @@ Types:
       GoKind: 22
       Pointee: 755 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 596
+      ID: 606
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1151584
       GoKind: 22
-      Pointee: 597 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 607 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 690
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
@@ -940,143 +940,143 @@ Types:
       GoKind: 22
       Pointee: 826 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 867488
       GoKind: 22
-      Pointee: 394 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 404 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 400
+      ID: 410
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 868544
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 411 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 868256
       GoKind: 22
-      Pointee: 258 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 268 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 868448
       GoKind: 22
-      Pointee: 399 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 409 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 396
+      ID: 406
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 868352
       GoKind: 22
-      Pointee: 397 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 407 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 869888
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 419 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 870080
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 423 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 869984
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 421 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 869792
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 417 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 668
+      ID: 678
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 667 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 677 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 870464
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 431 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 870176
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 425 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 870368
       GoKind: 22
-      Pointee: 419 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 429 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 870272
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 427 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 870560
       GoKind: 22
-      Pointee: 423 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 433 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 870848
       GoKind: 22
-      Pointee: 429 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 439 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 870944
       GoKind: 22
-      Pointee: 431 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 441 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 870752
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 437 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 870656
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 435 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 871136
       GoKind: 22
-      Pointee: 433 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 443 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 764
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1106,12 +1106,12 @@ Types:
       GoKind: 22
       Pointee: 763 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 859712
       GoKind: 22
-      Pointee: 357 StructureType github.com/cihub/seelog.baseError
+      Pointee: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 741
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1120,12 +1120,12 @@ Types:
       GoKind: 22
       Pointee: 742 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 358
+      ID: 368
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 859808
       GoKind: 22
-      Pointee: 359 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 369 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 731
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1148,12 +1148,12 @@ Types:
       GoKind: 22
       Pointee: 738 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 860000
       GoKind: 22
-      Pointee: 363 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 373 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 735
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1169,19 +1169,19 @@ Types:
       GoKind: 22
       Pointee: 757 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 859904
       GoKind: 22
-      Pointee: 361 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 371 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 860096
       GoKind: 22
-      Pointee: 365 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 375 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 843
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1197,289 +1197,289 @@ Types:
       GoKind: 22
       Pointee: 863 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 624
+      ID: 634
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1281280
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 635 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 540
+      ID: 550
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1046304
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 551 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 538
+      ID: 548
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1046176
       GoKind: 22
-      Pointee: 539 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 549 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 542
+      ID: 552
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1050656
       GoKind: 22
-      Pointee: 543 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 553 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 544
+      ID: 554
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1050784
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 555 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 534
+      ID: 544
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1035296
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 545 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 861632
       GoKind: 22
-      Pointee: 370 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 380 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 598
+      ID: 608
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1158752
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 609 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 584
+      ID: 594
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1143648
       GoKind: 22
-      Pointee: 585 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1143264
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 589 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 520
+      ID: 530
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1020192
       GoKind: 22
-      Pointee: 521 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 531 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 590
+      ID: 600
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1144032
       GoKind: 22
-      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 519
+      ID: 529
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1020064
       GoKind: 22
-      Pointee: 484 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 494 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 582
+      ID: 592
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1143520
       GoKind: 22
-      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 580
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1143392
       GoKind: 22
-      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 588
+      ID: 598
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1143904
       GoKind: 22
-      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 599 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1143776
       GoKind: 22
-      Pointee: 587 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 594
+      ID: 604
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1144416
       GoKind: 22
-      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 524
+      ID: 534
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1020448
       GoKind: 22
-      Pointee: 525 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 535 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1020320
       GoKind: 22
-      Pointee: 523 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 533 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 592
+      ID: 602
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1144288
       GoKind: 22
-      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 603 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 889088
       GoKind: 22
-      Pointee: 266 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 276 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 268
+      ID: 278
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 277 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 637
+      ID: 647
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1508800
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 648 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 548
+      ID: 558
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1065632
       GoKind: 22
-      Pointee: 549 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 559 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 890336
       GoKind: 22
-      Pointee: 269 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 279 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 606
+      ID: 616
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1196896
       GoKind: 22
-      Pointee: 607 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 617 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 890624
       GoKind: 22
-      Pointee: 468 StructureType golang.org/x/net/http2.connError
+      Pointee: 478 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 890528
       GoKind: 22
-      Pointee: 273 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 283 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 275
+      ID: 285
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 284 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 890816
       GoKind: 22
-      Pointee: 279 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 289 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 281
+      ID: 291
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 280 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 290 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 469
+      ID: 479
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 890720
       GoKind: 22
-      Pointee: 276 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 286 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 278
+      ID: 288
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 287 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 465
+      ID: 475
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 890432
       GoKind: 22
-      Pointee: 270 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 280 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 272
+      ID: 282
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 281 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 890912
       GoKind: 22
-      Pointee: 472 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 482 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 473
+      ID: 483
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 891008
       GoKind: 22
-      Pointee: 282 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 292 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 884768
       GoKind: 22
-      Pointee: 460 StructureType google.golang.org/grpc.dropError
+      Pointee: 470 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1193824
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 615 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1288800
       GoKind: 22
-      Pointee: 627 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 637 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 887360
       GoKind: 22
-      Pointee: 462 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 472 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 868
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1488,12 +1488,12 @@ Types:
       GoKind: 22
       Pointee: 869 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 546
+      ID: 556
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1059872
       GoKind: 22
-      Pointee: 547 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 557 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 852
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1502,54 +1502,54 @@ Types:
       GoKind: 22
       Pointee: 853 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 876512
       GoKind: 22
-      Pointee: 448 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 458 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 536
+      ID: 546
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1039520
       GoKind: 22
-      Pointee: 537 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 547 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 602
+      ID: 612
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1162976
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 613 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1162720
       GoKind: 22
-      Pointee: 601 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 611 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 453
+      ID: 463
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 878816
       GoKind: 22
-      Pointee: 454 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 464 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 455
+      ID: 465
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 878912
       GoKind: 22
-      Pointee: 456 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 466 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 868640
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 413 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 130
       Name: '*hash<context.canceler,struct {}>'
@@ -1561,10 +1561,10 @@ Types:
       ByteSize: 8
       Pointee: 745 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 201
+      ID: 207
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 202 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 208 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 913
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
@@ -1581,10 +1581,10 @@ Types:
       ByteSize: 8
       Pointee: 163 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 632
+      ID: 642
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 633 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 643 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 157
       Name: '*hash<string,interface {}>'
@@ -1596,12 +1596,12 @@ Types:
       ByteSize: 8
       Pointee: 153 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 891776
       GoKind: 22
-      Pointee: 475 UnresolvedPointeeType html/template.Error
+      Pointee: 485 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 96
       Name: '*int'
@@ -1638,19 +1638,19 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 862016
       GoKind: 22
-      Pointee: 372 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 382 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 576
+      ID: 586
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1139040
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 587 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 905
       Name: '*internal/poll.FD'
@@ -1659,19 +1659,19 @@ Types:
       GoKind: 22
       Pointee: 906 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 574
+      ID: 584
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1138912
       GoKind: 22
-      Pointee: 575 StructureType internal/poll.errNetClosing
+      Pointee: 585 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 311
+      ID: 321
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 848480
       GoKind: 22
-      Pointee: 312 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 322 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 870
       Name: '*io.PipeReader'
@@ -1701,19 +1701,19 @@ Types:
       GoKind: 22
       Pointee: 842 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1138144
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType io/fs.PathError
+      Pointee: 583 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 864896
       GoKind: 22
-      Pointee: 390 StructureType math/big.ErrNaN
+      Pointee: 400 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 920
       Name: '*mime/multipart.FileHeader'
@@ -1743,19 +1743,19 @@ Types:
       GoKind: 22
       Pointee: 857 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 558
+      ID: 568
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1123168
       GoKind: 22
-      Pointee: 559 UnresolvedPointeeType net.AddrError
+      Pointee: 569 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1256800
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType net.DNSError
+      Pointee: 622 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 881
       Name: '*net.IPConn'
@@ -1764,19 +1764,19 @@ Types:
       GoKind: 22
       Pointee: 882 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 609
+      ID: 619
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1256480
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType net.OpError
+      Pointee: 620 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 560
+      ID: 570
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1123296
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType net.ParseError
+      Pointee: 571 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 889
       Name: '*net.TCPConn'
@@ -1799,24 +1799,24 @@ Types:
       GoKind: 22
       Pointee: 888 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1122400
       GoKind: 22
-      Pointee: 552 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 562 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 553 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 563 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 489
+      ID: 499
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 999584
       GoKind: 22
-      Pointee: 490 StructureType net.canceledError
+      Pointee: 500 StructureType net.canceledError
     - __kind: PointerType
       ID: 879
       Name: '*net.conn'
@@ -1825,12 +1825,12 @@ Types:
       GoKind: 22
       Pointee: 880 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1744672
       GoKind: 22
-      Pointee: 656 StructureType net.dialResult·1
+      Pointee: 666 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 895
       Name: '*net.netFD'
@@ -1839,12 +1839,12 @@ Types:
       GoKind: 22
       Pointee: 896 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 283
+      ID: 293
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 841280
       GoKind: 22
-      Pointee: 284 UnresolvedPointeeType net.notFoundError
+      Pointee: 294 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 945
       Name: '*net.onlyValuesCtx'
@@ -1853,12 +1853,12 @@ Types:
       GoKind: 22
       Pointee: 946 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 285
+      ID: 295
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 841952
       GoKind: 22
-      Pointee: 286 StructureType net.result·2
+      Pointee: 296 StructureType net.result·2
     - __kind: PointerType
       ID: 885
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1874,33 +1874,33 @@ Types:
       GoKind: 22
       Pointee: 884 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1123936
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType net.temporaryError
+      Pointee: 573 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1257120
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType net.timeoutError
+      Pointee: 624 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 291
+      ID: 301
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 844544
       GoKind: 22
-      Pointee: 292 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 302 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 491
+      ID: 501
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1002912
       GoKind: 22
-      Pointee: 492 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 502 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 105
       Name: '*net/http.Request'
@@ -1958,26 +1958,26 @@ Types:
       GoKind: 22
       Pointee: 820 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 293
+      ID: 303
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 844736
       GoKind: 22
-      Pointee: 212 BaseType net/http.http2ConnectionError
+      Pointee: 222 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 294
+      ID: 304
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 844832
       GoKind: 22
-      Pointee: 295 StructureType net/http.http2GoAwayError
+      Pointee: 305 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1258080
       GoKind: 22
-      Pointee: 616 StructureType net/http.http2StreamError
+      Pointee: 626 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 849
       Name: '*net/http.http2clientStream'
@@ -1986,31 +1986,31 @@ Types:
       GoKind: 22
       Pointee: 850 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 300
+      ID: 310
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 845696
       GoKind: 22
-      Pointee: 301 StructureType net/http.http2connError
+      Pointee: 311 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 297
+      ID: 307
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 845216
       GoKind: 22
-      Pointee: 216 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 226 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 218
+      ID: 228
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 217 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 227 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 845312
       GoKind: 22
-      Pointee: 299 StructureType net/http.http2goAwayFlowError
+      Pointee: 309 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 813
       Name: '*net/http.http2gzipReader'
@@ -2019,36 +2019,36 @@ Types:
       GoKind: 22
       Pointee: 814 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 303
+      ID: 313
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 845888
       GoKind: 22
-      Pointee: 222 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 232 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 224
+      ID: 234
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 223 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 233 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 302
+      ID: 312
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 845792
       GoKind: 22
-      Pointee: 219 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 229 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 221
+      ID: 231
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 220 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 230 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 566
+      ID: 576
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1128160
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 577 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 809
       Name: '*net/http.http2missingBody'
@@ -2064,24 +2064,24 @@ Types:
       GoKind: 22
       Pointee: 822 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 497
+      ID: 507
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1004960
       GoKind: 22
-      Pointee: 498 StructureType net/http.http2noCachedConnError
+      Pointee: 508 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 296
+      ID: 306
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 845120
       GoKind: 22
-      Pointee: 213 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 223 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 215
+      ID: 225
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 214 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 224 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 817
       Name: '*net/http.http2requestBody'
@@ -2125,12 +2125,12 @@ Types:
       GoKind: 22
       Pointee: 840 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 493
+      ID: 503
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1004576
       GoKind: 22
-      Pointee: 494 StructureType net/http.nothingWrittenError
+      Pointee: 504 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 801
       Name: '*net/http.pattern'
@@ -2153,12 +2153,12 @@ Types:
       GoKind: 22
       Pointee: 838 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 304
+      ID: 314
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 846080
       GoKind: 22
-      Pointee: 305 StructureType net/http.requestBodyReadError
+      Pointee: 315 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 729
       Name: '*net/http.response'
@@ -2174,40 +2174,40 @@ Types:
       GoKind: 22
       Pointee: 941 StructureType net/http.segment
     - __kind: PointerType
-      ID: 289
+      ID: 299
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 844448
       GoKind: 22
-      Pointee: 290 StructureType net/http.statusError
+      Pointee: 300 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1259520
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 628 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1128032
       GoKind: 22
-      Pointee: 565 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 575 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 495
+      ID: 505
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1004704
       GoKind: 22
-      Pointee: 496 StructureType net/http.transportReadFromServerError
+      Pointee: 506 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 287
+      ID: 297
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 843680
       GoKind: 22
-      Pointee: 288 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 298 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 831
       Name: '*net/http/httputil.failureToReadBody'
@@ -2216,69 +2216,69 @@ Types:
       GoKind: 22
       Pointee: 832 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 317
+      ID: 327
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 850976
       GoKind: 22
-      Pointee: 318 StructureType net/netip.parseAddrError
+      Pointee: 328 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 315
+      ID: 325
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 850880
       GoKind: 22
-      Pointee: 316 StructureType net/netip.parsePrefixError
+      Pointee: 326 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 854240
       GoKind: 22
-      Pointee: 331 UnresolvedPointeeType net/textproto.Error
+      Pointee: 341 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 329
+      ID: 339
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 854144
       GoKind: 22
-      Pointee: 236 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 246 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 238
+      ID: 248
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 237 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 247 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 622
+      ID: 632
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1264160
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net/url.Error
+      Pointee: 633 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 853088
       GoKind: 22
-      Pointee: 230 GoStringHeaderType net/url.EscapeError
+      Pointee: 240 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 232
+      ID: 242
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 231 GoStringDataType net/url.EscapeError.str
+      Pointee: 241 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 853184
       GoKind: 22
-      Pointee: 233 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 243 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 235
+      ID: 245
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 234 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 244 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 790
       Name: '*net/url.URL'
@@ -2301,12 +2301,12 @@ Types:
       GoKind: 22
       Pointee: 902 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 499
+      ID: 509
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1006880
       GoKind: 22
-      Pointee: 500 UnresolvedPointeeType os.LinkError
+      Pointee: 510 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 145
       Name: '*os.Signal'
@@ -2315,12 +2315,12 @@ Types:
       GoKind: 22
       Pointee: 146 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1128672
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType os.SyscallError
+      Pointee: 579 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 899
       Name: '*os.fileWithoutReadFrom'
@@ -2336,26 +2336,26 @@ Types:
       GoKind: 22
       Pointee: 898 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 530
+      ID: 540
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1030048
       GoKind: 22
-      Pointee: 531 UnresolvedPointeeType os/exec.Error
+      Pointee: 541 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2004608
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 670 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 532
+      ID: 542
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1030176
       GoKind: 22
-      Pointee: 533 StructureType os/exec.wrappedError
+      Pointee: 543 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 122
       Name: '*os/signal.signalCtx'
@@ -2364,52 +2364,52 @@ Types:
       GoKind: 22
       Pointee: 123 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 458
+      ID: 468
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 882848
       GoKind: 22
-      Pointee: 263 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 273 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 265
+      ID: 275
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 274 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 882752
       GoKind: 22
-      Pointee: 262 BaseType os/user.UnknownUserIdError
+      Pointee: 272 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 313
+      ID: 323
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 849344
       GoKind: 22
-      Pointee: 314 UnresolvedPointeeType reflect.ValueError
+      Pointee: 324 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 869120
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 415 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1011488
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 517 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1013408
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 522 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2425,12 +2425,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1011616
       GoKind: 22
-      Pointee: 509 StructureType runtime.boundsError
+      Pointee: 519 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -2446,24 +2446,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 570
+      ID: 580
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1136992
       GoKind: 22
-      Pointee: 571 StructureType runtime.errorAddressString
+      Pointee: 581 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1011232
       GoKind: 22
-      Pointee: 476 GoStringHeaderType runtime.errorString
+      Pointee: 486 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 477 GoStringDataType runtime.errorString.str
+      Pointee: 487 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -2486,17 +2486,17 @@ Types:
       GoKind: 22
       Pointee: 135 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 510
+      ID: 520
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1013152
       GoKind: 22
-      Pointee: 479 GoStringHeaderType runtime.plainError
+      Pointee: 489 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 481
+      ID: 491
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 480 GoStringDataType runtime.plainError.str
+      Pointee: 490 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2519,12 +2519,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1010848
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType strconv.NumError
+      Pointee: 514 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -2650,12 +2650,12 @@ Types:
       GoKind: 22
       Pointee: 834 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 619
+      ID: 629
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1263040
       GoKind: 22
-      Pointee: 608 BaseType syscall.Errno
+      Pointee: 618 BaseType syscall.Errno
     - __kind: PointerType
       ID: 686
       Name: '*syscall.Signal'
@@ -2664,12 +2664,12 @@ Types:
       GoKind: 22
       Pointee: 685 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1069472
       GoKind: 22
-      Pointee: 551 StructureType text/template.ExecError
+      Pointee: 561 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 140
       Name: '*time.Location'
@@ -2678,12 +2678,12 @@ Types:
       GoKind: 22
       Pointee: 141 StructureType time.Location
     - __kind: PointerType
-      ID: 307
+      ID: 317
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 846944
       GoKind: 22
-      Pointee: 308 UnresolvedPointeeType time.ParseError
+      Pointee: 318 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 137
       Name: '*time.Timer'
@@ -2692,31 +2692,31 @@ Types:
       GoKind: 22
       Pointee: 138 StructureType time.Timer
     - __kind: PointerType
-      ID: 306
+      ID: 316
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 846848
       GoKind: 22
-      Pointee: 225 GoStringHeaderType time.fileSizeError
+      Pointee: 235 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 227
+      ID: 237
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 226 GoStringDataType time.fileSizeError.str
+      Pointee: 236 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 671
+      ID: 190
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370976
       GoKind: 22
-      Pointee: 672 StructureType time.zone
+      Pointee: 191 StructureType time.zone
     - __kind: PointerType
-      ID: 674
+      ID: 193
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 371040
       GoKind: 22
-      Pointee: 675 StructureType time.zoneTrans
+      Pointee: 194 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -2760,47 +2760,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 319
+      ID: 329
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 851744
       GoKind: 22
-      Pointee: 320 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 330 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 332
+      ID: 342
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 854624
       GoKind: 22
-      Pointee: 333 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 343 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 334
+      ID: 344
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 854720
       GoKind: 22
-      Pointee: 239 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 249 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 516
+      ID: 526
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1018656
       GoKind: 22
-      Pointee: 517 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 527 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1018784
       GoKind: 22
-      Pointee: 483 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 493 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 798
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: GoChannelType
-      ID: 669
+      ID: 679
       Name: <-chan time.Time
       GoRuntimeType: 558720
       GoKind: 18
@@ -2969,7 +2969,7 @@ Types:
       HasCount: true
       Element: 12 BaseType uint64
     - __kind: ArrayType
-      ID: 643
+      ID: 653
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 653280
@@ -3026,7 +3026,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 629 PointerType *crypto/x509.Certificate
+      Element: 639 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 680
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3132,11 +3132,11 @@ Types:
       ByteSize: 32
       Element: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 221
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 921
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
@@ -3150,31 +3150,31 @@ Types:
       ByteSize: 336
       Element: 783 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 203
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 165 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 662
+      ID: 672
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 635 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 201
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
       Element: 160 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 199
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
       Element: 155 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 648
+      ID: 658
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 468896
@@ -3189,9 +3189,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 665 GoSliceDataType []float64.array
+      Data: 675 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 675
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3212,9 +3212,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 198 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 204 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 204
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3235,9 +3235,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 206 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 212 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 212
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3257,7 +3257,7 @@ Types:
       HasCount: true
       Element: 767 BaseType github.com/cihub/seelog.LogLevel
     - __kind: ArrayType
-      ID: 191
+      ID: 197
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -3302,9 +3302,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 189 GoSliceDataType []os.Signal.array
+      Data: 195 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 195
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3314,7 +3314,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 647
+      ID: 657
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -3329,15 +3329,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 663 GoSliceDataType []string.array
+      Data: 673 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 663
+      ID: 673
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 670
+      ID: 189
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463264
@@ -3345,22 +3345,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 671 PointerType *time.zone
+          Type: 190 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 676 GoSliceDataType []time.zone.array
+      Data: 214 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 676
+      ID: 214
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 672 StructureType time.zone
+      Element: 191 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 673
+      ID: 192
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463328
@@ -3368,20 +3368,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 674 PointerType *time.zoneTrans
+          Type: 193 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 678 GoSliceDataType []time.zoneTrans.array
+      Data: 216 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 678
+      ID: 216
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 675 StructureType time.zoneTrans
+      Element: 194 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3429,12 +3429,12 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 208
+      ID: 218
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 209 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 219 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
       ID: 917
       Name: '[]val<[]*mime/multipart.FileHeader>'
@@ -3448,7 +3448,7 @@ Types:
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 647 GoSliceHeaderType []string
+      Element: 657 GoSliceHeaderType []string
     - __kind: ArrayType
       ID: 768
       Name: '[]val<bool>'
@@ -3457,28 +3457,28 @@ Types:
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 196
+      ID: 202
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 661
+      ID: 671
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 654 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 194
+      ID: 200
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 128 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 192
+      ID: 198
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -3491,7 +3491,7 @@ Types:
       HasCount: true
       Element: 187 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 450
+      ID: 460
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 877952
@@ -3506,9 +3506,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 451 GoSliceDataType archive/tar.headerError.array
+      Data: 461 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 451
+      ID: 461
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3574,7 +3574,7 @@ Types:
       KeyType: 767 BaseType github.com/cihub/seelog.LogLevel
       ValueType: 6 BaseType bool
     - __kind: GoHMapBucketType
-      ID: 204
+      ID: 210
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
@@ -3583,15 +3583,15 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 208 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 218 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 209 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 219 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 916
       Name: bucket<string,[]*mime/multipart.FileHeader>
@@ -3602,7 +3602,7 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
           Type: 917 ArrayType []val<[]*mime/multipart.FileHeader>
@@ -3621,7 +3621,7 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
           Type: 788 ArrayType []val<[]string>
@@ -3629,7 +3629,7 @@ Types:
           Offset: 328
           Type: 782 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 647 GoSliceHeaderType []string
+      ValueType: 657 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
       ID: 165
       Name: bucket<string,float64>
@@ -3640,17 +3640,17 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 196 ArrayType []val<float64>
+          Type: 202 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
           Type: 164 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 635
+      ID: 645
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
@@ -3659,15 +3659,15 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 661 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 671 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 634 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 654 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 160
       Name: bucket<string,interface {}>
@@ -3678,10 +3678,10 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 194 ArrayType []val<interface {}>
+          Type: 200 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
           Type: 159 PointerType *bucket<string,interface {}>
@@ -3697,10 +3697,10 @@ Types:
           Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 191 ArrayType []key<string>
+          Type: 197 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 192 ArrayType []val<string>
+          Type: 198 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 154 PointerType *bucket<string,string>
@@ -3737,13 +3737,13 @@ Types:
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: BaseType
-      ID: 254
+      ID: 264
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 781280
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 255
+      ID: 265
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 781376
@@ -3751,13 +3751,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 257 PointerType *compress/flate.InternalError.str
+          Type: 267 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 256 GoStringDataType compress/flate.InternalError.str
+      Data: 266 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 256
+      ID: 266
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3841,7 +3841,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 556
+      ID: 566
       Name: context.deadlineExceededError
       GoRuntimeType: 1306048
       GoKind: 25
@@ -3885,7 +3885,7 @@ Types:
           Type: 137 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3931,31 +3931,31 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 251
+      ID: 261
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 780992
       GoKind: 2
     - __kind: BaseType
-      ID: 252
+      ID: 262
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 781088
       GoKind: 2
     - __kind: BaseType
-      ID: 253
+      ID: 263
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 781184
       GoKind: 2
     - __kind: BaseType
-      ID: 228
+      ID: 238
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 778784
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 515
+      ID: 525
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4024,11 +4024,11 @@ Types:
       GoRuntimeType: 778592
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 324
+      ID: 334
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 322
+      ID: 332
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1637536
@@ -4039,26 +4039,26 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 643 ArrayType [5]uint8
+          Type: 653 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 644 GoInterfaceType net.Conn
+          Type: 654 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 482
+      ID: 492
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 967744
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 631
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 640
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 381
+      ID: 391
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1640416
@@ -4066,21 +4066,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 629 PointerType *crypto/x509.Certificate
+          Type: 639 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 653 BaseType crypto/x509.InvalidReason
+          Type: 663 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 375
+      ID: 385
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1097312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 377
+      ID: 387
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1437024
@@ -4088,24 +4088,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 629 PointerType *crypto/x509.Certificate
+          Type: 639 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 250
+      ID: 260
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 780800
       GoKind: 2
     - __kind: BaseType
-      ID: 653
+      ID: 663
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 546688
       GoKind: 2
     - __kind: StructureType
-      ID: 529
+      ID: 539
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1400192
@@ -4115,13 +4115,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 383
+      ID: 393
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1097568
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 379
+      ID: 389
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1640224
@@ -4129,15 +4129,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 629 PointerType *crypto/x509.Certificate
+          Type: 639 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 629 PointerType *crypto/x509.Certificate
+          Type: 639 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 442
+      ID: 452
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1277120
@@ -4147,7 +4147,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 446
+      ID: 456
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1277280
@@ -4157,47 +4157,47 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 444
+      ID: 454
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 229
+      ID: 239
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 778880
       GoKind: 6
     - __kind: BaseType
-      ID: 249
+      ID: 259
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 780608
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 344
+      ID: 354
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 527
+      ID: 537
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 336
+      ID: 346
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 352
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 340
+      ID: 350
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 338
+      ID: 348
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 346
+      ID: 356
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1267200
@@ -4207,15 +4207,15 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 437
+      ID: 447
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 435
+      ID: 445
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 259
+      ID: 269
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 782816
@@ -4223,18 +4223,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 261 PointerType *encoding/xml.UnmarshalError.str
+          Type: 271 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 260 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 270 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 260
+      ID: 270
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 440
+      ID: 450
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4251,11 +4251,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 310
+      ID: 320
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 512
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4271,11 +4271,11 @@ Types:
       GoRuntimeType: 543488
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 496
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 488
+      ID: 498
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4309,7 +4309,7 @@ Types:
       GoRuntimeType: 983200
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 367
+      ID: 377
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4319,7 +4319,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 349
+      ID: 359
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1638688
@@ -4327,7 +4327,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 645 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 655 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -4335,25 +4335,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 361
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 660
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 355
+      ID: 365
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1095904
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 662
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 243
+      ID: 253
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 779936
@@ -4361,18 +4361,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 245 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 255 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 244 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 254 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 244
+      ID: 254
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 645
+      ID: 655
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2127168
@@ -4380,13 +4380,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 646 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 656 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 13 GoStringHeaderType string
@@ -4395,7 +4395,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 648 GoSliceHeaderType []float64
+          Type: 658 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 16 BaseType int64
@@ -4404,13 +4404,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 649 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 659 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 651 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 661 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 13 GoStringHeaderType string
@@ -4421,13 +4421,13 @@ Types:
           Offset: 184
           Type: 16 BaseType int64
     - __kind: BaseType
-      ID: 646
+      ID: 656
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 545216
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 240
+      ID: 250
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 779840
@@ -4435,18 +4435,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 242 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 252 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 241 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 251 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 241
+      ID: 251
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 246
+      ID: 256
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 780032
@@ -4454,18 +4454,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 248 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 258 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 247 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 257 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 247
+      ID: 257
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 392
+      ID: 402
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
@@ -4681,16 +4681,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 200 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 206 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 205 GoMapType map[string]interface {}
+          Type: 211 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 689
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 210
+      ID: 220
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1822848
@@ -4771,7 +4771,7 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 597
+      ID: 607
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4823,29 +4823,29 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 394
+      ID: 404
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 401
+      ID: 411
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1099360
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 258
+      ID: 268
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 782144
       GoKind: 2
     - __kind: StructureType
-      ID: 399
+      ID: 409
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1099232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 397
+      ID: 407
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1437984
@@ -4858,7 +4858,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 409
+      ID: 419
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1438624
@@ -4871,7 +4871,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 413
+      ID: 423
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1641952
@@ -4887,7 +4887,7 @@ Types:
           Offset: 24
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1275680
@@ -4897,7 +4897,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 407
+      ID: 417
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1275360
@@ -4907,14 +4907,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 631
+      ID: 641
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1159008
       GoKind: 21
-      HeaderType: 633 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 643 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 654
+      ID: 664
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1033376
@@ -4929,15 +4929,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 667 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 677 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 667
+      ID: 677
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 421
+      ID: 431
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1438944
@@ -4945,12 +4945,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 631 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 641 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 631 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 641 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 415
+      ID: 425
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1275840
@@ -4960,7 +4960,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 419
+      ID: 429
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1642144
@@ -4971,12 +4971,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 654 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 654 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 417
+      ID: 427
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1438784
@@ -4989,7 +4989,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 423
+      ID: 433
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1276000
@@ -4997,9 +4997,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 139 StructureType time.Time
+          Type: 139 GoTimeType time.Time
     - __kind: StructureType
-      ID: 429
+      ID: 439
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1439264
@@ -5012,7 +5012,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 431
+      ID: 441
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1276320
@@ -5022,7 +5022,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 427
+      ID: 437
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1439104
@@ -5035,7 +5035,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1276160
@@ -5045,7 +5045,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 433
+      ID: 443
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1439424
@@ -5080,7 +5080,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 357
+      ID: 367
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1268480
@@ -5094,7 +5094,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 359
+      ID: 369
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1268640
@@ -5102,7 +5102,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 357 StructureType github.com/cihub/seelog.baseError
+          Type: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 732
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -5125,7 +5125,7 @@ Types:
           Offset: 8
           Type: 743 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 363
+      ID: 373
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1268960
@@ -5133,7 +5133,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 357 StructureType github.com/cihub/seelog.baseError
+          Type: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 736
       Name: github.com/cihub/seelog.splitDispatcher
@@ -5149,7 +5149,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 361
+      ID: 371
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1268800
@@ -5157,9 +5157,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 357 StructureType github.com/cihub/seelog.baseError
+          Type: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 365
+      ID: 375
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1269120
@@ -5167,7 +5167,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 357 StructureType github.com/cihub/seelog.baseError
+          Type: 367 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 860
       Name: github.com/cihub/seelog/archive.Reader
@@ -5196,42 +5196,42 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 635
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 551
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 539
+      ID: 549
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 543
+      ID: 553
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 555
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 545
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 370
+      ID: 380
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1270080
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 609
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 585
+      ID: 595
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1756544
@@ -5247,11 +5247,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 589
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 521
+      ID: 531
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1544608
@@ -5264,7 +5264,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 591
+      ID: 601
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1756992
@@ -5280,13 +5280,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 484
+      ID: 494
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 968416
       GoKind: 8
     - __kind: StructureType
-      ID: 583
+      ID: 593
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1756320
@@ -5302,13 +5302,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 657
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 779456
       GoKind: 8
     - __kind: StructureType
-      ID: 581
+      ID: 591
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1756096
@@ -5316,15 +5316,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 657 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 667 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 657 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 667 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 589
+      ID: 599
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1673024
@@ -5337,7 +5337,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1756768
@@ -5353,7 +5353,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 595
+      ID: 605
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1473664
@@ -5363,19 +5363,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 525
+      ID: 535
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1218208
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 523
+      ID: 533
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1218080
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 593
+      ID: 603
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1673216
@@ -5388,7 +5388,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 276
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 784736
@@ -5396,22 +5396,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 278 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 267 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 277 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 277
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 648
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 549
+      ID: 559
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1291520
@@ -5421,19 +5421,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 269
+      ID: 279
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 785312
       GoKind: 10
     - __kind: BaseType
-      ID: 636
+      ID: 646
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 980512
       GoKind: 10
     - __kind: StructureType
-      ID: 607
+      ID: 617
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1790368
@@ -5444,12 +5444,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 636 BaseType golang.org/x/net/http2.ErrCode
+          Type: 646 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 468
+      ID: 478
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1446144
@@ -5457,12 +5457,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 636 BaseType golang.org/x/net/http2.ErrCode
+          Type: 646 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 283
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 785504
@@ -5470,18 +5470,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 285 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 274 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 284 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 284
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 279
+      ID: 289
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 785696
@@ -5489,18 +5489,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 281 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 291 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 280 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 290 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 280
+      ID: 290
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 286
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 785600
@@ -5508,18 +5508,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 288 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 277 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 287 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 287
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 280
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 785408
@@ -5527,18 +5527,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 282 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 271 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 281 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 281
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 472
+      ID: 482
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1292160
@@ -5548,13 +5548,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 282
+      ID: 292
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 785792
       GoKind: 2
     - __kind: StructureType
-      ID: 460
+      ID: 470
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1287200
@@ -5564,11 +5564,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 615
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 627
+      ID: 637
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1817248
@@ -5584,7 +5584,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 462
+      ID: 472
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1445664
@@ -5601,7 +5601,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 547
+      ID: 557
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1407232
@@ -5615,25 +5615,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 448
+      ID: 458
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 537
+      ID: 547
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 613
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 601
+      ID: 611
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1354528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 454
+      ID: 464
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1280480
@@ -5643,7 +5643,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 456
+      ID: 466
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1280640
@@ -5653,7 +5653,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 413
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -5725,7 +5725,7 @@ Types:
       BucketType: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
       BucketsType: 769 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
     - __kind: GoHMapHeaderType
-      ID: 202
+      ID: 208
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -5746,18 +5746,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
-      BucketType: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 211 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 221 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
       ID: 914
       Name: hash<string,[]*mime/multipart.FileHeader>
@@ -5859,9 +5859,9 @@ Types:
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
       BucketType: 165 GoHMapBucketType bucket<string,float64>
-      BucketsType: 197 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 203 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 633
+      ID: 643
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -5882,18 +5882,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 634 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 634 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
-      BucketType: 635 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 662 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 672 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 158
       Name: hash<string,interface {}>
@@ -5927,7 +5927,7 @@ Types:
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
       BucketType: 160 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 195 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 201 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 153
       Name: hash<string,string>
@@ -5961,9 +5961,9 @@ Types:
           Offset: 40
           Type: 134 PointerType *runtime.mapextra
       BucketType: 155 GoHMapBucketType bucket<string,string>
-      BucketsType: 193 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 199 GoSliceDataType []bucket<string,string>.array
     - __kind: UnresolvedPointeeType
-      ID: 475
+      ID: 485
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -6010,7 +6010,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 372
+      ID: 382
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -6036,7 +6036,7 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 587
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6044,13 +6044,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 575
+      ID: 585
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1323328
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 312
+      ID: 322
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6198,7 +6198,7 @@ Types:
           Offset: 0
           Type: 851 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 583
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoMapType
@@ -6216,12 +6216,12 @@ Types:
       GoKind: 21
       HeaderType: 745 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 200
+      ID: 206
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 21
-      HeaderType: 202 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 208 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 912
       Name: map[string][]*mime/multipart.FileHeader
@@ -6244,7 +6244,7 @@ Types:
       GoKind: 21
       HeaderType: 163 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 205
+      ID: 211
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896480
@@ -6258,7 +6258,7 @@ Types:
       GoKind: 21
       HeaderType: 153 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 390
+      ID: 400
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1272480
@@ -6302,11 +6302,11 @@ Types:
           Offset: 8
           Type: 861 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 559
+      ID: 569
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 644
+      ID: 654
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1435264
@@ -6319,7 +6319,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 622
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6327,11 +6327,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 620
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 571
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6347,7 +6347,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 552
+      ID: 562
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1090912
@@ -6355,18 +6355,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 554 PointerType *net.UnknownNetworkError.str
+          Type: 564 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 553 GoStringDataType net.UnknownNetworkError.str
+      Data: 563 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 553
+      ID: 563
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 490
+      ID: 500
       Name: net.canceledError
       GoRuntimeType: 1216032
       GoKind: 25
@@ -6376,7 +6376,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 656
+      ID: 666
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2016832
@@ -6384,7 +6384,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 644 GoInterfaceType net.Conn
+          Type: 654 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -6411,7 +6411,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 284
+      ID: 294
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6428,7 +6428,7 @@ Types:
           Offset: 16
           Type: 111 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 286
+      ID: 296
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1632160
@@ -6436,7 +6436,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 639 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 649 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -6470,11 +6470,11 @@ Types:
           Offset: 0
           Type: 889 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 573
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 624
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6524,11 +6524,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 292
+      ID: 302
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 492
+      ID: 502
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6580,7 +6580,7 @@ Types:
           Type: 16 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6625,7 +6625,7 @@ Types:
           Type: 801 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 151 GoMapType map[string]string
@@ -6662,7 +6662,7 @@ Types:
           Type: 16 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6735,19 +6735,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 212
+      ID: 222
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 776384
       GoKind: 10
     - __kind: BaseType
-      ID: 628
+      ID: 638
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 965056
       GoKind: 10
     - __kind: StructureType
-      ID: 295
+      ID: 305
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1633696
@@ -6758,12 +6758,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 628 BaseType net/http.http2ErrCode
+          Type: 638 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 616
+      ID: 626
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1806752
@@ -6774,7 +6774,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 628 BaseType net/http.http2ErrCode
+          Type: 638 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
@@ -6783,7 +6783,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 301
+      ID: 311
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1435744
@@ -6791,12 +6791,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 628 BaseType net/http.http2ErrCode
+          Type: 638 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 216
+      ID: 226
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 776576
@@ -6804,18 +6804,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 218 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 228 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 217 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 227 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 217
+      ID: 227
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 299
+      ID: 309
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1092192
       GoKind: 25
@@ -6825,7 +6825,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 222
+      ID: 232
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 776768
@@ -6833,18 +6833,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 224 PointerType *net/http.http2headerFieldNameError.str
+          Type: 234 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 223 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 233 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 223
+      ID: 233
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 219
+      ID: 229
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 776672
@@ -6852,18 +6852,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 221 PointerType *net/http.http2headerFieldValueError.str
+          Type: 231 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 220 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 230 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 220
+      ID: 230
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 577
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -6879,13 +6879,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 498
+      ID: 508
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1216672
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 213
+      ID: 223
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 776480
@@ -6893,13 +6893,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 215 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 225 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 214 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 224 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 214
+      ID: 224
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -6942,7 +6942,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 494
+      ID: 504
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1392512
@@ -6982,7 +6982,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 305
+      ID: 315
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1260320
@@ -7057,7 +7057,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 647 GoSliceHeaderType []string
+          Type: 657 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 775 StructureType sync/atomic.Bool
@@ -7093,7 +7093,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 290
+      ID: 300
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1435584
@@ -7106,17 +7106,17 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 628
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 565
+      ID: 575
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1310528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 496
+      ID: 506
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1392672
@@ -7126,7 +7126,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 288
+      ID: 298
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7136,7 +7136,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 318
+      ID: 328
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1636960
@@ -7152,7 +7152,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 316
+      ID: 326
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1436064
@@ -7165,11 +7165,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 331
+      ID: 341
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 236
+      ID: 246
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 779168
@@ -7177,22 +7177,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 238 PointerType *net/textproto.ProtocolError.str
+          Type: 248 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 237 GoStringDataType net/textproto.ProtocolError.str
+      Data: 247 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 237
+      ID: 247
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 633
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 230
+      ID: 240
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 778976
@@ -7200,18 +7200,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 232 PointerType *net/url.EscapeError.str
+          Type: 242 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 231 GoStringDataType net/url.EscapeError.str
+      Data: 241 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 231
+      ID: 241
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 233
+      ID: 243
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 779072
@@ -7219,13 +7219,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 235 PointerType *net/url.InvalidHostError.str
+          Type: 245 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 234 GoStringDataType net/url.InvalidHostError.str
+      Data: 244 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 234
+      ID: 244
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7285,7 +7285,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 500
+      ID: 510
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7302,7 +7302,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 579
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7344,15 +7344,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 531
+      ID: 541
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 670
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 533
+      ID: 543
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1544992
@@ -7386,7 +7386,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 273
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 783968
@@ -7394,36 +7394,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *os/user.UnknownGroupIdError.str
+          Type: 275 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 264 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 274 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 274
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 262
+      ID: 272
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 783872
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 314
+      ID: 324
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 415
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 517
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 522
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7435,7 +7435,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 509
+      ID: 519
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1796192
@@ -7452,9 +7452,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 658 BaseType runtime.boundsErrorCode
+          Type: 668 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 658
+      ID: 668
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 543680
@@ -7474,7 +7474,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 571
+      ID: 581
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1667648
@@ -7487,7 +7487,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 476
+      ID: 486
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 966304
@@ -7495,13 +7495,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 478 PointerType *runtime.errorString.str
+          Type: 488 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 477 GoStringDataType runtime.errorString.str
+      Data: 487 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 477
+      ID: 487
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8127,7 +8127,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 479
+      ID: 489
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 966880
@@ -8135,13 +8135,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 481 PointerType *runtime.plainError.str
+          Type: 491 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 480 GoStringDataType runtime.plainError.str
+      Data: 490 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 480
+      ID: 490
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8223,7 +8223,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 514
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8588,7 +8588,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 608
+      ID: 618
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1217312
@@ -8600,7 +8600,7 @@ Types:
       GoRuntimeType: 967072
       GoKind: 2
     - __kind: StructureType
-      ID: 551
+      ID: 561
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1549216
@@ -8630,10 +8630,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 670 GoSliceHeaderType []time.zone
+          Type: 189 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 673 GoSliceHeaderType []time.zoneTrans
+          Type: 192 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -8645,12 +8645,12 @@ Types:
           Type: 16 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 671 PointerType *time.zone
+          Type: 190 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 308
+      ID: 318
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 139
       Name: time.Time
       ByteSize: 24
@@ -8666,6 +8666,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 140 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 138
       Name: time.Timer
@@ -8675,12 +8683,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 669 GoChannelType <-chan time.Time
+          Type: 679 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 225
+      ID: 235
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 776864
@@ -8688,18 +8696,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 227 PointerType *time.fileSizeError.str
+          Type: 237 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 226 GoStringDataType time.fileSizeError.str
+      Data: 236 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 226
+      ID: 236
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 672
+      ID: 191
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1458304
@@ -8715,7 +8723,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 675
+      ID: 194
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1664192
@@ -8776,7 +8784,7 @@ Types:
       GoRuntimeType: 543616
       GoKind: 26
     - __kind: StructureType
-      ID: 639
+      ID: 649
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1967808
@@ -8787,10 +8795,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 640 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 650 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 641 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 651 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -8805,18 +8813,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 642 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 652 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 642
+      ID: 652
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 967360
       GoKind: 9
     - __kind: StructureType
-      ID: 640
+      ID: 650
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1825664
@@ -8841,17 +8849,17 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 320
+      ID: 330
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 641
+      ID: 651
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 544512
       GoKind: 8
     - __kind: StructureType
-      ID: 333
+      ID: 343
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1265280
@@ -8861,13 +8869,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 239
+      ID: 249
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 779264
       GoKind: 2
     - __kind: StructureType
-      ID: 517
+      ID: 527
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1544416
@@ -8880,7 +8888,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 483
+      ID: 493
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 968224

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -120,7 +120,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 665 PointerType *crypto/x509.Certificate
+      Pointee: 675 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 723
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -144,10 +144,10 @@ Types:
       ByteSize: 8
       Pointee: 789 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 229
+      ID: 235
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 230 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 236 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 970
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -164,10 +164,10 @@ Types:
       ByteSize: 8
       Pointee: 170 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 670
+      ID: 680
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 671 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 164
       Name: '**table<string,interface {}>'
@@ -210,30 +210,30 @@ Types:
       ByteSize: 8
       Pointee: 998 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 708
+      ID: 718
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 707 GoSliceDataType []float64.array
+      Pointee: 717 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 225
+      ID: 231
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 230 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 233
+      ID: 239
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1004
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1003 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 199
+      ID: 205
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []os.Signal.array
+      Pointee: 204 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -242,20 +242,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 706
+      ID: 716
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 705 GoSliceDataType []string.array
+      Pointee: 715 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 719
+      ID: 241
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 718 GoSliceDataType []time.zone.array
+      Pointee: 240 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 721
+      ID: 243
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 720 GoSliceDataType []time.zoneTrans.array
+      Pointee: 242 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 991
       Name: '*[]uint8'
@@ -274,17 +274,17 @@ Types:
       ByteSize: 8
       Pointee: 186 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 485
+      ID: 495
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 945248
       GoKind: 22
-      Pointee: 486 GoSliceHeaderType archive/tar.headerError
+      Pointee: 496 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 487 GoSliceDataType archive/tar.headerError.array
+      Pointee: 497 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 898
       Name: '*archive/zip.checksumReader'
@@ -335,24 +335,24 @@ Types:
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 423
+      ID: 433
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 930944
       GoKind: 22
-      Pointee: 287 BaseType compress/flate.CorruptInputError
+      Pointee: 297 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 931040
       GoKind: 22
-      Pointee: 288 GoStringHeaderType compress/flate.InternalError
+      Pointee: 298 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 290
+      ID: 300
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType compress/flate.InternalError.str
+      Pointee: 299 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 932
       Name: '*compress/flate.decompressor'
@@ -382,12 +382,12 @@ Types:
       GoKind: 22
       Pointee: 118 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1202848
       GoKind: 22
-      Pointee: 592 StructureType context.deadlineExceededError
+      Pointee: 602 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1005
       Name: '*context.emptyCtx'
@@ -431,47 +431,47 @@ Types:
       GoKind: 22
       Pointee: 126 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 419
+      ID: 429
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929696
       GoKind: 22
-      Pointee: 283 BaseType crypto/aes.KeySizeError
+      Pointee: 293 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929888
       GoKind: 22
-      Pointee: 284 BaseType crypto/des.KeySizeError
+      Pointee: 294 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 421
+      ID: 431
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930176
       GoKind: 22
-      Pointee: 285 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 295 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930464
       GoKind: 22
-      Pointee: 286 BaseType crypto/rc4.KeySizeError
+      Pointee: 296 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 358
+      ID: 368
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 260 BaseType crypto/tls.AlertError
+      Pointee: 270 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1055456
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 561 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 962
       Name: '*crypto/tls.Conn'
@@ -487,206 +487,206 @@ Types:
       GoKind: 22
       Pointee: 850 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 919232
       GoKind: 22
-      Pointee: 357 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 367 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 354
+      ID: 364
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 919136
       GoKind: 22
-      Pointee: 355 StructureType crypto/tls.RecordHeaderError
+      Pointee: 365 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1053792
       GoKind: 22
-      Pointee: 518 BaseType crypto/tls.alert
+      Pointee: 528 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 656
+      ID: 666
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1437600
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 667 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 665
+      ID: 675
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2081952
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 676 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 929504
       GoKind: 22
-      Pointee: 416 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 426 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 409
+      ID: 419
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 929024
       GoKind: 22
-      Pointee: 410 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 420 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 411
+      ID: 421
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 929120
       GoKind: 22
-      Pointee: 412 StructureType crypto/x509.HostnameError
+      Pointee: 422 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 928928
       GoKind: 22
-      Pointee: 282 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 292 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1065056
       GoKind: 22
-      Pointee: 565 StructureType crypto/x509.SystemRootsError
+      Pointee: 575 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 929600
       GoKind: 22
-      Pointee: 418 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 428 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 413
+      ID: 423
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 929408
       GoKind: 22
-      Pointee: 414 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 424 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 477
+      ID: 487
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 940928
       GoKind: 22
-      Pointee: 478 StructureType encoding/asn1.StructuralError
+      Pointee: 488 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 481
+      ID: 491
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941120
       GoKind: 22
-      Pointee: 482 StructureType encoding/asn1.SyntaxError
+      Pointee: 492 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 479
+      ID: 489
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 941024
       GoKind: 22
-      Pointee: 480 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 490 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 919520
       GoKind: 22
-      Pointee: 261 BaseType encoding/base64.CorruptInputError
+      Pointee: 271 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 281 BaseType encoding/hex.InvalidByteError
+      Pointee: 291 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 376
+      ID: 386
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922880
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 387 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1060576
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 573 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 922496
       GoKind: 22
-      Pointee: 369 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 379 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 922784
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 385 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 372
+      ID: 382
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 922688
       GoKind: 22
-      Pointee: 373 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 383 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 370
+      ID: 380
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 922592
       GoKind: 22
-      Pointee: 371 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 381 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 923264
       GoKind: 22
-      Pointee: 379 StructureType encoding/json.jsonError
+      Pointee: 389 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 472
+      ID: 482
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 938144
       GoKind: 22
-      Pointee: 473 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 483 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 938048
       GoKind: 22
-      Pointee: 471 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 481 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 938240
       GoKind: 22
-      Pointee: 292 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 302 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 294
+      ID: 304
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 293 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 303 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 475
+      ID: 485
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 476 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 486 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -695,19 +695,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 342
+      ID: 352
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 914720
       GoKind: 22
-      Pointee: 343 UnresolvedPointeeType errors.errorString
+      Pointee: 353 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 537
+      ID: 547
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1046752
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType errors.joinError
+      Pointee: 548 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -723,26 +723,26 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 521
+      ID: 531
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1036512
       GoKind: 22
-      Pointee: 522 UnresolvedPointeeType fmt.wrapError
+      Pointee: 532 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1036640
       GoKind: 22
-      Pointee: 524 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 534 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 399
+      ID: 409
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927296
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 410 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 790
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -751,83 +751,83 @@ Types:
       GoKind: 22
       Pointee: 791 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 924512
       GoKind: 22
-      Pointee: 382 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 392 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 383
+      ID: 393
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 924608
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 394 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 685
+      ID: 695
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 924320
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 696 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 924896
       GoKind: 22
-      Pointee: 388 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 398 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 687
+      ID: 697
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 698 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 385
+      ID: 395
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 275 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 285 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 277
+      ID: 287
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 276 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 286 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 924224
       GoKind: 22
-      Pointee: 272 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 282 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 274
+      ID: 284
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 273 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 283 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 924800
       GoKind: 22
-      Pointee: 278 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 288 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 280
+      ID: 290
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 279 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 427
+      ID: 437
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 932000
       GoKind: 22
-      Pointee: 428 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 438 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 781
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
@@ -885,12 +885,12 @@ Types:
       GoKind: 22
       Pointee: 731 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 240
+      ID: 250
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1210912
       GoKind: 22
-      Pointee: 241 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 251 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 179
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
@@ -906,12 +906,12 @@ Types:
       GoKind: 22
       Pointee: 797 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 632
+      ID: 642
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1231904
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 643 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 732
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
@@ -948,143 +948,143 @@ Types:
       GoKind: 22
       Pointee: 879 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 429
+      ID: 439
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 934208
       GoKind: 22
-      Pointee: 430 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 440 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 935264
       GoKind: 22
-      Pointee: 437 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 447 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 934976
       GoKind: 22
-      Pointee: 291 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 301 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 935168
       GoKind: 22
-      Pointee: 435 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 445 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 935072
       GoKind: 22
-      Pointee: 433 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 443 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 444
+      ID: 454
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 936608
       GoKind: 22
-      Pointee: 445 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 455 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 448
+      ID: 458
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 936800
       GoKind: 22
-      Pointee: 449 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 459 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 446
+      ID: 456
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 936704
       GoKind: 22
-      Pointee: 447 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 457 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 442
+      ID: 452
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 936512
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 453 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 710
+      ID: 720
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 709 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 456
+      ID: 466
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 937184
       GoKind: 22
-      Pointee: 457 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 467 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 936896
       GoKind: 22
-      Pointee: 451 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 461 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 454
+      ID: 464
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 937088
       GoKind: 22
-      Pointee: 455 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 465 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 936992
       GoKind: 22
-      Pointee: 453 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 463 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 458
+      ID: 468
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 937280
       GoKind: 22
-      Pointee: 459 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 937568
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 475 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 937664
       GoKind: 22
-      Pointee: 467 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 477 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 462
+      ID: 472
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 937472
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 473 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 460
+      ID: 470
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 471 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 937856
       GoKind: 22
-      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 806
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1114,12 +1114,12 @@ Types:
       GoKind: 22
       Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 926048
       GoKind: 22
-      Pointee: 390 StructureType github.com/cihub/seelog.baseError
+      Pointee: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 783
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1128,12 +1128,12 @@ Types:
       GoKind: 22
       Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 391
+      ID: 401
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 926144
       GoKind: 22
-      Pointee: 392 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 402 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 773
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1156,12 +1156,12 @@ Types:
       GoKind: 22
       Pointee: 780 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 926336
       GoKind: 22
-      Pointee: 396 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 406 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 777
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1177,19 +1177,19 @@ Types:
       GoKind: 22
       Pointee: 799 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 926240
       GoKind: 22
-      Pointee: 394 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 404 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 926432
       GoKind: 22
-      Pointee: 398 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 408 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 896
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1205,289 +1205,289 @@ Types:
       GoKind: 22
       Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 660
+      ID: 670
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1456000
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 671 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 576
+      ID: 586
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1082976
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 587 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 574
+      ID: 584
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1082848
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 585 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1087328
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 589 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 580
+      ID: 590
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1087456
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 591 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 570
+      ID: 580
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1071968
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 581 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 927968
       GoKind: 22
-      Pointee: 403 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 413 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 634
+      ID: 644
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1240096
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 645 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1223840
       GoKind: 22
-      Pointee: 621 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 631 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 614
+      ID: 624
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1223456
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 625 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 556
+      ID: 566
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1058400
       GoKind: 22
-      Pointee: 557 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 567 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1224224
       GoKind: 22
-      Pointee: 627 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 637 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1058272
       GoKind: 22
-      Pointee: 520 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 530 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1223712
       GoKind: 22
-      Pointee: 619 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 629 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 616
+      ID: 626
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1223584
       GoKind: 22
-      Pointee: 617 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 627 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 624
+      ID: 634
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1224096
       GoKind: 22
-      Pointee: 625 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 635 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 622
+      ID: 632
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1223968
       GoKind: 22
-      Pointee: 623 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 633 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 630
+      ID: 640
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1224608
       GoKind: 22
-      Pointee: 631 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 560
+      ID: 570
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1058656
       GoKind: 22
-      Pointee: 561 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 571 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 558
+      ID: 568
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1058528
       GoKind: 22
-      Pointee: 559 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 569 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 628
+      ID: 638
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1224480
       GoKind: 22
-      Pointee: 629 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 639 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 499
+      ID: 509
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 956672
       GoKind: 22
-      Pointee: 299 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 309 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 301
+      ID: 311
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 300 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 310 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 673
+      ID: 683
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1692192
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 684 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 584
+      ID: 594
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1102176
       GoKind: 22
-      Pointee: 585 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 595 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 957920
       GoKind: 22
-      Pointee: 302 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 312 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 642
+      ID: 652
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1278240
       GoKind: 22
-      Pointee: 643 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 653 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 958208
       GoKind: 22
-      Pointee: 504 StructureType golang.org/x/net/http2.connError
+      Pointee: 514 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 958112
       GoKind: 22
-      Pointee: 306 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 316 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 308
+      ID: 318
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 317 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 958400
       GoKind: 22
-      Pointee: 312 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 314
+      ID: 324
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 313 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 323 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 958304
       GoKind: 22
-      Pointee: 309 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 319 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 311
+      ID: 321
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 310 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 320 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 958016
       GoKind: 22
-      Pointee: 303 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 313 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 305
+      ID: 315
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 304 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 314 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 958496
       GoKind: 22
-      Pointee: 508 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 518 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 509
+      ID: 519
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 958592
       GoKind: 22
-      Pointee: 315 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 325 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 495
+      ID: 505
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 952352
       GoKind: 22
-      Pointee: 496 StructureType google.golang.org/grpc.dropError
+      Pointee: 506 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1275296
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 651 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 662
+      ID: 672
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1463520
       GoKind: 22
-      Pointee: 663 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 673 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 497
+      ID: 507
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 954944
       GoKind: 22
-      Pointee: 498 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 508 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 921
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1496,12 +1496,12 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 582
+      ID: 592
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1096416
       GoKind: 22
-      Pointee: 583 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 593 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 905
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1510,61 +1510,61 @@ Types:
       GoKind: 22
       Pointee: 906 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 483
+      ID: 493
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 943904
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 494 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1076576
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 583 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1244192
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 649 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 636
+      ID: 646
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1243936
       GoKind: 22
-      Pointee: 637 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 647 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 489
+      ID: 499
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 946208
       GoKind: 22
-      Pointee: 490 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 500 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 491
+      ID: 501
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 946304
       GoKind: 22
-      Pointee: 492 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 502 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 935360
       GoKind: 22
-      Pointee: 439 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 449 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 510
+      ID: 520
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 959360
       GoKind: 22
-      Pointee: 511 UnresolvedPointeeType html/template.Error
+      Pointee: 521 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -1601,26 +1601,26 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 928544
       GoKind: 22
-      Pointee: 407 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 417 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 928448
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 415 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 612
+      ID: 622
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1218976
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 623 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 960
       Name: '*internal/poll.FD'
@@ -1629,19 +1629,19 @@ Types:
       GoKind: 22
       Pointee: 961 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1218848
       GoKind: 22
-      Pointee: 611 StructureType internal/poll.errNetClosing
+      Pointee: 621 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 915104
       GoKind: 22
-      Pointee: 345 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 355 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 925
       Name: '*io.PipeReader'
@@ -1671,12 +1671,12 @@ Types:
       GoKind: 22
       Pointee: 895 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1218080
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType io/fs.PathError
+      Pointee: 619 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 137
       Name: '*map<context.canceler,struct {}>'
@@ -1688,10 +1688,10 @@ Types:
       ByteSize: 8
       Pointee: 787 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 227
+      ID: 233
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 228 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 234 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 968
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1708,10 +1708,10 @@ Types:
       ByteSize: 8
       Pointee: 168 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 668
+      ID: 678
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 669 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 162
       Name: '*map<string,interface {}>'
@@ -1723,12 +1723,12 @@ Types:
       ByteSize: 8
       Pointee: 158 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 425
+      ID: 435
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 931616
       GoKind: 22
-      Pointee: 426 StructureType math/big.ErrNaN
+      Pointee: 436 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 980
       Name: '*mime/multipart.FileHeader'
@@ -1758,19 +1758,19 @@ Types:
       GoKind: 22
       Pointee: 910 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 594
+      ID: 604
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1204000
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType net.AddrError
+      Pointee: 605 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 647
+      ID: 657
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1430720
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType net.DNSError
+      Pointee: 658 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 936
       Name: '*net.IPConn'
@@ -1779,19 +1779,19 @@ Types:
       GoKind: 22
       Pointee: 937 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 645
+      ID: 655
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1430400
       GoKind: 22
-      Pointee: 646 UnresolvedPointeeType net.OpError
+      Pointee: 656 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 596
+      ID: 606
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1204128
       GoKind: 22
-      Pointee: 597 UnresolvedPointeeType net.ParseError
+      Pointee: 607 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 944
       Name: '*net.TCPConn'
@@ -1814,24 +1814,24 @@ Types:
       GoKind: 22
       Pointee: 943 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1203232
       GoKind: 22
-      Pointee: 588 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 598 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 590
+      ID: 600
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 589 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 599 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 525
+      ID: 535
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1037536
       GoKind: 22
-      Pointee: 526 StructureType net.canceledError
+      Pointee: 536 StructureType net.canceledError
     - __kind: PointerType
       ID: 934
       Name: '*net.conn'
@@ -1840,12 +1840,12 @@ Types:
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 691
+      ID: 701
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1864960
       GoKind: 22
-      Pointee: 692 StructureType net.dialResult·1
+      Pointee: 702 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 950
       Name: '*net.netFD'
@@ -1854,12 +1854,12 @@ Types:
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 316
+      ID: 326
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907712
       GoKind: 22
-      Pointee: 317 UnresolvedPointeeType net.notFoundError
+      Pointee: 327 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1006
       Name: '*net.onlyValuesCtx'
@@ -1868,12 +1868,12 @@ Types:
       GoKind: 22
       Pointee: 1007 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 318
+      ID: 328
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908384
       GoKind: 22
-      Pointee: 319 StructureType net.result·2
+      Pointee: 329 StructureType net.result·2
     - __kind: PointerType
       ID: 940
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1889,33 +1889,33 @@ Types:
       GoKind: 22
       Pointee: 939 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 598
+      ID: 608
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1204768
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType net.temporaryError
+      Pointee: 609 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1431040
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType net.timeoutError
+      Pointee: 660 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 324
+      ID: 334
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 910976
       GoKind: 22
-      Pointee: 325 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 335 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 527
+      ID: 537
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1040992
       GoKind: 22
-      Pointee: 528 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 538 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -1973,26 +1973,26 @@ Types:
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 326
+      ID: 336
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 911168
       GoKind: 22
-      Pointee: 244 BaseType net/http.http2ConnectionError
+      Pointee: 254 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 911264
       GoKind: 22
-      Pointee: 328 StructureType net/http.http2GoAwayError
+      Pointee: 338 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1432000
       GoKind: 22
-      Pointee: 652 StructureType net/http.http2StreamError
+      Pointee: 662 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 902
       Name: '*net/http.http2clientStream'
@@ -2001,31 +2001,31 @@ Types:
       GoKind: 22
       Pointee: 903 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 333
+      ID: 343
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 912320
       GoKind: 22
-      Pointee: 334 StructureType net/http.http2connError
+      Pointee: 344 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 248 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 258 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 250
+      ID: 260
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 249 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 259 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 911840
       GoKind: 22
-      Pointee: 332 StructureType net/http.http2goAwayFlowError
+      Pointee: 342 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 866
       Name: '*net/http.http2gzipReader'
@@ -2034,36 +2034,36 @@ Types:
       GoKind: 22
       Pointee: 867 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 912512
       GoKind: 22
-      Pointee: 254 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 264 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 256
+      ID: 266
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 255 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 265 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 912416
       GoKind: 22
-      Pointee: 251 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 261 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 253
+      ID: 263
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 252 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 262 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 602
+      ID: 612
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1208736
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 613 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 862
       Name: '*net/http.http2missingBody'
@@ -2079,24 +2079,24 @@ Types:
       GoKind: 22
       Pointee: 875 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 533
+      ID: 543
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1043296
       GoKind: 22
-      Pointee: 534 StructureType net/http.http2noCachedConnError
+      Pointee: 544 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 329
+      ID: 339
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 911648
       GoKind: 22
-      Pointee: 245 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 255 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 247
+      ID: 257
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 246 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 256 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 870
       Name: '*net/http.http2requestBody'
@@ -2140,12 +2140,12 @@ Types:
       GoKind: 22
       Pointee: 893 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1042912
       GoKind: 22
-      Pointee: 530 StructureType net/http.nothingWrittenError
+      Pointee: 540 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 854
       Name: '*net/http.pattern'
@@ -2168,12 +2168,12 @@ Types:
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 912704
       GoKind: 22
-      Pointee: 338 StructureType net/http.requestBodyReadError
+      Pointee: 348 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 771
       Name: '*net/http.response'
@@ -2189,33 +2189,33 @@ Types:
       GoKind: 22
       Pointee: 1002 StructureType net/http.segment
     - __kind: PointerType
-      ID: 322
+      ID: 332
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 910880
       GoKind: 22
-      Pointee: 323 StructureType net/http.statusError
+      Pointee: 333 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 653
+      ID: 663
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1433440
       GoKind: 22
-      Pointee: 654 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 664 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1208608
       GoKind: 22
-      Pointee: 601 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 611 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 531
+      ID: 541
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1043040
       GoKind: 22
-      Pointee: 532 StructureType net/http.transportReadFromServerError
+      Pointee: 542 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 923
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2224,12 +2224,12 @@ Types:
       GoKind: 22
       Pointee: 924 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 320
+      ID: 330
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 321 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 331 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 884
       Name: '*net/http/httputil.failureToReadBody'
@@ -2238,69 +2238,69 @@ Types:
       GoKind: 22
       Pointee: 885 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 351 StructureType net/netip.parseAddrError
+      Pointee: 361 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 917408
       GoKind: 22
-      Pointee: 349 StructureType net/netip.parsePrefixError
+      Pointee: 359 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 363
+      ID: 373
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 920768
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType net/textproto.Error
+      Pointee: 374 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 920672
       GoKind: 22
-      Pointee: 268 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 278 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 270
+      ID: 280
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 269 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 279 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 658
+      ID: 668
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1438080
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType net/url.Error
+      Pointee: 669 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 919616
       GoKind: 22
-      Pointee: 262 GoStringHeaderType net/url.EscapeError
+      Pointee: 272 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 264
+      ID: 274
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 263 GoStringDataType net/url.EscapeError.str
+      Pointee: 273 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 265 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 275 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 267
+      ID: 277
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 266 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 276 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 843
       Name: '*net/url.URL'
@@ -2326,10 +2326,10 @@ Types:
       ByteSize: 8
       Pointee: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 236
+      ID: 246
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 237 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 974
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2341,25 +2341,25 @@ Types:
       ByteSize: 8
       Pointee: 838 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 218
+      ID: 224
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 219 StructureType noalg.map.group[string]float64
+      Pointee: 225 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 699
+      ID: 709
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 700 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 210
+      ID: 216
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 211 StructureType noalg.map.group[string]interface {}
+      Pointee: 217 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 202
+      ID: 208
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[string]string
+      Pointee: 209 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 956
       Name: '*os.File'
@@ -2368,12 +2368,12 @@ Types:
       GoKind: 22
       Pointee: 957 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 535
+      ID: 545
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1045216
       GoKind: 22
-      Pointee: 536 UnresolvedPointeeType os.LinkError
+      Pointee: 546 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 150
       Name: '*os.Signal'
@@ -2382,12 +2382,12 @@ Types:
       GoKind: 22
       Pointee: 151 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1209248
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType os.SyscallError
+      Pointee: 615 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 954
       Name: '*os.fileWithoutReadFrom'
@@ -2403,26 +2403,26 @@ Types:
       GoKind: 22
       Pointee: 953 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 566
+      ID: 576
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1067104
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType os/exec.Error
+      Pointee: 577 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 695
+      ID: 705
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2132416
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 706 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1067232
       GoKind: 22
-      Pointee: 569 StructureType os/exec.wrappedError
+      Pointee: 579 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 127
       Name: '*os/signal.signalCtx'
@@ -2431,52 +2431,52 @@ Types:
       GoKind: 22
       Pointee: 128 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 950432
       GoKind: 22
-      Pointee: 296 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 306 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 297 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 307 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 493
+      ID: 503
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 950336
       GoKind: 22
-      Pointee: 295 BaseType os/user.UnknownUserIdError
+      Pointee: 305 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 915872
       GoKind: 22
-      Pointee: 347 UnresolvedPointeeType reflect.ValueError
+      Pointee: 357 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 440
+      ID: 450
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 935840
       GoKind: 22
-      Pointee: 441 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 451 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 543
+      ID: 553
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1049824
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 554 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 547
+      ID: 557
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1051616
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 558 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2492,12 +2492,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 545
+      ID: 555
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1049952
       GoKind: 22
-      Pointee: 546 StructureType runtime.boundsError
+      Pointee: 556 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -2513,24 +2513,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 606
+      ID: 616
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1217440
       GoKind: 22
-      Pointee: 607 StructureType runtime.errorAddressString
+      Pointee: 617 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 541
+      ID: 551
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1049440
       GoKind: 22
-      Pointee: 512 GoStringHeaderType runtime.errorString
+      Pointee: 522 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 513 GoStringDataType runtime.errorString.str
+      Pointee: 523 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2546,17 +2546,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 542
+      ID: 552
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1049568
       GoKind: 22
-      Pointee: 515 GoStringHeaderType runtime.plainError
+      Pointee: 525 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 516 GoStringDataType runtime.plainError.str
+      Pointee: 526 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2586,12 +2586,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1049056
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType strconv.NumError
+      Pointee: 550 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -2717,12 +2717,12 @@ Types:
       GoKind: 22
       Pointee: 887 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1436960
       GoKind: 22
-      Pointee: 644 BaseType syscall.Errno
+      Pointee: 654 BaseType syscall.Errno
     - __kind: PointerType
       ID: 728
       Name: '*syscall.Signal'
@@ -2741,10 +2741,10 @@ Types:
       ByteSize: 8
       Pointee: 808 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 230
+      ID: 236
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 234 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 244 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 971
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2759,29 +2759,29 @@ Types:
       ID: 170
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 216 StructureType table<string,float64>
+      Pointee: 222 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 671
+      ID: 681
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 697 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 707 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 165
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 208 StructureType table<string,interface {}>
+      Pointee: 214 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 160
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 200 StructureType table<string,string>
+      Pointee: 206 StructureType table<string,string>
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1106016
       GoKind: 22
-      Pointee: 587 StructureType text/template.ExecError
+      Pointee: 597 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 145
       Name: '*time.Location'
@@ -2790,12 +2790,12 @@ Types:
       GoKind: 22
       Pointee: 146 StructureType time.Location
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 913568
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType time.ParseError
+      Pointee: 351 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 142
       Name: '*time.Timer'
@@ -2804,31 +2804,31 @@ Types:
       GoKind: 22
       Pointee: 143 StructureType time.Timer
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 913472
       GoKind: 22
-      Pointee: 257 GoStringHeaderType time.fileSizeError
+      Pointee: 267 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 259
+      ID: 269
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 258 GoStringDataType time.fileSizeError.str
+      Pointee: 268 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 713
+      ID: 199
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396576
       GoKind: 22
-      Pointee: 714 StructureType time.zone
+      Pointee: 200 StructureType time.zone
     - __kind: PointerType
-      ID: 716
+      ID: 202
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 717 StructureType time.zoneTrans
+      Pointee: 203 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -2872,47 +2872,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 352
+      ID: 362
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 353 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 363 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 365
+      ID: 375
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 366 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 376 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 367
+      ID: 377
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 921056
       GoKind: 22
-      Pointee: 271 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 281 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1056992
       GoKind: 22
-      Pointee: 553 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 563 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1057120
       GoKind: 22
-      Pointee: 519 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 529 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 851
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: GoChannelType
-      ID: 711
+      ID: 721
       Name: <-chan time.Time
       GoRuntimeType: 606496
       GoKind: 18
@@ -3097,7 +3097,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 679
+      ID: 689
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 708864
@@ -3145,7 +3145,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 665 PointerType *crypto/x509.Certificate
+      Element: 675 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 722
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3205,11 +3205,11 @@ Types:
       ByteSize: 8
       Element: 789 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 252
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 230 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 236 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 981
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3223,25 +3223,25 @@ Types:
       ByteSize: 8
       Element: 830 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 228
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 170 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 703
+      ID: 713
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 671 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 220
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 165 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 212
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3293,7 +3293,7 @@ Types:
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 684
+      ID: 694
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 497792
@@ -3308,9 +3308,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 707 GoSliceDataType []float64.array
+      Data: 717 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 707
+      ID: 717
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3331,9 +3331,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 224 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 230 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 230
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3354,9 +3354,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 232 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 238
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3397,11 +3397,11 @@ Types:
       ByteSize: 24
       Element: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 253
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 237 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 982
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3415,29 +3415,29 @@ Types:
       ByteSize: 328
       Element: 838 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 229
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 219 StructureType noalg.map.group[string]float64
+      Element: 225 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 704
+      ID: 714
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 700 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 221
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 211 StructureType noalg.map.group[string]interface {}
+      Element: 217 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 213
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 203 StructureType noalg.map.group[string]string
+      Element: 209 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 149
       Name: '[]os.Signal'
@@ -3454,9 +3454,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 198 GoSliceDataType []os.Signal.array
+      Data: 204 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 204
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3466,7 +3466,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 683
+      ID: 693
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -3481,15 +3481,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 705 GoSliceDataType []string.array
+      Data: 715 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 705
+      ID: 715
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 712
+      ID: 198
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 490944
@@ -3497,22 +3497,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 713 PointerType *time.zone
+          Type: 199 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 718 GoSliceDataType []time.zone.array
+      Data: 240 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 718
+      ID: 240
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 714 StructureType time.zone
+      Element: 200 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 715
+      ID: 201
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491008
@@ -3520,20 +3520,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 716 PointerType *time.zoneTrans
+          Type: 202 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 720 GoSliceDataType []time.zoneTrans.array
+      Data: 242 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 720
+      ID: 242
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 717 StructureType time.zoneTrans
+      Element: 203 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3581,7 +3581,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 486
+      ID: 496
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 945344
@@ -3596,9 +3596,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 487 GoSliceDataType archive/tar.headerError.array
+      Data: 497 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 497
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3656,13 +3656,13 @@ Types:
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: BaseType
-      ID: 287
+      ID: 297
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 846144
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 298
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 846240
@@ -3670,13 +3670,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *compress/flate.InternalError.str
+          Type: 300 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType compress/flate.InternalError.str
+      Data: 299 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 299
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3760,7 +3760,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 592
+      ID: 602
       Name: context.deadlineExceededError
       GoRuntimeType: 1480640
       GoKind: 25
@@ -3804,7 +3804,7 @@ Types:
           Type: 142 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 144 StructureType time.Time
+          Type: 144 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3850,37 +3850,37 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 283
+      ID: 293
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 2
     - __kind: BaseType
-      ID: 284
+      ID: 294
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845856
       GoKind: 2
     - __kind: BaseType
-      ID: 285
+      ID: 295
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845952
       GoKind: 2
     - __kind: BaseType
-      ID: 286
+      ID: 296
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846048
       GoKind: 2
     - __kind: BaseType
-      ID: 260
+      ID: 270
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 843552
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 561
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3949,11 +3949,11 @@ Types:
       GoRuntimeType: 843360
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 357
+      ID: 367
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 355
+      ID: 365
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1755104
@@ -3964,26 +3964,26 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 679 ArrayType [5]uint8
+          Type: 689 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 680 GoInterfaceType net.Conn
+          Type: 690 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 518
+      ID: 528
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1004224
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 667
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 676
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 416
+      ID: 426
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1757216
@@ -3991,21 +3991,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 665 PointerType *crypto/x509.Certificate
+          Type: 675 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 689 BaseType crypto/x509.InvalidReason
+          Type: 699 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 410
+      ID: 420
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1133984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 412
+      ID: 422
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1620320
@@ -4013,24 +4013,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 665 PointerType *crypto/x509.Certificate
+          Type: 675 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 282
+      ID: 292
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 845568
       GoKind: 2
     - __kind: BaseType
-      ID: 689
+      ID: 699
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 594336
       GoKind: 2
     - __kind: StructureType
-      ID: 565
+      ID: 575
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1580480
@@ -4040,13 +4040,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 418
+      ID: 428
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1134240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 414
+      ID: 424
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1757024
@@ -4054,15 +4054,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 665 PointerType *crypto/x509.Certificate
+          Type: 675 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 665 PointerType *crypto/x509.Certificate
+          Type: 675 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 478
+      ID: 488
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1451840
@@ -4072,7 +4072,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 482
+      ID: 492
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1452000
@@ -4082,47 +4082,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 480
+      ID: 490
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 261
+      ID: 271
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 843648
       GoKind: 6
     - __kind: BaseType
-      ID: 281
+      ID: 291
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 845376
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 387
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 573
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 369
+      ID: 379
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 385
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 373
+      ID: 383
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 371
+      ID: 381
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 379
+      ID: 389
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1441120
@@ -4132,15 +4132,15 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 473
+      ID: 483
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 471
+      ID: 481
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 292
+      ID: 302
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 847680
@@ -4148,18 +4148,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 294 PointerType *encoding/xml.UnmarshalError.str
+          Type: 304 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 293 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 303 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 293
+      ID: 303
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 476
+      ID: 486
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4176,11 +4176,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 343
+      ID: 353
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 548
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4196,11 +4196,11 @@ Types:
       GoRuntimeType: 591136
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 522
+      ID: 532
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 524
+      ID: 534
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4234,7 +4234,7 @@ Types:
       GoRuntimeType: 1020064
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 410
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4244,7 +4244,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 382
+      ID: 392
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1756064
@@ -4252,7 +4252,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 681 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 691 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4260,25 +4260,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 394
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 696
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 388
+      ID: 398
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1132704
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 698
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 275
+      ID: 285
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 844704
@@ -4286,18 +4286,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 277 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 287 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 276 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 286 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 276
+      ID: 286
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 681
+      ID: 691
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2263264
@@ -4305,13 +4305,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 682 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 692 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4320,7 +4320,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 684 GoSliceHeaderType []float64
+          Type: 694 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4329,13 +4329,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 685 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 695 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 687 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 697 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4346,13 +4346,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 682
+      ID: 692
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 592864
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 272
+      ID: 282
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 844608
@@ -4360,18 +4360,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 274 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 284 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 273 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 283 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 273
+      ID: 283
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 278
+      ID: 288
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 844800
@@ -4379,18 +4379,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 280 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 290 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 279 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 279
+      ID: 289
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 428
+      ID: 438
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
@@ -4606,16 +4606,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 226 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 232 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 231 GoMapType map[string]interface {}
+          Type: 237 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 731
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 241
+      ID: 251
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1946656
@@ -4696,7 +4696,7 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 643
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4748,29 +4748,29 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 430
+      ID: 440
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 437
+      ID: 447
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1135904
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 291
+      ID: 301
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 2
     - __kind: StructureType
-      ID: 435
+      ID: 445
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1135776
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 433
+      ID: 443
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1621120
@@ -4783,7 +4783,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 445
+      ID: 455
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1621760
@@ -4796,7 +4796,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 449
+      ID: 459
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1758752
@@ -4812,7 +4812,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 447
+      ID: 457
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1450400
@@ -4822,7 +4822,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 443
+      ID: 453
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1450080
@@ -4832,14 +4832,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 667
+      ID: 677
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1522880
       GoKind: 21
-      HeaderType: 669 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 690
+      ID: 700
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1070304
@@ -4854,15 +4854,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 709 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 709
+      ID: 719
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 457
+      ID: 467
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1622080
@@ -4870,12 +4870,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 667 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 667 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 451
+      ID: 461
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1450560
@@ -4885,7 +4885,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 455
+      ID: 465
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1758944
@@ -4896,12 +4896,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 690 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 690 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 453
+      ID: 463
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1621920
@@ -4914,7 +4914,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 459
+      ID: 469
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1450720
@@ -4922,9 +4922,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 144 StructureType time.Time
+          Type: 144 GoTimeType time.Time
     - __kind: StructureType
-      ID: 465
+      ID: 475
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1622400
@@ -4937,7 +4937,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 467
+      ID: 477
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1451040
@@ -4947,7 +4947,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 463
+      ID: 473
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1622240
@@ -4960,7 +4960,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 461
+      ID: 471
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1450880
@@ -4970,7 +4970,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 469
+      ID: 479
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1622560
@@ -5005,7 +5005,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 390
+      ID: 400
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1442400
@@ -5019,7 +5019,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 392
+      ID: 402
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1442560
@@ -5027,7 +5027,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 390 StructureType github.com/cihub/seelog.baseError
+          Type: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 774
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -5050,7 +5050,7 @@ Types:
           Offset: 8
           Type: 785 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 396
+      ID: 406
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1442880
@@ -5058,7 +5058,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 390 StructureType github.com/cihub/seelog.baseError
+          Type: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 778
       Name: github.com/cihub/seelog.splitDispatcher
@@ -5074,7 +5074,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 394
+      ID: 404
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1442720
@@ -5082,9 +5082,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 390 StructureType github.com/cihub/seelog.baseError
+          Type: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 398
+      ID: 408
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1443040
@@ -5092,7 +5092,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 390 StructureType github.com/cihub/seelog.baseError
+          Type: 400 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 913
       Name: github.com/cihub/seelog/archive.Reader
@@ -5121,42 +5121,42 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 671
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 587
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 585
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 589
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 591
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 581
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 403
+      ID: 413
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1444000
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 645
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 621
+      ID: 631
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1877728
@@ -5172,11 +5172,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 625
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 567
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1728768
@@ -5189,7 +5189,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 627
+      ID: 637
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1878176
@@ -5205,13 +5205,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 520
+      ID: 530
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1004896
       GoKind: 8
     - __kind: StructureType
-      ID: 619
+      ID: 629
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1877504
@@ -5227,13 +5227,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 693
+      ID: 703
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 844224
       GoKind: 8
     - __kind: StructureType
-      ID: 617
+      ID: 627
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1877280
@@ -5241,15 +5241,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 693 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 693 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 625
+      ID: 635
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1789440
@@ -5262,7 +5262,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 623
+      ID: 633
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1877952
@@ -5278,7 +5278,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 631
+      ID: 641
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1657056
@@ -5288,19 +5288,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 561
+      ID: 571
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1300704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 559
+      ID: 569
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1300576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 629
+      ID: 639
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1789632
@@ -5313,7 +5313,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 299
+      ID: 309
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 849600
@@ -5321,22 +5321,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 301 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 311 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 300 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 310 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 300
+      ID: 310
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 684
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 585
+      ID: 595
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1466240
@@ -5346,19 +5346,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 302
+      ID: 312
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 850176
       GoKind: 10
     - __kind: BaseType
-      ID: 672
+      ID: 682
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1017088
       GoKind: 10
     - __kind: StructureType
-      ID: 643
+      ID: 653
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1911776
@@ -5369,12 +5369,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 672 BaseType golang.org/x/net/http2.ErrCode
+          Type: 682 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 504
+      ID: 514
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1629280
@@ -5382,12 +5382,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 672 BaseType golang.org/x/net/http2.ErrCode
+          Type: 682 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 316
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850368
@@ -5395,18 +5395,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 318 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 317 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 317
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 312
+      ID: 322
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 850560
@@ -5414,18 +5414,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 314 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 324 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 313 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 323 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 313
+      ID: 323
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 309
+      ID: 319
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 850464
@@ -5433,18 +5433,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 311 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 321 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 310 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 320 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 310
+      ID: 320
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 303
+      ID: 313
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850272
@@ -5452,18 +5452,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 305 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 315 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 304 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 314 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 304
+      ID: 314
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 508
+      ID: 518
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1466880
@@ -5473,13 +5473,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 315
+      ID: 325
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 2
     - __kind: StructureType
-      ID: 496
+      ID: 506
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1461920
@@ -5489,11 +5489,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 651
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 663
+      ID: 673
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1941056
@@ -5509,7 +5509,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 498
+      ID: 508
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1628800
@@ -5526,7 +5526,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 583
+      ID: 593
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1588160
@@ -5540,25 +5540,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 494
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 583
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 649
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 637
+      ID: 647
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1532480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 490
+      ID: 500
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1455200
@@ -5568,7 +5568,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 492
+      ID: 502
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1455360
@@ -5578,7 +5578,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 439
+      ID: 449
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5610,19 +5610,19 @@ Types:
       GroupType: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 816 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 235
+      ID: 245
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 236 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 246 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 237 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 973
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5652,63 +5652,63 @@ Types:
       GroupType: 838 StructureType noalg.map.group[string][]string
       GroupSliceType: 842 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 217
+      ID: 223
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 218 PointerType *noalg.map.group[string]float64
+          Type: 224 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 219 StructureType noalg.map.group[string]float64
-      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 225 StructureType noalg.map.group[string]float64
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 698
+      ID: 708
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 699 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 709 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 700 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 704 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 714 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 209
+      ID: 215
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 210 PointerType *noalg.map.group[string]interface {}
+          Type: 216 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 211 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 215 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 217 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 207
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[string]string
+          Type: 208 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[string]string
-      GroupSliceType: 207 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 209 StructureType noalg.map.group[string]string
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 511
+      ID: 521
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5755,7 +5755,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 407
+      ID: 417
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5781,11 +5781,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 415
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 623
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5793,13 +5793,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 611
+      ID: 621
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1497920
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 345
+      ID: 355
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5960,7 +5960,7 @@ Types:
           Offset: 0
           Type: 904 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 619
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6028,7 +6028,7 @@ Types:
       TablePtrSliceType: 815 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 228
+      ID: 234
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6041,7 +6041,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 229 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 235 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6057,8 +6057,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 237 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 969
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6153,10 +6153,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 222 GoSliceDataType []*table<string,float64>.array
-      GroupType: 219 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 228 GoSliceDataType []*table<string,float64>.array
+      GroupType: 225 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 669
+      ID: 679
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6169,7 +6169,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 670 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 680 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6185,8 +6185,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 703 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 700 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 713 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 163
       Name: map<string,interface {}>
@@ -6217,8 +6217,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 214 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 211 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 220 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 217 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 158
       Name: map<string,string>
@@ -6249,8 +6249,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 206 GoSliceDataType []*table<string,string>.array
-      GroupType: 203 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
+      GroupType: 209 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 136
       Name: map[context.canceler]struct {}
@@ -6266,12 +6266,12 @@ Types:
       GoKind: 21
       HeaderType: 787 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 226
+      ID: 232
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1153056
       GoKind: 21
-      HeaderType: 228 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 234 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 967
       Name: map[string][]*mime/multipart.FileHeader
@@ -6294,7 +6294,7 @@ Types:
       GoKind: 21
       HeaderType: 168 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 231
+      ID: 237
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1146272
@@ -6308,7 +6308,7 @@ Types:
       GoKind: 21
       HeaderType: 158 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 426
+      ID: 436
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1447200
@@ -6352,11 +6352,11 @@ Types:
           Offset: 8
           Type: 914 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 605
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 680
+      ID: 690
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1618400
@@ -6369,7 +6369,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 658
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6377,11 +6377,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 646
+      ID: 656
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 597
+      ID: 607
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6397,7 +6397,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 588
+      ID: 598
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1127456
@@ -6405,18 +6405,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 590 PointerType *net.UnknownNetworkError.str
+          Type: 600 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 589 GoStringDataType net.UnknownNetworkError.str
+      Data: 599 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 589
+      ID: 599
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 526
+      ID: 536
       Name: net.canceledError
       GoRuntimeType: 1298272
       GoKind: 25
@@ -6426,7 +6426,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 692
+      ID: 702
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2147104
@@ -6434,7 +6434,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 680 GoInterfaceType net.Conn
+          Type: 690 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -6461,7 +6461,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 317
+      ID: 327
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6478,7 +6478,7 @@ Types:
           Offset: 16
           Type: 116 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 319
+      ID: 329
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1750304
@@ -6486,7 +6486,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 675 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 685 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6520,11 +6520,11 @@ Types:
           Offset: 0
           Type: 944 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 609
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 660
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6574,11 +6574,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 325
+      ID: 335
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 528
+      ID: 538
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6630,7 +6630,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6675,7 +6675,7 @@ Types:
           Type: 854 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 156 GoMapType map[string]string
@@ -6712,7 +6712,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6785,19 +6785,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 244
+      ID: 254
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 841152
       GoKind: 10
     - __kind: BaseType
-      ID: 664
+      ID: 674
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1001536
       GoKind: 10
     - __kind: StructureType
-      ID: 328
+      ID: 338
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1752032
@@ -6808,12 +6808,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 664 BaseType net/http.http2ErrCode
+          Type: 674 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 652
+      ID: 662
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1931328
@@ -6824,7 +6824,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 664 BaseType net/http.http2ErrCode
+          Type: 674 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
@@ -6833,7 +6833,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 334
+      ID: 344
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1618880
@@ -6841,12 +6841,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 664 BaseType net/http.http2ErrCode
+          Type: 674 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 248
+      ID: 258
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841344
@@ -6854,18 +6854,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 250 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 260 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 249 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 259 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 249
+      ID: 259
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 332
+      ID: 342
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1128736
       GoKind: 25
@@ -6875,7 +6875,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 254
+      ID: 264
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 841536
@@ -6883,18 +6883,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 256 PointerType *net/http.http2headerFieldNameError.str
+          Type: 266 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 255 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 265 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 255
+      ID: 265
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 251
+      ID: 261
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 841440
@@ -6902,18 +6902,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 253 PointerType *net/http.http2headerFieldValueError.str
+          Type: 263 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 252 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 262 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 252
+      ID: 262
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 613
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -6929,13 +6929,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 534
+      ID: 544
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1298912
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 245
+      ID: 255
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841248
@@ -6943,13 +6943,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 247 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 257 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 246 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 256 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 246
+      ID: 256
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -6992,7 +6992,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 530
+      ID: 540
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1572320
@@ -7032,7 +7032,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 338
+      ID: 348
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1434240
@@ -7107,7 +7107,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 822 StructureType sync/atomic.Bool
@@ -7143,7 +7143,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 323
+      ID: 333
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1618720
@@ -7156,17 +7156,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 654
+      ID: 664
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 601
+      ID: 611
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1485280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 532
+      ID: 542
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1572480
@@ -7184,12 +7184,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 680 GoInterfaceType net.Conn
+          Type: 690 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 680 GoInterfaceType net.Conn
+          Type: 690 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 321
+      ID: 331
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7199,7 +7199,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 351
+      ID: 361
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1754720
@@ -7215,7 +7215,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 349
+      ID: 359
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1619360
@@ -7228,11 +7228,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 374
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 268
+      ID: 278
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 843936
@@ -7240,22 +7240,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 270 PointerType *net/textproto.ProtocolError.str
+          Type: 280 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 269 GoStringDataType net/textproto.ProtocolError.str
+      Data: 279 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 269
+      ID: 279
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 669
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 262
+      ID: 272
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 843744
@@ -7263,18 +7263,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 264 PointerType *net/url.EscapeError.str
+          Type: 274 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 263 GoStringDataType net/url.EscapeError.str
+      Data: 273 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 263
+      ID: 273
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 265
+      ID: 275
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 843840
@@ -7282,13 +7282,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 267 PointerType *net/url.InvalidHostError.str
+          Type: 277 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 266 GoStringDataType net/url.InvalidHostError.str
+      Data: 276 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 266
+      ID: 276
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7362,14 +7362,14 @@ Types:
       HasCount: true
       Element: 813 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 238
+      ID: 248
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 239 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 249 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 976
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7389,41 +7389,41 @@ Types:
       HasCount: true
       Element: 840 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 220
+      ID: 226
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 221 StructureType noalg.struct { key string; elem float64 }
+      Element: 227 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 701
+      ID: 711
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 771456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 702 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 712 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 212
+      ID: 218
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem interface {} }
+      Element: 219 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 204
+      ID: 210
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 205 StructureType noalg.struct { key string; elem string }
+      Element: 211 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 191
       Name: noalg.map.group[context.canceler]struct {}
@@ -7451,7 +7451,7 @@ Types:
           Offset: 8
           Type: 812 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 237
+      ID: 247
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1327200
@@ -7462,7 +7462,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 238 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 248 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 975
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7490,7 +7490,7 @@ Types:
           Offset: 8
           Type: 839 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 219
+      ID: 225
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1326944
@@ -7501,9 +7501,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 220 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 226 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 700
+      ID: 710
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1375968
@@ -7514,9 +7514,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 701 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 711 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 211
+      ID: 217
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1308896
@@ -7527,9 +7527,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 218 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 203
+      ID: 209
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1313760
@@ -7540,7 +7540,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 204 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 193
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7568,7 +7568,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 239
+      ID: 249
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1327072
@@ -7579,7 +7579,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 240 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 250 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 977
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7605,9 +7605,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 683 GoSliceHeaderType []string
+          Type: 693 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 221
+      ID: 227
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1326816
@@ -7620,7 +7620,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 702
+      ID: 712
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1375840
@@ -7631,9 +7631,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 690 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 213
+      ID: 219
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1308768
@@ -7646,7 +7646,7 @@ Types:
           Offset: 16
           Type: 135 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 205
+      ID: 211
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1313632
@@ -7663,7 +7663,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 536
+      ID: 546
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7680,7 +7680,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 615
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7722,15 +7722,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 577
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 706
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 569
+      ID: 579
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1729152
@@ -7764,7 +7764,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 296
+      ID: 306
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 848832
@@ -7772,36 +7772,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 298 PointerType *os/user.UnknownGroupIdError.str
+          Type: 308 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 297 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 307 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 297
+      ID: 307
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 295
+      ID: 305
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 848736
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 347
+      ID: 357
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 441
+      ID: 451
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 554
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 558
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7813,7 +7813,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 546
+      ID: 556
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1919616
@@ -7830,9 +7830,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 694 BaseType runtime.boundsErrorCode
+          Type: 704 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 694
+      ID: 704
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 591328
@@ -7852,7 +7852,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 607
+      ID: 617
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1784256
@@ -7865,7 +7865,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 512
+      ID: 522
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1002784
@@ -7873,13 +7873,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 514 PointerType *runtime.errorString.str
+          Type: 524 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 513 GoStringDataType runtime.errorString.str
+      Data: 523 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 513
+      ID: 523
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8535,7 +8535,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 515
+      ID: 525
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1002880
@@ -8543,13 +8543,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 517 PointerType *runtime.plainError.str
+          Type: 527 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 516 GoStringDataType runtime.plainError.str
+      Data: 526 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 516
+      ID: 526
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8635,7 +8635,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 550
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9006,7 +9006,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 644
+      ID: 654
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1299808
@@ -9066,7 +9066,7 @@ Types:
           Offset: 16
           Type: 809 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 234
+      ID: 244
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9088,7 +9088,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 235 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 245 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 972
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9138,7 +9138,7 @@ Types:
           Offset: 16
           Type: 836 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 216
+      ID: 222
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9160,9 +9160,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 217 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 223 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 697
+      ID: 707
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9184,9 +9184,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 698 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 708 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 208
+      ID: 214
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9208,9 +9208,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 209 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 215 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 200
+      ID: 206
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9232,9 +9232,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<string,string>
+          Type: 207 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1733376
@@ -9264,10 +9264,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 712 GoSliceHeaderType []time.zone
+          Type: 198 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 715 GoSliceHeaderType []time.zoneTrans
+          Type: 201 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9279,12 +9279,12 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 713 PointerType *time.zone
+          Type: 199 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 351
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 144
       Name: time.Time
       ByteSize: 24
@@ -9300,6 +9300,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 145 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 143
       Name: time.Timer
@@ -9309,12 +9317,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 711 GoChannelType <-chan time.Time
+          Type: 721 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 257
+      ID: 267
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 841632
@@ -9322,18 +9330,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 259 PointerType *time.fileSizeError.str
+          Type: 269 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 258 GoStringDataType time.fileSizeError.str
+      Data: 268 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 258
+      ID: 268
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 714
+      ID: 200
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1642080
@@ -9349,7 +9357,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 717
+      ID: 203
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1780992
@@ -9410,7 +9418,7 @@ Types:
       GoRuntimeType: 591264
       GoKind: 26
     - __kind: StructureType
-      ID: 675
+      ID: 685
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2096000
@@ -9421,10 +9429,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 676 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 686 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 677 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 687 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9439,18 +9447,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 678 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 688 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 678
+      ID: 688
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1003840
       GoKind: 9
     - __kind: StructureType
-      ID: 676
+      ID: 686
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1949216
@@ -9475,17 +9483,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 353
+      ID: 363
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 677
+      ID: 687
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 592160
       GoKind: 8
     - __kind: StructureType
-      ID: 366
+      ID: 376
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1439200
@@ -9495,13 +9503,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 271
+      ID: 281
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 844032
       GoKind: 2
     - __kind: StructureType
-      ID: 553
+      ID: 563
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1728576
@@ -9514,7 +9522,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 519
+      ID: 529
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1004704

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -120,7 +120,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 684 PointerType *crypto/x509.Certificate
+      Pointee: 694 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 742
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -150,10 +150,10 @@ Types:
       ByteSize: 8
       Pointee: 808 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 234
+      ID: 240
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 235 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 241 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 989
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -170,10 +170,10 @@ Types:
       ByteSize: 8
       Pointee: 172 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 689
+      ID: 699
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 690 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 166
       Name: '**table<string,interface {}>'
@@ -221,30 +221,30 @@ Types:
       ByteSize: 8
       Pointee: 1018 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 727
+      ID: 737
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 726 GoSliceDataType []float64.array
+      Pointee: 736 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 230
+      ID: 236
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 235 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 238
+      ID: 244
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1024
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1023 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 204
+      ID: 210
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []os.Signal.array
+      Pointee: 209 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -253,20 +253,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 725
+      ID: 735
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 724 GoSliceDataType []string.array
+      Pointee: 734 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 738
+      ID: 246
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 737 GoSliceDataType []time.zone.array
+      Pointee: 245 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 740
+      ID: 248
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 739 GoSliceDataType []time.zoneTrans.array
+      Pointee: 247 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1011
       Name: '*[]uint8'
@@ -285,17 +285,17 @@ Types:
       ByteSize: 8
       Pointee: 188 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 949920
       GoKind: 22
-      Pointee: 499 GoSliceHeaderType archive/tar.headerError
+      Pointee: 509 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 500 GoSliceDataType archive/tar.headerError.array
+      Pointee: 510 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 915
       Name: '*archive/zip.checksumReader'
@@ -346,24 +346,24 @@ Types:
       GoKind: 22
       Pointee: 117 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 935616
       GoKind: 22
-      Pointee: 295 BaseType compress/flate.CorruptInputError
+      Pointee: 305 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 437
+      ID: 447
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 935712
       GoKind: 22
-      Pointee: 296 GoStringHeaderType compress/flate.InternalError
+      Pointee: 306 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 297 GoStringDataType compress/flate.InternalError.str
+      Pointee: 307 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 951
       Name: '*compress/flate.decompressor'
@@ -393,12 +393,12 @@ Types:
       GoKind: 22
       Pointee: 120 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1206816
       GoKind: 22
-      Pointee: 609 StructureType context.deadlineExceededError
+      Pointee: 619 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1025
       Name: '*context.emptyCtx'
@@ -442,54 +442,54 @@ Types:
       GoKind: 22
       Pointee: 128 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 934368
       GoKind: 22
-      Pointee: 291 BaseType crypto/aes.KeySizeError
+      Pointee: 301 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 433
+      ID: 443
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 934560
       GoKind: 22
-      Pointee: 292 BaseType crypto/des.KeySizeError
+      Pointee: 302 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 934848
       GoKind: 22
-      Pointee: 293 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 303 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 587
+      ID: 597
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1079328
       GoKind: 22
-      Pointee: 588 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 598 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 435
+      ID: 445
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935136
       GoKind: 22
-      Pointee: 294 BaseType crypto/rc4.KeySizeError
+      Pointee: 304 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 370
+      ID: 380
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 924096
       GoKind: 22
-      Pointee: 265 BaseType crypto/tls.AlertError
+      Pointee: 275 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 563
+      ID: 573
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1059744
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 574 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 981
       Name: '*crypto/tls.Conn'
@@ -505,213 +505,213 @@ Types:
       GoKind: 22
       Pointee: 869 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 923808
       GoKind: 22
-      Pointee: 367 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 377 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 365 StructureType crypto/tls.RecordHeaderError
+      Pointee: 375 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1058080
       GoKind: 22
-      Pointee: 531 BaseType crypto/tls.alert
+      Pointee: 541 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 923904
       GoKind: 22
-      Pointee: 369 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 379 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 673
+      ID: 683
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1442240
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 684 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 684
+      ID: 694
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2088896
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 695 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 934176
       GoKind: 22
-      Pointee: 429 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 439 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 933696
       GoKind: 22
-      Pointee: 423 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 433 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 933792
       GoKind: 22
-      Pointee: 425 StructureType crypto/x509.HostnameError
+      Pointee: 435 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 421
+      ID: 431
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 933600
       GoKind: 22
-      Pointee: 290 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 300 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 579
+      ID: 589
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1069600
       GoKind: 22
-      Pointee: 580 StructureType crypto/x509.SystemRootsError
+      Pointee: 590 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 934272
       GoKind: 22
-      Pointee: 431 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 441 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 934080
       GoKind: 22
-      Pointee: 427 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 437 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 945600
       GoKind: 22
-      Pointee: 491 StructureType encoding/asn1.StructuralError
+      Pointee: 501 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 945792
       GoKind: 22
-      Pointee: 495 StructureType encoding/asn1.SyntaxError
+      Pointee: 505 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 945696
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 503 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 924192
       GoKind: 22
-      Pointee: 266 BaseType encoding/base64.CorruptInputError
+      Pointee: 276 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 413
+      ID: 423
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 932352
       GoKind: 22
-      Pointee: 286 BaseType encoding/hex.InvalidByteError
+      Pointee: 296 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927552
       GoKind: 22
-      Pointee: 389 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 399 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 575
+      ID: 585
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1064864
       GoKind: 22
-      Pointee: 576 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 586 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927168
       GoKind: 22
-      Pointee: 381 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 391 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 927456
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 397 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 927360
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 395 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 927264
       GoKind: 22
-      Pointee: 383 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 393 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 927936
       GoKind: 22
-      Pointee: 391 StructureType encoding/json.jsonError
+      Pointee: 401 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 485
+      ID: 495
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 942816
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 496 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 483
+      ID: 493
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 942720
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 494 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 487
+      ID: 497
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 942912
       GoKind: 22
-      Pointee: 300 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 310 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 302
+      ID: 312
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 301 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 311 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 943008
       GoKind: 22
-      Pointee: 489 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 499 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -720,19 +720,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType errors.errorString
+      Pointee: 361 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1051040
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType errors.joinError
+      Pointee: 561 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -748,26 +748,26 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 534
+      ID: 544
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1040672
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType fmt.wrapError
+      Pointee: 545 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 536
+      ID: 546
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1040800
       GoKind: 22
-      Pointee: 537 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 547 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 411
+      ID: 421
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 412 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 809
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -776,83 +776,83 @@ Types:
       GoKind: 22
       Pointee: 810 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 929184
       GoKind: 22
-      Pointee: 394 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 404 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 929280
       GoKind: 22
-      Pointee: 396 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 406 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 704
+      ID: 714
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 928992
       GoKind: 22
-      Pointee: 705 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 399
+      ID: 409
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 929568
       GoKind: 22
-      Pointee: 400 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 410 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 706
+      ID: 716
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 929088
       GoKind: 22
-      Pointee: 707 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 717 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 929376
       GoKind: 22
-      Pointee: 280 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 290 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 282
+      ID: 292
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 291 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 392
+      ID: 402
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 928896
       GoKind: 22
-      Pointee: 277 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 287 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 279
+      ID: 289
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 288 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 929472
       GoKind: 22
-      Pointee: 283 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 293 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 285
+      ID: 295
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 294 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 440
+      ID: 450
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 936672
       GoKind: 22
-      Pointee: 441 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 451 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 800
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
@@ -910,12 +910,12 @@ Types:
       GoKind: 22
       Pointee: 750 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 245
+      ID: 255
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1214752
       GoKind: 22
-      Pointee: 246 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 256 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 181
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
@@ -931,12 +931,12 @@ Types:
       GoKind: 22
       Pointee: 816 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1235744
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 660 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 751
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
@@ -973,143 +973,143 @@ Types:
       GoKind: 22
       Pointee: 898 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 442
+      ID: 452
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 938880
       GoKind: 22
-      Pointee: 443 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 453 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 939936
       GoKind: 22
-      Pointee: 450 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 444
+      ID: 454
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 939648
       GoKind: 22
-      Pointee: 299 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 309 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 939840
       GoKind: 22
-      Pointee: 448 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 458 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 939744
       GoKind: 22
-      Pointee: 446 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 456 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 941280
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 468 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 941472
       GoKind: 22
-      Pointee: 462 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 472 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 941376
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 470 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 455
+      ID: 465
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 941184
       GoKind: 22
-      Pointee: 456 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 466 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 729
+      ID: 739
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 728 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 469
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 941856
       GoKind: 22
-      Pointee: 470 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 941568
       GoKind: 22
-      Pointee: 464 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 474 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 941760
       GoKind: 22
-      Pointee: 468 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 465
+      ID: 475
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 941664
       GoKind: 22
-      Pointee: 466 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 476 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 941952
       GoKind: 22
-      Pointee: 472 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 477
+      ID: 487
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 942240
       GoKind: 22
-      Pointee: 478 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 479
+      ID: 489
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 942336
       GoKind: 22
-      Pointee: 480 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 475
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 942144
       GoKind: 22
-      Pointee: 476 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 473
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 942048
       GoKind: 22
-      Pointee: 474 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 481
+      ID: 491
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 942528
       GoKind: 22
-      Pointee: 482 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 825
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1139,12 +1139,12 @@ Types:
       GoKind: 22
       Pointee: 824 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 930720
       GoKind: 22
-      Pointee: 402 StructureType github.com/cihub/seelog.baseError
+      Pointee: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 802
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1153,12 +1153,12 @@ Types:
       GoKind: 22
       Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 403
+      ID: 413
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 930816
       GoKind: 22
-      Pointee: 404 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 414 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 792
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1181,12 +1181,12 @@ Types:
       GoKind: 22
       Pointee: 799 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 407
+      ID: 417
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 931008
       GoKind: 22
-      Pointee: 408 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 418 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 796
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1202,19 +1202,19 @@ Types:
       GoKind: 22
       Pointee: 818 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 405
+      ID: 415
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 930912
       GoKind: 22
-      Pointee: 406 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 416 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 409
+      ID: 419
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 931104
       GoKind: 22
-      Pointee: 410 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 420 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 913
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1230,289 +1230,289 @@ Types:
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 677
+      ID: 687
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1460320
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 688 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1087648
       GoKind: 22
-      Pointee: 594 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 604 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1087520
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 602 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 595
+      ID: 605
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1092000
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 606 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 597
+      ID: 607
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1092128
       GoKind: 22
-      Pointee: 598 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 608 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 585
+      ID: 595
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1076512
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 596 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 932544
       GoKind: 22
-      Pointee: 415 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 425 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1244192
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 662 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 637
+      ID: 647
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1227680
       GoKind: 22
-      Pointee: 638 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 631
+      ID: 641
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1227296
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 642 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 569
+      ID: 579
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1062688
       GoKind: 22
-      Pointee: 570 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 643
+      ID: 653
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1228064
       GoKind: 22
-      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1062560
       GoKind: 22
-      Pointee: 533 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 543 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 635
+      ID: 645
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1227552
       GoKind: 22
-      Pointee: 636 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 633
+      ID: 643
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1227424
       GoKind: 22
-      Pointee: 634 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 641
+      ID: 651
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1227936
       GoKind: 22
-      Pointee: 642 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 652 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 639
+      ID: 649
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1227808
       GoKind: 22
-      Pointee: 640 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 650 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 647
+      ID: 657
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1228448
       GoKind: 22
-      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 573
+      ID: 583
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1062944
       GoKind: 22
-      Pointee: 574 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 584 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 571
+      ID: 581
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1062816
       GoKind: 22
-      Pointee: 572 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 582 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 645
+      ID: 655
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1228320
       GoKind: 22
-      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 512
+      ID: 522
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 961344
       GoKind: 22
-      Pointee: 307 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 317 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 309
+      ID: 319
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 318 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 692
+      ID: 702
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1697440
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 703 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 601
+      ID: 611
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1106848
       GoKind: 22
-      Pointee: 602 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 612 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 962592
       GoKind: 22
-      Pointee: 310 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 320 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1282464
       GoKind: 22
-      Pointee: 660 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 670 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 516
+      ID: 526
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 962880
       GoKind: 22
-      Pointee: 517 StructureType golang.org/x/net/http2.connError
+      Pointee: 527 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 515
+      ID: 525
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 962784
       GoKind: 22
-      Pointee: 314 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 324 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 316
+      ID: 326
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 315 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 325 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 519
+      ID: 529
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 963072
       GoKind: 22
-      Pointee: 320 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 330 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 322
+      ID: 332
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 321 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 331 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 962976
       GoKind: 22
-      Pointee: 317 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 327 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 319
+      ID: 329
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 318 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 328 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 962688
       GoKind: 22
-      Pointee: 311 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 321 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 313
+      ID: 323
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 312 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 322 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 520
+      ID: 530
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 963168
       GoKind: 22
-      Pointee: 521 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 531 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 963264
       GoKind: 22
-      Pointee: 323 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 333 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 957024
       GoKind: 22
-      Pointee: 509 StructureType google.golang.org/grpc.dropError
+      Pointee: 519 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1279520
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 668 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 679
+      ID: 689
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1467840
       GoKind: 22
-      Pointee: 680 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 690 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 510
+      ID: 520
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 959616
       GoKind: 22
-      Pointee: 511 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 521 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 940
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1521,12 +1521,12 @@ Types:
       GoKind: 22
       Pointee: 941 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 599
+      ID: 609
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1101088
       GoKind: 22
-      Pointee: 600 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 610 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 924
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1535,61 +1535,61 @@ Types:
       GoKind: 22
       Pointee: 925 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 948576
       GoKind: 22
-      Pointee: 497 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 507 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 589
+      ID: 599
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1081248
       GoKind: 22
-      Pointee: 590 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 600 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1248416
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 666 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 653
+      ID: 663
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1248160
       GoKind: 22
-      Pointee: 654 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 664 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 950880
       GoKind: 22
-      Pointee: 503 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 513 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 504
+      ID: 514
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 950976
       GoKind: 22
-      Pointee: 505 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 515 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 451
+      ID: 461
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 452 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 462 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 964032
       GoKind: 22
-      Pointee: 524 UnresolvedPointeeType html/template.Error
+      Pointee: 534 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 102
       Name: '*int'
@@ -1626,33 +1626,33 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType int8
     - __kind: PointerType
-      ID: 681
+      ID: 691
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2262912
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType internal/abi.Type
+      Pointee: 692 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 419
+      ID: 429
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 933216
       GoKind: 22
-      Pointee: 420 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 430 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 933120
       GoKind: 22
-      Pointee: 418 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 428 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 629
+      ID: 639
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1222816
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 640 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 979
       Name: '*internal/poll.FD'
@@ -1661,38 +1661,38 @@ Types:
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 627
+      ID: 637
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1222688
       GoKind: 22
-      Pointee: 628 StructureType internal/poll.errNetClosing
+      Pointee: 638 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 352
+      ID: 362
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 919392
       GoKind: 22
-      Pointee: 353 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 363 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 933024
       GoKind: 22
-      Pointee: 287 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 297 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 289
+      ID: 299
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 298 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1068576
       GoKind: 22
-      Pointee: 578 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 588 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 944
       Name: '*io.PipeReader'
@@ -1722,12 +1722,12 @@ Types:
       GoKind: 22
       Pointee: 912 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 625
+      ID: 635
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1221664
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType io/fs.PathError
+      Pointee: 636 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 139
       Name: '*map<context.canceler,struct {}>'
@@ -1739,10 +1739,10 @@ Types:
       ByteSize: 8
       Pointee: 806 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 232
+      ID: 238
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 233 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 239 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 987
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1759,10 +1759,10 @@ Types:
       ByteSize: 8
       Pointee: 170 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 687
+      ID: 697
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 688 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 164
       Name: '*map<string,interface {}>'
@@ -1774,12 +1774,12 @@ Types:
       ByteSize: 8
       Pointee: 160 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 936288
       GoKind: 22
-      Pointee: 439 StructureType math/big.ErrNaN
+      Pointee: 449 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 999
       Name: '*mime/multipart.FileHeader'
@@ -1809,19 +1809,19 @@ Types:
       GoKind: 22
       Pointee: 929 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1207968
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType net.AddrError
+      Pointee: 622 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 664
+      ID: 674
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1434560
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType net.DNSError
+      Pointee: 675 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 955
       Name: '*net.IPConn'
@@ -1830,19 +1830,19 @@ Types:
       GoKind: 22
       Pointee: 956 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 662
+      ID: 672
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1434240
       GoKind: 22
-      Pointee: 663 UnresolvedPointeeType net.OpError
+      Pointee: 673 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1208096
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType net.ParseError
+      Pointee: 624 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 963
       Name: '*net.TCPConn'
@@ -1865,24 +1865,24 @@ Types:
       GoKind: 22
       Pointee: 962 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1207200
       GoKind: 22
-      Pointee: 605 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 615 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 607
+      ID: 617
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 606 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 616 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 538
+      ID: 548
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1041696
       GoKind: 22
-      Pointee: 539 StructureType net.canceledError
+      Pointee: 549 StructureType net.canceledError
     - __kind: PointerType
       ID: 953
       Name: '*net.conn'
@@ -1891,12 +1891,12 @@ Types:
       GoKind: 22
       Pointee: 954 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 710
+      ID: 720
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1874176
       GoKind: 22
-      Pointee: 711 StructureType net.dialResult·1
+      Pointee: 721 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 969
       Name: '*net.netFD'
@@ -1905,12 +1905,12 @@ Types:
       GoKind: 22
       Pointee: 970 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 324
+      ID: 334
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 912000
       GoKind: 22
-      Pointee: 325 UnresolvedPointeeType net.notFoundError
+      Pointee: 335 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1026
       Name: '*net.onlyValuesCtx'
@@ -1919,12 +1919,12 @@ Types:
       GoKind: 22
       Pointee: 1027 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 326
+      ID: 336
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 327 StructureType net.result·2
+      Pointee: 337 StructureType net.result·2
     - __kind: PointerType
       ID: 959
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1940,33 +1940,33 @@ Types:
       GoKind: 22
       Pointee: 958 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1208736
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType net.temporaryError
+      Pointee: 626 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 666
+      ID: 676
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1434880
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType net.timeoutError
+      Pointee: 677 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 332
+      ID: 342
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 915264
       GoKind: 22
-      Pointee: 333 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 343 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 540
+      ID: 550
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1045152
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 551 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 112
       Name: '*net/http.Request'
@@ -2024,26 +2024,26 @@ Types:
       GoKind: 22
       Pointee: 892 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 334
+      ID: 344
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 249 BaseType net/http.http2ConnectionError
+      Pointee: 259 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 915552
       GoKind: 22
-      Pointee: 336 StructureType net/http.http2GoAwayError
+      Pointee: 346 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 668
+      ID: 678
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1435840
       GoKind: 22
-      Pointee: 669 StructureType net/http.http2StreamError
+      Pointee: 679 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 921
       Name: '*net/http.http2clientStream'
@@ -2052,31 +2052,31 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 341
+      ID: 351
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 342 StructureType net/http.http2connError
+      Pointee: 352 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916032
       GoKind: 22
-      Pointee: 253 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 263 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 255
+      ID: 265
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 254 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 916128
       GoKind: 22
-      Pointee: 340 StructureType net/http.http2goAwayFlowError
+      Pointee: 350 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 885
       Name: '*net/http.http2gzipReader'
@@ -2085,36 +2085,36 @@ Types:
       GoKind: 22
       Pointee: 886 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 259 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 269 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 261
+      ID: 271
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 260 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 270 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 343
+      ID: 353
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 916704
       GoKind: 22
-      Pointee: 256 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 266 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 258
+      ID: 268
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 257 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 267 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 619
+      ID: 629
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1212576
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 630 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 881
       Name: '*net/http.http2missingBody'
@@ -2130,24 +2130,24 @@ Types:
       GoKind: 22
       Pointee: 894 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 546
+      ID: 556
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1047456
       GoKind: 22
-      Pointee: 547 StructureType net/http.http2noCachedConnError
+      Pointee: 557 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 915936
       GoKind: 22
-      Pointee: 250 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 260 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 252
+      ID: 262
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 251 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 261 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 889
       Name: '*net/http.http2requestBody'
@@ -2191,12 +2191,12 @@ Types:
       GoKind: 22
       Pointee: 910 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 542
+      ID: 552
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1047072
       GoKind: 22
-      Pointee: 543 StructureType net/http.nothingWrittenError
+      Pointee: 553 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 873
       Name: '*net/http.pattern'
@@ -2219,12 +2219,12 @@ Types:
       GoKind: 22
       Pointee: 918 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 346 StructureType net/http.requestBodyReadError
+      Pointee: 356 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 790
       Name: '*net/http.response'
@@ -2240,33 +2240,33 @@ Types:
       GoKind: 22
       Pointee: 1022 StructureType net/http.segment
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 915168
       GoKind: 22
-      Pointee: 331 StructureType net/http.statusError
+      Pointee: 341 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 670
+      ID: 680
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1437440
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 681 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1212448
       GoKind: 22
-      Pointee: 618 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 628 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 544
+      ID: 554
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1047200
       GoKind: 22
-      Pointee: 545 StructureType net/http.transportReadFromServerError
+      Pointee: 555 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 942
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2275,12 +2275,12 @@ Types:
       GoKind: 22
       Pointee: 943 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 329 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 339 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 903
       Name: '*net/http/httputil.failureToReadBody'
@@ -2289,69 +2289,69 @@ Types:
       GoKind: 22
       Pointee: 904 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 361 StructureType net/netip.parseAddrError
+      Pointee: 371 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 358
+      ID: 368
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 921984
       GoKind: 22
-      Pointee: 359 StructureType net/netip.parsePrefixError
+      Pointee: 369 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 376 UnresolvedPointeeType net/textproto.Error
+      Pointee: 386 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 925344
       GoKind: 22
-      Pointee: 273 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 283 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 275
+      ID: 285
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 284 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 675
+      ID: 685
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1442560
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType net/url.Error
+      Pointee: 686 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 372
+      ID: 382
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 924288
       GoKind: 22
-      Pointee: 267 GoStringHeaderType net/url.EscapeError
+      Pointee: 277 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 269
+      ID: 279
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType net/url.EscapeError.str
+      Pointee: 278 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 924384
       GoKind: 22
-      Pointee: 270 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 280 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 272
+      ID: 282
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 281 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 862
       Name: '*net/url.URL'
@@ -2377,10 +2377,10 @@ Types:
       ByteSize: 8
       Pointee: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 241
+      ID: 251
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 242 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 993
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2392,25 +2392,25 @@ Types:
       ByteSize: 8
       Pointee: 857 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 223
+      ID: 229
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 224 StructureType noalg.map.group[string]float64
+      Pointee: 230 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 718
+      ID: 728
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 719 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 215
+      ID: 221
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 216 StructureType noalg.map.group[string]interface {}
+      Pointee: 222 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 207
+      ID: 213
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 208 StructureType noalg.map.group[string]string
+      Pointee: 214 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 975
       Name: '*os.File'
@@ -2419,12 +2419,12 @@ Types:
       GoKind: 22
       Pointee: 976 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 548
+      ID: 558
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1049504
       GoKind: 22
-      Pointee: 549 UnresolvedPointeeType os.LinkError
+      Pointee: 559 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 152
       Name: '*os.Signal'
@@ -2433,12 +2433,12 @@ Types:
       GoKind: 22
       Pointee: 153 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 621
+      ID: 631
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1212960
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType os.SyscallError
+      Pointee: 632 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 973
       Name: '*os.fileWithoutReadFrom'
@@ -2454,26 +2454,26 @@ Types:
       GoKind: 22
       Pointee: 972 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 581
+      ID: 591
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1071648
       GoKind: 22
-      Pointee: 582 UnresolvedPointeeType os/exec.Error
+      Pointee: 592 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 714
+      ID: 724
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2140640
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 725 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 583
+      ID: 593
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1071776
       GoKind: 22
-      Pointee: 584 StructureType os/exec.wrappedError
+      Pointee: 594 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 129
       Name: '*os/signal.signalCtx'
@@ -2482,52 +2482,52 @@ Types:
       GoKind: 22
       Pointee: 130 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 955104
       GoKind: 22
-      Pointee: 304 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 314 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 306
+      ID: 316
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 305 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 315 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 955008
       GoKind: 22
-      Pointee: 303 BaseType os/user.UnknownUserIdError
+      Pointee: 313 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 354
+      ID: 364
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 355 UnresolvedPointeeType reflect.ValueError
+      Pointee: 365 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 453
+      ID: 463
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 940512
       GoKind: 22
-      Pointee: 454 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 464 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 556
+      ID: 566
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1054112
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 567 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 560
+      ID: 570
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1055904
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 571 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2543,12 +2543,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 558
+      ID: 568
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1054240
       GoKind: 22
-      Pointee: 559 StructureType runtime.boundsError
+      Pointee: 569 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -2564,24 +2564,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 623
+      ID: 633
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1221152
       GoKind: 22
-      Pointee: 624 StructureType runtime.errorAddressString
+      Pointee: 634 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1053728
       GoKind: 22
-      Pointee: 525 GoStringHeaderType runtime.errorString
+      Pointee: 535 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 527
+      ID: 537
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 526 GoStringDataType runtime.errorString.str
+      Pointee: 536 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2604,17 +2604,17 @@ Types:
       GoKind: 22
       Pointee: 190 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1053856
       GoKind: 22
-      Pointee: 528 GoStringHeaderType runtime.plainError
+      Pointee: 538 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 530
+      ID: 540
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 529 GoStringDataType runtime.plainError.str
+      Pointee: 539 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2630,12 +2630,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 921696
       GoKind: 22
-      Pointee: 357 StructureType runtime.synctestDeadlockError
+      Pointee: 367 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -2651,12 +2651,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1053344
       GoKind: 22
-      Pointee: 553 UnresolvedPointeeType strconv.NumError
+      Pointee: 563 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -2782,12 +2782,12 @@ Types:
       GoKind: 22
       Pointee: 906 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 672
+      ID: 682
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1441440
       GoKind: 22
-      Pointee: 661 BaseType syscall.Errno
+      Pointee: 671 BaseType syscall.Errno
     - __kind: PointerType
       ID: 747
       Name: '*syscall.Signal'
@@ -2806,10 +2806,10 @@ Types:
       ByteSize: 8
       Pointee: 827 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 235
+      ID: 241
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 239 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 249 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 990
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2824,29 +2824,29 @@ Types:
       ID: 172
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 221 StructureType table<string,float64>
+      Pointee: 227 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 690
+      ID: 700
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 716 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 726 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 167
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 213 StructureType table<string,interface {}>
+      Pointee: 219 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 162
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 205 StructureType table<string,string>
+      Pointee: 211 StructureType table<string,string>
     - __kind: PointerType
-      ID: 603
+      ID: 613
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1110688
       GoKind: 22
-      Pointee: 604 StructureType text/template.ExecError
+      Pointee: 614 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 147
       Name: '*time.Location'
@@ -2855,12 +2855,12 @@ Types:
       GoKind: 22
       Pointee: 148 StructureType time.Location
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 917856
       GoKind: 22
-      Pointee: 349 UnresolvedPointeeType time.ParseError
+      Pointee: 359 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 144
       Name: '*time.Timer'
@@ -2869,31 +2869,31 @@ Types:
       GoKind: 22
       Pointee: 145 StructureType time.Timer
     - __kind: PointerType
-      ID: 347
+      ID: 357
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 917760
       GoKind: 22
-      Pointee: 262 GoStringHeaderType time.fileSizeError
+      Pointee: 272 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 264
+      ID: 274
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 263 GoStringDataType time.fileSizeError.str
+      Pointee: 273 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 732
+      ID: 204
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399360
       GoKind: 22
-      Pointee: 733 StructureType time.zone
+      Pointee: 205 StructureType time.zone
     - __kind: PointerType
-      ID: 735
+      ID: 207
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399424
       GoKind: 22
-      Pointee: 736 StructureType time.zoneTrans
+      Pointee: 208 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -2937,47 +2937,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 922848
       GoKind: 22
-      Pointee: 363 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 373 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 925632
       GoKind: 22
-      Pointee: 378 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 388 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 379
+      ID: 389
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 925728
       GoKind: 22
-      Pointee: 276 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 286 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1061280
       GoKind: 22
-      Pointee: 566 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 576 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1061408
       GoKind: 22
-      Pointee: 532 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 542 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 870
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
     - __kind: GoChannelType
-      ID: 730
+      ID: 740
       Name: <-chan time.Time
       GoRuntimeType: 610304
       GoKind: 18
@@ -3155,7 +3155,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 698
+      ID: 708
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 712448
@@ -3203,7 +3203,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 684 PointerType *crypto/x509.Certificate
+      Element: 694 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 741
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3286,11 +3286,11 @@ Types:
       ByteSize: 8
       Element: 808 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 257
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 235 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 241 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 1000
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3304,25 +3304,25 @@ Types:
       ByteSize: 8
       Element: 849 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 233
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 172 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 722
+      ID: 732
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 690 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 225
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 167 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 217
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3374,7 +3374,7 @@ Types:
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 703
+      ID: 713
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 501024
@@ -3389,9 +3389,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 726 GoSliceDataType []float64.array
+      Data: 736 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 726
+      ID: 736
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3412,9 +3412,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 235 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 235
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3435,9 +3435,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 237 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 243
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3478,11 +3478,11 @@ Types:
       ByteSize: 24
       Element: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 258
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 242 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 1001
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3496,29 +3496,29 @@ Types:
       ByteSize: 328
       Element: 857 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 234
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 224 StructureType noalg.map.group[string]float64
+      Element: 230 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 723
+      ID: 733
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 719 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 226
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 216 StructureType noalg.map.group[string]interface {}
+      Element: 222 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 218
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 208 StructureType noalg.map.group[string]string
+      Element: 214 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 151
       Name: '[]os.Signal'
@@ -3535,9 +3535,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 203 GoSliceDataType []os.Signal.array
+      Data: 209 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 209
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3547,7 +3547,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 702
+      ID: 712
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -3562,15 +3562,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 724 GoSliceDataType []string.array
+      Data: 734 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 724
+      ID: 734
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 731
+      ID: 203
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494176
@@ -3578,22 +3578,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 732 PointerType *time.zone
+          Type: 204 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 737 GoSliceDataType []time.zone.array
+      Data: 245 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 737
+      ID: 245
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 733 StructureType time.zone
+      Element: 205 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 734
+      ID: 206
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494240
@@ -3601,20 +3601,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 735 PointerType *time.zoneTrans
+          Type: 207 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 739 GoSliceDataType []time.zoneTrans.array
+      Data: 247 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 739
+      ID: 247
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 736 StructureType time.zoneTrans
+      Element: 208 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3662,7 +3662,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 499
+      ID: 509
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 950016
@@ -3677,9 +3677,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 500 GoSliceDataType archive/tar.headerError.array
+      Data: 510 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 510
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3737,13 +3737,13 @@ Types:
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: BaseType
-      ID: 295
+      ID: 305
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 849568
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 296
+      ID: 306
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 849664
@@ -3751,13 +3751,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 298 PointerType *compress/flate.InternalError.str
+          Type: 308 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 297 GoStringDataType compress/flate.InternalError.str
+      Data: 307 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 297
+      ID: 307
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3841,7 +3841,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 609
+      ID: 619
       Name: context.deadlineExceededError
       GoRuntimeType: 1485152
       GoKind: 25
@@ -3885,7 +3885,7 @@ Types:
           Type: 144 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 146 StructureType time.Time
+          Type: 146 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3931,43 +3931,43 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 291
+      ID: 301
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849184
       GoKind: 2
     - __kind: BaseType
-      ID: 292
+      ID: 302
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849280
       GoKind: 2
     - __kind: BaseType
-      ID: 293
+      ID: 303
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849376
       GoKind: 2
     - __kind: StructureType
-      ID: 588
+      ID: 598
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1309024
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 294
+      ID: 304
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849472
       GoKind: 2
     - __kind: BaseType
-      ID: 265
+      ID: 275
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 846880
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 574
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4039,11 +4039,11 @@ Types:
       GoRuntimeType: 846592
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 367
+      ID: 377
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 365
+      ID: 375
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1762080
@@ -4054,10 +4054,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 698 ArrayType [5]uint8
+          Type: 708 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 699 GoInterfaceType net.Conn
+          Type: 709 GoInterfaceType net.Conn
     - __kind: BaseType
       ID: 1013
       Name: crypto/tls.SignatureScheme
@@ -4065,25 +4065,25 @@ Types:
       GoRuntimeType: 846688
       GoKind: 9
     - __kind: BaseType
-      ID: 531
+      ID: 541
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1008608
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 369
+      ID: 379
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 684
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 695
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 429
+      ID: 439
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1764192
@@ -4091,21 +4091,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 684 PointerType *crypto/x509.Certificate
+          Type: 694 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 708 BaseType crypto/x509.InvalidReason
+          Type: 718 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 423
+      ID: 433
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1138816
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1625024
@@ -4113,24 +4113,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 684 PointerType *crypto/x509.Certificate
+          Type: 694 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 290
+      ID: 300
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 848992
       GoKind: 2
     - __kind: BaseType
-      ID: 708
+      ID: 718
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 598144
       GoKind: 2
     - __kind: StructureType
-      ID: 580
+      ID: 590
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1585792
@@ -4140,13 +4140,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 431
+      ID: 441
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1139072
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 427
+      ID: 437
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1764000
@@ -4154,15 +4154,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 684 PointerType *crypto/x509.Certificate
+          Type: 694 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 684 PointerType *crypto/x509.Certificate
+          Type: 694 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1456160
@@ -4172,7 +4172,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 495
+      ID: 505
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1456320
@@ -4182,47 +4182,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 503
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 266
+      ID: 276
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 846976
       GoKind: 6
     - __kind: BaseType
-      ID: 286
+      ID: 296
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 848704
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 389
+      ID: 399
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 576
+      ID: 586
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 381
+      ID: 391
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 397
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 395
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 383
+      ID: 393
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 391
+      ID: 401
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1445600
@@ -4232,15 +4232,15 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 496
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 494
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 300
+      ID: 310
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 851104
@@ -4248,18 +4248,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 302 PointerType *encoding/xml.UnmarshalError.str
+          Type: 312 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 301 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 311 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 301
+      ID: 311
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 489
+      ID: 499
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4276,11 +4276,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 361
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 561
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4296,11 +4296,11 @@ Types:
       GoRuntimeType: 594944
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 545
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 537
+      ID: 547
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4334,7 +4334,7 @@ Types:
       GoRuntimeType: 1024448
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 412
+      ID: 422
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4344,7 +4344,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 394
+      ID: 404
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1763040
@@ -4352,7 +4352,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 700 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 710 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4360,25 +4360,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 396
+      ID: 406
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 705
+      ID: 715
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 400
+      ID: 410
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1137536
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 707
+      ID: 717
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 290
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 848032
@@ -4386,18 +4386,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 292 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 281 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 291 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 291
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 700
+      ID: 710
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2270528
@@ -4405,13 +4405,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 701 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 711 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4420,7 +4420,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 703 GoSliceHeaderType []float64
+          Type: 713 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4429,13 +4429,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 704 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 714 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 706 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 716 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4446,13 +4446,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 701
+      ID: 711
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 596672
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 287
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 847936
@@ -4460,18 +4460,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 289 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 278 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 288 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 288
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 293
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 848128
@@ -4479,18 +4479,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 295 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 294 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 294
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 441
+      ID: 451
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
@@ -4706,16 +4706,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 231 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 237 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 236 GoMapType map[string]interface {}
+          Type: 242 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 750
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 246
+      ID: 256
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1955104
@@ -4796,7 +4796,7 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 660
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4848,29 +4848,29 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 443
+      ID: 453
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 450
+      ID: 460
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1140736
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 299
+      ID: 309
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 850432
       GoKind: 2
     - __kind: StructureType
-      ID: 448
+      ID: 458
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1140608
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 446
+      ID: 456
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1625824
@@ -4883,7 +4883,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 458
+      ID: 468
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1626464
@@ -4896,7 +4896,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 462
+      ID: 472
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1765728
@@ -4912,7 +4912,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 460
+      ID: 470
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1454720
@@ -4922,7 +4922,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 456
+      ID: 466
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1454400
@@ -4932,14 +4932,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 686
+      ID: 696
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1528192
       GoKind: 21
-      HeaderType: 688 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 709
+      ID: 719
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1074848
@@ -4954,15 +4954,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 728 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 728
+      ID: 738
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 470
+      ID: 480
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1626784
@@ -4970,12 +4970,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 686 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 686 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 464
+      ID: 474
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1454880
@@ -4985,7 +4985,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 468
+      ID: 478
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1765920
@@ -4996,12 +4996,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 709 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 709 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 466
+      ID: 476
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1626624
@@ -5014,7 +5014,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 472
+      ID: 482
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1455040
@@ -5022,9 +5022,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 146 StructureType time.Time
+          Type: 146 GoTimeType time.Time
     - __kind: StructureType
-      ID: 478
+      ID: 488
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1627104
@@ -5037,7 +5037,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 480
+      ID: 490
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1455360
@@ -5047,7 +5047,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 476
+      ID: 486
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1626944
@@ -5060,7 +5060,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 474
+      ID: 484
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1455200
@@ -5070,7 +5070,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 482
+      ID: 492
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1627264
@@ -5105,7 +5105,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 402
+      ID: 412
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1446880
@@ -5119,7 +5119,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 404
+      ID: 414
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1447040
@@ -5127,7 +5127,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 402 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 793
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -5150,7 +5150,7 @@ Types:
           Offset: 8
           Type: 804 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 408
+      ID: 418
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1447360
@@ -5158,7 +5158,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 402 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 797
       Name: github.com/cihub/seelog.splitDispatcher
@@ -5174,7 +5174,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 406
+      ID: 416
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1447200
@@ -5182,9 +5182,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 402 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 410
+      ID: 420
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1447520
@@ -5192,7 +5192,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 402 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 932
       Name: github.com/cihub/seelog/archive.Reader
@@ -5221,42 +5221,42 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 688
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 594
+      ID: 604
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 602
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 606
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 598
+      ID: 608
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 596
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 415
+      ID: 425
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1448480
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 662
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 648
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1886496
@@ -5272,11 +5272,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 642
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 570
+      ID: 580
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1734400
@@ -5289,7 +5289,7 @@ Types:
           Offset: 1
           Type: 19 BaseType int8
     - __kind: StructureType
-      ID: 644
+      ID: 654
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1886944
@@ -5305,13 +5305,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 533
+      ID: 543
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1009280
       GoKind: 8
     - __kind: StructureType
-      ID: 636
+      ID: 646
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1886272
@@ -5327,13 +5327,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 712
+      ID: 722
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 847552
       GoKind: 8
     - __kind: StructureType
-      ID: 634
+      ID: 644
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1886048
@@ -5341,15 +5341,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 712 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 712 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 642
+      ID: 652
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1797376
@@ -5362,7 +5362,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 640
+      ID: 650
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1886720
@@ -5378,7 +5378,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 648
+      ID: 658
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1662112
@@ -5388,19 +5388,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 574
+      ID: 584
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1305184
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 572
+      ID: 582
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1305056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 646
+      ID: 656
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1797568
@@ -5413,7 +5413,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 317
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 853024
@@ -5421,22 +5421,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 319 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 318 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 318
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 703
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 602
+      ID: 612
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1470560
@@ -5446,19 +5446,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 310
+      ID: 320
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 853600
       GoKind: 10
     - __kind: BaseType
-      ID: 691
+      ID: 701
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1021472
       GoKind: 10
     - __kind: StructureType
-      ID: 660
+      ID: 670
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1919872
@@ -5469,12 +5469,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 691 BaseType golang.org/x/net/http2.ErrCode
+          Type: 701 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 517
+      ID: 527
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1633984
@@ -5482,12 +5482,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 691 BaseType golang.org/x/net/http2.ErrCode
+          Type: 701 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 314
+      ID: 324
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 853792
@@ -5495,18 +5495,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 316 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 326 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 315 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 325 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 315
+      ID: 325
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 320
+      ID: 330
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 853984
@@ -5514,18 +5514,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 322 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 332 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 321 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 331 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 321
+      ID: 331
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 317
+      ID: 327
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 853888
@@ -5533,18 +5533,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 319 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 329 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 318 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 328 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 318
+      ID: 328
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 311
+      ID: 321
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 853696
@@ -5552,18 +5552,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 313 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 323 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 312 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 322 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 312
+      ID: 322
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 521
+      ID: 531
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1471200
@@ -5573,13 +5573,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 323
+      ID: 333
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 854080
       GoKind: 2
     - __kind: StructureType
-      ID: 509
+      ID: 519
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1466240
@@ -5589,11 +5589,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 668
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 680
+      ID: 690
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1949024
@@ -5609,7 +5609,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 511
+      ID: 521
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1633504
@@ -5626,7 +5626,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 600
+      ID: 610
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1593312
@@ -5640,25 +5640,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 497
+      ID: 507
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 590
+      ID: 600
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 666
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 654
+      ID: 664
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1537792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 503
+      ID: 513
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1459520
@@ -5668,7 +5668,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 505
+      ID: 515
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1459680
@@ -5678,7 +5678,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 452
+      ID: 462
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5710,19 +5710,19 @@ Types:
       GroupType: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 835 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 240
+      ID: 250
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 241 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 251 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 242 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 248 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 992
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5752,63 +5752,63 @@ Types:
       GroupType: 857 StructureType noalg.map.group[string][]string
       GroupSliceType: 861 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 222
+      ID: 228
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 223 PointerType *noalg.map.group[string]float64
+          Type: 229 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 224 StructureType noalg.map.group[string]float64
-      GroupSliceType: 228 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 230 StructureType noalg.map.group[string]float64
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 717
+      ID: 727
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 718 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 728 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 719 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 723 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 733 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 214
+      ID: 220
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 215 PointerType *noalg.map.group[string]interface {}
+          Type: 221 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 216 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 220 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 222 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 226 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 206
+      ID: 212
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 207 PointerType *noalg.map.group[string]string
+          Type: 213 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 208 StructureType noalg.map.group[string]string
-      GroupSliceType: 212 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 214 StructureType noalg.map.group[string]string
+      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 524
+      ID: 534
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5855,11 +5855,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 692
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 420
+      ID: 430
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5885,11 +5885,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 418
+      ID: 428
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 640
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5897,13 +5897,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 638
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1503232
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 353
+      ID: 363
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5984,7 +5984,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 297
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 848896
@@ -5992,18 +5992,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 299 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 288 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 298 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 298
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 578
+      ID: 588
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1584832
@@ -6011,7 +6011,7 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 681 PointerType *internal/abi.Type
+          Type: 691 PointerType *internal/abi.Type
     - __kind: StructureType
       ID: 135
       Name: internal/sync.Mutex
@@ -6093,7 +6093,7 @@ Types:
           Offset: 0
           Type: 923 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 636
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6167,7 +6167,7 @@ Types:
       TablePtrSliceType: 834 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 233
+      ID: 239
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6180,7 +6180,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 234 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 240 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6199,8 +6199,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 247 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 242 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 988
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6304,10 +6304,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 227 GoSliceDataType []*table<string,float64>.array
-      GroupType: 224 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 233 GoSliceDataType []*table<string,float64>.array
+      GroupType: 230 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 688
+      ID: 698
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6320,7 +6320,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 689 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 699 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6339,8 +6339,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 722 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 719 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 732 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 165
       Name: map<string,interface {}>
@@ -6374,8 +6374,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 219 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 216 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 225 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 222 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 160
       Name: map<string,string>
@@ -6409,8 +6409,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 211 GoSliceDataType []*table<string,string>.array
-      GroupType: 208 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 217 GoSliceDataType []*table<string,string>.array
+      GroupType: 214 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 138
       Name: map[context.canceler]struct {}
@@ -6426,12 +6426,12 @@ Types:
       GoKind: 21
       HeaderType: 806 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 231
+      ID: 237
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1157632
       GoKind: 21
-      HeaderType: 233 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 239 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 986
       Name: map[string][]*mime/multipart.FileHeader
@@ -6454,7 +6454,7 @@ Types:
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 236
+      ID: 242
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1151104
@@ -6468,7 +6468,7 @@ Types:
       GoKind: 21
       HeaderType: 160 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 439
+      ID: 449
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1451360
@@ -6512,11 +6512,11 @@ Types:
           Offset: 8
           Type: 933 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 622
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 699
+      ID: 709
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1622624
@@ -6529,7 +6529,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 675
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6537,11 +6537,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 663
+      ID: 673
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 624
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6557,7 +6557,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 605
+      ID: 615
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1132288
@@ -6565,18 +6565,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 607 PointerType *net.UnknownNetworkError.str
+          Type: 617 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 606 GoStringDataType net.UnknownNetworkError.str
+      Data: 616 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 606
+      ID: 616
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 539
+      ID: 549
       Name: net.canceledError
       GoRuntimeType: 1302752
       GoKind: 25
@@ -6586,7 +6586,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 711
+      ID: 721
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2153920
@@ -6594,7 +6594,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 699 GoInterfaceType net.Conn
+          Type: 709 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -6621,7 +6621,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 325
+      ID: 335
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6638,7 +6638,7 @@ Types:
           Offset: 16
           Type: 118 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 327
+      ID: 337
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1757280
@@ -6646,7 +6646,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 694 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 704 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6680,11 +6680,11 @@ Types:
           Offset: 0
           Type: 963 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 626
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 677
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6734,11 +6734,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 333
+      ID: 343
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 551
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6790,7 +6790,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6835,7 +6835,7 @@ Types:
           Type: 873 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 158 GoMapType map[string]string
@@ -6872,7 +6872,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6945,19 +6945,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 249
+      ID: 259
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 844576
       GoKind: 10
     - __kind: BaseType
-      ID: 683
+      ID: 693
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1005824
       GoKind: 10
     - __kind: StructureType
-      ID: 336
+      ID: 346
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1759008
@@ -6968,12 +6968,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 683 BaseType net/http.http2ErrCode
+          Type: 693 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 669
+      ID: 679
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1938528
@@ -6984,7 +6984,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 683 BaseType net/http.http2ErrCode
+          Type: 693 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
@@ -6993,7 +6993,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 342
+      ID: 352
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1623104
@@ -7001,12 +7001,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 683 BaseType net/http.http2ErrCode
+          Type: 693 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 253
+      ID: 263
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 844768
@@ -7014,18 +7014,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 255 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 265 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 254 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 254
+      ID: 264
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 340
+      ID: 350
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1133568
       GoKind: 25
@@ -7035,7 +7035,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 259
+      ID: 269
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 844960
@@ -7043,18 +7043,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 261 PointerType *net/http.http2headerFieldNameError.str
+          Type: 271 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 260 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 270 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 260
+      ID: 270
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 256
+      ID: 266
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 844864
@@ -7062,18 +7062,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 258 PointerType *net/http.http2headerFieldValueError.str
+          Type: 268 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 257 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 267 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 257
+      ID: 267
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 630
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -7089,13 +7089,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 547
+      ID: 557
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1303392
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 250
+      ID: 260
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 844672
@@ -7103,13 +7103,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 252 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 262 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 251 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 261 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 251
+      ID: 261
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7152,7 +7152,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 543
+      ID: 553
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1577472
@@ -7192,7 +7192,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 346
+      ID: 356
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1438240
@@ -7267,7 +7267,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 841 StructureType sync/atomic.Bool
@@ -7306,7 +7306,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 331
+      ID: 341
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1622944
@@ -7319,17 +7319,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 681
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 618
+      ID: 628
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1489792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 545
+      ID: 555
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1577632
@@ -7347,12 +7347,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 699 GoInterfaceType net.Conn
+          Type: 709 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 699 GoInterfaceType net.Conn
+          Type: 709 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 329
+      ID: 339
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7362,7 +7362,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 361
+      ID: 371
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1761696
@@ -7378,7 +7378,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 359
+      ID: 369
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1624064
@@ -7391,11 +7391,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 376
+      ID: 386
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 283
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 847264
@@ -7403,22 +7403,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *net/textproto.ProtocolError.str
+          Type: 285 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType net/textproto.ProtocolError.str
+      Data: 284 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 284
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 686
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 277
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 847072
@@ -7426,18 +7426,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *net/url.EscapeError.str
+          Type: 279 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType net/url.EscapeError.str
+      Data: 278 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 278
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 280
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 847168
@@ -7445,13 +7445,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *net/url.InvalidHostError.str
+          Type: 282 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 271 GoStringDataType net/url.InvalidHostError.str
+      Data: 281 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 281
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7525,14 +7525,14 @@ Types:
       HasCount: true
       Element: 832 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 243
+      ID: 253
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 244 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 254 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 995
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7552,41 +7552,41 @@ Types:
       HasCount: true
       Element: 859 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 225
+      ID: 231
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 226 StructureType noalg.struct { key string; elem float64 }
+      Element: 232 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 720
+      ID: 730
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 776448
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 721 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 731 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 217
+      ID: 223
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 218 StructureType noalg.struct { key string; elem interface {} }
+      Element: 224 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 209
+      ID: 215
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 210 StructureType noalg.struct { key string; elem string }
+      Element: 216 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 196
       Name: noalg.map.group[context.canceler]struct {}
@@ -7614,7 +7614,7 @@ Types:
           Offset: 8
           Type: 831 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 242
+      ID: 252
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1331296
@@ -7625,7 +7625,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 243 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 253 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 994
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7653,7 +7653,7 @@ Types:
           Offset: 8
           Type: 858 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 224
+      ID: 230
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1331040
@@ -7664,9 +7664,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 225 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 231 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 719
+      ID: 729
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1380192
@@ -7677,9 +7677,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 720 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 730 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 216
+      ID: 222
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1313376
@@ -7690,9 +7690,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 217 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 223 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 208
+      ID: 214
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1318368
@@ -7703,7 +7703,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 209 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 215 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 198
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7731,7 +7731,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 244
+      ID: 254
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1331168
@@ -7742,7 +7742,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 245 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 255 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 996
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7768,9 +7768,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 702 GoSliceHeaderType []string
+          Type: 712 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 226
+      ID: 232
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1330912
@@ -7783,7 +7783,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 721
+      ID: 731
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1380064
@@ -7794,9 +7794,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 709 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 218
+      ID: 224
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1313248
@@ -7809,7 +7809,7 @@ Types:
           Offset: 16
           Type: 137 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 210
+      ID: 216
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1318240
@@ -7826,7 +7826,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 549
+      ID: 559
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7843,7 +7843,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 632
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7885,15 +7885,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 582
+      ID: 592
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 725
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 584
+      ID: 594
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1734784
@@ -7927,7 +7927,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 304
+      ID: 314
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 852256
@@ -7935,36 +7935,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 306 PointerType *os/user.UnknownGroupIdError.str
+          Type: 316 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 305 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 315 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 305
+      ID: 315
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 303
+      ID: 313
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 852160
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 355
+      ID: 365
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 454
+      ID: 464
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 567
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 571
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7976,7 +7976,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 559
+      ID: 569
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1927264
@@ -7993,9 +7993,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 713 BaseType runtime.boundsErrorCode
+          Type: 723 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 713
+      ID: 723
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 595136
@@ -8015,7 +8015,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 624
+      ID: 634
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1792384
@@ -8028,7 +8028,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 525
+      ID: 535
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1007072
@@ -8036,13 +8036,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 527 PointerType *runtime.errorString.str
+          Type: 537 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 526 GoStringDataType runtime.errorString.str
+      Data: 536 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 526
+      ID: 536
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8705,7 +8705,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 528
+      ID: 538
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1007168
@@ -8713,13 +8713,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 530 PointerType *runtime.plainError.str
+          Type: 540 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 529 GoStringDataType runtime.plainError.str
+      Data: 539 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 529
+      ID: 539
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8760,7 +8760,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 357
+      ID: 367
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1623744
@@ -8818,7 +8818,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 553
+      ID: 563
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9189,7 +9189,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 661
+      ID: 671
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1304288
@@ -9249,7 +9249,7 @@ Types:
           Offset: 16
           Type: 828 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 239
+      ID: 249
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9271,7 +9271,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 240 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 250 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 991
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9321,7 +9321,7 @@ Types:
           Offset: 16
           Type: 855 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 221
+      ID: 227
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9343,9 +9343,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 222 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 228 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 716
+      ID: 726
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9367,9 +9367,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 717 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 727 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 213
+      ID: 219
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9391,9 +9391,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 214 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 220 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 205
+      ID: 211
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9415,9 +9415,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 206 GoSwissMapGroupsType groupReference<string,string>
+          Type: 212 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 604
+      ID: 614
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1739008
@@ -9447,10 +9447,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 731 GoSliceHeaderType []time.zone
+          Type: 203 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 734 GoSliceHeaderType []time.zoneTrans
+          Type: 206 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9462,12 +9462,12 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 732 PointerType *time.zone
+          Type: 204 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 349
+      ID: 359
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 146
       Name: time.Time
       ByteSize: 24
@@ -9483,6 +9483,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 147 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 145
       Name: time.Timer
@@ -9492,12 +9500,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 730 GoChannelType <-chan time.Time
+          Type: 740 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 262
+      ID: 272
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 845056
@@ -9505,18 +9513,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 264 PointerType *time.fileSizeError.str
+          Type: 274 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 263 GoStringDataType time.fileSizeError.str
+      Data: 273 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 263
+      ID: 273
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 733
+      ID: 205
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1646944
@@ -9532,7 +9540,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 736
+      ID: 208
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1788928
@@ -9593,7 +9601,7 @@ Types:
       GoRuntimeType: 595072
       GoKind: 26
     - __kind: StructureType
-      ID: 694
+      ID: 704
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2103264
@@ -9604,10 +9612,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 695 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 696 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 706 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9622,18 +9630,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 697 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 697
+      ID: 707
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1008224
       GoKind: 9
     - __kind: StructureType
-      ID: 695
+      ID: 705
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1958176
@@ -9658,17 +9666,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 363
+      ID: 373
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 696
+      ID: 706
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 595968
       GoKind: 8
     - __kind: StructureType
-      ID: 378
+      ID: 388
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1443680
@@ -9678,13 +9686,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 276
+      ID: 286
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 847360
       GoKind: 2
     - __kind: StructureType
-      ID: 566
+      ID: 576
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1734208
@@ -9697,7 +9705,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 532
+      ID: 542
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1009088

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.26rc1.yaml
@@ -120,7 +120,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 694 PointerType *crypto/x509.Certificate
+      Pointee: 704 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 752
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -150,10 +150,10 @@ Types:
       ByteSize: 8
       Pointee: 818 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 244
+      ID: 250
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 245 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 251 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 999
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -170,10 +170,10 @@ Types:
       ByteSize: 8
       Pointee: 182 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 699
+      ID: 709
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 710 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 176
       Name: '**table<string,interface {}>'
@@ -221,30 +221,30 @@ Types:
       ByteSize: 8
       Pointee: 1028 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 737
+      ID: 747
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 736 GoSliceDataType []float64.array
+      Pointee: 746 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 240
+      ID: 246
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 245 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 248
+      ID: 254
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 253 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1034
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1033 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 214
+      ID: 220
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []os.Signal.array
+      Pointee: 219 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -253,20 +253,20 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 735
+      ID: 745
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 734 GoSliceDataType []string.array
+      Pointee: 744 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 748
+      ID: 256
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 747 GoSliceDataType []time.zone.array
+      Pointee: 255 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 750
+      ID: 258
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 749 GoSliceDataType []time.zoneTrans.array
+      Pointee: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1021
       Name: '*[]uint8'
@@ -285,17 +285,17 @@ Types:
       ByteSize: 8
       Pointee: 198 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 959488
       GoKind: 22
-      Pointee: 509 GoSliceHeaderType archive/tar.headerError
+      Pointee: 519 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 510 GoSliceDataType archive/tar.headerError.array
+      Pointee: 520 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 921
       Name: '*archive/zip.checksumReader'
@@ -353,24 +353,24 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 392
+      ID: 402
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 934720
       GoKind: 22
-      Pointee: 290 BaseType compress/flate.CorruptInputError
+      Pointee: 300 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 291 GoStringHeaderType compress/flate.InternalError
+      Pointee: 301 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 293
+      ID: 303
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 292 GoStringDataType compress/flate.InternalError.str
+      Pointee: 302 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 961
       Name: '*compress/flate.decompressor'
@@ -407,12 +407,12 @@ Types:
       GoKind: 22
       Pointee: 128 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1215136
       GoKind: 22
-      Pointee: 619 StructureType context.deadlineExceededError
+      Pointee: 629 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1035
       Name: '*context.emptyCtx'
@@ -456,54 +456,54 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 944512
       GoKind: 22
-      Pointee: 309 BaseType crypto/aes.KeySizeError
+      Pointee: 319 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 944704
       GoKind: 22
-      Pointee: 310 BaseType crypto/des.KeySizeError
+      Pointee: 320 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 451
+      ID: 461
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 944992
       GoKind: 22
-      Pointee: 311 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 321 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 597
+      ID: 607
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1088288
       GoKind: 22
-      Pointee: 598 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 608 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945280
       GoKind: 22
-      Pointee: 312 BaseType crypto/rc4.KeySizeError
+      Pointee: 322 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 932800
       GoKind: 22
-      Pointee: 279 BaseType crypto/tls.AlertError
+      Pointee: 289 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 573
+      ID: 583
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1069344
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 584 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 991
       Name: '*crypto/tls.Conn'
@@ -519,187 +519,187 @@ Types:
       GoKind: 22
       Pointee: 879 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 932896
       GoKind: 22
-      Pointee: 383 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 393 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 379
+      ID: 389
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 932704
       GoKind: 22
-      Pointee: 380 StructureType crypto/tls.RecordHeaderError
+      Pointee: 390 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1067680
       GoKind: 22
-      Pointee: 541 BaseType crypto/tls.alert
+      Pointee: 551 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 932992
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 395 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 683
+      ID: 693
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1452640
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 694 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 694
+      ID: 704
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2078368
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 705 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 944128
       GoKind: 22
-      Pointee: 446 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 456 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 439
+      ID: 449
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 943168
       GoKind: 22
-      Pointee: 440 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 450 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 441
+      ID: 451
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 943648
       GoKind: 22
-      Pointee: 442 StructureType crypto/x509.HostnameError
+      Pointee: 452 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 943072
       GoKind: 22
-      Pointee: 308 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 318 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 589
+      ID: 599
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1079328
       GoKind: 22
-      Pointee: 590 StructureType crypto/x509.SystemRootsError
+      Pointee: 600 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 944224
       GoKind: 22
-      Pointee: 448 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 458 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 944032
       GoKind: 22
-      Pointee: 444 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 454 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 954880
       GoKind: 22
-      Pointee: 501 StructureType encoding/asn1.StructuralError
+      Pointee: 511 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 504
+      ID: 514
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 955072
       GoKind: 22
-      Pointee: 505 StructureType encoding/asn1.SyntaxError
+      Pointee: 515 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 954976
       GoKind: 22
-      Pointee: 503 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 513 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 933184
       GoKind: 22
-      Pointee: 280 BaseType encoding/base64.CorruptInputError
+      Pointee: 290 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 941824
       GoKind: 22
-      Pointee: 304 BaseType encoding/hex.InvalidByteError
+      Pointee: 314 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 405
+      ID: 415
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 937024
       GoKind: 22
-      Pointee: 406 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 416 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 585
+      ID: 595
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1074464
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 596 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 936640
       GoKind: 22
-      Pointee: 398 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 408 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 403
+      ID: 413
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 936928
       GoKind: 22
-      Pointee: 404 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 414 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 936832
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 412 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 399
+      ID: 409
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 936736
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 407
+      ID: 417
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 408 StructureType encoding/json.jsonError
+      Pointee: 418 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 952288
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 509 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -708,19 +708,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 927712
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType errors.errorString
+      Pointee: 375 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 560
+      ID: 570
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1060512
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType errors.joinError
+      Pointee: 571 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -736,26 +736,26 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 544
+      ID: 554
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1049888
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType fmt.wrapError
+      Pointee: 555 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 546
+      ID: 556
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1050016
       GoKind: 22
-      Pointee: 547 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 557 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941344
       GoKind: 22
-      Pointee: 429 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 439 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 819
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -764,83 +764,83 @@ Types:
       GoKind: 22
       Pointee: 820 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 938656
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 421 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 938752
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 423 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 714
+      ID: 724
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 938464
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 725 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 939040
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 427 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 716
+      ID: 726
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 938560
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 727 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 938848
       GoKind: 22
-      Pointee: 298 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 308 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 300
+      ID: 310
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 299 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 309 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 409
+      ID: 419
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 938368
       GoKind: 22
-      Pointee: 295 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 305 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 297
+      ID: 307
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 296 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 938944
       GoKind: 22
-      Pointee: 301 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 311 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 303
+      ID: 313
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 302 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 312 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 455
+      ID: 465
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 946336
       GoKind: 22
-      Pointee: 456 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 466 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 810
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
@@ -898,12 +898,12 @@ Types:
       GoKind: 22
       Pointee: 760 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 255
+      ID: 265
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1222816
       GoKind: 22
-      Pointee: 256 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 266 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 191
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
@@ -919,12 +919,12 @@ Types:
       GoKind: 22
       Pointee: 826 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1244960
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 670 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
       ID: 761
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
@@ -961,143 +961,143 @@ Types:
       GoKind: 22
       Pointee: 904 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 948544
       GoKind: 22
-      Pointee: 458 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 468 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 949600
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 475 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 949312
       GoKind: 22
-      Pointee: 313 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 323 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 462
+      ID: 472
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 949504
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 473 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 460
+      ID: 470
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 949408
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 471 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 472
+      ID: 482
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 950944
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 483 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 476
+      ID: 486
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 951136
       GoKind: 22
-      Pointee: 477 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 487 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 951040
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 485 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 950848
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 481 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 739
+      ID: 749
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 748 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 484
+      ID: 494
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 951520
       GoKind: 22
-      Pointee: 485 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 495 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 951232
       GoKind: 22
-      Pointee: 479 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 489 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 482
+      ID: 492
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 951424
       GoKind: 22
-      Pointee: 483 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 493 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 480
+      ID: 490
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 951328
       GoKind: 22
-      Pointee: 481 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 491 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 951616
       GoKind: 22
-      Pointee: 487 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 497 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 951904
       GoKind: 22
-      Pointee: 493 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 503 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 952000
       GoKind: 22
-      Pointee: 495 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 505 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 951808
       GoKind: 22
-      Pointee: 491 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 501 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 951712
       GoKind: 22
-      Pointee: 489 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 499 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 952192
       GoKind: 22
-      Pointee: 497 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 507 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 835
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1127,12 +1127,12 @@ Types:
       GoKind: 22
       Pointee: 834 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 940192
       GoKind: 22
-      Pointee: 419 StructureType github.com/cihub/seelog.baseError
+      Pointee: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 812
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1141,12 +1141,12 @@ Types:
       GoKind: 22
       Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 940288
       GoKind: 22
-      Pointee: 421 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 431 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 802
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1169,12 +1169,12 @@ Types:
       GoKind: 22
       Pointee: 809 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 940480
       GoKind: 22
-      Pointee: 425 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 435 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 806
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1190,19 +1190,19 @@ Types:
       GoKind: 22
       Pointee: 828 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 940384
       GoKind: 22
-      Pointee: 423 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 433 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 940576
       GoKind: 22
-      Pointee: 427 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 437 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 919
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1218,289 +1218,289 @@ Types:
       GoKind: 22
       Pointee: 945 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 687
+      ID: 697
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1471680
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 698 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 603
+      ID: 613
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1096608
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 614 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 601
+      ID: 611
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1096480
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 612 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 605
+      ID: 615
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1100960
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 616 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 607
+      ID: 617
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1101088
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 618 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 595
+      ID: 605
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1085472
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 606 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 942016
       GoKind: 22
-      Pointee: 432 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 442 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 661
+      ID: 671
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1253664
       GoKind: 22
-      Pointee: 662 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 672 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 647
+      ID: 657
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1237024
       GoKind: 22
-      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 641
+      ID: 651
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1236640
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 652 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 579
+      ID: 589
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1072288
       GoKind: 22
-      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 653
+      ID: 663
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1237408
       GoKind: 22
-      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1072160
       GoKind: 22
-      Pointee: 543 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 553 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 645
+      ID: 655
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1236896
       GoKind: 22
-      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 643
+      ID: 653
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1236768
       GoKind: 22
-      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1237280
       GoKind: 22
-      Pointee: 652 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1237152
       GoKind: 22
-      Pointee: 650 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1237792
       GoKind: 22
-      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 583
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1072544
       GoKind: 22
-      Pointee: 584 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 581
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1072416
       GoKind: 22
-      Pointee: 582 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1237664
       GoKind: 22
-      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 970912
       GoKind: 22
-      Pointee: 318 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 328 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 320
+      ID: 330
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 329 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 702
+      ID: 712
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1714752
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 713 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1115808
       GoKind: 22
-      Pointee: 612 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 622 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 972160
       GoKind: 22
-      Pointee: 321 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 331 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 669
+      ID: 679
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1292320
       GoKind: 22
-      Pointee: 670 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 680 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 526
+      ID: 536
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 972448
       GoKind: 22
-      Pointee: 527 StructureType golang.org/x/net/http2.connError
+      Pointee: 537 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 525
+      ID: 535
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 972352
       GoKind: 22
-      Pointee: 325 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 335 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 336 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 972640
       GoKind: 22
-      Pointee: 331 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 341 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 333
+      ID: 343
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 342 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 528
+      ID: 538
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 972544
       GoKind: 22
-      Pointee: 328 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 338 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 339 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 524
+      ID: 534
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 972256
       GoKind: 22
-      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 332 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 324
+      ID: 334
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 333 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 530
+      ID: 540
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 972736
       GoKind: 22
-      Pointee: 531 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 541 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 532
+      ID: 542
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 972832
       GoKind: 22
-      Pointee: 334 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 344 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 966592
       GoKind: 22
-      Pointee: 519 StructureType google.golang.org/grpc.dropError
+      Pointee: 529 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 667
+      ID: 677
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1289376
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 678 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 689
+      ID: 699
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1479200
       GoKind: 22
-      Pointee: 690 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 700 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 520
+      ID: 530
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 969184
       GoKind: 22
-      Pointee: 521 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 531 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 950
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1509,12 +1509,12 @@ Types:
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 609
+      ID: 619
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1110048
       GoKind: 22
-      Pointee: 610 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 620 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 934
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1523,61 +1523,61 @@ Types:
       GoKind: 22
       Pointee: 935 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 958144
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 517 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 599
+      ID: 609
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1090208
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 610 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 665
+      ID: 675
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1258400
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 676 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 663
+      ID: 673
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1258144
       GoKind: 22
-      Pointee: 664 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 674 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 512
+      ID: 522
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 960448
       GoKind: 22
-      Pointee: 513 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 523 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 960544
       GoKind: 22
-      Pointee: 515 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 525 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 949696
       GoKind: 22
-      Pointee: 467 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 477 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 533
+      ID: 543
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 973600
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType html/template.Error
+      Pointee: 544 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 107
       Name: '*int'
@@ -1614,33 +1614,33 @@ Types:
       GoKind: 22
       Pointee: 21 BaseType int8
     - __kind: PointerType
-      ID: 691
+      ID: 701
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2272544
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType internal/abi.Type
+      Pointee: 702 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 942688
       GoKind: 22
-      Pointee: 437 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 447 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 942592
       GoKind: 22
-      Pointee: 435 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 445 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 639
+      ID: 649
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1231264
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 650 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 989
       Name: '*internal/poll.FD'
@@ -1649,19 +1649,19 @@ Types:
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 637
+      ID: 647
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1231136
       GoKind: 22
-      Pointee: 638 StructureType internal/poll.errNetClosing
+      Pointee: 648 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 928096
       GoKind: 22
-      Pointee: 367 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 377 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -1670,31 +1670,31 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 433
+      ID: 443
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 942496
       GoKind: 22
-      Pointee: 305 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 315 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 307
+      ID: 317
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 316 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 587
+      ID: 597
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1078176
       GoKind: 22
-      Pointee: 588 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 598 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 376
+      ID: 386
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 931744
       GoKind: 22
-      Pointee: 278 BaseType internal/strconv.Error
+      Pointee: 288 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 954
       Name: '*io.PipeReader'
@@ -1724,12 +1724,12 @@ Types:
       GoKind: 22
       Pointee: 918 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 635
+      ID: 645
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1230112
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType io/fs.PathError
+      Pointee: 646 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 145
       Name: '*map<context.canceler,struct {}>'
@@ -1741,10 +1741,10 @@ Types:
       ByteSize: 8
       Pointee: 816 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 242
+      ID: 248
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 243 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 249 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 997
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1761,10 +1761,10 @@ Types:
       ByteSize: 8
       Pointee: 180 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 697
+      ID: 707
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 708 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 174
       Name: '*map<string,interface {}>'
@@ -1776,12 +1776,12 @@ Types:
       ByteSize: 8
       Pointee: 170 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 453
+      ID: 463
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 945952
       GoKind: 22
-      Pointee: 454 StructureType math/big.ErrNaN
+      Pointee: 464 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 1009
       Name: '*mime/multipart.FileHeader'
@@ -1811,19 +1811,19 @@ Types:
       GoKind: 22
       Pointee: 939 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 621
+      ID: 631
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1216288
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType net.AddrError
+      Pointee: 632 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 674
+      ID: 684
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1445440
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType net.DNSError
+      Pointee: 685 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 965
       Name: '*net.IPConn'
@@ -1832,19 +1832,19 @@ Types:
       GoKind: 22
       Pointee: 966 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 672
+      ID: 682
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1445120
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType net.OpError
+      Pointee: 683 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 623
+      ID: 633
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1216416
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType net.ParseError
+      Pointee: 634 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 973
       Name: '*net.TCPConn'
@@ -1867,24 +1867,24 @@ Types:
       GoKind: 22
       Pointee: 972 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1215520
       GoKind: 22
-      Pointee: 615 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 625 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 616 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 626 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 548
+      ID: 558
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1050912
       GoKind: 22
-      Pointee: 549 StructureType net.canceledError
+      Pointee: 559 StructureType net.canceledError
     - __kind: PointerType
       ID: 963
       Name: '*net.conn'
@@ -1893,12 +1893,12 @@ Types:
       GoKind: 22
       Pointee: 964 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 720
+      ID: 730
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1892800
       GoKind: 22
-      Pointee: 721 StructureType net.dialResult·1
+      Pointee: 731 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 979
       Name: '*net.netFD'
@@ -1907,12 +1907,12 @@ Types:
       GoKind: 22
       Pointee: 980 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 920512
       GoKind: 22
-      Pointee: 336 UnresolvedPointeeType net.notFoundError
+      Pointee: 346 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1036
       Name: '*net.onlyValuesCtx'
@@ -1921,12 +1921,12 @@ Types:
       GoKind: 22
       Pointee: 1037 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 338 StructureType net.result·2
+      Pointee: 348 StructureType net.result·2
     - __kind: PointerType
       ID: 969
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1942,33 +1942,33 @@ Types:
       GoKind: 22
       Pointee: 968 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 625
+      ID: 635
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1217056
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType net.temporaryError
+      Pointee: 636 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 676
+      ID: 686
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1445760
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType net.timeoutError
+      Pointee: 687 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 343
+      ID: 353
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 344 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 354 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1054624
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 561 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 118
       Name: '*net/http.Request'
@@ -2026,26 +2026,26 @@ Types:
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 923968
       GoKind: 22
-      Pointee: 259 BaseType net/http.http2ConnectionError
+      Pointee: 269 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 924064
       GoKind: 22
-      Pointee: 347 StructureType net/http.http2GoAwayError
+      Pointee: 357 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 678
+      ID: 688
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1446560
       GoKind: 22
-      Pointee: 679 StructureType net/http.http2StreamError
+      Pointee: 689 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 927
       Name: '*net/http.http2clientStream'
@@ -2054,31 +2054,31 @@ Types:
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 352
+      ID: 362
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 353 StructureType net/http.http2connError
+      Pointee: 363 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 349
+      ID: 359
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 924544
       GoKind: 22
-      Pointee: 263 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 273 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 265
+      ID: 275
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 274 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 924640
       GoKind: 22
-      Pointee: 351 StructureType net/http.http2goAwayFlowError
+      Pointee: 361 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 929
       Name: '*net/http.http2gzipReader'
@@ -2087,36 +2087,36 @@ Types:
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 925312
       GoKind: 22
-      Pointee: 269 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 279 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 271
+      ID: 281
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 270 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 280 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 354
+      ID: 364
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 925216
       GoKind: 22
-      Pointee: 266 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 276 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 268
+      ID: 278
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 277 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 629
+      ID: 639
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1220640
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 640 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 891
       Name: '*net/http.http2missingBody'
@@ -2132,24 +2132,24 @@ Types:
       GoKind: 22
       Pointee: 900 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 556
+      ID: 566
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1056800
       GoKind: 22
-      Pointee: 557 StructureType net/http.http2noCachedConnError
+      Pointee: 567 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 260 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 270 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 262
+      ID: 272
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 261 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 271 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 897
       Name: '*net/http.http2requestBody'
@@ -2193,12 +2193,12 @@ Types:
       GoKind: 22
       Pointee: 916 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1056544
       GoKind: 22
-      Pointee: 553 StructureType net/http.nothingWrittenError
+      Pointee: 563 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 883
       Name: '*net/http.pattern'
@@ -2221,12 +2221,12 @@ Types:
       GoKind: 22
       Pointee: 924 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 925504
       GoKind: 22
-      Pointee: 357 StructureType net/http.requestBodyReadError
+      Pointee: 367 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 800
       Name: '*net/http.response'
@@ -2242,33 +2242,33 @@ Types:
       GoKind: 22
       Pointee: 1032 StructureType net/http.segment
     - __kind: PointerType
-      ID: 341
+      ID: 351
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 923680
       GoKind: 22
-      Pointee: 342 StructureType net/http.statusError
+      Pointee: 352 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 680
+      ID: 690
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1448000
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 691 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 627
+      ID: 637
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1220512
       GoKind: 22
-      Pointee: 628 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 638 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1056672
       GoKind: 22
-      Pointee: 555 StructureType net/http.transportReadFromServerError
+      Pointee: 565 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 952
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2277,12 +2277,12 @@ Types:
       GoKind: 22
       Pointee: 953 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 340 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 350 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 909
       Name: '*net/http/httputil.failureToReadBody'
@@ -2291,69 +2291,69 @@ Types:
       GoKind: 22
       Pointee: 910 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 930976
       GoKind: 22
-      Pointee: 375 StructureType net/netip.parseAddrError
+      Pointee: 385 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 372
+      ID: 382
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 930880
       GoKind: 22
-      Pointee: 373 StructureType net/netip.parsePrefixError
+      Pointee: 383 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 934432
       GoKind: 22
-      Pointee: 391 UnresolvedPointeeType net/textproto.Error
+      Pointee: 401 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 287 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 297 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 289
+      ID: 299
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 298 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 685
+      ID: 695
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1452960
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType net/url.Error
+      Pointee: 696 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 933280
       GoKind: 22
-      Pointee: 281 GoStringHeaderType net/url.EscapeError
+      Pointee: 291 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 283
+      ID: 293
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 282 GoStringDataType net/url.EscapeError.str
+      Pointee: 292 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 933376
       GoKind: 22
-      Pointee: 284 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 294 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 286
+      ID: 296
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 295 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 872
       Name: '*net/url.URL'
@@ -2379,10 +2379,10 @@ Types:
       ByteSize: 8
       Pointee: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 251
+      ID: 261
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 1003
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2394,25 +2394,25 @@ Types:
       ByteSize: 8
       Pointee: 867 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 233
+      ID: 239
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 234 StructureType noalg.map.group[string]float64
+      Pointee: 240 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 728
+      ID: 738
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 225
+      ID: 231
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 226 StructureType noalg.map.group[string]interface {}
+      Pointee: 232 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 217
+      ID: 223
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 218 StructureType noalg.map.group[string]string
+      Pointee: 224 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 985
       Name: '*os.File'
@@ -2421,12 +2421,12 @@ Types:
       GoKind: 22
       Pointee: 986 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 558
+      ID: 568
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1058976
       GoKind: 22
-      Pointee: 559 UnresolvedPointeeType os.LinkError
+      Pointee: 569 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 163
       Name: '*os.Signal'
@@ -2435,12 +2435,12 @@ Types:
       GoKind: 22
       Pointee: 164 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 631
+      ID: 641
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1221024
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType os.SyscallError
+      Pointee: 642 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 983
       Name: '*os.fileWithoutReadFrom'
@@ -2456,26 +2456,26 @@ Types:
       GoKind: 22
       Pointee: 982 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1081120
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType os/exec.Error
+      Pointee: 602 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 724
+      ID: 734
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2162464
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 735 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1081248
       GoKind: 22
-      Pointee: 594 StructureType os/exec.wrappedError
+      Pointee: 604 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 137
       Name: '*os/signal.signalCtx'
@@ -2484,64 +2484,64 @@ Types:
       GoKind: 22
       Pointee: 138 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 358
+      ID: 368
       Name: '*os/signal.signalError'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 272 GoStringHeaderType os/signal.signalError
+      Pointee: 282 GoStringHeaderType os/signal.signalError
     - __kind: PointerType
-      ID: 274
+      ID: 284
       Name: '*os/signal.signalError.str'
       ByteSize: 8
-      Pointee: 273 GoStringDataType os/signal.signalError.str
+      Pointee: 283 GoStringDataType os/signal.signalError.str
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 964672
       GoKind: 22
-      Pointee: 315 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 325 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 317
+      ID: 327
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 316 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 326 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 516
+      ID: 526
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 964576
       GoKind: 22
-      Pointee: 314 BaseType os/user.UnknownUserIdError
+      Pointee: 324 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 928864
       GoKind: 22
-      Pointee: 369 UnresolvedPointeeType reflect.ValueError
+      Pointee: 379 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 950176
       GoKind: 22
-      Pointee: 469 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 479 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 566
+      ID: 576
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1064864
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 577 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 570
+      ID: 580
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1065504
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 581 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -2557,12 +2557,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1064992
       GoKind: 22
-      Pointee: 569 StructureType runtime.boundsError
+      Pointee: 579 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -2578,24 +2578,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 633
+      ID: 643
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1229600
       GoKind: 22
-      Pointee: 634 StructureType runtime.errorAddressString
+      Pointee: 644 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1063200
       GoKind: 22
-      Pointee: 535 GoStringHeaderType runtime.errorString
+      Pointee: 545 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 537
+      ID: 547
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType runtime.errorString.str
+      Pointee: 546 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -2618,17 +2618,17 @@ Types:
       GoKind: 22
       Pointee: 200 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1063328
       GoKind: 22
-      Pointee: 538 GoStringHeaderType runtime.plainError
+      Pointee: 548 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 540
+      ID: 550
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 539 GoStringDataType runtime.plainError.str
+      Pointee: 549 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -2644,12 +2644,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 370
+      ID: 380
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 930592
       GoKind: 22
-      Pointee: 371 StructureType runtime.synctestDeadlockError
+      Pointee: 381 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -2672,12 +2672,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1062816
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType strconv.NumError
+      Pointee: 573 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -2803,12 +2803,12 @@ Types:
       GoKind: 22
       Pointee: 912 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 682
+      ID: 692
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1451840
       GoKind: 22
-      Pointee: 671 BaseType syscall.Errno
+      Pointee: 681 BaseType syscall.Errno
     - __kind: PointerType
       ID: 757
       Name: '*syscall.Signal'
@@ -2827,10 +2827,10 @@ Types:
       ByteSize: 8
       Pointee: 837 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 245
+      ID: 251
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 249 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 259 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 1000
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2845,29 +2845,29 @@ Types:
       ID: 182
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 231 StructureType table<string,float64>
+      Pointee: 237 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 700
+      ID: 710
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 726 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 736 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 223 StructureType table<string,interface {}>
+      Pointee: 229 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 172
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 215 StructureType table<string,string>
+      Pointee: 221 StructureType table<string,string>
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1119648
       GoKind: 22
-      Pointee: 614 StructureType text/template.ExecError
+      Pointee: 624 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 158
       Name: '*time.Location'
@@ -2876,12 +2876,12 @@ Types:
       GoKind: 22
       Pointee: 159 StructureType time.Location
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 926560
       GoKind: 22
-      Pointee: 363 UnresolvedPointeeType time.ParseError
+      Pointee: 373 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 155
       Name: '*time.Timer'
@@ -2890,38 +2890,38 @@ Types:
       GoKind: 22
       Pointee: 156 StructureType time.Timer
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 926368
       GoKind: 22
-      Pointee: 275 GoStringHeaderType time.fileSizeError
+      Pointee: 285 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 277
+      ID: 287
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 276 GoStringDataType time.fileSizeError.str
+      Pointee: 286 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 926464
       GoKind: 22
-      Pointee: 361 UnresolvedPointeeType time.parseDurationError
+      Pointee: 371 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 742
+      ID: 214
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 404544
       GoKind: 22
-      Pointee: 743 StructureType time.zone
+      Pointee: 215 StructureType time.zone
     - __kind: PointerType
-      ID: 745
+      ID: 217
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 404608
       GoKind: 22
-      Pointee: 746 StructureType time.zoneTrans
+      Pointee: 218 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -2965,47 +2965,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 931840
       GoKind: 22
-      Pointee: 378 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 388 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 394
+      ID: 404
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 935104
       GoKind: 22
-      Pointee: 395 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 405 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 396
+      ID: 406
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 935200
       GoKind: 22
-      Pointee: 294 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 304 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 575
+      ID: 585
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1070880
       GoKind: 22
-      Pointee: 576 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 586 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1071008
       GoKind: 22
-      Pointee: 542 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 552 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 880
       Name: <-chan struct {}
       GoRuntimeType: 613440
       GoKind: 18
     - __kind: GoChannelType
-      ID: 740
+      ID: 750
       Name: <-chan time.Time
       GoRuntimeType: 619136
       GoKind: 18
@@ -3183,7 +3183,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 708
+      ID: 718
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 719712
@@ -3231,7 +3231,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 694 PointerType *crypto/x509.Certificate
+      Element: 704 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 751
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3314,11 +3314,11 @@ Types:
       ByteSize: 8
       Element: 818 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 267
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 245 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 251 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 1010
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3332,25 +3332,25 @@ Types:
       ByteSize: 8
       Element: 859 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 243
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 182 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 732
+      ID: 742
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 710 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 235
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 177 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 227
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3402,7 +3402,7 @@ Types:
       ByteSize: 24
       Element: 41 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 713
+      ID: 723
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 507104
@@ -3417,9 +3417,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 736 GoSliceDataType []float64.array
+      Data: 746 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 736
+      ID: 746
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3440,9 +3440,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 239 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 245 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 245
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3463,9 +3463,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 253 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 253
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3506,11 +3506,11 @@ Types:
       ByteSize: 24
       Element: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 268
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 1011
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3524,29 +3524,29 @@ Types:
       ByteSize: 328
       Element: 867 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 244
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 234 StructureType noalg.map.group[string]float64
+      Element: 240 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 733
+      ID: 743
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 236
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 226 StructureType noalg.map.group[string]interface {}
+      Element: 232 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 228
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 218 StructureType noalg.map.group[string]string
+      Element: 224 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 162
       Name: '[]os.Signal'
@@ -3563,9 +3563,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType []os.Signal.array
+      Data: 219 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 219
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3575,7 +3575,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 712
+      ID: 722
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 507360
@@ -3590,15 +3590,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 734 GoSliceDataType []string.array
+      Data: 744 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 734
+      ID: 744
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 741
+      ID: 213
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 500192
@@ -3606,22 +3606,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 742 PointerType *time.zone
+          Type: 214 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 747 GoSliceDataType []time.zone.array
+      Data: 255 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 747
+      ID: 255
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 743 StructureType time.zone
+      Element: 215 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 744
+      ID: 216
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 500256
@@ -3629,20 +3629,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 745 PointerType *time.zoneTrans
+          Type: 217 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 749 GoSliceDataType []time.zoneTrans.array
+      Data: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 749
+      ID: 257
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 746 StructureType time.zoneTrans
+      Element: 218 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 41
       Name: '[]uint8'
@@ -3690,7 +3690,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 509
+      ID: 519
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 959584
@@ -3705,9 +3705,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 510 GoSliceDataType archive/tar.headerError.array
+      Data: 520 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 510
+      ID: 520
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3765,13 +3765,13 @@ Types:
       GoRuntimeType: 600704
       GoKind: 15
     - __kind: BaseType
-      ID: 290
+      ID: 300
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 854528
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 291
+      ID: 301
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 854624
@@ -3779,13 +3779,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 293 PointerType *compress/flate.InternalError.str
+          Type: 303 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 292 GoStringDataType compress/flate.InternalError.str
+      Data: 302 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 292
+      ID: 302
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3893,7 +3893,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 619
+      ID: 629
       Name: context.deadlineExceededError
       GoRuntimeType: 1496640
       GoKind: 25
@@ -3937,7 +3937,7 @@ Types:
           Type: 155 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 157 StructureType time.Time
+          Type: 157 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3983,43 +3983,43 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 309
+      ID: 319
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 856640
       GoKind: 2
     - __kind: BaseType
-      ID: 310
+      ID: 320
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 856736
       GoKind: 2
     - __kind: BaseType
-      ID: 311
+      ID: 321
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 856832
       GoKind: 2
     - __kind: StructureType
-      ID: 598
+      ID: 608
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1319776
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 312
+      ID: 322
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 856928
       GoKind: 2
     - __kind: BaseType
-      ID: 279
+      ID: 289
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 854048
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 584
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4091,11 +4091,11 @@ Types:
       GoRuntimeType: 853760
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 383
+      ID: 393
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 380
+      ID: 390
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1779776
@@ -4106,10 +4106,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 708 ArrayType [5]uint8
+          Type: 718 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 709 GoInterfaceType net.Conn
+          Type: 719 GoInterfaceType net.Conn
     - __kind: BaseType
       ID: 1023
       Name: crypto/tls.SignatureScheme
@@ -4117,25 +4117,25 @@ Types:
       GoRuntimeType: 853856
       GoKind: 9
     - __kind: BaseType
-      ID: 541
+      ID: 551
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1018016
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 395
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 694
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 705
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 446
+      ID: 456
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1781888
@@ -4143,21 +4143,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 704 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 718 BaseType crypto/x509.InvalidReason
+          Type: 728 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 440
+      ID: 450
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1147968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 442
+      ID: 452
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1640672
@@ -4165,24 +4165,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 704 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 308
+      ID: 318
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 856352
       GoKind: 2
     - __kind: BaseType
-      ID: 718
+      ID: 728
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 604032
       GoKind: 2
     - __kind: StructureType
-      ID: 590
+      ID: 600
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1600320
@@ -4192,13 +4192,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 448
+      ID: 458
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1148224
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 444
+      ID: 454
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1781696
@@ -4206,15 +4206,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 704 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 704 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 501
+      ID: 511
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1467520
@@ -4224,7 +4224,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 505
+      ID: 515
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1467680
@@ -4234,47 +4234,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 503
+      ID: 513
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 280
+      ID: 290
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 854144
       GoKind: 6
     - __kind: BaseType
-      ID: 304
+      ID: 314
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 856064
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 406
+      ID: 416
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 596
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 398
+      ID: 408
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 404
+      ID: 414
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 412
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 410
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 408
+      ID: 418
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1456640
@@ -4284,7 +4284,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 509
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4301,11 +4301,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 375
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 571
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4321,11 +4321,11 @@ Types:
       GoRuntimeType: 600896
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 555
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 547
+      ID: 557
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4359,7 +4359,7 @@ Types:
       GoRuntimeType: 1033952
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 429
+      ID: 439
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4369,7 +4369,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1780736
@@ -4377,7 +4377,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 710 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 720 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4385,25 +4385,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 423
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 725
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 417
+      ID: 427
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1146560
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 727
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 298
+      ID: 308
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 855392
@@ -4411,18 +4411,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 300 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 310 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 299 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 309 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 299
+      ID: 309
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 710
+      ID: 720
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2293504
@@ -4430,13 +4430,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 711 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 721 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4445,7 +4445,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 713 GoSliceHeaderType []float64
+          Type: 723 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4454,13 +4454,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 714 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 724 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 716 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 726 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4471,13 +4471,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 711
+      ID: 721
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 602560
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 295
+      ID: 305
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 855296
@@ -4485,18 +4485,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 297 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 307 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 296 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 296
+      ID: 306
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 301
+      ID: 311
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 855488
@@ -4504,18 +4504,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 303 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 313 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 302 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 312 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 302
+      ID: 312
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 456
+      ID: 466
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
@@ -4731,16 +4731,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 241 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 247 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 246 GoMapType map[string]interface {}
+          Type: 252 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 760
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 256
+      ID: 266
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1974336
@@ -4821,7 +4821,7 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 670
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4873,29 +4873,29 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 458
+      ID: 468
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 465
+      ID: 475
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1149632
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 313
+      ID: 323
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 857696
       GoKind: 2
     - __kind: StructureType
-      ID: 463
+      ID: 473
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1149504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 461
+      ID: 471
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1641792
@@ -4908,7 +4908,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 473
+      ID: 483
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1642432
@@ -4921,7 +4921,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 477
+      ID: 487
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1783808
@@ -4937,7 +4937,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 475
+      ID: 485
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1466080
@@ -4947,7 +4947,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 471
+      ID: 481
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1465760
@@ -4957,14 +4957,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 696
+      ID: 706
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1541920
       GoKind: 21
-      HeaderType: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 708 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 719
+      ID: 729
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1084320
@@ -4979,15 +4979,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 748 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 738
+      ID: 748
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 485
+      ID: 495
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1642752
@@ -4995,12 +4995,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 706 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 706 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 479
+      ID: 489
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1466240
@@ -5010,7 +5010,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 483
+      ID: 493
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1784000
@@ -5021,12 +5021,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 481
+      ID: 491
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1642592
@@ -5039,7 +5039,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 487
+      ID: 497
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1466400
@@ -5047,9 +5047,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 157 StructureType time.Time
+          Type: 157 GoTimeType time.Time
     - __kind: StructureType
-      ID: 493
+      ID: 503
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1643072
@@ -5062,7 +5062,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 495
+      ID: 505
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1466720
@@ -5072,7 +5072,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1642912
@@ -5085,7 +5085,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 489
+      ID: 499
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1466560
@@ -5095,7 +5095,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 497
+      ID: 507
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1643232
@@ -5130,7 +5130,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 419
+      ID: 429
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1457920
@@ -5144,7 +5144,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 421
+      ID: 431
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1458080
@@ -5152,7 +5152,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 419 StructureType github.com/cihub/seelog.baseError
+          Type: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 803
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -5175,7 +5175,7 @@ Types:
           Offset: 8
           Type: 814 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1458400
@@ -5183,7 +5183,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 419 StructureType github.com/cihub/seelog.baseError
+          Type: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 807
       Name: github.com/cihub/seelog.splitDispatcher
@@ -5199,7 +5199,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 423
+      ID: 433
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1458240
@@ -5207,9 +5207,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 419 StructureType github.com/cihub/seelog.baseError
+          Type: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 427
+      ID: 437
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1458560
@@ -5217,7 +5217,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 419 StructureType github.com/cihub/seelog.baseError
+          Type: 429 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 942
       Name: github.com/cihub/seelog/archive.Reader
@@ -5246,42 +5246,42 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 698
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 614
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 612
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 616
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 618
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 606
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 432
+      ID: 442
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1459520
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 662
+      ID: 672
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 648
+      ID: 658
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1905344
@@ -5297,11 +5297,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 652
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 590
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1752096
@@ -5314,7 +5314,7 @@ Types:
           Offset: 1
           Type: 21 BaseType int8
     - __kind: StructureType
-      ID: 654
+      ID: 664
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1905792
@@ -5330,13 +5330,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 543
+      ID: 553
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1018688
       GoKind: 8
     - __kind: StructureType
-      ID: 646
+      ID: 656
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1905120
@@ -5352,13 +5352,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 722
+      ID: 732
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 854912
       GoKind: 8
     - __kind: StructureType
-      ID: 644
+      ID: 654
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1904896
@@ -5366,15 +5366,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 732 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 732 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 652
+      ID: 662
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1816192
@@ -5387,7 +5387,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 650
+      ID: 660
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1905568
@@ -5403,7 +5403,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 658
+      ID: 668
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1678080
@@ -5413,19 +5413,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 584
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1315680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 582
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1315552
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 656
+      ID: 666
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1816384
@@ -5438,7 +5438,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 318
+      ID: 328
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 860192
@@ -5446,22 +5446,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 320 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 330 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 329 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 319
+      ID: 329
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 713
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 612
+      ID: 622
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1481920
@@ -5471,19 +5471,19 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 321
+      ID: 331
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 860768
       GoKind: 10
     - __kind: BaseType
-      ID: 701
+      ID: 711
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1030976
       GoKind: 10
     - __kind: StructureType
-      ID: 670
+      ID: 680
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1938272
@@ -5494,12 +5494,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 701 BaseType golang.org/x/net/http2.ErrCode
+          Type: 711 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 527
+      ID: 537
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1649952
@@ -5507,12 +5507,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 701 BaseType golang.org/x/net/http2.ErrCode
+          Type: 711 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 335
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 860960
@@ -5520,18 +5520,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 337 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 336 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 336
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 341
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 861152
@@ -5539,18 +5539,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 343 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 342 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 342
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 338
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 861056
@@ -5558,18 +5558,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 340 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 339 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 339
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 332
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 860864
@@ -5577,18 +5577,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 334 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 333 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 333
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 531
+      ID: 541
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1482560
@@ -5598,13 +5598,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 334
+      ID: 344
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 861248
       GoKind: 2
     - __kind: StructureType
-      ID: 519
+      ID: 529
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1477600
@@ -5614,11 +5614,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 678
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 690
+      ID: 700
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1968512
@@ -5634,7 +5634,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 521
+      ID: 531
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1649472
@@ -5651,7 +5651,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 610
+      ID: 620
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1608160
@@ -5665,25 +5665,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 517
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 610
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 676
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 664
+      ID: 674
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1551680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 513
+      ID: 523
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1470880
@@ -5693,7 +5693,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 515
+      ID: 525
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1471040
@@ -5703,7 +5703,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 467
+      ID: 477
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5735,19 +5735,19 @@ Types:
       GroupType: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 845 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 250
+      ID: 260
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 251 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 261 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 268 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 1002
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5777,63 +5777,63 @@ Types:
       GroupType: 867 StructureType noalg.map.group[string][]string
       GroupSliceType: 871 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 232
+      ID: 238
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 233 PointerType *noalg.map.group[string]float64
+          Type: 239 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 234 StructureType noalg.map.group[string]float64
-      GroupSliceType: 238 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 240 StructureType noalg.map.group[string]float64
+      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 727
+      ID: 737
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 728 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 738 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 733 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 743 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 224
+      ID: 230
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 225 PointerType *noalg.map.group[string]interface {}
+          Type: 231 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 226 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 230 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 232 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 216
+      ID: 222
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 217 PointerType *noalg.map.group[string]string
+          Type: 223 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 218 StructureType noalg.map.group[string]string
-      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 224 StructureType noalg.map.group[string]string
+      GroupSliceType: 228 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 544
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5880,17 +5880,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 723
+      ID: 733
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 603456
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 702
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 437
+      ID: 447
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5916,11 +5916,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 435
+      ID: 445
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 650
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5928,13 +5928,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 648
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1515520
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 367
+      ID: 377
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6006,7 +6006,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 305
+      ID: 315
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 856256
@@ -6014,18 +6014,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 317 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 306 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 316 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 316
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 588
+      ID: 598
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1599360
@@ -6033,9 +6033,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 691 PointerType *internal/abi.Type
+          Type: 701 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 278
+      ID: 288
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 853568
@@ -6121,7 +6121,7 @@ Types:
           Offset: 0
           Type: 933 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 646
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6195,7 +6195,7 @@ Types:
       TablePtrSliceType: 844 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 243
+      ID: 249
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6208,7 +6208,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 244 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 250 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6227,8 +6227,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 267 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 998
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6332,10 +6332,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 237 GoSliceDataType []*table<string,float64>.array
-      GroupType: 234 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 243 GoSliceDataType []*table<string,float64>.array
+      GroupType: 240 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 698
+      ID: 708
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6348,7 +6348,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 699 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 709 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6367,8 +6367,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 732 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 742 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 175
       Name: map<string,interface {}>
@@ -6402,8 +6402,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 229 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 226 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 232 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 170
       Name: map<string,string>
@@ -6437,8 +6437,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 221 GoSliceDataType []*table<string,string>.array
-      GroupType: 218 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 227 GoSliceDataType []*table<string,string>.array
+      GroupType: 224 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 144
       Name: map[context.canceler]struct {}
@@ -6454,12 +6454,12 @@ Types:
       GoKind: 21
       HeaderType: 816 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 241
+      ID: 247
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1166528
       GoKind: 21
-      HeaderType: 243 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 249 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 996
       Name: map[string][]*mime/multipart.FileHeader
@@ -6482,7 +6482,7 @@ Types:
       GoKind: 21
       HeaderType: 180 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 246
+      ID: 252
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1160000
@@ -6496,7 +6496,7 @@ Types:
       GoKind: 21
       HeaderType: 170 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 454
+      ID: 464
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1462720
@@ -6540,11 +6540,11 @@ Types:
           Offset: 8
           Type: 943 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 632
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 709
+      ID: 719
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1637952
@@ -6557,7 +6557,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 685
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6565,11 +6565,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 683
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 634
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6585,7 +6585,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 615
+      ID: 625
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1141056
@@ -6593,18 +6593,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 617 PointerType *net.UnknownNetworkError.str
+          Type: 627 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 616 GoStringDataType net.UnknownNetworkError.str
+      Data: 626 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 616
+      ID: 626
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 549
+      ID: 559
       Name: net.canceledError
       GoRuntimeType: 1313120
       GoKind: 25
@@ -6614,7 +6614,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 721
+      ID: 731
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2175744
@@ -6622,7 +6622,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 709 GoInterfaceType net.Conn
+          Type: 719 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -6649,7 +6649,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 336
+      ID: 346
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6666,7 +6666,7 @@ Types:
           Offset: 16
           Type: 124 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 338
+      ID: 348
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1774592
@@ -6674,7 +6674,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 704 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 714 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6708,11 +6708,11 @@ Types:
           Offset: 0
           Type: 973 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 636
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 687
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6762,11 +6762,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 344
+      ID: 354
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 561
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6818,7 +6818,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6863,7 +6863,7 @@ Types:
           Type: 883 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 168 GoMapType map[string]string
@@ -6900,7 +6900,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6973,19 +6973,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 259
+      ID: 269
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 851552
       GoKind: 10
     - __kind: BaseType
-      ID: 693
+      ID: 703
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1015232
       GoKind: 10
     - __kind: StructureType
-      ID: 347
+      ID: 357
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1776320
@@ -6996,12 +6996,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 703 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 679
+      ID: 689
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1956736
@@ -7012,7 +7012,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 703 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
@@ -7021,7 +7021,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 353
+      ID: 363
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1638432
@@ -7029,12 +7029,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 703 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 273
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 851744
@@ -7042,18 +7042,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 275 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 274 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 274
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 351
+      ID: 361
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1142336
       GoKind: 25
@@ -7063,7 +7063,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 269
+      ID: 279
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 851936
@@ -7071,18 +7071,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 271 PointerType *net/http.http2headerFieldNameError.str
+          Type: 281 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 270 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 280 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 270
+      ID: 280
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 276
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 851840
@@ -7090,18 +7090,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *net/http.http2headerFieldValueError.str
+          Type: 278 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 267 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 277 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 277
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 640
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -7117,13 +7117,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 557
+      ID: 567
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1314016
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 260
+      ID: 270
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 851648
@@ -7131,13 +7131,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 262 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 272 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 261 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 271 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 261
+      ID: 271
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7180,7 +7180,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 553
+      ID: 563
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1591520
@@ -7220,7 +7220,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 357
+      ID: 367
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1448800
@@ -7295,7 +7295,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 150 StructureType sync/atomic.Bool
@@ -7334,7 +7334,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 342
+      ID: 352
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1638272
@@ -7347,17 +7347,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 691
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 638
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1501120
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 555
+      ID: 565
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1591680
@@ -7375,12 +7375,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 709 GoInterfaceType net.Conn
+          Type: 719 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 709 GoInterfaceType net.Conn
+          Type: 719 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 340
+      ID: 350
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7390,7 +7390,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 375
+      ID: 385
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1779392
@@ -7406,7 +7406,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 373
+      ID: 383
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1639552
@@ -7419,11 +7419,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 391
+      ID: 401
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 297
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 854432
@@ -7431,22 +7431,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *net/textproto.ProtocolError.str
+          Type: 299 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 288 GoStringDataType net/textproto.ProtocolError.str
+      Data: 298 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 298
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 696
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 281
+      ID: 291
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 854240
@@ -7454,18 +7454,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 283 PointerType *net/url.EscapeError.str
+          Type: 293 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 282 GoStringDataType net/url.EscapeError.str
+      Data: 292 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 282
+      ID: 292
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 294
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 854336
@@ -7473,13 +7473,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *net/url.InvalidHostError.str
+          Type: 296 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 285 GoStringDataType net/url.InvalidHostError.str
+      Data: 295 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 295
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7553,14 +7553,14 @@ Types:
       HasCount: true
       Element: 842 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 253
+      ID: 263
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 722752
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 254 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 264 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 1005
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7580,41 +7580,41 @@ Types:
       HasCount: true
       Element: 869 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 235
+      ID: 241
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 722656
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 236 StructureType noalg.struct { key string; elem float64 }
+      Element: 242 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 730
+      ID: 740
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 783616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 731 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 741 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 227
+      ID: 233
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 698880
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 228 StructureType noalg.struct { key string; elem interface {} }
+      Element: 234 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 219
+      ID: 225
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 712608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 220 StructureType noalg.struct { key string; elem string }
+      Element: 226 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 206
       Name: noalg.map.group[context.canceler]struct {}
@@ -7642,7 +7642,7 @@ Types:
           Offset: 8
           Type: 841 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 252
+      ID: 262
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1342432
@@ -7653,7 +7653,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 253 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 263 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 1004
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7681,7 +7681,7 @@ Types:
           Offset: 8
           Type: 868 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 234
+      ID: 240
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1342176
@@ -7692,9 +7692,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 235 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 241 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 729
+      ID: 739
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1390944
@@ -7705,9 +7705,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 730 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 740 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 226
+      ID: 232
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1324128
@@ -7718,9 +7718,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 227 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 233 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 218
+      ID: 224
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1329248
@@ -7731,7 +7731,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 219 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 225 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 208
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7759,7 +7759,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 254
+      ID: 264
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1342304
@@ -7770,7 +7770,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 255 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 265 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 1006
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7796,9 +7796,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 712 GoSliceHeaderType []string
+          Type: 722 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 236
+      ID: 242
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1342048
@@ -7811,7 +7811,7 @@ Types:
           Offset: 16
           Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 731
+      ID: 741
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1390816
@@ -7822,9 +7822,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 228
+      ID: 234
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1324000
@@ -7837,7 +7837,7 @@ Types:
           Offset: 16
           Type: 143 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 220
+      ID: 226
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1329120
@@ -7854,7 +7854,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 559
+      ID: 569
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7871,7 +7871,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 642
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7913,15 +7913,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 602
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 735
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 594
+      ID: 604
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1752480
@@ -7955,7 +7955,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 272
+      ID: 282
       Name: os/signal.signalError
       ByteSize: 16
       GoRuntimeType: 852032
@@ -7963,18 +7963,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 274 PointerType *os/signal.signalError.str
+          Type: 284 PointerType *os/signal.signalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 273 GoStringDataType os/signal.signalError.str
+      Data: 283 GoStringDataType os/signal.signalError.str
     - __kind: GoStringDataType
-      ID: 273
+      ID: 283
       Name: os/signal.signalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 315
+      ID: 325
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 859424
@@ -7982,36 +7982,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 317 PointerType *os/user.UnknownGroupIdError.str
+          Type: 327 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 316 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 326 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 316
+      ID: 326
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 314
+      ID: 324
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 859328
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 369
+      ID: 379
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 469
+      ID: 479
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 577
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 581
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -8023,7 +8023,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 569
+      ID: 579
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1945664
@@ -8040,7 +8040,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 723 BaseType internal/abi.BoundsErrorCode
+          Type: 733 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -8056,7 +8056,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 634
+      ID: 644
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1810624
@@ -8069,7 +8069,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 545
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1016480
@@ -8077,13 +8077,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *runtime.errorString.str
+          Type: 547 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 536 GoStringDataType runtime.errorString.str
+      Data: 546 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 546
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8768,7 +8768,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 538
+      ID: 548
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1016576
@@ -8776,13 +8776,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 540 PointerType *runtime.plainError.str
+          Type: 550 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 539 GoStringDataType runtime.plainError.str
+      Data: 549 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 539
+      ID: 549
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8823,7 +8823,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 371
+      ID: 381
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1639232
@@ -8895,7 +8895,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 573
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9282,7 +9282,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 671
+      ID: 681
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1314784
@@ -9342,7 +9342,7 @@ Types:
           Offset: 16
           Type: 838 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 249
+      ID: 259
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9364,7 +9364,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 250 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 260 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 1001
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9414,7 +9414,7 @@ Types:
           Offset: 16
           Type: 865 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 231
+      ID: 237
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9436,9 +9436,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 232 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 238 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 726
+      ID: 736
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9460,9 +9460,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 727 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 737 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 223
+      ID: 229
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9484,9 +9484,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 224 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 230 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 215
+      ID: 221
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9508,9 +9508,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 216 GoSwissMapGroupsType groupReference<string,string>
+          Type: 222 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 614
+      ID: 624
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1756704
@@ -9540,10 +9540,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 741 GoSliceHeaderType []time.zone
+          Type: 213 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 744 GoSliceHeaderType []time.zoneTrans
+          Type: 216 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9555,12 +9555,12 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 742 PointerType *time.zone
+          Type: 214 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 363
+      ID: 373
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 157
       Name: time.Time
       ByteSize: 24
@@ -9576,6 +9576,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 158 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 156
       Name: time.Timer
@@ -9585,12 +9593,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 740 GoChannelType <-chan time.Time
+          Type: 750 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 275
+      ID: 285
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 852128
@@ -9598,22 +9606,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 277 PointerType *time.fileSizeError.str
+          Type: 287 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 276 GoStringDataType time.fileSizeError.str
+      Data: 286 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 276
+      ID: 286
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 361
+      ID: 371
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 743
+      ID: 215
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1662528
@@ -9629,7 +9637,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 746
+      ID: 218
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1807168
@@ -9690,7 +9698,7 @@ Types:
       GoRuntimeType: 601024
       GoKind: 26
     - __kind: StructureType
-      ID: 704
+      ID: 714
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2124800
@@ -9701,10 +9709,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 715 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 706 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 716 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9719,18 +9727,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 717 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 707
+      ID: 717
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1017632
       GoKind: 9
     - __kind: StructureType
-      ID: 705
+      ID: 715
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1977408
@@ -9755,17 +9763,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 378
+      ID: 388
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 706
+      ID: 716
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 601856
       GoKind: 8
     - __kind: StructureType
-      ID: 395
+      ID: 405
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1454720
@@ -9775,13 +9783,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 294
+      ID: 304
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 854720
       GoKind: 2
     - __kind: StructureType
-      ID: 576
+      ID: 586
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1751904
@@ -9794,7 +9802,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 542
+      ID: 552
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1018496

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -135,7 +135,7 @@ Types:
       ID: 911
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 618 PointerType *crypto/x509.Certificate
+      Pointee: 628 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 670
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -180,30 +180,30 @@ Types:
       ByteSize: 8
       Pointee: 922 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 654 GoSliceDataType []float64.array
+      Pointee: 664 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 200
+      ID: 206
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Pointee: 205 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: PointerType
-      ID: 208
+      ID: 214
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 213 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 928
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 927 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 191
+      ID: 197
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []os.Signal.array
+      Pointee: 196 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -212,20 +212,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 653
+      ID: 663
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 652 GoSliceDataType []string.array
+      Pointee: 662 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 666
+      ID: 216
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 665 GoSliceDataType []time.zone.array
+      Pointee: 215 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 668
+      ID: 218
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 667 GoSliceDataType []time.zoneTrans.array
+      Pointee: 217 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 915
       Name: '*[]uint8'
@@ -244,17 +244,17 @@ Types:
       ByteSize: 8
       Pointee: 182 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 872416
       GoKind: 22
-      Pointee: 458 GoSliceHeaderType archive/tar.headerError
+      Pointee: 468 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 460
+      ID: 470
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 459 GoSliceDataType archive/tar.headerError.array
+      Pointee: 469 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 830
       Name: '*archive/zip.checksumReader'
@@ -301,10 +301,10 @@ Types:
       ByteSize: 8
       Pointee: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 204
+      ID: 210
       Name: '*bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 900
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -321,10 +321,10 @@ Types:
       ByteSize: 8
       Pointee: 166 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 623
+      ID: 633
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 624 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 160
       Name: '*bucket<string,interface {}>'
@@ -350,24 +350,24 @@ Types:
       GoKind: 22
       Pointee: 108 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 846784
       GoKind: 22
-      Pointee: 255 BaseType compress/flate.CorruptInputError
+      Pointee: 265 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 846880
       GoKind: 22
-      Pointee: 256 GoStringHeaderType compress/flate.InternalError
+      Pointee: 266 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 258
+      ID: 268
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 257 GoStringDataType compress/flate.InternalError.str
+      Pointee: 267 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 862
       Name: '*compress/flate.decompressor'
@@ -397,12 +397,12 @@ Types:
       GoKind: 22
       Pointee: 112 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1094880
       GoKind: 22
-      Pointee: 551 StructureType context.deadlineExceededError
+      Pointee: 561 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 929
       Name: '*context.emptyCtx'
@@ -446,40 +446,40 @@ Types:
       GoKind: 22
       Pointee: 120 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 845824
       GoKind: 22
-      Pointee: 252 BaseType crypto/aes.KeySizeError
+      Pointee: 262 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 846016
       GoKind: 22
-      Pointee: 253 BaseType crypto/des.KeySizeError
+      Pointee: 263 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 379
+      ID: 389
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 846304
       GoKind: 22
-      Pointee: 254 BaseType crypto/rc4.KeySizeError
+      Pointee: 264 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 326
+      ID: 336
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 836512
       GoKind: 22
-      Pointee: 229 BaseType crypto/tls.AlertError
+      Pointee: 239 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 993600
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 522 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 892
       Name: '*crypto/tls.Conn'
@@ -495,206 +495,206 @@ Types:
       GoKind: 22
       Pointee: 782 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 324
+      ID: 334
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 836320
       GoKind: 22
-      Pointee: 325 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 335 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 322
+      ID: 332
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 836224
       GoKind: 22
-      Pointee: 323 StructureType crypto/tls.RecordHeaderError
+      Pointee: 333 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 510
+      ID: 520
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 991936
       GoKind: 22
-      Pointee: 479 BaseType crypto/tls.alert
+      Pointee: 489 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1233568
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 622 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1905280
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 629 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 845632
       GoKind: 22
-      Pointee: 374 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 384 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 367
+      ID: 377
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 845152
       GoKind: 22
-      Pointee: 368 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 378 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 845248
       GoKind: 22
-      Pointee: 370 StructureType crypto/x509.HostnameError
+      Pointee: 380 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 845056
       GoKind: 22
-      Pointee: 251 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 261 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 525
+      ID: 535
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1002560
       GoKind: 22
-      Pointee: 526 StructureType crypto/x509.SystemRootsError
+      Pointee: 536 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 845728
       GoKind: 22
-      Pointee: 376 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 386 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 845536
       GoKind: 22
-      Pointee: 372 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 382 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 855040
       GoKind: 22
-      Pointee: 417 StructureType encoding/asn1.StructuralError
+      Pointee: 427 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 855232
       GoKind: 22
-      Pointee: 421 StructureType encoding/asn1.SyntaxError
+      Pointee: 431 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 855136
       GoKind: 22
-      Pointee: 419 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 429 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 836608
       GoKind: 22
-      Pointee: 230 BaseType encoding/base64.CorruptInputError
+      Pointee: 240 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 844000
       GoKind: 22
-      Pointee: 250 BaseType encoding/hex.InvalidByteError
+      Pointee: 260 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 840352
       GoKind: 22
-      Pointee: 347 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 357 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 998592
       GoKind: 22
-      Pointee: 524 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 534 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839968
       GoKind: 22
-      Pointee: 339 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 349 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 840256
       GoKind: 22
-      Pointee: 345 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 355 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 342
+      ID: 352
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 840160
       GoKind: 22
-      Pointee: 343 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 353 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 840064
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 351 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 840736
       GoKind: 22
-      Pointee: 349 StructureType encoding/json.jsonError
+      Pointee: 359 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 866272
       GoKind: 22
-      Pointee: 448 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 458 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 866176
       GoKind: 22
-      Pointee: 446 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 456 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 866368
       GoKind: 22
-      Pointee: 264 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 274 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 266
+      ID: 276
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 265 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 275 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 866464
       GoKind: 22
-      Pointee: 451 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 461 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -703,19 +703,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 310
+      ID: 320
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 831712
       GoKind: 22
-      Pointee: 311 UnresolvedPointeeType errors.errorString
+      Pointee: 321 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 984896
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType errors.joinError
+      Pointee: 509 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -731,26 +731,26 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 482
+      ID: 492
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 974912
       GoKind: 22
-      Pointee: 483 UnresolvedPointeeType fmt.wrapError
+      Pointee: 493 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 484
+      ID: 494
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 975040
       GoKind: 22
-      Pointee: 485 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 495 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 843520
       GoKind: 22
-      Pointee: 360 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 370 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 735
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -759,193 +759,193 @@ Types:
       GoKind: 22
       Pointee: 736 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 351
+      ID: 361
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 842080
       GoKind: 22
-      Pointee: 352 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 362 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 842176
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 364 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 841888
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 649 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 357
+      ID: 367
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 842464
       GoKind: 22
-      Pointee: 358 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 368 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 841984
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 651 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 842272
       GoKind: 22
-      Pointee: 244 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 254 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 246
+      ID: 256
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 245 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 255 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 841792
       GoKind: 22
-      Pointee: 241 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 251 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 243
+      ID: 253
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 242 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 252 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 842368
       GoKind: 22
-      Pointee: 247 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 257 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 249
+      ID: 259
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 248 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 258 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 423
+      ID: 433
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 855712
       GoKind: 22
-      Pointee: 424 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 434 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 855616
       GoKind: 22
-      Pointee: 259 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 269 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 852448
       GoKind: 22
-      Pointee: 391 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 401 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 394
+      ID: 404
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 852640
       GoKind: 22
-      Pointee: 395 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 405 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 392
+      ID: 402
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 852544
       GoKind: 22
-      Pointee: 393 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 403 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 852352
       GoKind: 22
-      Pointee: 389 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 399 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 656 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 666 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 853024
       GoKind: 22
-      Pointee: 403 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 413 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 396
+      ID: 406
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 852736
       GoKind: 22
-      Pointee: 397 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 407 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 400
+      ID: 410
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 852928
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 411 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 852832
       GoKind: 22
-      Pointee: 399 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 409 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 853120
       GoKind: 22
-      Pointee: 405 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 415 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 853408
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 421 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 853504
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 423 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 853312
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 419 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 853216
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 417 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 853696
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 425 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 749
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -975,12 +975,12 @@ Types:
       GoKind: 22
       Pointee: 748 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 433
+      ID: 443
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 863488
       GoKind: 22
-      Pointee: 434 StructureType github.com/cihub/seelog.baseError
+      Pointee: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 728
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -989,12 +989,12 @@ Types:
       GoKind: 22
       Pointee: 729 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 435
+      ID: 445
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 863584
       GoKind: 22
-      Pointee: 436 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 446 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 720
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1017,12 +1017,12 @@ Types:
       GoKind: 22
       Pointee: 727 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 439
+      ID: 449
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 863776
       GoKind: 22
-      Pointee: 440 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 450 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 724
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1038,19 +1038,19 @@ Types:
       GoKind: 22
       Pointee: 742 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 437
+      ID: 447
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 863680
       GoKind: 22
-      Pointee: 438 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 448 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 441
+      ID: 451
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 863872
       GoKind: 22
-      Pointee: 442 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 452 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 828
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1066,268 +1066,268 @@ Types:
       GoKind: 22
       Pointee: 848 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 537
+      ID: 547
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1022784
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 548 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1022912
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 550 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 531
+      ID: 541
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1007552
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 542 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 844192
       GoKind: 22
-      Pointee: 363 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 373 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 533
+      ID: 543
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1010496
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 544 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 579
+      ID: 589
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1117920
       GoKind: 22
-      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 573
+      ID: 583
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1117536
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 584 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 997568
       GoKind: 22
-      Pointee: 518 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 528 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 585
+      ID: 595
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1118304
       GoKind: 22
-      Pointee: 586 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 596 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 516
+      ID: 526
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 997440
       GoKind: 22
-      Pointee: 481 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 491 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1117792
       GoKind: 22
-      Pointee: 578 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 588 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 575
+      ID: 585
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1117664
       GoKind: 22
-      Pointee: 576 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 586 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 583
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1118176
       GoKind: 22
-      Pointee: 584 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 581
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1118048
       GoKind: 22
-      Pointee: 582 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 589
+      ID: 599
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1118688
       GoKind: 22
-      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 600 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 521
+      ID: 531
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 997824
       GoKind: 22
-      Pointee: 522 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 532 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 519
+      ID: 529
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 997696
       GoKind: 22
-      Pointee: 520 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 530 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 587
+      ID: 597
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1118560
       GoKind: 22
-      Pointee: 588 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 598 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 456
+      ID: 466
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871648
       GoKind: 22
-      Pointee: 267 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 277 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 269
+      ID: 279
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 278 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1468256
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 637 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 543
+      ID: 553
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1039680
       GoKind: 22
-      Pointee: 544 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 554 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 873664
       GoKind: 22
-      Pointee: 270 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 280 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 597
+      ID: 607
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1170016
       GoKind: 22
-      Pointee: 598 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 608 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 22
-      Pointee: 465 StructureType golang.org/x/net/http2.connError
+      Pointee: 475 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 22
-      Pointee: 274 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 284 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 276
+      ID: 286
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 275 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 285 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 22
-      Pointee: 280 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 290 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 282
+      ID: 292
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 291 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 22
-      Pointee: 277 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 287 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 279
+      ID: 289
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 288 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 462
+      ID: 472
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 873760
       GoKind: 22
-      Pointee: 271 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 281 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 273
+      ID: 283
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 282 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 22
-      Pointee: 469 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 479 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 22
-      Pointee: 283 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 293 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 865696
       GoKind: 22
-      Pointee: 444 StructureType google.golang.org/grpc.dropError
+      Pointee: 454 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 595
+      ID: 605
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1166688
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 606 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1257568
       GoKind: 22
-      Pointee: 616 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 626 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 454
+      ID: 464
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869920
       GoKind: 22
-      Pointee: 455 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 465 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 853
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1336,12 +1336,12 @@ Types:
       GoKind: 22
       Pointee: 854 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 541
+      ID: 551
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1033920
       GoKind: 22
-      Pointee: 542 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 552 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 837
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1350,40 +1350,40 @@ Types:
       GoKind: 22
       Pointee: 838 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 425
+      ID: 435
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 857920
       GoKind: 22
-      Pointee: 426 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 436 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 535
+      ID: 545
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1012032
       GoKind: 22
-      Pointee: 536 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 546 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1133152
       GoKind: 22
-      Pointee: 594 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 604 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1132896
       GoKind: 22
-      Pointee: 592 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 602 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 839008
       GoKind: 22
-      Pointee: 337 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 347 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 679
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
@@ -1441,12 +1441,12 @@ Types:
       GoKind: 22
       Pointee: 678 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 210
+      ID: 220
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1103200
       GoKind: 22
-      Pointee: 211 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 221 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 175
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
@@ -1483,33 +1483,33 @@ Types:
       GoKind: 22
       Pointee: 811 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 850720
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 395 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 427
+      ID: 437
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 858496
       GoKind: 22
-      Pointee: 428 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 438 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 429
+      ID: 439
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 858592
       GoKind: 22
-      Pointee: 430 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 440 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 867232
       GoKind: 22
-      Pointee: 453 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 463 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 129
       Name: '*hash<context.canceler,struct {}>'
@@ -1521,10 +1521,10 @@ Types:
       ByteSize: 8
       Pointee: 732 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 202
+      ID: 208
       Name: '*hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 203 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 209 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 898
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
@@ -1541,10 +1541,10 @@ Types:
       ByteSize: 8
       Pointee: 164 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 621
+      ID: 631
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 622 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 632 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 158
       Name: '*hash<string,interface {}>'
@@ -1556,12 +1556,12 @@ Types:
       ByteSize: 8
       Pointee: 154 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 875104
       GoKind: 22
-      Pointee: 472 UnresolvedPointeeType html/template.Error
+      Pointee: 482 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 95
       Name: '*int'
@@ -1598,19 +1598,19 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 844576
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 375 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 571
+      ID: 581
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1111648
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 582 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 890
       Name: '*internal/poll.FD'
@@ -1619,19 +1619,19 @@ Types:
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 569
+      ID: 579
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1111520
       GoKind: 22
-      Pointee: 570 StructureType internal/poll.errNetClosing
+      Pointee: 580 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 312
+      ID: 322
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 832096
       GoKind: 22
-      Pointee: 313 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 323 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 855
       Name: '*io.PipeReader'
@@ -1661,19 +1661,19 @@ Types:
       GoKind: 22
       Pointee: 827 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1110752
       GoKind: 22
-      Pointee: 568 UnresolvedPointeeType io/fs.PathError
+      Pointee: 578 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 847456
       GoKind: 22
-      Pointee: 383 StructureType math/big.ErrNaN
+      Pointee: 393 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 905
       Name: '*mime/multipart.FileHeader'
@@ -1703,19 +1703,19 @@ Types:
       GoKind: 22
       Pointee: 842 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 553
+      ID: 563
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1096032
       GoKind: 22
-      Pointee: 554 UnresolvedPointeeType net.AddrError
+      Pointee: 564 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 602
+      ID: 612
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1226688
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType net.DNSError
+      Pointee: 613 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 866
       Name: '*net.IPConn'
@@ -1724,19 +1724,19 @@ Types:
       GoKind: 22
       Pointee: 867 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1226368
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType net.OpError
+      Pointee: 611 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1096160
       GoKind: 22
-      Pointee: 556 UnresolvedPointeeType net.ParseError
+      Pointee: 566 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 874
       Name: '*net.TCPConn'
@@ -1759,24 +1759,24 @@ Types:
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1095264
       GoKind: 22
-      Pointee: 547 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 557 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 548 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 558 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 975936
       GoKind: 22
-      Pointee: 487 StructureType net.canceledError
+      Pointee: 497 StructureType net.canceledError
     - __kind: PointerType
       ID: 864
       Name: '*net.conn'
@@ -1785,12 +1785,12 @@ Types:
       GoKind: 22
       Pointee: 865 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 644
+      ID: 654
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1700672
       GoKind: 22
-      Pointee: 645 StructureType net.dialResult·1
+      Pointee: 655 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 880
       Name: '*net.netFD'
@@ -1799,12 +1799,12 @@ Types:
       GoKind: 22
       Pointee: 881 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 284
+      ID: 294
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 824896
       GoKind: 22
-      Pointee: 285 UnresolvedPointeeType net.notFoundError
+      Pointee: 295 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 930
       Name: '*net.onlyValuesCtx'
@@ -1813,12 +1813,12 @@ Types:
       GoKind: 22
       Pointee: 931 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 286
+      ID: 296
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 825568
       GoKind: 22
-      Pointee: 287 StructureType net.result·2
+      Pointee: 297 StructureType net.result·2
     - __kind: PointerType
       ID: 870
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1834,33 +1834,33 @@ Types:
       GoKind: 22
       Pointee: 869 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1096800
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType net.temporaryError
+      Pointee: 568 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1227008
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType net.timeoutError
+      Pointee: 615 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 292
+      ID: 302
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 828160
       GoKind: 22
-      Pointee: 293 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 303 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 979264
       GoKind: 22
-      Pointee: 489 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 499 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 105
       Name: '*net/http.Request'
@@ -1918,26 +1918,26 @@ Types:
       GoKind: 22
       Pointee: 805 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 294
+      ID: 304
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 828352
       GoKind: 22
-      Pointee: 213 BaseType net/http.http2ConnectionError
+      Pointee: 223 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 295
+      ID: 305
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 828448
       GoKind: 22
-      Pointee: 296 StructureType net/http.http2GoAwayError
+      Pointee: 306 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 606
+      ID: 616
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1227968
       GoKind: 22
-      Pointee: 607 StructureType net/http.http2StreamError
+      Pointee: 617 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 834
       Name: '*net/http.http2clientStream'
@@ -1946,31 +1946,31 @@ Types:
       GoKind: 22
       Pointee: 835 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 301
+      ID: 311
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 829312
       GoKind: 22
-      Pointee: 302 StructureType net/http.http2connError
+      Pointee: 312 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 828832
       GoKind: 22
-      Pointee: 217 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 227 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 219
+      ID: 229
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 218 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 228 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 299
+      ID: 309
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 828928
       GoKind: 22
-      Pointee: 300 StructureType net/http.http2goAwayFlowError
+      Pointee: 310 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 798
       Name: '*net/http.http2gzipReader'
@@ -1979,36 +1979,36 @@ Types:
       GoKind: 22
       Pointee: 799 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 304
+      ID: 314
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 829504
       GoKind: 22
-      Pointee: 223 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 233 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 225
+      ID: 235
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 224 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 234 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 303
+      ID: 313
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 829408
       GoKind: 22
-      Pointee: 220 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 230 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 222
+      ID: 232
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 221 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 231 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 561
+      ID: 571
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1101024
       GoKind: 22
-      Pointee: 562 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 572 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 794
       Name: '*net/http.http2missingBody'
@@ -2024,24 +2024,24 @@ Types:
       GoKind: 22
       Pointee: 807 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 981312
       GoKind: 22
-      Pointee: 495 StructureType net/http.http2noCachedConnError
+      Pointee: 505 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 297
+      ID: 307
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 828736
       GoKind: 22
-      Pointee: 214 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 224 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 216
+      ID: 226
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 215 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 225 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 802
       Name: '*net/http.http2requestBody'
@@ -2085,12 +2085,12 @@ Types:
       GoKind: 22
       Pointee: 825 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 980928
       GoKind: 22
-      Pointee: 491 StructureType net/http.nothingWrittenError
+      Pointee: 501 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 786
       Name: '*net/http.pattern'
@@ -2113,12 +2113,12 @@ Types:
       GoKind: 22
       Pointee: 823 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 305
+      ID: 315
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 829696
       GoKind: 22
-      Pointee: 306 StructureType net/http.requestBodyReadError
+      Pointee: 316 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 718
       Name: '*net/http.response'
@@ -2134,40 +2134,40 @@ Types:
       GoKind: 22
       Pointee: 926 StructureType net/http.segment
     - __kind: PointerType
-      ID: 290
+      ID: 300
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 828064
       GoKind: 22
-      Pointee: 291 StructureType net/http.statusError
+      Pointee: 301 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1229408
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 619 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 559
+      ID: 569
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1100896
       GoKind: 22
-      Pointee: 560 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 570 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 981056
       GoKind: 22
-      Pointee: 493 StructureType net/http.transportReadFromServerError
+      Pointee: 503 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 288
+      ID: 298
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 827296
       GoKind: 22
-      Pointee: 289 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 299 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 816
       Name: '*net/http/httputil.failureToReadBody'
@@ -2176,69 +2176,69 @@ Types:
       GoKind: 22
       Pointee: 817 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 318
+      ID: 328
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 834592
       GoKind: 22
-      Pointee: 319 StructureType net/netip.parseAddrError
+      Pointee: 329 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 316
+      ID: 326
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 834496
       GoKind: 22
-      Pointee: 317 StructureType net/netip.parsePrefixError
+      Pointee: 327 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 837856
       GoKind: 22
-      Pointee: 332 UnresolvedPointeeType net/textproto.Error
+      Pointee: 342 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 837760
       GoKind: 22
-      Pointee: 237 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 247 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 239
+      ID: 249
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 238 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 248 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1234048
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType net/url.Error
+      Pointee: 624 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836704
       GoKind: 22
-      Pointee: 231 GoStringHeaderType net/url.EscapeError
+      Pointee: 241 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 233
+      ID: 243
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 232 GoStringDataType net/url.EscapeError.str
+      Pointee: 242 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 329
+      ID: 339
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836800
       GoKind: 22
-      Pointee: 234 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 244 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 236
+      ID: 246
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 235 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 245 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 775
       Name: '*net/url.URL'
@@ -2261,12 +2261,12 @@ Types:
       GoKind: 22
       Pointee: 887 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 983232
       GoKind: 22
-      Pointee: 497 UnresolvedPointeeType os.LinkError
+      Pointee: 507 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 144
       Name: '*os.Signal'
@@ -2275,12 +2275,12 @@ Types:
       GoKind: 22
       Pointee: 145 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 563
+      ID: 573
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1101536
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType os.SyscallError
+      Pointee: 574 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 884
       Name: '*os.fileWithoutReadFrom'
@@ -2296,26 +2296,26 @@ Types:
       GoKind: 22
       Pointee: 883 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 527
+      ID: 537
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1005888
       GoKind: 22
-      Pointee: 528 UnresolvedPointeeType os/exec.Error
+      Pointee: 538 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 648
+      ID: 658
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1951328
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 659 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1006016
       GoKind: 22
-      Pointee: 530 StructureType os/exec.wrappedError
+      Pointee: 540 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 121
       Name: '*os/signal.signalCtx'
@@ -2324,52 +2324,52 @@ Types:
       GoKind: 22
       Pointee: 122 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 862528
       GoKind: 22
-      Pointee: 261 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 271 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 263
+      ID: 273
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 272 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 862432
       GoKind: 22
-      Pointee: 260 BaseType os/user.UnknownUserIdError
+      Pointee: 270 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 314
+      ID: 324
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 832960
       GoKind: 22
-      Pointee: 315 UnresolvedPointeeType reflect.ValueError
+      Pointee: 325 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 851680
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 397 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 987840
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 514 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 989760
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 519 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2385,12 +2385,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 987968
       GoKind: 22
-      Pointee: 506 StructureType runtime.boundsError
+      Pointee: 516 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -2406,24 +2406,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1109600
       GoKind: 22
-      Pointee: 566 StructureType runtime.errorAddressString
+      Pointee: 576 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 987584
       GoKind: 22
-      Pointee: 473 GoStringHeaderType runtime.errorString
+      Pointee: 483 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 475
+      ID: 485
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 474 GoStringDataType runtime.errorString.str
+      Pointee: 484 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -2446,17 +2446,17 @@ Types:
       GoKind: 22
       Pointee: 134 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 989504
       GoKind: 22
-      Pointee: 476 GoStringHeaderType runtime.plainError
+      Pointee: 486 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 477 GoStringDataType runtime.plainError.str
+      Pointee: 487 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2479,12 +2479,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 987200
       GoKind: 22
-      Pointee: 501 UnresolvedPointeeType strconv.NumError
+      Pointee: 511 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -2610,12 +2610,12 @@ Types:
       GoKind: 22
       Pointee: 819 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1232928
       GoKind: 22
-      Pointee: 599 BaseType syscall.Errno
+      Pointee: 609 BaseType syscall.Errno
     - __kind: PointerType
       ID: 675
       Name: '*syscall.Signal'
@@ -2624,12 +2624,12 @@ Types:
       GoKind: 22
       Pointee: 674 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 545
+      ID: 555
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1044160
       GoKind: 22
-      Pointee: 546 StructureType text/template.ExecError
+      Pointee: 556 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 139
       Name: '*time.Location'
@@ -2638,12 +2638,12 @@ Types:
       GoKind: 22
       Pointee: 140 StructureType time.Location
     - __kind: PointerType
-      ID: 308
+      ID: 318
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 830560
       GoKind: 22
-      Pointee: 309 UnresolvedPointeeType time.ParseError
+      Pointee: 319 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 136
       Name: '*time.Timer'
@@ -2652,31 +2652,31 @@ Types:
       GoKind: 22
       Pointee: 137 StructureType time.Timer
     - __kind: PointerType
-      ID: 307
+      ID: 317
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 830464
       GoKind: 22
-      Pointee: 226 GoStringHeaderType time.fileSizeError
+      Pointee: 236 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 228
+      ID: 238
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 227 GoStringDataType time.fileSizeError.str
+      Pointee: 237 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 660
+      ID: 191
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367072
       GoKind: 22
-      Pointee: 661 StructureType time.zone
+      Pointee: 192 StructureType time.zone
     - __kind: PointerType
-      ID: 663
+      ID: 194
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 664 StructureType time.zoneTrans
+      Pointee: 195 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -2720,47 +2720,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 320
+      ID: 330
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 835360
       GoKind: 22
-      Pointee: 321 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 331 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 333
+      ID: 343
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 838240
       GoKind: 22
-      Pointee: 334 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 344 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 838336
       GoKind: 22
-      Pointee: 240 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 250 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 995008
       GoKind: 22
-      Pointee: 514 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 524 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 515
+      ID: 525
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 995136
       GoKind: 22
-      Pointee: 480 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 490 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 783
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: GoChannelType
-      ID: 658
+      ID: 668
       Name: <-chan time.Time
       GoRuntimeType: 549952
       GoKind: 18
@@ -2929,7 +2929,7 @@ Types:
       HasCount: true
       Element: 12 BaseType uint64
     - __kind: ArrayType
-      ID: 632
+      ID: 642
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 641792
@@ -2986,7 +2986,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 618 PointerType *crypto/x509.Certificate
+      Element: 628 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 669
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -3092,11 +3092,11 @@ Types:
       ByteSize: 32
       Element: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 222
       Name: '[]bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 906
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
@@ -3110,31 +3110,31 @@ Types:
       ByteSize: 336
       Element: 768 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 204
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 166 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 651
+      ID: 661
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 624 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 202
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
       Element: 161 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 200
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
       Element: 156 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 637
+      ID: 647
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 464448
@@ -3149,9 +3149,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 654 GoSliceDataType []float64.array
+      Data: 664 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 654
+      ID: 664
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3172,9 +3172,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 199 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 205 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 205
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3195,9 +3195,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 207 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 213 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 213
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3217,7 +3217,7 @@ Types:
       HasCount: true
       Element: 752 BaseType github.com/cihub/seelog.LogLevel
     - __kind: ArrayType
-      ID: 192
+      ID: 198
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -3262,9 +3262,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 190 GoSliceDataType []os.Signal.array
+      Data: 196 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 196
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3274,7 +3274,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 636
+      ID: 646
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -3289,15 +3289,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 652 GoSliceDataType []string.array
+      Data: 662 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 652
+      ID: 662
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 659
+      ID: 190
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459040
@@ -3305,22 +3305,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 660 PointerType *time.zone
+          Type: 191 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 665 GoSliceDataType []time.zone.array
+      Data: 215 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 215
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 661 StructureType time.zone
+      Element: 192 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 662
+      ID: 193
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459104
@@ -3328,20 +3328,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 663 PointerType *time.zoneTrans
+          Type: 194 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 667 GoSliceDataType []time.zoneTrans.array
+      Data: 217 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 667
+      ID: 217
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 664 StructureType time.zoneTrans
+      Element: 195 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3389,12 +3389,12 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 209
+      ID: 219
       Name: '[]val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 210 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 220 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
       ID: 902
       Name: '[]val<[]*mime/multipart.FileHeader>'
@@ -3408,7 +3408,7 @@ Types:
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 636 GoSliceHeaderType []string
+      Element: 646 GoSliceHeaderType []string
     - __kind: ArrayType
       ID: 753
       Name: '[]val<bool>'
@@ -3417,28 +3417,28 @@ Types:
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 197
+      ID: 203
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 650
+      ID: 660
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 643 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 195
+      ID: 201
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 127 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 193
+      ID: 199
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -3451,7 +3451,7 @@ Types:
       HasCount: true
       Element: 188 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 458
+      ID: 468
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 872512
@@ -3466,9 +3466,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 459 GoSliceDataType archive/tar.headerError.array
+      Data: 469 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 469
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3534,7 +3534,7 @@ Types:
       KeyType: 752 BaseType github.com/cihub/seelog.LogLevel
       ValueType: 6 BaseType bool
     - __kind: GoHMapBucketType
-      ID: 205
+      ID: 211
       Name: bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
@@ -3543,15 +3543,15 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 209 ArrayType []val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 219 ArrayType []val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 210 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      ValueType: 220 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 901
       Name: bucket<string,[]*mime/multipart.FileHeader>
@@ -3562,7 +3562,7 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
           Type: 902 ArrayType []val<[]*mime/multipart.FileHeader>
@@ -3581,7 +3581,7 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
           Type: 773 ArrayType []val<[]string>
@@ -3589,7 +3589,7 @@ Types:
           Offset: 328
           Type: 767 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 636 GoSliceHeaderType []string
+      ValueType: 646 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
       ID: 166
       Name: bucket<string,float64>
@@ -3600,17 +3600,17 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 197 ArrayType []val<float64>
+          Type: 203 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
           Type: 165 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 624
+      ID: 634
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
@@ -3619,15 +3619,15 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 650 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 660 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 623 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 643 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 161
       Name: bucket<string,interface {}>
@@ -3638,10 +3638,10 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 195 ArrayType []val<interface {}>
+          Type: 201 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
           Type: 160 PointerType *bucket<string,interface {}>
@@ -3657,10 +3657,10 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 193 ArrayType []val<string>
+          Type: 199 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 155 PointerType *bucket<string,string>
@@ -3697,13 +3697,13 @@ Types:
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: BaseType
-      ID: 255
+      ID: 265
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 768832
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 256
+      ID: 266
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 768928
@@ -3711,13 +3711,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 258 PointerType *compress/flate.InternalError.str
+          Type: 268 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 257 GoStringDataType compress/flate.InternalError.str
+      Data: 267 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 257
+      ID: 267
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3801,7 +3801,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 551
+      ID: 561
       Name: context.deadlineExceededError
       GoRuntimeType: 1274816
       GoKind: 25
@@ -3845,7 +3845,7 @@ Types:
           Type: 136 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 138 StructureType time.Time
+          Type: 138 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3891,31 +3891,31 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 252
+      ID: 262
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: BaseType
-      ID: 253
+      ID: 263
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768640
       GoKind: 2
     - __kind: BaseType
-      ID: 254
+      ID: 264
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768736
       GoKind: 2
     - __kind: BaseType
-      ID: 229
+      ID: 239
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 766240
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 522
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3984,11 +3984,11 @@ Types:
       GoRuntimeType: 766048
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 325
+      ID: 335
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 323
+      ID: 333
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1595520
@@ -3999,26 +3999,26 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 632 ArrayType [5]uint8
+          Type: 642 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 633 GoInterfaceType net.Conn
+          Type: 643 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 479
+      ID: 489
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 944896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 622
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 629
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 374
+      ID: 384
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1598400
@@ -4026,21 +4026,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 618 PointerType *crypto/x509.Certificate
+          Type: 628 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 642 BaseType crypto/x509.InvalidReason
+          Type: 652 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 368
+      ID: 378
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1070848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 370
+      ID: 380
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1401376
@@ -4048,24 +4048,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 618 PointerType *crypto/x509.Certificate
+          Type: 628 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 251
+      ID: 261
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 768352
       GoKind: 2
     - __kind: BaseType
-      ID: 642
+      ID: 652
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537344
       GoKind: 2
     - __kind: StructureType
-      ID: 526
+      ID: 536
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1364864
@@ -4075,13 +4075,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 376
+      ID: 386
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1071104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 372
+      ID: 382
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1598208
@@ -4089,15 +4089,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 618 PointerType *crypto/x509.Certificate
+          Type: 628 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 618 PointerType *crypto/x509.Certificate
+          Type: 628 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 417
+      ID: 427
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1245408
@@ -4107,7 +4107,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 421
+      ID: 431
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1245568
@@ -4117,47 +4117,47 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 419
+      ID: 429
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 230
+      ID: 240
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 766336
       GoKind: 6
     - __kind: BaseType
-      ID: 250
+      ID: 260
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 768160
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 347
+      ID: 357
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 524
+      ID: 534
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 339
+      ID: 349
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 345
+      ID: 355
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 343
+      ID: 353
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 351
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 349
+      ID: 359
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1237088
@@ -4167,15 +4167,15 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 448
+      ID: 458
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 446
+      ID: 456
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 264
+      ID: 274
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 771520
@@ -4183,18 +4183,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 266 PointerType *encoding/xml.UnmarshalError.str
+          Type: 276 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 265 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 275 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 265
+      ID: 275
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 451
+      ID: 461
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4211,11 +4211,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 311
+      ID: 321
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 509
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4231,11 +4231,11 @@ Types:
       GoRuntimeType: 534528
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 483
+      ID: 493
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 485
+      ID: 495
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4269,7 +4269,7 @@ Types:
       GoRuntimeType: 960256
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 360
+      ID: 370
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4279,7 +4279,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 352
+      ID: 362
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1596864
@@ -4287,7 +4287,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 634 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 644 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -4295,25 +4295,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 364
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 649
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 358
+      ID: 368
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1069824
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 651
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 244
+      ID: 254
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 767584
@@ -4321,18 +4321,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 246 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 256 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 245 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 255 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 245
+      ID: 255
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 634
+      ID: 644
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2067520
@@ -4340,13 +4340,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 635 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 645 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 13 GoStringHeaderType string
@@ -4355,7 +4355,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 637 GoSliceHeaderType []float64
+          Type: 647 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4364,13 +4364,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 638 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 648 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 640 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 650 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 13 GoStringHeaderType string
@@ -4381,13 +4381,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 635
+      ID: 645
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 536128
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 241
+      ID: 251
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 767488
@@ -4395,18 +4395,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 243 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 253 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 242 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 252 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 242
+      ID: 252
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 247
+      ID: 257
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 767680
@@ -4414,30 +4414,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 249 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 259 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 248 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 258 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 248
+      ID: 258
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 424
+      ID: 434
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1073664
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 259
+      ID: 269
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 770080
       GoKind: 2
     - __kind: StructureType
-      ID: 391
+      ID: 401
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1402336
@@ -4450,7 +4450,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 395
+      ID: 405
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1600128
@@ -4466,7 +4466,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 393
+      ID: 403
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1243968
@@ -4476,7 +4476,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 389
+      ID: 399
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1243648
@@ -4486,14 +4486,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 620
+      ID: 630
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1129568
       GoKind: 21
-      HeaderType: 622 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 632 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 643
+      ID: 653
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1006912
@@ -4508,15 +4508,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 656 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 666 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 656
+      ID: 666
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 403
+      ID: 413
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1402656
@@ -4524,12 +4524,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 620 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 630 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 620 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 630 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 397
+      ID: 407
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1244128
@@ -4539,7 +4539,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 401
+      ID: 411
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1600320
@@ -4550,12 +4550,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 643 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 643 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 399
+      ID: 409
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1402496
@@ -4568,7 +4568,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 405
+      ID: 415
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1244288
@@ -4576,9 +4576,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 138 StructureType time.Time
+          Type: 138 GoTimeType time.Time
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1402976
@@ -4591,7 +4591,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 413
+      ID: 423
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1244608
@@ -4601,7 +4601,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 409
+      ID: 419
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1402816
@@ -4614,7 +4614,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 407
+      ID: 417
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1244448
@@ -4624,7 +4624,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 415
+      ID: 425
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1403136
@@ -4659,7 +4659,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 434
+      ID: 444
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1250528
@@ -4673,7 +4673,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 436
+      ID: 446
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1250688
@@ -4681,7 +4681,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 434 StructureType github.com/cihub/seelog.baseError
+          Type: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 721
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -4704,7 +4704,7 @@ Types:
           Offset: 8
           Type: 730 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 440
+      ID: 450
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1251008
@@ -4712,7 +4712,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 434 StructureType github.com/cihub/seelog.baseError
+          Type: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 725
       Name: github.com/cihub/seelog.splitDispatcher
@@ -4728,7 +4728,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 438
+      ID: 448
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1250848
@@ -4736,9 +4736,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 434 StructureType github.com/cihub/seelog.baseError
+          Type: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 442
+      ID: 452
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1251168
@@ -4746,7 +4746,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 434 StructureType github.com/cihub/seelog.baseError
+          Type: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 845
       Name: github.com/cihub/seelog/archive.Reader
@@ -4775,30 +4775,30 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 548
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 550
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 542
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 363
+      ID: 373
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1238368
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 544
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 590
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1712768
@@ -4814,11 +4814,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 584
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 518
+      ID: 528
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1503296
@@ -4831,7 +4831,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 586
+      ID: 596
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1713216
@@ -4847,13 +4847,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 481
+      ID: 491
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 946048
       GoKind: 8
     - __kind: StructureType
-      ID: 578
+      ID: 588
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1712544
@@ -4869,13 +4869,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 646
+      ID: 656
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 767104
       GoKind: 8
     - __kind: StructureType
-      ID: 576
+      ID: 586
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1712320
@@ -4883,15 +4883,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 646 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 656 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 646 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 656 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 584
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1632352
@@ -4904,7 +4904,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 582
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1712992
@@ -4920,7 +4920,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 590
+      ID: 600
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1438112
@@ -4930,19 +4930,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 522
+      ID: 532
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1189792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 520
+      ID: 530
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1189664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 588
+      ID: 598
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1632544
@@ -4955,7 +4955,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 277
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 772192
@@ -4963,22 +4963,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 279 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 268 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 278 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 278
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 637
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 544
+      ID: 554
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1260288
@@ -4988,19 +4988,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 270
+      ID: 280
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 772768
       GoKind: 10
     - __kind: BaseType
-      ID: 625
+      ID: 635
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 957568
       GoKind: 10
     - __kind: StructureType
-      ID: 598
+      ID: 608
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1745472
@@ -5011,12 +5011,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 625 BaseType golang.org/x/net/http2.ErrCode
+          Type: 635 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 465
+      ID: 475
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1409856
@@ -5024,12 +5024,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 625 BaseType golang.org/x/net/http2.ErrCode
+          Type: 635 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 274
+      ID: 284
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 772960
@@ -5037,18 +5037,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 276 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 286 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 275 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 285 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 275
+      ID: 285
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 290
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 773152
@@ -5056,18 +5056,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 292 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 281 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 291 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 291
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 287
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 773056
@@ -5075,18 +5075,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 289 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 278 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 288 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 288
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 281
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 772864
@@ -5094,18 +5094,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 283 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 272 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 282 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 282
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 469
+      ID: 479
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1261568
@@ -5115,13 +5115,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 283
+      ID: 293
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 773248
       GoKind: 2
     - __kind: StructureType
-      ID: 444
+      ID: 454
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1255968
@@ -5131,11 +5131,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 606
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 616
+      ID: 626
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1770048
@@ -5151,7 +5151,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 455
+      ID: 465
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1408896
@@ -5168,7 +5168,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 542
+      ID: 552
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1371744
@@ -5182,25 +5182,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 426
+      ID: 436
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 536
+      ID: 546
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 594
+      ID: 604
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 592
+      ID: 602
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1320896
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 337
+      ID: 347
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -5446,16 +5446,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 201 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 207 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 206 GoMapType map[string]interface {}
+          Type: 212 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 678
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 211
+      ID: 221
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1776864
@@ -5554,11 +5554,11 @@ Types:
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 395
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 428
+      ID: 438
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1247808
@@ -5568,7 +5568,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 430
+      ID: 440
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1247968
@@ -5578,7 +5578,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 453
+      ID: 463
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -5650,7 +5650,7 @@ Types:
       BucketType: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
       BucketsType: 754 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
     - __kind: GoHMapHeaderType
-      ID: 203
+      ID: 209
       Name: hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -5671,18 +5671,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
-      BucketType: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 212 GoSliceDataType []bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 222 GoSliceDataType []bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
       ID: 899
       Name: hash<string,[]*mime/multipart.FileHeader>
@@ -5784,9 +5784,9 @@ Types:
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
       BucketType: 166 GoHMapBucketType bucket<string,float64>
-      BucketsType: 198 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 204 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 622
+      ID: 632
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -5807,18 +5807,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 623 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 623 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
-      BucketType: 624 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 651 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 661 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 159
       Name: hash<string,interface {}>
@@ -5852,7 +5852,7 @@ Types:
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
       BucketType: 161 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 196 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 202 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 154
       Name: hash<string,string>
@@ -5886,9 +5886,9 @@ Types:
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
       BucketType: 156 GoHMapBucketType bucket<string,string>
-      BucketsType: 194 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 200 GoSliceDataType []bucket<string,string>.array
     - __kind: UnresolvedPointeeType
-      ID: 472
+      ID: 482
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5935,7 +5935,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 375
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5961,7 +5961,7 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 582
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5969,13 +5969,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 570
+      ID: 580
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1291616
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 313
+      ID: 323
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6123,7 +6123,7 @@ Types:
           Offset: 0
           Type: 836 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 568
+      ID: 578
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoMapType
@@ -6141,12 +6141,12 @@ Types:
       GoKind: 21
       HeaderType: 732 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 201
+      ID: 207
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 888352
       GoKind: 21
-      HeaderType: 203 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 209 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 897
       Name: map[string][]*mime/multipart.FileHeader
@@ -6169,7 +6169,7 @@ Types:
       GoKind: 21
       HeaderType: 164 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 206
+      ID: 212
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 880096
@@ -6183,7 +6183,7 @@ Types:
       GoKind: 21
       HeaderType: 154 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 383
+      ID: 393
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1240768
@@ -6227,11 +6227,11 @@ Types:
           Offset: 8
           Type: 846 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 554
+      ID: 564
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 633
+      ID: 643
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1399616
@@ -6244,7 +6244,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 613
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6252,11 +6252,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 611
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 556
+      ID: 566
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6272,7 +6272,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 547
+      ID: 557
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1064960
@@ -6280,18 +6280,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 549 PointerType *net.UnknownNetworkError.str
+          Type: 559 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 548 GoStringDataType net.UnknownNetworkError.str
+      Data: 558 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 548
+      ID: 558
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 487
+      ID: 497
       Name: net.canceledError
       GoRuntimeType: 1187360
       GoKind: 25
@@ -6301,7 +6301,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 655
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1962208
@@ -6309,7 +6309,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 633 GoInterfaceType net.Conn
+          Type: 643 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -6336,7 +6336,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 285
+      ID: 295
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6353,7 +6353,7 @@ Types:
           Offset: 16
           Type: 110 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 287
+      ID: 297
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1590336
@@ -6361,7 +6361,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 628 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 638 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -6395,11 +6395,11 @@ Types:
           Offset: 0
           Type: 874 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 568
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 615
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6449,11 +6449,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 293
+      ID: 303
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 489
+      ID: 499
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6505,7 +6505,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6550,7 +6550,7 @@ Types:
           Type: 786 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 152 GoMapType map[string]string
@@ -6587,7 +6587,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6660,19 +6660,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 213
+      ID: 223
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 764128
       GoKind: 10
     - __kind: BaseType
-      ID: 617
+      ID: 627
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 942208
       GoKind: 10
     - __kind: StructureType
-      ID: 296
+      ID: 306
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1591872
@@ -6683,12 +6683,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 617 BaseType net/http.http2ErrCode
+          Type: 627 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 617
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1760064
@@ -6699,7 +6699,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 617 BaseType net/http.http2ErrCode
+          Type: 627 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
@@ -6708,7 +6708,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 302
+      ID: 312
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1400096
@@ -6716,12 +6716,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 617 BaseType net/http.http2ErrCode
+          Type: 627 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 217
+      ID: 227
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 764320
@@ -6729,18 +6729,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 219 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 229 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 218 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 228 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 218
+      ID: 228
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 300
+      ID: 310
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1066240
       GoKind: 25
@@ -6750,7 +6750,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 223
+      ID: 233
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 764512
@@ -6758,18 +6758,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 225 PointerType *net/http.http2headerFieldNameError.str
+          Type: 235 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 224 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 234 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 224
+      ID: 234
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 220
+      ID: 230
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 764416
@@ -6777,18 +6777,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 222 PointerType *net/http.http2headerFieldValueError.str
+          Type: 232 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 221 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 231 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 221
+      ID: 231
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 562
+      ID: 572
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -6804,13 +6804,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 495
+      ID: 505
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1188000
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 214
+      ID: 224
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 764224
@@ -6818,13 +6818,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 216 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 226 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 215 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 225 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 215
+      ID: 225
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -6867,7 +6867,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1356864
@@ -6907,7 +6907,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 306
+      ID: 316
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1230208
@@ -6982,7 +6982,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 760 StructureType sync/atomic.Bool
@@ -7018,7 +7018,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 291
+      ID: 301
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1399936
@@ -7031,17 +7031,17 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 619
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 560
+      ID: 570
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1279296
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 493
+      ID: 503
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1357024
@@ -7051,7 +7051,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 289
+      ID: 299
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7061,7 +7061,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 319
+      ID: 329
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1594944
@@ -7077,7 +7077,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 317
+      ID: 327
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1400416
@@ -7090,11 +7090,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 332
+      ID: 342
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 237
+      ID: 247
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 766624
@@ -7102,22 +7102,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 239 PointerType *net/textproto.ProtocolError.str
+          Type: 249 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 238 GoStringDataType net/textproto.ProtocolError.str
+      Data: 248 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 238
+      ID: 248
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 624
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 231
+      ID: 241
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 766432
@@ -7125,18 +7125,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 233 PointerType *net/url.EscapeError.str
+          Type: 243 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 232 GoStringDataType net/url.EscapeError.str
+      Data: 242 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 232
+      ID: 242
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 234
+      ID: 244
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 766528
@@ -7144,13 +7144,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 236 PointerType *net/url.InvalidHostError.str
+          Type: 246 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 235 GoStringDataType net/url.InvalidHostError.str
+      Data: 245 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 235
+      ID: 245
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7210,7 +7210,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 497
+      ID: 507
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7227,7 +7227,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 574
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7269,15 +7269,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 528
+      ID: 538
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 659
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 530
+      ID: 540
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1503488
@@ -7311,7 +7311,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 271
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 770848
@@ -7319,36 +7319,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *os/user.UnknownGroupIdError.str
+          Type: 273 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 262 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 272 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 272
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 260
+      ID: 270
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 770752
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 315
+      ID: 325
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 397
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 514
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 519
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7360,7 +7360,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 506
+      ID: 516
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1750624
@@ -7377,9 +7377,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 647 BaseType runtime.boundsErrorCode
+          Type: 657 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 647
+      ID: 657
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 534720
@@ -7399,7 +7399,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 566
+      ID: 576
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1626592
@@ -7412,7 +7412,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 473
+      ID: 483
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 943456
@@ -7420,13 +7420,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 475 PointerType *runtime.errorString.str
+          Type: 485 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 474 GoStringDataType runtime.errorString.str
+      Data: 484 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 474
+      ID: 484
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8052,7 +8052,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 476
+      ID: 486
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 944032
@@ -8060,13 +8060,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 478 PointerType *runtime.plainError.str
+          Type: 488 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 477 GoStringDataType runtime.plainError.str
+      Data: 487 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 477
+      ID: 487
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8148,7 +8148,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 501
+      ID: 511
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8513,7 +8513,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 599
+      ID: 609
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1188640
@@ -8525,7 +8525,7 @@ Types:
       GoRuntimeType: 944224
       GoKind: 2
     - __kind: StructureType
-      ID: 546
+      ID: 556
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1507712
@@ -8555,10 +8555,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 659 GoSliceHeaderType []time.zone
+          Type: 190 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 662 GoSliceHeaderType []time.zoneTrans
+          Type: 193 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -8570,12 +8570,12 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 660 PointerType *time.zone
+          Type: 191 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 309
+      ID: 319
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 138
       Name: time.Time
       ByteSize: 24
@@ -8591,6 +8591,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 139 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 137
       Name: time.Timer
@@ -8600,12 +8608,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 658 GoChannelType <-chan time.Time
+          Type: 668 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 226
+      ID: 236
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 764608
@@ -8613,18 +8621,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 228 PointerType *time.fileSizeError.str
+          Type: 238 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 227 GoStringDataType time.fileSizeError.str
+      Data: 237 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 227
+      ID: 237
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 661
+      ID: 192
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1421024
@@ -8640,7 +8648,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 664
+      ID: 195
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1623328
@@ -8701,7 +8709,7 @@ Types:
       GoRuntimeType: 534656
       GoKind: 26
     - __kind: StructureType
-      ID: 628
+      ID: 638
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1920960
@@ -8712,10 +8720,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 629 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 639 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 630 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 640 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -8730,18 +8738,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 631 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 641 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 631
+      ID: 641
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 944512
       GoKind: 9
     - __kind: StructureType
-      ID: 629
+      ID: 639
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1779424
@@ -8766,17 +8774,17 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 321
+      ID: 331
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 630
+      ID: 640
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 535552
       GoKind: 8
     - __kind: StructureType
-      ID: 334
+      ID: 344
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1235168
@@ -8786,13 +8794,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 240
+      ID: 250
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 766720
       GoKind: 2
     - __kind: StructureType
-      ID: 514
+      ID: 524
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1502912
@@ -8805,7 +8813,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 480
+      ID: 490
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 945376

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -136,7 +136,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 654 PointerType *crypto/x509.Certificate
+      Pointee: 664 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 712
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -160,10 +160,10 @@ Types:
       ByteSize: 8
       Pointee: 776 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 230
+      ID: 236
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 231 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 237 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 955
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -180,10 +180,10 @@ Types:
       ByteSize: 8
       Pointee: 171 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 660 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 670 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 165
       Name: '**table<string,interface {}>'
@@ -226,30 +226,30 @@ Types:
       ByteSize: 8
       Pointee: 983 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 697
+      ID: 707
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 696 GoSliceDataType []float64.array
+      Pointee: 706 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 226
+      ID: 232
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Pointee: 231 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: PointerType
-      ID: 234
+      ID: 240
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 239 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 989
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 988 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 200
+      ID: 206
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []os.Signal.array
+      Pointee: 205 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -258,20 +258,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 695
+      ID: 705
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 694 GoSliceDataType []string.array
+      Pointee: 704 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 708
+      ID: 242
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 707 GoSliceDataType []time.zone.array
+      Pointee: 241 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 710
+      ID: 244
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 709 GoSliceDataType []time.zoneTrans.array
+      Pointee: 243 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 976
       Name: '*[]uint8'
@@ -290,17 +290,17 @@ Types:
       ByteSize: 8
       Pointee: 187 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 493
+      ID: 503
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 939104
       GoKind: 22
-      Pointee: 494 GoSliceHeaderType archive/tar.headerError
+      Pointee: 504 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 495 GoSliceDataType archive/tar.headerError.array
+      Pointee: 505 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 883
       Name: '*archive/zip.checksumReader'
@@ -351,24 +351,24 @@ Types:
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 912512
       GoKind: 22
-      Pointee: 288 BaseType compress/flate.CorruptInputError
+      Pointee: 298 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 912608
       GoKind: 22
-      Pointee: 289 GoStringHeaderType compress/flate.InternalError
+      Pointee: 299 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 291
+      ID: 301
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 290 GoStringDataType compress/flate.InternalError.str
+      Pointee: 300 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 917
       Name: '*compress/flate.decompressor'
@@ -398,12 +398,12 @@ Types:
       GoKind: 22
       Pointee: 117 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1173728
       GoKind: 22
-      Pointee: 587 StructureType context.deadlineExceededError
+      Pointee: 597 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 990
       Name: '*context.emptyCtx'
@@ -447,47 +447,47 @@ Types:
       GoKind: 22
       Pointee: 125 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911264
       GoKind: 22
-      Pointee: 284 BaseType crypto/aes.KeySizeError
+      Pointee: 294 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 413
+      ID: 423
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911456
       GoKind: 22
-      Pointee: 285 BaseType crypto/des.KeySizeError
+      Pointee: 295 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 286 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 296 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 912032
       GoKind: 22
-      Pointee: 287 BaseType crypto/rc4.KeySizeError
+      Pointee: 297 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 902048
       GoKind: 22
-      Pointee: 261 BaseType crypto/tls.AlertError
+      Pointee: 271 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 547
+      ID: 557
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1029472
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 558 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 947
       Name: '*crypto/tls.Conn'
@@ -503,206 +503,206 @@ Types:
       GoKind: 22
       Pointee: 835 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 357
+      ID: 367
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 901856
       GoKind: 22
-      Pointee: 358 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 368 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 901760
       GoKind: 22
-      Pointee: 356 StructureType crypto/tls.RecordHeaderError
+      Pointee: 366 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 546
+      ID: 556
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1027808
       GoKind: 22
-      Pointee: 515 BaseType crypto/tls.alert
+      Pointee: 525 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 647
+      ID: 657
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1406240
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 658 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 654
+      ID: 664
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2031072
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 665 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 911072
       GoKind: 22
-      Pointee: 409 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 419 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 910592
       GoKind: 22
-      Pointee: 403 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 413 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 405 StructureType crypto/x509.HostnameError
+      Pointee: 415 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 910496
       GoKind: 22
-      Pointee: 283 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 293 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 561
+      ID: 571
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1037792
       GoKind: 22
-      Pointee: 562 StructureType crypto/x509.SystemRootsError
+      Pointee: 572 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 911168
       GoKind: 22
-      Pointee: 411 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 421 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 910976
       GoKind: 22
-      Pointee: 407 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 417 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 921440
       GoKind: 22
-      Pointee: 453 StructureType encoding/asn1.StructuralError
+      Pointee: 463 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 456
+      ID: 466
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 921632
       GoKind: 22
-      Pointee: 457 StructureType encoding/asn1.SyntaxError
+      Pointee: 467 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 454
+      ID: 464
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 921536
       GoKind: 22
-      Pointee: 455 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 465 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 902144
       GoKind: 22
-      Pointee: 262 BaseType encoding/base64.CorruptInputError
+      Pointee: 272 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 394
+      ID: 404
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 909344
       GoKind: 22
-      Pointee: 282 BaseType encoding/hex.InvalidByteError
+      Pointee: 292 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 379
+      ID: 389
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 905696
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 390 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 559
+      ID: 569
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1034464
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 570 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 905312
       GoKind: 22
-      Pointee: 372 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 382 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 905600
       GoKind: 22
-      Pointee: 378 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 388 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 905504
       GoKind: 22
-      Pointee: 376 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 386 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 905408
       GoKind: 22
-      Pointee: 374 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 384 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 906080
       GoKind: 22
-      Pointee: 382 StructureType encoding/json.jsonError
+      Pointee: 392 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 483
+      ID: 493
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932960
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 494 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 481
+      ID: 491
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 932864
       GoKind: 22
-      Pointee: 482 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 492 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 485
+      ID: 495
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 933056
       GoKind: 22
-      Pointee: 297 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 307 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 299
+      ID: 309
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 308 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 933152
       GoKind: 22
-      Pointee: 487 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 497 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -711,19 +711,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 343
+      ID: 353
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 897344
       GoKind: 22
-      Pointee: 344 UnresolvedPointeeType errors.errorString
+      Pointee: 354 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 534
+      ID: 544
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1020768
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType errors.joinError
+      Pointee: 545 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -739,26 +739,26 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1010528
       GoKind: 22
-      Pointee: 519 UnresolvedPointeeType fmt.wrapError
+      Pointee: 529 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 520
+      ID: 530
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1010656
       GoKind: 22
-      Pointee: 521 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 531 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 392
+      ID: 402
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 393 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 403 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 777
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -767,193 +767,193 @@ Types:
       GoKind: 22
       Pointee: 778 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 907424
       GoKind: 22
-      Pointee: 385 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 395 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 907520
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 397 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 674
+      ID: 684
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 907232
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 685 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 907808
       GoKind: 22
-      Pointee: 391 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 401 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 676
+      ID: 686
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 907328
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 687 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 907616
       GoKind: 22
-      Pointee: 276 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 286 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 278
+      ID: 288
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 287 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 383
+      ID: 393
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 907136
       GoKind: 22
-      Pointee: 273 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 283 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 275
+      ID: 285
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 907712
       GoKind: 22
-      Pointee: 279 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 289 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 281
+      ID: 291
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 280 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 290 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 922208
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 470 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 458
+      ID: 468
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 922112
       GoKind: 22
-      Pointee: 292 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 302 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 437 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 918464
       GoKind: 22
-      Pointee: 431 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 441 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 918368
       GoKind: 22
-      Pointee: 429 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 439 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 435 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 699
+      ID: 709
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 698 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 708 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 439 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 449 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 918560
       GoKind: 22
-      Pointee: 433 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 443 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 918752
       GoKind: 22
-      Pointee: 437 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 447 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 918656
       GoKind: 22
-      Pointee: 435 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 445 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 440
+      ID: 450
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 918944
       GoKind: 22
-      Pointee: 441 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 451 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 446
+      ID: 456
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 919232
       GoKind: 22
-      Pointee: 447 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 457 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 448
+      ID: 458
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 919328
       GoKind: 22
-      Pointee: 449 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 459 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 444
+      ID: 454
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 919136
       GoKind: 22
-      Pointee: 445 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 455 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 442
+      ID: 452
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 919040
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 453 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 919520
       GoKind: 22
-      Pointee: 451 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 461 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 791
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -983,12 +983,12 @@ Types:
       GoKind: 22
       Pointee: 790 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 469
+      ID: 479
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 930176
       GoKind: 22
-      Pointee: 470 StructureType github.com/cihub/seelog.baseError
+      Pointee: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 770
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -997,12 +997,12 @@ Types:
       GoKind: 22
       Pointee: 771 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 930272
       GoKind: 22
-      Pointee: 472 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 482 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 762
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1025,12 +1025,12 @@ Types:
       GoKind: 22
       Pointee: 769 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 475
+      ID: 485
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 930464
       GoKind: 22
-      Pointee: 476 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 486 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 766
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1046,19 +1046,19 @@ Types:
       GoKind: 22
       Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 473
+      ID: 483
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 930368
       GoKind: 22
-      Pointee: 474 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 484 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 477
+      ID: 487
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 930560
       GoKind: 22
-      Pointee: 478 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 488 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 881
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1074,268 +1074,268 @@ Types:
       GoKind: 22
       Pointee: 901 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 573
+      ID: 583
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1057248
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 584 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 575
+      ID: 585
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1057376
       GoKind: 22
-      Pointee: 576 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 586 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1042144
       GoKind: 22
-      Pointee: 568 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 578 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 909536
       GoKind: 22
-      Pointee: 396 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 406 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 569
+      ID: 579
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1045600
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 580 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1196128
       GoKind: 22
-      Pointee: 616 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 626 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 609
+      ID: 619
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1195744
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 620 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 553
+      ID: 563
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1033568
       GoKind: 22
-      Pointee: 554 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 564 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 621
+      ID: 631
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1196512
       GoKind: 22
-      Pointee: 622 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 632 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1033440
       GoKind: 22
-      Pointee: 517 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 527 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1196000
       GoKind: 22
-      Pointee: 614 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 624 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1195872
       GoKind: 22
-      Pointee: 612 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 622 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 619
+      ID: 629
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1196384
       GoKind: 22
-      Pointee: 620 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 630 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1196256
       GoKind: 22
-      Pointee: 618 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 628 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 625
+      ID: 635
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1196896
       GoKind: 22
-      Pointee: 626 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 636 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1033824
       GoKind: 22
-      Pointee: 558 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 568 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1033696
       GoKind: 22
-      Pointee: 556 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 566 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 623
+      ID: 633
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1196768
       GoKind: 22
-      Pointee: 624 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 634 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 300 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 310 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 302
+      ID: 312
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 301 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 311 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 662
+      ID: 672
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1649408
       GoKind: 22
-      Pointee: 663 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 673 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 579
+      ID: 589
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1074016
       GoKind: 22
-      Pointee: 580 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 590 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 497
+      ID: 507
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 940352
       GoKind: 22
-      Pointee: 303 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 313 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 633
+      ID: 643
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1249376
       GoKind: 22
-      Pointee: 634 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 644 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 940640
       GoKind: 22
-      Pointee: 501 StructureType golang.org/x/net/http2.connError
+      Pointee: 511 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 499
+      ID: 509
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940544
       GoKind: 22
-      Pointee: 307 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 317 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 309
+      ID: 319
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 318 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 940832
       GoKind: 22
-      Pointee: 313 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 323 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 315
+      ID: 325
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 324 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 940736
       GoKind: 22
-      Pointee: 310 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 320 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 312
+      ID: 322
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 321 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940448
       GoKind: 22
-      Pointee: 304 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 314 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 306
+      ID: 316
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 305 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 315 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 504
+      ID: 514
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 940928
       GoKind: 22
-      Pointee: 505 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 515 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 941024
       GoKind: 22
-      Pointee: 316 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 326 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 479
+      ID: 489
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 932384
       GoKind: 22
-      Pointee: 480 StructureType google.golang.org/grpc.dropError
+      Pointee: 490 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 631
+      ID: 641
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1246176
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 642 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1431040
       GoKind: 22
-      Pointee: 652 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 662 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 936608
       GoKind: 22
-      Pointee: 491 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 501 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 906
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1344,12 +1344,12 @@ Types:
       GoKind: 22
       Pointee: 907 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1068256
       GoKind: 22
-      Pointee: 578 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 588 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 890
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1358,40 +1358,40 @@ Types:
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 462 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 472 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 571
+      ID: 581
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1047008
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 582 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 629
+      ID: 639
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1212384
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 640 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 627
+      ID: 637
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1212128
       GoKind: 22
-      Pointee: 628 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 638 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 904352
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 380 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 721
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
@@ -1449,12 +1449,12 @@ Types:
       GoKind: 22
       Pointee: 720 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 241
+      ID: 251
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1181792
       GoKind: 22
-      Pointee: 242 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 252 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 180
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
@@ -1491,40 +1491,40 @@ Types:
       GoKind: 22
       Pointee: 864 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 421 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 431 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 924992
       GoKind: 22
-      Pointee: 464 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 474 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 465
+      ID: 475
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 925088
       GoKind: 22
-      Pointee: 466 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 476 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 933920
       GoKind: 22
-      Pointee: 489 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 499 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 941792
       GoKind: 22
-      Pointee: 508 UnresolvedPointeeType html/template.Error
+      Pointee: 518 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -1561,26 +1561,26 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 399
+      ID: 409
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 410 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 910016
       GoKind: 22
-      Pointee: 398 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 408 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 607
+      ID: 617
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1189600
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 618 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 945
       Name: '*internal/poll.FD'
@@ -1589,19 +1589,19 @@ Types:
       GoKind: 22
       Pointee: 946 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 605
+      ID: 615
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1189472
       GoKind: 22
-      Pointee: 606 StructureType internal/poll.errNetClosing
+      Pointee: 616 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 897728
       GoKind: 22
-      Pointee: 346 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 356 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 910
       Name: '*io.PipeReader'
@@ -1631,12 +1631,12 @@ Types:
       GoKind: 22
       Pointee: 880 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 603
+      ID: 613
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1188704
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType io/fs.PathError
+      Pointee: 614 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 136
       Name: '*map<context.canceler,struct {}>'
@@ -1648,10 +1648,10 @@ Types:
       ByteSize: 8
       Pointee: 774 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 228
+      ID: 234
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 229 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 235 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 953
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1668,10 +1668,10 @@ Types:
       ByteSize: 8
       Pointee: 169 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 658 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 668 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 163
       Name: '*map<string,interface {}>'
@@ -1683,12 +1683,12 @@ Types:
       ByteSize: 8
       Pointee: 159 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 913280
       GoKind: 22
-      Pointee: 419 StructureType math/big.ErrNaN
+      Pointee: 429 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 965
       Name: '*mime/multipart.FileHeader'
@@ -1718,19 +1718,19 @@ Types:
       GoKind: 22
       Pointee: 895 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 589
+      ID: 599
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1174880
       GoKind: 22
-      Pointee: 590 UnresolvedPointeeType net.AddrError
+      Pointee: 600 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1399360
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType net.DNSError
+      Pointee: 649 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 921
       Name: '*net.IPConn'
@@ -1739,19 +1739,19 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 636
+      ID: 646
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1399040
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType net.OpError
+      Pointee: 647 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1175008
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType net.ParseError
+      Pointee: 602 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 929
       Name: '*net.TCPConn'
@@ -1774,24 +1774,24 @@ Types:
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 588
+      ID: 598
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1174112
       GoKind: 22
-      Pointee: 583 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 593 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 585
+      ID: 595
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 584 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 594 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1011552
       GoKind: 22
-      Pointee: 523 StructureType net.canceledError
+      Pointee: 533 StructureType net.canceledError
     - __kind: PointerType
       ID: 919
       Name: '*net.conn'
@@ -1800,12 +1800,12 @@ Types:
       GoKind: 22
       Pointee: 920 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 680
+      ID: 690
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1817760
       GoKind: 22
-      Pointee: 681 StructureType net.dialResult·1
+      Pointee: 691 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 935
       Name: '*net.netFD'
@@ -1814,12 +1814,12 @@ Types:
       GoKind: 22
       Pointee: 936 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 317
+      ID: 327
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 890336
       GoKind: 22
-      Pointee: 318 UnresolvedPointeeType net.notFoundError
+      Pointee: 328 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 991
       Name: '*net.onlyValuesCtx'
@@ -1828,12 +1828,12 @@ Types:
       GoKind: 22
       Pointee: 992 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 319
+      ID: 329
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 891008
       GoKind: 22
-      Pointee: 320 StructureType net.result·2
+      Pointee: 330 StructureType net.result·2
     - __kind: PointerType
       ID: 925
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1849,33 +1849,33 @@ Types:
       GoKind: 22
       Pointee: 924 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1175648
       GoKind: 22
-      Pointee: 594 UnresolvedPointeeType net.temporaryError
+      Pointee: 604 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1399680
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType net.timeoutError
+      Pointee: 651 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 325
+      ID: 335
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 893600
       GoKind: 22
-      Pointee: 326 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 336 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 524
+      ID: 534
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1015008
       GoKind: 22
-      Pointee: 525 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 535 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -1933,26 +1933,26 @@ Types:
       GoKind: 22
       Pointee: 858 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 893792
       GoKind: 22
-      Pointee: 245 BaseType net/http.http2ConnectionError
+      Pointee: 255 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 893888
       GoKind: 22
-      Pointee: 329 StructureType net/http.http2GoAwayError
+      Pointee: 339 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 642
+      ID: 652
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1400640
       GoKind: 22
-      Pointee: 643 StructureType net/http.http2StreamError
+      Pointee: 653 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 887
       Name: '*net/http.http2clientStream'
@@ -1961,31 +1961,31 @@ Types:
       GoKind: 22
       Pointee: 888 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 334
+      ID: 344
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 894944
       GoKind: 22
-      Pointee: 335 StructureType net/http.http2connError
+      Pointee: 345 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 894368
       GoKind: 22
-      Pointee: 249 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 259 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 251
+      ID: 261
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 250 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 260 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 332
+      ID: 342
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 894464
       GoKind: 22
-      Pointee: 333 StructureType net/http.http2goAwayFlowError
+      Pointee: 343 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 851
       Name: '*net/http.http2gzipReader'
@@ -1994,36 +1994,36 @@ Types:
       GoKind: 22
       Pointee: 852 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 895136
       GoKind: 22
-      Pointee: 255 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 265 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 257
+      ID: 267
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 256 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 266 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 895040
       GoKind: 22
-      Pointee: 252 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 262 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 254
+      ID: 264
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 253 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 263 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 597
+      ID: 607
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1179616
       GoKind: 22
-      Pointee: 598 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 608 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 847
       Name: '*net/http.http2missingBody'
@@ -2039,24 +2039,24 @@ Types:
       GoKind: 22
       Pointee: 860 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 530
+      ID: 540
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1017312
       GoKind: 22
-      Pointee: 531 StructureType net/http.http2noCachedConnError
+      Pointee: 541 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 894272
       GoKind: 22
-      Pointee: 246 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 256 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 248
+      ID: 258
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 247 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 257 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 855
       Name: '*net/http.http2requestBody'
@@ -2100,12 +2100,12 @@ Types:
       GoKind: 22
       Pointee: 878 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 526
+      ID: 536
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1016928
       GoKind: 22
-      Pointee: 527 StructureType net/http.nothingWrittenError
+      Pointee: 537 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 839
       Name: '*net/http.pattern'
@@ -2128,12 +2128,12 @@ Types:
       GoKind: 22
       Pointee: 876 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 895328
       GoKind: 22
-      Pointee: 339 StructureType net/http.requestBodyReadError
+      Pointee: 349 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 760
       Name: '*net/http.response'
@@ -2149,33 +2149,33 @@ Types:
       GoKind: 22
       Pointee: 987 StructureType net/http.segment
     - __kind: PointerType
-      ID: 323
+      ID: 333
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 893504
       GoKind: 22
-      Pointee: 324 StructureType net/http.statusError
+      Pointee: 334 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 644
+      ID: 654
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1402080
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 655 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 595
+      ID: 605
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1179488
       GoKind: 22
-      Pointee: 596 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 606 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 528
+      ID: 538
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1017056
       GoKind: 22
-      Pointee: 529 StructureType net/http.transportReadFromServerError
+      Pointee: 539 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 908
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2184,12 +2184,12 @@ Types:
       GoKind: 22
       Pointee: 909 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 321
+      ID: 331
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 892736
       GoKind: 22
-      Pointee: 322 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 332 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 869
       Name: '*net/http/httputil.failureToReadBody'
@@ -2198,69 +2198,69 @@ Types:
       GoKind: 22
       Pointee: 870 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 351
+      ID: 361
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 900128
       GoKind: 22
-      Pointee: 352 StructureType net/netip.parseAddrError
+      Pointee: 362 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 349
+      ID: 359
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 900032
       GoKind: 22
-      Pointee: 350 StructureType net/netip.parsePrefixError
+      Pointee: 360 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 903392
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType net/textproto.Error
+      Pointee: 375 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 363
+      ID: 373
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 903296
       GoKind: 22
-      Pointee: 269 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 279 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 271
+      ID: 281
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 270 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 280 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1406720
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType net/url.Error
+      Pointee: 660 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 902240
       GoKind: 22
-      Pointee: 263 GoStringHeaderType net/url.EscapeError
+      Pointee: 273 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 265
+      ID: 275
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType net/url.EscapeError.str
+      Pointee: 274 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 902336
       GoKind: 22
-      Pointee: 266 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 276 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 268
+      ID: 278
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 277 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 828
       Name: '*net/url.URL'
@@ -2286,10 +2286,10 @@ Types:
       ByteSize: 8
       Pointee: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 237
+      ID: 247
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 238 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 959
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2301,25 +2301,25 @@ Types:
       ByteSize: 8
       Pointee: 823 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 219
+      ID: 225
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 220 StructureType noalg.map.group[string]float64
+      Pointee: 226 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 688
+      ID: 698
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 689 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 211
+      ID: 217
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 212 StructureType noalg.map.group[string]interface {}
+      Pointee: 218 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 203
+      ID: 209
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[string]string
+      Pointee: 210 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 941
       Name: '*os.File'
@@ -2328,12 +2328,12 @@ Types:
       GoKind: 22
       Pointee: 942 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 532
+      ID: 542
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1019232
       GoKind: 22
-      Pointee: 533 UnresolvedPointeeType os.LinkError
+      Pointee: 543 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 149
       Name: '*os.Signal'
@@ -2342,12 +2342,12 @@ Types:
       GoKind: 22
       Pointee: 150 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 599
+      ID: 609
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1180128
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType os.SyscallError
+      Pointee: 610 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 939
       Name: '*os.fileWithoutReadFrom'
@@ -2363,26 +2363,26 @@ Types:
       GoKind: 22
       Pointee: 938 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 563
+      ID: 573
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1040736
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType os/exec.Error
+      Pointee: 574 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 684
+      ID: 694
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2075136
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 695 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1040864
       GoKind: 22
-      Pointee: 566 StructureType os/exec.wrappedError
+      Pointee: 576 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 126
       Name: '*os/signal.signalCtx'
@@ -2391,52 +2391,52 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 929216
       GoKind: 22
-      Pointee: 294 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 304 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 296
+      ID: 306
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 295 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 305 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 929120
       GoKind: 22
-      Pointee: 293 BaseType os/user.UnknownUserIdError
+      Pointee: 303 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 347
+      ID: 357
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 898496
       GoKind: 22
-      Pointee: 348 UnresolvedPointeeType reflect.ValueError
+      Pointee: 358 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 423 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 433 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 540
+      ID: 550
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1023840
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 551 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 544
+      ID: 554
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1025632
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 555 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2452,12 +2452,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 542
+      ID: 552
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1023968
       GoKind: 22
-      Pointee: 543 StructureType runtime.boundsError
+      Pointee: 553 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -2473,24 +2473,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 601
+      ID: 611
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1188064
       GoKind: 22
-      Pointee: 602 StructureType runtime.errorAddressString
+      Pointee: 612 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 538
+      ID: 548
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1023456
       GoKind: 22
-      Pointee: 509 GoStringHeaderType runtime.errorString
+      Pointee: 519 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 510 GoStringDataType runtime.errorString.str
+      Pointee: 520 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2506,17 +2506,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1023584
       GoKind: 22
-      Pointee: 512 GoStringHeaderType runtime.plainError
+      Pointee: 522 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 513 GoStringDataType runtime.plainError.str
+      Pointee: 523 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2546,12 +2546,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 536
+      ID: 546
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1023072
       GoKind: 22
-      Pointee: 537 UnresolvedPointeeType strconv.NumError
+      Pointee: 547 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -2677,12 +2677,12 @@ Types:
       GoKind: 22
       Pointee: 872 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 646
+      ID: 656
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1405600
       GoKind: 22
-      Pointee: 635 BaseType syscall.Errno
+      Pointee: 645 BaseType syscall.Errno
     - __kind: PointerType
       ID: 717
       Name: '*syscall.Signal'
@@ -2701,10 +2701,10 @@ Types:
       ByteSize: 8
       Pointee: 793 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 231
+      ID: 237
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 235 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 245 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 956
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2719,29 +2719,29 @@ Types:
       ID: 171
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 217 StructureType table<string,float64>
+      Pointee: 223 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 660
+      ID: 670
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 686 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 696 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 166
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 209 StructureType table<string,interface {}>
+      Pointee: 215 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 161
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 201 StructureType table<string,string>
+      Pointee: 207 StructureType table<string,string>
     - __kind: PointerType
-      ID: 581
+      ID: 591
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1078496
       GoKind: 22
-      Pointee: 582 StructureType text/template.ExecError
+      Pointee: 592 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 144
       Name: '*time.Location'
@@ -2750,12 +2750,12 @@ Types:
       GoKind: 22
       Pointee: 145 StructureType time.Location
     - __kind: PointerType
-      ID: 341
+      ID: 351
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 896192
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType time.ParseError
+      Pointee: 352 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 141
       Name: '*time.Timer'
@@ -2764,31 +2764,31 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType time.Timer
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 896096
       GoKind: 22
-      Pointee: 258 GoStringHeaderType time.fileSizeError
+      Pointee: 268 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 260
+      ID: 270
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 259 GoStringDataType time.fileSizeError.str
+      Pointee: 269 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 702
+      ID: 200
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391776
       GoKind: 22
-      Pointee: 703 StructureType time.zone
+      Pointee: 201 StructureType time.zone
     - __kind: PointerType
-      ID: 705
+      ID: 203
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391840
       GoKind: 22
-      Pointee: 706 StructureType time.zoneTrans
+      Pointee: 204 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -2832,47 +2832,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 900896
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 364 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 903584
       GoKind: 22
-      Pointee: 367 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 377 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 903680
       GoKind: 22
-      Pointee: 272 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 282 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1031008
       GoKind: 22
-      Pointee: 550 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 560 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 551
+      ID: 561
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1031136
       GoKind: 22
-      Pointee: 516 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 526 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 836
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: GoChannelType
-      ID: 700
+      ID: 710
       Name: <-chan time.Time
       GoRuntimeType: 596160
       GoKind: 18
@@ -3057,7 +3057,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 668
+      ID: 678
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 695744
@@ -3105,7 +3105,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 654 PointerType *crypto/x509.Certificate
+      Element: 664 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 711
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -3165,11 +3165,11 @@ Types:
       ByteSize: 8
       Element: 776 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 253
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 231 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 237 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 966
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3183,25 +3183,25 @@ Types:
       ByteSize: 8
       Element: 815 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 229
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 171 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 692
+      ID: 702
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 660 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 670 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 221
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 166 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 213
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3253,7 +3253,7 @@ Types:
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 673
+      ID: 683
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 492576
@@ -3268,9 +3268,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 696 GoSliceDataType []float64.array
+      Data: 706 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 696
+      ID: 706
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3291,9 +3291,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 225 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 231 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 231
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3314,9 +3314,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 233 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 239 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 239
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3357,11 +3357,11 @@ Types:
       ByteSize: 24
       Element: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 254
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 238 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 967
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3375,29 +3375,29 @@ Types:
       ByteSize: 328
       Element: 823 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 230
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 220 StructureType noalg.map.group[string]float64
+      Element: 226 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 693
+      ID: 703
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 689 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 222
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 212 StructureType noalg.map.group[string]interface {}
+      Element: 218 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 214
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 204 StructureType noalg.map.group[string]string
+      Element: 210 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 148
       Name: '[]os.Signal'
@@ -3414,9 +3414,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 199 GoSliceDataType []os.Signal.array
+      Data: 205 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 205
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3426,7 +3426,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 672
+      ID: 682
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -3441,15 +3441,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 694 GoSliceDataType []string.array
+      Data: 704 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 694
+      ID: 704
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 701
+      ID: 199
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -3457,22 +3457,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 702 PointerType *time.zone
+          Type: 200 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 707 GoSliceDataType []time.zone.array
+      Data: 241 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 707
+      ID: 241
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 703 StructureType time.zone
+      Element: 201 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 704
+      ID: 202
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -3480,20 +3480,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 705 PointerType *time.zoneTrans
+          Type: 203 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 709 GoSliceDataType []time.zoneTrans.array
+      Data: 243 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 709
+      ID: 243
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 706 StructureType time.zoneTrans
+      Element: 204 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3541,7 +3541,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 494
+      ID: 504
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 939200
@@ -3556,9 +3556,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 495 GoSliceDataType archive/tar.headerError.array
+      Data: 505 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 505
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3616,13 +3616,13 @@ Types:
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: BaseType
-      ID: 288
+      ID: 298
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 832544
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 289
+      ID: 299
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -3630,13 +3630,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 291 PointerType *compress/flate.InternalError.str
+          Type: 301 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 290 GoStringDataType compress/flate.InternalError.str
+      Data: 300 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 290
+      ID: 300
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3720,7 +3720,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: context.deadlineExceededError
       GoRuntimeType: 1448288
       GoKind: 25
@@ -3764,7 +3764,7 @@ Types:
           Type: 141 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 143 StructureType time.Time
+          Type: 143 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3810,37 +3810,37 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 284
+      ID: 294
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 832160
       GoKind: 2
     - __kind: BaseType
-      ID: 285
+      ID: 295
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 832256
       GoKind: 2
     - __kind: BaseType
-      ID: 286
+      ID: 296
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 832352
       GoKind: 2
     - __kind: BaseType
-      ID: 287
+      ID: 297
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 832448
       GoKind: 2
     - __kind: BaseType
-      ID: 261
+      ID: 271
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 829856
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 558
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3909,11 +3909,11 @@ Types:
       GoRuntimeType: 829664
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 358
+      ID: 368
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 356
+      ID: 366
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1710080
@@ -3924,26 +3924,26 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 668 ArrayType [5]uint8
+          Type: 678 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 669 GoInterfaceType net.Conn
+          Type: 679 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 515
+      ID: 525
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 979808
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 658
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 665
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 409
+      ID: 419
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1712192
@@ -3951,21 +3951,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 654 PointerType *crypto/x509.Certificate
+          Type: 664 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 678 BaseType crypto/x509.InvalidReason
+          Type: 688 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 403
+      ID: 413
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1105120
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 405
+      ID: 415
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1582784
@@ -3973,24 +3973,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 654 PointerType *crypto/x509.Certificate
+          Type: 664 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 283
+      ID: 293
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 831968
       GoKind: 2
     - __kind: BaseType
-      ID: 678
+      ID: 688
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 583424
       GoKind: 2
     - __kind: StructureType
-      ID: 562
+      ID: 572
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1543424
@@ -4000,13 +4000,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1105376
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 407
+      ID: 417
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1712000
@@ -4014,15 +4014,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 654 PointerType *crypto/x509.Certificate
+          Type: 664 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 654 PointerType *crypto/x509.Certificate
+          Type: 664 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 453
+      ID: 463
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1418880
@@ -4032,7 +4032,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 457
+      ID: 467
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1419040
@@ -4042,47 +4042,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 455
+      ID: 465
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 262
+      ID: 272
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 829952
       GoKind: 6
     - __kind: BaseType
-      ID: 282
+      ID: 292
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 831776
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 390
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 570
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 372
+      ID: 382
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 378
+      ID: 388
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 376
+      ID: 386
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 374
+      ID: 384
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 382
+      ID: 392
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1409760
@@ -4092,15 +4092,15 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 494
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 482
+      ID: 492
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 307
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 835232
@@ -4108,18 +4108,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *encoding/xml.UnmarshalError.str
+          Type: 309 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 308 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 308
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 487
+      ID: 497
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4136,11 +4136,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 344
+      ID: 354
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 545
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4156,11 +4156,11 @@ Types:
       GoRuntimeType: 580608
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 519
+      ID: 529
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 521
+      ID: 531
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4194,7 +4194,7 @@ Types:
       GoRuntimeType: 995552
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 393
+      ID: 403
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4204,7 +4204,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 385
+      ID: 395
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1711232
@@ -4212,7 +4212,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 670 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 680 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4220,25 +4220,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 397
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 685
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 391
+      ID: 401
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1104224
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 687
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 286
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 831200
@@ -4246,18 +4246,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 288 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 287 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 287
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 670
+      ID: 680
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2198944
@@ -4265,13 +4265,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 671 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 681 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4280,7 +4280,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 673 GoSliceHeaderType []float64
+          Type: 683 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4289,13 +4289,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 674 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 684 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 676 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 686 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4306,13 +4306,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 671
+      ID: 681
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 582208
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 283
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 831104
@@ -4320,18 +4320,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 285 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 284
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 279
+      ID: 289
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 831296
@@ -4339,30 +4339,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 281 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 291 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 280 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 290 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 280
+      ID: 290
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 460
+      ID: 470
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1107936
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 292
+      ID: 302
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 833792
       GoKind: 2
     - __kind: StructureType
-      ID: 427
+      ID: 437
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1583584
@@ -4375,7 +4375,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 431
+      ID: 441
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1713920
@@ -4391,7 +4391,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 429
+      ID: 439
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1417440
@@ -4401,7 +4401,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1417120
@@ -4411,14 +4411,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 656
+      ID: 666
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1489568
       GoKind: 21
-      HeaderType: 658 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 668 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 679
+      ID: 689
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1041760
@@ -4433,15 +4433,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 698 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 708 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 698
+      ID: 708
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 439
+      ID: 449
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1583904
@@ -4449,12 +4449,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 656 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 666 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 656 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 666 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 433
+      ID: 443
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1417600
@@ -4464,7 +4464,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 437
+      ID: 447
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1714112
@@ -4475,12 +4475,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 679 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 679 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 435
+      ID: 445
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1583744
@@ -4493,7 +4493,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 441
+      ID: 451
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1417760
@@ -4501,9 +4501,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 143 StructureType time.Time
+          Type: 143 GoTimeType time.Time
     - __kind: StructureType
-      ID: 447
+      ID: 457
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1584224
@@ -4516,7 +4516,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 449
+      ID: 459
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1418080
@@ -4526,7 +4526,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 445
+      ID: 455
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1584064
@@ -4539,7 +4539,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 443
+      ID: 453
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1417920
@@ -4549,7 +4549,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 451
+      ID: 461
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1584384
@@ -4584,7 +4584,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 470
+      ID: 480
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1424000
@@ -4598,7 +4598,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 472
+      ID: 482
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1424160
@@ -4606,7 +4606,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 470 StructureType github.com/cihub/seelog.baseError
+          Type: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 763
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -4629,7 +4629,7 @@ Types:
           Offset: 8
           Type: 772 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 476
+      ID: 486
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1424480
@@ -4637,7 +4637,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 470 StructureType github.com/cihub/seelog.baseError
+          Type: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 767
       Name: github.com/cihub/seelog.splitDispatcher
@@ -4653,7 +4653,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 474
+      ID: 484
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1424320
@@ -4661,9 +4661,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 470 StructureType github.com/cihub/seelog.baseError
+          Type: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 478
+      ID: 488
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1424640
@@ -4671,7 +4671,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 470 StructureType github.com/cihub/seelog.baseError
+          Type: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 898
       Name: github.com/cihub/seelog/archive.Reader
@@ -4700,30 +4700,30 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 584
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 576
+      ID: 586
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 568
+      ID: 578
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 396
+      ID: 406
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1411040
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 580
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 616
+      ID: 626
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1830752
@@ -4739,11 +4739,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 620
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 554
+      ID: 564
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1684832
@@ -4756,7 +4756,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 622
+      ID: 632
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1831200
@@ -4772,13 +4772,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 517
+      ID: 527
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 980960
       GoKind: 8
     - __kind: StructureType
-      ID: 614
+      ID: 624
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1830528
@@ -4794,13 +4794,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 682
+      ID: 692
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 830720
       GoKind: 8
     - __kind: StructureType
-      ID: 612
+      ID: 622
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1830304
@@ -4808,15 +4808,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 682 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 692 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 682 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 692 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 620
+      ID: 630
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1745760
@@ -4829,7 +4829,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 618
+      ID: 628
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1830976
@@ -4845,7 +4845,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 626
+      ID: 636
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1619456
@@ -4855,19 +4855,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 558
+      ID: 568
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1270432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 556
+      ID: 566
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1270304
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 624
+      ID: 634
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1745952
@@ -4880,7 +4880,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 300
+      ID: 310
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835904
@@ -4888,22 +4888,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 302 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 312 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 301 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 311 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 301
+      ID: 311
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 663
+      ID: 673
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 590
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1433760
@@ -4913,19 +4913,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 303
+      ID: 313
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 836480
       GoKind: 10
     - __kind: BaseType
-      ID: 661
+      ID: 671
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 992576
       GoKind: 10
     - __kind: StructureType
-      ID: 634
+      ID: 644
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1863904
@@ -4936,12 +4936,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 661 BaseType golang.org/x/net/http2.ErrCode
+          Type: 671 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 501
+      ID: 511
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1591104
@@ -4949,12 +4949,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 661 BaseType golang.org/x/net/http2.ErrCode
+          Type: 671 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 317
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836672
@@ -4962,18 +4962,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 319 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 318 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 318
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 323
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836864
@@ -4981,18 +4981,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 325 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 314 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 324 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 324
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 320
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -5000,18 +5000,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 322 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 311 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 321 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 321
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 304
+      ID: 314
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836576
@@ -5019,18 +5019,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 306 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 316 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 305 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 315 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 305
+      ID: 315
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 505
+      ID: 515
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1435040
@@ -5040,13 +5040,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 316
+      ID: 326
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836960
       GoKind: 2
     - __kind: StructureType
-      ID: 480
+      ID: 490
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1429440
@@ -5056,11 +5056,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 642
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 652
+      ID: 662
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1890656
@@ -5076,7 +5076,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1590144
@@ -5093,7 +5093,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 578
+      ID: 588
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1550944
@@ -5107,25 +5107,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 462
+      ID: 472
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 582
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 640
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 638
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1497728
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 380
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -5371,16 +5371,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 227 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 233 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 232 GoMapType map[string]interface {}
+          Type: 238 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 720
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 242
+      ID: 252
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1897472
@@ -5479,11 +5479,11 @@ Types:
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 421
+      ID: 431
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 464
+      ID: 474
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1421280
@@ -5493,7 +5493,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 466
+      ID: 476
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1421440
@@ -5503,7 +5503,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 489
+      ID: 499
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5535,19 +5535,19 @@ Types:
       GroupType: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 801 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 236
+      ID: 246
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 237 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 247 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 238 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 958
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5577,63 +5577,63 @@ Types:
       GroupType: 823 StructureType noalg.map.group[string][]string
       GroupSliceType: 827 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 218
+      ID: 224
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 219 PointerType *noalg.map.group[string]float64
+          Type: 225 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 220 StructureType noalg.map.group[string]float64
-      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 226 StructureType noalg.map.group[string]float64
+      GroupSliceType: 230 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 687
+      ID: 697
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 688 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 698 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 689 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 693 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 703 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 210
+      ID: 216
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 211 PointerType *noalg.map.group[string]interface {}
+          Type: 217 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 212 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 218 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 208
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[string]string
+          Type: 209 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[string]string
-      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 210 StructureType noalg.map.group[string]string
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 508
+      ID: 518
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5680,7 +5680,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 410
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5706,11 +5706,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 398
+      ID: 408
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 618
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5718,13 +5718,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 606
+      ID: 616
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1465088
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 346
+      ID: 356
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5885,7 +5885,7 @@ Types:
           Offset: 0
           Type: 889 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 614
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -5953,7 +5953,7 @@ Types:
       TablePtrSliceType: 800 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 229
+      ID: 235
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -5966,7 +5966,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 230 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 236 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5982,8 +5982,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 238 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 253 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 954
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6078,10 +6078,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 223 GoSliceDataType []*table<string,float64>.array
-      GroupType: 220 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 229 GoSliceDataType []*table<string,float64>.array
+      GroupType: 226 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 658
+      ID: 668
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6094,7 +6094,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 659 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 669 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6110,8 +6110,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 692 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 689 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 702 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 164
       Name: map<string,interface {}>
@@ -6142,8 +6142,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 215 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 212 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 218 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 159
       Name: map<string,string>
@@ -6174,8 +6174,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 207 GoSliceDataType []*table<string,string>.array
-      GroupType: 204 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
+      GroupType: 210 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 135
       Name: map[context.canceler]struct {}
@@ -6191,12 +6191,12 @@ Types:
       GoKind: 21
       HeaderType: 774 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 227
+      ID: 233
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1124288
       GoKind: 21
-      HeaderType: 229 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 235 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 952
       Name: map[string][]*mime/multipart.FileHeader
@@ -6219,7 +6219,7 @@ Types:
       GoKind: 21
       HeaderType: 169 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 232
+      ID: 238
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1117280
@@ -6233,7 +6233,7 @@ Types:
       GoKind: 21
       HeaderType: 159 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 419
+      ID: 429
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1414240
@@ -6277,11 +6277,11 @@ Types:
           Offset: 8
           Type: 899 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 590
+      ID: 600
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 669
+      ID: 679
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1580864
@@ -6294,7 +6294,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 649
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6302,11 +6302,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 647
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 602
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6322,7 +6322,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 583
+      ID: 593
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1099104
@@ -6330,18 +6330,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 585 PointerType *net.UnknownNetworkError.str
+          Type: 595 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 584 GoStringDataType net.UnknownNetworkError.str
+      Data: 594 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 584
+      ID: 594
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 523
+      ID: 533
       Name: net.canceledError
       GoRuntimeType: 1267872
       GoKind: 25
@@ -6351,7 +6351,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 681
+      ID: 691
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2087776
@@ -6359,7 +6359,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 669 GoInterfaceType net.Conn
+          Type: 679 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -6386,7 +6386,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 318
+      ID: 328
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6403,7 +6403,7 @@ Types:
           Offset: 16
           Type: 115 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 320
+      ID: 330
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1705472
@@ -6411,7 +6411,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 664 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 674 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6445,11 +6445,11 @@ Types:
           Offset: 0
           Type: 929 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 594
+      ID: 604
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 651
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6499,11 +6499,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 326
+      ID: 336
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 525
+      ID: 535
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6555,7 +6555,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6600,7 +6600,7 @@ Types:
           Type: 839 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 157 GoMapType map[string]string
@@ -6637,7 +6637,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6710,19 +6710,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 245
+      ID: 255
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 827744
       GoKind: 10
     - __kind: BaseType
-      ID: 653
+      ID: 663
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 977120
       GoKind: 10
     - __kind: StructureType
-      ID: 329
+      ID: 339
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1707200
@@ -6733,12 +6733,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 653 BaseType net/http.http2ErrCode
+          Type: 663 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 643
+      ID: 653
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1881440
@@ -6749,7 +6749,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 653 BaseType net/http.http2ErrCode
+          Type: 663 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
@@ -6758,7 +6758,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 335
+      ID: 345
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1581344
@@ -6766,12 +6766,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 653 BaseType net/http.http2ErrCode
+          Type: 663 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 249
+      ID: 259
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 827936
@@ -6779,18 +6779,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 251 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 261 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 250 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 260 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 250
+      ID: 260
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 333
+      ID: 343
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1100384
       GoKind: 25
@@ -6800,7 +6800,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 255
+      ID: 265
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 828128
@@ -6808,18 +6808,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 257 PointerType *net/http.http2headerFieldNameError.str
+          Type: 267 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 256 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 266 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 256
+      ID: 266
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 252
+      ID: 262
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 828032
@@ -6827,18 +6827,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 254 PointerType *net/http.http2headerFieldValueError.str
+          Type: 264 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 253 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 263 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 253
+      ID: 263
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 598
+      ID: 608
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -6854,13 +6854,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 531
+      ID: 541
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1268512
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 246
+      ID: 256
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 827840
@@ -6868,13 +6868,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 248 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 258 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 247 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 257 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 247
+      ID: 257
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -6917,7 +6917,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 527
+      ID: 537
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1534944
@@ -6957,7 +6957,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 339
+      ID: 349
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1402880
@@ -7032,7 +7032,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 807 StructureType sync/atomic.Bool
@@ -7068,7 +7068,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 324
+      ID: 334
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1581184
@@ -7081,17 +7081,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 655
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 596
+      ID: 606
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1452928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 529
+      ID: 539
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1535104
@@ -7109,12 +7109,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 669 GoInterfaceType net.Conn
+          Type: 679 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 669 GoInterfaceType net.Conn
+          Type: 679 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 322
+      ID: 332
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7124,7 +7124,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 352
+      ID: 362
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1709696
@@ -7140,7 +7140,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 350
+      ID: 360
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1581824
@@ -7153,11 +7153,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 375
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 269
+      ID: 279
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 830240
@@ -7165,22 +7165,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 271 PointerType *net/textproto.ProtocolError.str
+          Type: 281 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 270 GoStringDataType net/textproto.ProtocolError.str
+      Data: 280 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 270
+      ID: 280
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 660
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 273
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 830048
@@ -7188,18 +7188,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *net/url.EscapeError.str
+          Type: 275 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 264 GoStringDataType net/url.EscapeError.str
+      Data: 274 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 274
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 276
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 830144
@@ -7207,13 +7207,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *net/url.InvalidHostError.str
+          Type: 278 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 267 GoStringDataType net/url.InvalidHostError.str
+      Data: 277 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 277
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7287,14 +7287,14 @@ Types:
       HasCount: true
       Element: 798 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 239
+      ID: 249
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 698624
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 240 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 250 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 961
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7314,41 +7314,41 @@ Types:
       HasCount: true
       Element: 825 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 221
+      ID: 227
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 698528
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem float64 }
+      Element: 228 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 690
+      ID: 700
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 754080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 691 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 701 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 213
+      ID: 219
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 675840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 214 StructureType noalg.struct { key string; elem interface {} }
+      Element: 220 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 205
+      ID: 211
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key string; elem string }
+      Element: 212 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 192
       Name: noalg.map.group[context.canceler]struct {}
@@ -7376,7 +7376,7 @@ Types:
           Offset: 8
           Type: 797 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 238
+      ID: 248
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1297056
@@ -7387,7 +7387,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 239 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 249 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 960
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7415,7 +7415,7 @@ Types:
           Offset: 8
           Type: 824 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 220
+      ID: 226
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1296800
@@ -7426,9 +7426,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 227 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 689
+      ID: 699
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1338528
@@ -7439,9 +7439,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 690 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 700 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 212
+      ID: 218
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1278496
@@ -7452,9 +7452,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 213 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 219 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 204
+      ID: 210
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1283360
@@ -7465,7 +7465,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 211 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 194
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7493,7 +7493,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 240
+      ID: 250
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1296928
@@ -7504,7 +7504,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 241 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 251 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 962
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7530,9 +7530,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 222
+      ID: 228
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1296672
@@ -7545,7 +7545,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 691
+      ID: 701
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1338400
@@ -7556,9 +7556,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 679 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 214
+      ID: 220
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1278368
@@ -7571,7 +7571,7 @@ Types:
           Offset: 16
           Type: 134 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 206
+      ID: 212
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1283232
@@ -7588,7 +7588,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 533
+      ID: 543
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7605,7 +7605,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 610
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7647,15 +7647,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 574
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 695
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 566
+      ID: 576
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1685024
@@ -7689,7 +7689,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 294
+      ID: 304
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 834560
@@ -7697,36 +7697,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 296 PointerType *os/user.UnknownGroupIdError.str
+          Type: 306 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 295 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 305 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 295
+      ID: 305
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 293
+      ID: 303
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 834464
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 348
+      ID: 358
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 423
+      ID: 433
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 551
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 555
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7738,7 +7738,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 543
+      ID: 553
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1870848
@@ -7755,9 +7755,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 683 BaseType runtime.boundsErrorCode
+          Type: 693 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 683
+      ID: 693
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 580800
@@ -7777,7 +7777,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 602
+      ID: 612
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1740192
@@ -7790,7 +7790,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 509
+      ID: 519
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 978368
@@ -7798,13 +7798,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 511 PointerType *runtime.errorString.str
+          Type: 521 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 510 GoStringDataType runtime.errorString.str
+      Data: 520 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 510
+      ID: 520
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8460,7 +8460,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 512
+      ID: 522
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 978464
@@ -8468,13 +8468,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 514 PointerType *runtime.plainError.str
+          Type: 524 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 513 GoStringDataType runtime.plainError.str
+      Data: 523 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 513
+      ID: 523
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8560,7 +8560,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 537
+      ID: 547
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8931,7 +8931,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 635
+      ID: 645
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1269408
@@ -8991,7 +8991,7 @@ Types:
           Offset: 16
           Type: 794 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 235
+      ID: 245
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9013,7 +9013,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 236 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 246 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 957
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9063,7 +9063,7 @@ Types:
           Offset: 16
           Type: 821 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 217
+      ID: 223
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9085,9 +9085,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 218 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 224 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 686
+      ID: 696
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9109,9 +9109,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 687 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 697 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 209
+      ID: 215
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9133,9 +9133,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 210 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 216 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 201
+      ID: 207
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9157,9 +9157,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<string,string>
+          Type: 208 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 582
+      ID: 592
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1689248
@@ -9189,10 +9189,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 701 GoSliceHeaderType []time.zone
+          Type: 199 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 704 GoSliceHeaderType []time.zoneTrans
+          Type: 202 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9204,12 +9204,12 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 702 PointerType *time.zone
+          Type: 200 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 352
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 143
       Name: time.Time
       ByteSize: 24
@@ -9225,6 +9225,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 144 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 142
       Name: time.Timer
@@ -9234,12 +9242,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 700 GoChannelType <-chan time.Time
+          Type: 710 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 258
+      ID: 268
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 828224
@@ -9247,18 +9255,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 260 PointerType *time.fileSizeError.str
+          Type: 270 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 259 GoStringDataType time.fileSizeError.str
+      Data: 269 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 259
+      ID: 269
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 703
+      ID: 201
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1602752
@@ -9274,7 +9282,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 706
+      ID: 204
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1737120
@@ -9335,7 +9343,7 @@ Types:
       GoRuntimeType: 580736
       GoKind: 26
     - __kind: StructureType
-      ID: 664
+      ID: 674
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2045152
@@ -9346,10 +9354,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 665 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 675 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 666 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 676 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9364,18 +9372,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 667 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 677 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 667
+      ID: 677
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 979424
       GoKind: 9
     - __kind: StructureType
-      ID: 665
+      ID: 675
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1899776
@@ -9400,17 +9408,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 364
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 666
+      ID: 676
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 581632
       GoKind: 8
     - __kind: StructureType
-      ID: 367
+      ID: 377
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1407840
@@ -9420,13 +9428,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 272
+      ID: 282
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 830336
       GoKind: 2
     - __kind: StructureType
-      ID: 550
+      ID: 560
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1684448
@@ -9439,7 +9447,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 516
+      ID: 526
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 980288

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -136,7 +136,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 675 PointerType *crypto/x509.Certificate
+      Pointee: 685 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 733
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -166,10 +166,10 @@ Types:
       ByteSize: 8
       Pointee: 797 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 235
+      ID: 241
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 236 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 242 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 976
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -186,10 +186,10 @@ Types:
       ByteSize: 8
       Pointee: 173 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 680
+      ID: 690
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 167
       Name: '**table<string,interface {}>'
@@ -237,30 +237,30 @@ Types:
       ByteSize: 8
       Pointee: 1005 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 718
+      ID: 728
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 717 GoSliceDataType []float64.array
+      Pointee: 727 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 231
+      ID: 237
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Pointee: 236 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: PointerType
-      ID: 239
+      ID: 245
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 244 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1011
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1010 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 205
+      ID: 211
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []os.Signal.array
+      Pointee: 210 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -269,20 +269,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 716
+      ID: 726
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 715 GoSliceDataType []string.array
+      Pointee: 725 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 729
+      ID: 247
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 728 GoSliceDataType []time.zone.array
+      Pointee: 246 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 731
+      ID: 249
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 730 GoSliceDataType []time.zoneTrans.array
+      Pointee: 248 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 998
       Name: '*[]uint8'
@@ -301,17 +301,17 @@ Types:
       ByteSize: 8
       Pointee: 189 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 946176
       GoKind: 22
-      Pointee: 509 GoSliceHeaderType archive/tar.headerError
+      Pointee: 519 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 510 GoSliceDataType archive/tar.headerError.array
+      Pointee: 520 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 902
       Name: '*archive/zip.checksumReader'
@@ -362,24 +362,24 @@ Types:
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 429
+      ID: 439
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 919488
       GoKind: 22
-      Pointee: 296 BaseType compress/flate.CorruptInputError
+      Pointee: 306 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 919584
       GoKind: 22
-      Pointee: 297 GoStringHeaderType compress/flate.InternalError
+      Pointee: 307 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 299
+      ID: 309
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType compress/flate.InternalError.str
+      Pointee: 308 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 938
       Name: '*compress/flate.decompressor'
@@ -409,12 +409,12 @@ Types:
       GoKind: 22
       Pointee: 119 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 605
+      ID: 615
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1182464
       GoKind: 22
-      Pointee: 606 StructureType context.deadlineExceededError
+      Pointee: 616 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1012
       Name: '*context.emptyCtx'
@@ -458,54 +458,54 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 425
+      ID: 435
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918240
       GoKind: 22
-      Pointee: 292 BaseType crypto/aes.KeySizeError
+      Pointee: 302 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918432
       GoKind: 22
-      Pointee: 293 BaseType crypto/des.KeySizeError
+      Pointee: 303 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 427
+      ID: 437
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918720
       GoKind: 22
-      Pointee: 294 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 304 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1053664
       GoKind: 22
-      Pointee: 587 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 597 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 295 BaseType crypto/rc4.KeySizeError
+      Pointee: 305 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 909024
       GoKind: 22
-      Pointee: 266 BaseType crypto/tls.AlertError
+      Pointee: 276 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1037920
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 573 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 968
       Name: '*crypto/tls.Conn'
@@ -521,213 +521,213 @@ Types:
       GoKind: 22
       Pointee: 856 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 367
+      ID: 377
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 368 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 378 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 365
+      ID: 375
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 366 StructureType crypto/tls.RecordHeaderError
+      Pointee: 376 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 561
+      ID: 571
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1036256
       GoKind: 22
-      Pointee: 530 BaseType crypto/tls.alert
+      Pointee: 540 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 908832
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 380 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 666
+      ID: 676
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1416032
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 677 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 675
+      ID: 685
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2043968
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 686 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 421
+      ID: 431
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 918048
       GoKind: 22
-      Pointee: 422 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 432 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 416 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 426 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 917664
       GoKind: 22
-      Pointee: 418 StructureType crypto/x509.HostnameError
+      Pointee: 428 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 291 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 301 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1046496
       GoKind: 22
-      Pointee: 579 StructureType crypto/x509.SystemRootsError
+      Pointee: 589 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 423
+      ID: 433
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 918144
       GoKind: 22
-      Pointee: 424 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 434 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 419
+      ID: 429
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 917952
       GoKind: 22
-      Pointee: 420 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 430 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 465
+      ID: 475
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 928416
       GoKind: 22
-      Pointee: 466 StructureType encoding/asn1.StructuralError
+      Pointee: 476 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 469
+      ID: 479
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 928608
       GoKind: 22
-      Pointee: 470 StructureType encoding/asn1.SyntaxError
+      Pointee: 480 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 928512
       GoKind: 22
-      Pointee: 468 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 478 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 372
+      ID: 382
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 909120
       GoKind: 22
-      Pointee: 267 BaseType encoding/base64.CorruptInputError
+      Pointee: 277 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 916224
       GoKind: 22
-      Pointee: 287 BaseType encoding/hex.InvalidByteError
+      Pointee: 297 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 391
+      ID: 401
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 392 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 402 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 574
+      ID: 584
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1042912
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 585 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 383
+      ID: 393
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 912288
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 394 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 390 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 400 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 912480
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 398 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 385
+      ID: 395
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 912384
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 396 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 913056
       GoKind: 22
-      Pointee: 394 StructureType encoding/json.jsonError
+      Pointee: 404 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 509 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 939936
       GoKind: 22
-      Pointee: 497 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 507 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 940128
       GoKind: 22
-      Pointee: 305 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 315 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 307
+      ID: 317
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 316 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 940224
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 512 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -736,19 +736,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 351
+      ID: 361
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 352 UnresolvedPointeeType errors.errorString
+      Pointee: 362 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1029216
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType errors.joinError
+      Pointee: 560 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -764,26 +764,26 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 533
+      ID: 543
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1018848
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType fmt.wrapError
+      Pointee: 544 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 535
+      ID: 545
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1018976
       GoKind: 22
-      Pointee: 536 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 546 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915744
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 415 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 798
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -792,200 +792,200 @@ Types:
       GoKind: 22
       Pointee: 799 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 396
+      ID: 406
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 397 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 407 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 914496
       GoKind: 22
-      Pointee: 399 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 409 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 695
+      ID: 705
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 914208
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 706 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 914784
       GoKind: 22
-      Pointee: 403 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 413 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 697
+      ID: 707
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 400
+      ID: 410
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 914592
       GoKind: 22
-      Pointee: 281 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 291 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 283
+      ID: 293
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 282 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 292 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 914112
       GoKind: 22
-      Pointee: 278 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 288 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 280
+      ID: 290
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 279 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 914688
       GoKind: 22
-      Pointee: 284 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 294 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 286
+      ID: 296
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 929280
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 485 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 929088
       GoKind: 22
-      Pointee: 300 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 310 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 472
+      ID: 482
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 929184
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
+      Pointee: 483 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 439
+      ID: 449
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 925248
       GoKind: 22
-      Pointee: 440 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 450 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 444 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 454 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 441
+      ID: 451
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 925344
       GoKind: 22
-      Pointee: 442 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 452 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 437
+      ID: 447
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 925152
       GoKind: 22
-      Pointee: 438 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 448 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 720
+      ID: 730
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 451
+      ID: 461
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 925824
       GoKind: 22
-      Pointee: 452 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 462 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 925536
       GoKind: 22
-      Pointee: 446 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 456 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 925728
       GoKind: 22
-      Pointee: 450 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 460 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 925632
       GoKind: 22
-      Pointee: 448 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 458 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 453
+      ID: 463
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 925920
       GoKind: 22
-      Pointee: 454 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 464 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 470 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 926304
       GoKind: 22
-      Pointee: 462 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 472 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 468 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 455
+      ID: 465
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 926016
       GoKind: 22
-      Pointee: 456 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 466 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 464 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 474 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 812
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1015,12 +1015,12 @@ Types:
       GoKind: 22
       Pointee: 811 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 484
+      ID: 494
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 937248
       GoKind: 22
-      Pointee: 485 StructureType github.com/cihub/seelog.baseError
+      Pointee: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 791
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1029,12 +1029,12 @@ Types:
       GoKind: 22
       Pointee: 792 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 937344
       GoKind: 22
-      Pointee: 487 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 497 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 783
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1057,12 +1057,12 @@ Types:
       GoKind: 22
       Pointee: 790 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 937536
       GoKind: 22
-      Pointee: 491 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 501 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 787
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1078,19 +1078,19 @@ Types:
       GoKind: 22
       Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 937440
       GoKind: 22
-      Pointee: 489 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 499 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 493 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 503 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 900
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1106,268 +1106,268 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 592
+      ID: 602
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1066080
       GoKind: 22
-      Pointee: 593 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 603 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 594
+      ID: 604
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1066208
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 605 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 584
+      ID: 594
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1050848
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 595 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 407
+      ID: 417
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 916416
       GoKind: 22
-      Pointee: 408 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 418 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 588
+      ID: 598
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1054432
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 599 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 634
+      ID: 644
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1204736
       GoKind: 22
-      Pointee: 635 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 628
+      ID: 638
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1204352
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 639 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1042016
       GoKind: 22
-      Pointee: 569 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 579 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1205120
       GoKind: 22
-      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1041888
       GoKind: 22
-      Pointee: 532 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 542 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 632
+      ID: 642
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1204608
       GoKind: 22
-      Pointee: 633 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 630
+      ID: 640
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1204480
       GoKind: 22
-      Pointee: 631 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1204992
       GoKind: 22
-      Pointee: 639 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 649 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 636
+      ID: 646
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1204864
       GoKind: 22
-      Pointee: 637 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 647 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 644
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1205504
       GoKind: 22
-      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1042272
       GoKind: 22
-      Pointee: 573 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 570
+      ID: 580
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1042144
       GoKind: 22
-      Pointee: 571 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 642
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1205376
       GoKind: 22
-      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 945408
       GoKind: 22
-      Pointee: 308 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 318 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 310
+      ID: 320
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 309 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 683
+      ID: 693
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1660448
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 694 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 598
+      ID: 608
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1082848
       GoKind: 22
-      Pointee: 599 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 609 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 512
+      ID: 522
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 947424
       GoKind: 22
-      Pointee: 311 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 321 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 652
+      ID: 662
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1258368
       GoKind: 22
-      Pointee: 653 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 663 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 515
+      ID: 525
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 947712
       GoKind: 22
-      Pointee: 516 StructureType golang.org/x/net/http2.connError
+      Pointee: 526 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 947616
       GoKind: 22
-      Pointee: 315 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 325 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 317
+      ID: 327
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 316 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 947904
       GoKind: 22
-      Pointee: 321 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 331 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 323
+      ID: 333
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 322 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 947808
       GoKind: 22
-      Pointee: 318 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 328 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 320
+      ID: 330
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 319 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 947520
       GoKind: 22
-      Pointee: 312 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 314
+      ID: 324
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 313 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 519
+      ID: 529
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 948000
       GoKind: 22
-      Pointee: 520 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 530 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 521
+      ID: 531
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 948096
       GoKind: 22
-      Pointee: 324 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 334 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 939456
       GoKind: 22
-      Pointee: 495 StructureType google.golang.org/grpc.dropError
+      Pointee: 505 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 650
+      ID: 660
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1255168
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 661 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 670
+      ID: 680
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1440512
       GoKind: 22
-      Pointee: 671 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 681 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 943680
       GoKind: 22
-      Pointee: 506 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 516 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 927
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1376,12 +1376,12 @@ Types:
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 596
+      ID: 606
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1077088
       GoKind: 22
-      Pointee: 597 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 607 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 911
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1390,40 +1390,40 @@ Types:
       GoKind: 22
       Pointee: 912 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 476
+      ID: 486
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 931488
       GoKind: 22
-      Pointee: 477 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 487 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 590
+      ID: 600
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1055840
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 601 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 648
+      ID: 658
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1221376
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 659 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 646
+      ID: 656
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1221120
       GoKind: 22
-      Pointee: 647 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 657 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 392 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 742
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
@@ -1481,12 +1481,12 @@ Types:
       GoKind: 22
       Pointee: 741 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 246
+      ID: 256
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1190400
       GoKind: 22
-      Pointee: 247 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 257 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 182
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
@@ -1523,40 +1523,40 @@ Types:
       GoKind: 22
       Pointee: 885 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 433
+      ID: 443
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 434 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 444 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932064
       GoKind: 22
-      Pointee: 479 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 489 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 480
+      ID: 490
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 932160
       GoKind: 22
-      Pointee: 481 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 491 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 940992
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 514 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 948864
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType html/template.Error
+      Pointee: 533 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -1593,33 +1593,33 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
-      ID: 672
+      ID: 682
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2205728
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType internal/abi.Type
+      Pointee: 683 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 917088
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 423 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 411 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 421 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1198208
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 637 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 966
       Name: '*internal/poll.FD'
@@ -1628,38 +1628,38 @@ Types:
       GoKind: 22
       Pointee: 967 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 624
+      ID: 634
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1198080
       GoKind: 22
-      Pointee: 625 StructureType internal/poll.errNetClosing
+      Pointee: 635 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 904320
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 364 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 409
+      ID: 419
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 916896
       GoKind: 22
-      Pointee: 288 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 298 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 290
+      ID: 300
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 299 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 576
+      ID: 586
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1045472
       GoKind: 22
-      Pointee: 577 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 587 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 931
       Name: '*io.PipeReader'
@@ -1689,12 +1689,12 @@ Types:
       GoKind: 22
       Pointee: 899 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 622
+      ID: 632
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1197056
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType io/fs.PathError
+      Pointee: 633 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 138
       Name: '*map<context.canceler,struct {}>'
@@ -1706,10 +1706,10 @@ Types:
       ByteSize: 8
       Pointee: 795 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 233
+      ID: 239
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 234 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 240 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 974
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1726,10 +1726,10 @@ Types:
       ByteSize: 8
       Pointee: 171 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 678
+      ID: 688
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 165
       Name: '*map<string,interface {}>'
@@ -1741,12 +1741,12 @@ Types:
       ByteSize: 8
       Pointee: 161 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920256
       GoKind: 22
-      Pointee: 432 StructureType math/big.ErrNaN
+      Pointee: 442 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 986
       Name: '*mime/multipart.FileHeader'
@@ -1776,19 +1776,19 @@ Types:
       GoKind: 22
       Pointee: 916 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1183616
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType net.AddrError
+      Pointee: 619 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1408352
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType net.DNSError
+      Pointee: 668 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 942
       Name: '*net.IPConn'
@@ -1797,19 +1797,19 @@ Types:
       GoKind: 22
       Pointee: 943 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1408032
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType net.OpError
+      Pointee: 666 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1183744
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType net.ParseError
+      Pointee: 621 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 950
       Name: '*net.TCPConn'
@@ -1832,24 +1832,24 @@ Types:
       GoKind: 22
       Pointee: 949 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 607
+      ID: 617
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1182848
       GoKind: 22
-      Pointee: 602 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 612 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 603 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 613 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 537
+      ID: 547
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1019872
       GoKind: 22
-      Pointee: 538 StructureType net.canceledError
+      Pointee: 548 StructureType net.canceledError
     - __kind: PointerType
       ID: 940
       Name: '*net.conn'
@@ -1858,12 +1858,12 @@ Types:
       GoKind: 22
       Pointee: 941 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 701
+      ID: 711
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1832736
       GoKind: 22
-      Pointee: 702 StructureType net.dialResult·1
+      Pointee: 712 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 956
       Name: '*net.netFD'
@@ -1872,12 +1872,12 @@ Types:
       GoKind: 22
       Pointee: 957 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 325
+      ID: 335
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 896928
       GoKind: 22
-      Pointee: 326 UnresolvedPointeeType net.notFoundError
+      Pointee: 336 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1013
       Name: '*net.onlyValuesCtx'
@@ -1886,12 +1886,12 @@ Types:
       GoKind: 22
       Pointee: 1014 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 897600
       GoKind: 22
-      Pointee: 328 StructureType net.result·2
+      Pointee: 338 StructureType net.result·2
     - __kind: PointerType
       ID: 946
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1907,33 +1907,33 @@ Types:
       GoKind: 22
       Pointee: 945 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 612
+      ID: 622
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1184384
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType net.temporaryError
+      Pointee: 623 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1408672
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType net.timeoutError
+      Pointee: 670 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 333
+      ID: 343
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 334 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 344 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1023328
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 550 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 112
       Name: '*net/http.Request'
@@ -1991,26 +1991,26 @@ Types:
       GoKind: 22
       Pointee: 879 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 900384
       GoKind: 22
-      Pointee: 250 BaseType net/http.http2ConnectionError
+      Pointee: 260 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 900480
       GoKind: 22
-      Pointee: 337 StructureType net/http.http2GoAwayError
+      Pointee: 347 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 661
+      ID: 671
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1409632
       GoKind: 22
-      Pointee: 662 StructureType net/http.http2StreamError
+      Pointee: 672 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 908
       Name: '*net/http.http2clientStream'
@@ -2019,31 +2019,31 @@ Types:
       GoKind: 22
       Pointee: 909 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 342
+      ID: 352
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 901536
       GoKind: 22
-      Pointee: 343 StructureType net/http.http2connError
+      Pointee: 353 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900960
       GoKind: 22
-      Pointee: 254 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 264 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 256
+      ID: 266
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 255 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 901056
       GoKind: 22
-      Pointee: 341 StructureType net/http.http2goAwayFlowError
+      Pointee: 351 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 872
       Name: '*net/http.http2gzipReader'
@@ -2052,36 +2052,36 @@ Types:
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 260 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 270 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 262
+      ID: 272
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 261 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 271 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 901632
       GoKind: 22
-      Pointee: 257 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 267 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 259
+      ID: 269
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 258 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 268 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 616
+      ID: 626
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1188224
       GoKind: 22
-      Pointee: 617 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 627 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 868
       Name: '*net/http.http2missingBody'
@@ -2097,24 +2097,24 @@ Types:
       GoKind: 22
       Pointee: 881 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 545
+      ID: 555
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1025632
       GoKind: 22
-      Pointee: 546 StructureType net/http.http2noCachedConnError
+      Pointee: 556 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 251 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 261 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 253
+      ID: 263
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 252 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 262 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 876
       Name: '*net/http.http2requestBody'
@@ -2158,12 +2158,12 @@ Types:
       GoKind: 22
       Pointee: 897 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 541
+      ID: 551
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1025248
       GoKind: 22
-      Pointee: 542 StructureType net/http.nothingWrittenError
+      Pointee: 552 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 860
       Name: '*net/http.pattern'
@@ -2186,12 +2186,12 @@ Types:
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 901920
       GoKind: 22
-      Pointee: 347 StructureType net/http.requestBodyReadError
+      Pointee: 357 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 781
       Name: '*net/http.response'
@@ -2207,33 +2207,33 @@ Types:
       GoKind: 22
       Pointee: 1009 StructureType net/http.segment
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 900096
       GoKind: 22
-      Pointee: 332 StructureType net/http.statusError
+      Pointee: 342 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 663
+      ID: 673
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1411232
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 674 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 614
+      ID: 624
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1188096
       GoKind: 22
-      Pointee: 615 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 625 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 543
+      ID: 553
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1025376
       GoKind: 22
-      Pointee: 544 StructureType net/http.transportReadFromServerError
+      Pointee: 554 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 929
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2242,12 +2242,12 @@ Types:
       GoKind: 22
       Pointee: 930 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 329
+      ID: 339
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 899328
       GoKind: 22
-      Pointee: 330 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 340 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 890
       Name: '*net/http/httputil.failureToReadBody'
@@ -2256,69 +2256,69 @@ Types:
       GoKind: 22
       Pointee: 891 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 362 StructureType net/netip.parseAddrError
+      Pointee: 372 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 906912
       GoKind: 22
-      Pointee: 360 StructureType net/netip.parsePrefixError
+      Pointee: 370 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 376
+      ID: 386
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 910368
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType net/textproto.Error
+      Pointee: 387 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 910272
       GoKind: 22
-      Pointee: 274 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 284 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 276
+      ID: 286
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 275 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 285 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 668
+      ID: 678
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1416352
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType net/url.Error
+      Pointee: 679 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 909216
       GoKind: 22
-      Pointee: 268 GoStringHeaderType net/url.EscapeError
+      Pointee: 278 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 270
+      ID: 280
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 269 GoStringDataType net/url.EscapeError.str
+      Pointee: 279 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 909312
       GoKind: 22
-      Pointee: 271 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 281 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 273
+      ID: 283
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 282 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 849
       Name: '*net/url.URL'
@@ -2344,10 +2344,10 @@ Types:
       ByteSize: 8
       Pointee: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 242
+      ID: 252
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 243 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 980
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2359,25 +2359,25 @@ Types:
       ByteSize: 8
       Pointee: 844 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 224
+      ID: 230
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[string]float64
+      Pointee: 231 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 709
+      ID: 719
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 216
+      ID: 222
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[string]interface {}
+      Pointee: 223 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 208
+      ID: 214
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[string]string
+      Pointee: 215 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 962
       Name: '*os.File'
@@ -2386,12 +2386,12 @@ Types:
       GoKind: 22
       Pointee: 963 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 547
+      ID: 557
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1027680
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType os.LinkError
+      Pointee: 558 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 151
       Name: '*os.Signal'
@@ -2400,12 +2400,12 @@ Types:
       GoKind: 22
       Pointee: 152 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1188608
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType os.SyscallError
+      Pointee: 629 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 960
       Name: '*os.fileWithoutReadFrom'
@@ -2421,26 +2421,26 @@ Types:
       GoKind: 22
       Pointee: 959 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 580
+      ID: 590
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1049440
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType os/exec.Error
+      Pointee: 591 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 705
+      ID: 715
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2089344
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 716 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 582
+      ID: 592
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1049568
       GoKind: 22
-      Pointee: 583 StructureType os/exec.wrappedError
+      Pointee: 593 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 128
       Name: '*os/signal.signalCtx'
@@ -2449,52 +2449,52 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 483
+      ID: 493
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 936288
       GoKind: 22
-      Pointee: 302 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 312 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 304
+      ID: 314
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 303 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 313 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 482
+      ID: 492
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 936192
       GoKind: 22
-      Pointee: 301 BaseType os/user.UnknownUserIdError
+      Pointee: 311 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 356 UnresolvedPointeeType reflect.ValueError
+      Pointee: 366 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 435
+      ID: 445
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 436 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 446 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1032288
       GoKind: 22
-      Pointee: 556 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 566 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 559
+      ID: 569
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1034080
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 570 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2510,12 +2510,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1032416
       GoKind: 22
-      Pointee: 558 StructureType runtime.boundsError
+      Pointee: 568 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -2531,24 +2531,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1196544
       GoKind: 22
-      Pointee: 621 StructureType runtime.errorAddressString
+      Pointee: 631 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 553
+      ID: 563
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1031904
       GoKind: 22
-      Pointee: 524 GoStringHeaderType runtime.errorString
+      Pointee: 534 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 526
+      ID: 536
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 525 GoStringDataType runtime.errorString.str
+      Pointee: 535 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2571,17 +2571,17 @@ Types:
       GoKind: 22
       Pointee: 191 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1032032
       GoKind: 22
-      Pointee: 527 GoStringHeaderType runtime.plainError
+      Pointee: 537 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 528 GoStringDataType runtime.plainError.str
+      Pointee: 538 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2597,12 +2597,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 357
+      ID: 367
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 358 StructureType runtime.synctestDeadlockError
+      Pointee: 368 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -2618,12 +2618,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 551
+      ID: 561
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1031520
       GoKind: 22
-      Pointee: 552 UnresolvedPointeeType strconv.NumError
+      Pointee: 562 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -2749,12 +2749,12 @@ Types:
       GoKind: 22
       Pointee: 893 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 665
+      ID: 675
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1415232
       GoKind: 22
-      Pointee: 654 BaseType syscall.Errno
+      Pointee: 664 BaseType syscall.Errno
     - __kind: PointerType
       ID: 738
       Name: '*syscall.Signal'
@@ -2773,10 +2773,10 @@ Types:
       ByteSize: 8
       Pointee: 814 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 236
+      ID: 242
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 240 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 250 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 977
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2791,29 +2791,29 @@ Types:
       ID: 173
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 222 StructureType table<string,float64>
+      Pointee: 228 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 681
+      ID: 691
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 707 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 717 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 168
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 214 StructureType table<string,interface {}>
+      Pointee: 220 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 163
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 206 StructureType table<string,string>
+      Pointee: 212 StructureType table<string,string>
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1087328
       GoKind: 22
-      Pointee: 601 StructureType text/template.ExecError
+      Pointee: 611 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 146
       Name: '*time.Location'
@@ -2822,12 +2822,12 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType time.Location
     - __kind: PointerType
-      ID: 349
+      ID: 359
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902784
       GoKind: 22
-      Pointee: 350 UnresolvedPointeeType time.ParseError
+      Pointee: 360 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 143
       Name: '*time.Timer'
@@ -2836,31 +2836,31 @@ Types:
       GoKind: 22
       Pointee: 144 StructureType time.Timer
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 263 GoStringHeaderType time.fileSizeError
+      Pointee: 273 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 265
+      ID: 275
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType time.fileSizeError.str
+      Pointee: 274 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 723
+      ID: 205
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394880
       GoKind: 22
-      Pointee: 724 StructureType time.zone
+      Pointee: 206 StructureType time.zone
     - __kind: PointerType
-      ID: 726
+      ID: 208
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394944
       GoKind: 22
-      Pointee: 727 StructureType time.zoneTrans
+      Pointee: 209 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -2904,47 +2904,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 363
+      ID: 373
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 907776
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 374 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 910560
       GoKind: 22
-      Pointee: 379 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 389 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 910656
       GoKind: 22
-      Pointee: 277 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 287 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1039456
       GoKind: 22
-      Pointee: 565 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 575 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 566
+      ID: 576
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1039584
       GoKind: 22
-      Pointee: 531 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 541 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 857
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
     - __kind: GoChannelType
-      ID: 721
+      ID: 731
       Name: <-chan time.Time
       GoRuntimeType: 600960
       GoKind: 18
@@ -3122,7 +3122,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 689
+      ID: 699
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 700928
@@ -3170,7 +3170,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 675 PointerType *crypto/x509.Certificate
+      Element: 685 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 732
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -3253,11 +3253,11 @@ Types:
       ByteSize: 8
       Element: 797 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 258
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 236 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 242 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 987
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3271,25 +3271,25 @@ Types:
       ByteSize: 8
       Element: 836 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 234
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 173 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 713
+      ID: 723
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 226
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 168 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 218
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3341,7 +3341,7 @@ Types:
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 694
+      ID: 704
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 496192
@@ -3356,9 +3356,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 717 GoSliceDataType []float64.array
+      Data: 727 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 717
+      ID: 727
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3379,9 +3379,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 230 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 236 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 236
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3402,9 +3402,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 238 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 244 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 244
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3445,11 +3445,11 @@ Types:
       ByteSize: 24
       Element: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 259
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 243 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 988
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3463,29 +3463,29 @@ Types:
       ByteSize: 328
       Element: 844 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 235
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 225 StructureType noalg.map.group[string]float64
+      Element: 231 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 724
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 227
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 217 StructureType noalg.map.group[string]interface {}
+      Element: 223 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 219
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 209 StructureType noalg.map.group[string]string
+      Element: 215 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 150
       Name: '[]os.Signal'
@@ -3502,9 +3502,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 204 GoSliceDataType []os.Signal.array
+      Data: 210 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 210
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3514,7 +3514,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 693
+      ID: 703
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -3529,15 +3529,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 715 GoSliceDataType []string.array
+      Data: 725 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 715
+      ID: 725
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 722
+      ID: 204
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489504
@@ -3545,22 +3545,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 723 PointerType *time.zone
+          Type: 205 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 728 GoSliceDataType []time.zone.array
+      Data: 246 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 728
+      ID: 246
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 724 StructureType time.zone
+      Element: 206 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 725
+      ID: 207
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489568
@@ -3568,20 +3568,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 726 PointerType *time.zoneTrans
+          Type: 208 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 730 GoSliceDataType []time.zoneTrans.array
+      Data: 248 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 730
+      ID: 248
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 727 StructureType time.zoneTrans
+      Element: 209 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3629,7 +3629,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 509
+      ID: 519
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 946272
@@ -3644,9 +3644,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 510 GoSliceDataType archive/tar.headerError.array
+      Data: 520 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 510
+      ID: 520
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3704,13 +3704,13 @@ Types:
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: BaseType
-      ID: 296
+      ID: 306
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 838112
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 307
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 838208
@@ -3718,13 +3718,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *compress/flate.InternalError.str
+          Type: 309 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType compress/flate.InternalError.str
+      Data: 308 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 308
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3808,7 +3808,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 606
+      ID: 616
       Name: context.deadlineExceededError
       GoRuntimeType: 1457792
       GoKind: 25
@@ -3852,7 +3852,7 @@ Types:
           Type: 143 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 145 StructureType time.Time
+          Type: 145 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3898,43 +3898,43 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 292
+      ID: 302
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837728
       GoKind: 2
     - __kind: BaseType
-      ID: 293
+      ID: 303
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837824
       GoKind: 2
     - __kind: BaseType
-      ID: 294
+      ID: 304
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837920
       GoKind: 2
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1283264
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 295
+      ID: 305
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838016
       GoKind: 2
     - __kind: BaseType
-      ID: 266
+      ID: 276
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835328
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 573
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4006,11 +4006,11 @@ Types:
       GoRuntimeType: 835040
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 368
+      ID: 378
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 366
+      ID: 376
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1722848
@@ -4021,10 +4021,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 689 ArrayType [5]uint8
+          Type: 699 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 690 GoInterfaceType net.Conn
+          Type: 700 GoInterfaceType net.Conn
     - __kind: BaseType
       ID: 1000
       Name: crypto/tls.SignatureScheme
@@ -4032,25 +4032,25 @@ Types:
       GoRuntimeType: 835136
       GoKind: 9
     - __kind: BaseType
-      ID: 530
+      ID: 540
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 987552
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 380
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 677
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 686
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 422
+      ID: 432
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1724960
@@ -4058,21 +4058,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 685 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 699 BaseType crypto/x509.InvalidReason
+          Type: 709 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 416
+      ID: 426
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1114304
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 418
+      ID: 428
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1593280
@@ -4080,24 +4080,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 685 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 291
+      ID: 301
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 837536
       GoKind: 2
     - __kind: BaseType
-      ID: 699
+      ID: 709
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 588224
       GoKind: 2
     - __kind: StructureType
-      ID: 579
+      ID: 589
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1554208
@@ -4107,13 +4107,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 424
+      ID: 434
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1114560
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 420
+      ID: 430
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1724768
@@ -4121,15 +4121,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 685 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 685 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 466
+      ID: 476
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1428352
@@ -4139,7 +4139,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 470
+      ID: 480
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1428512
@@ -4149,47 +4149,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 468
+      ID: 478
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 267
+      ID: 277
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 6
     - __kind: BaseType
-      ID: 287
+      ID: 297
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 837248
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 392
+      ID: 402
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 585
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 394
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 390
+      ID: 400
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 398
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 396
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 394
+      ID: 404
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1419392
@@ -4199,15 +4199,15 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 509
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 497
+      ID: 507
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 305
+      ID: 315
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 840800
@@ -4215,18 +4215,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *encoding/xml.UnmarshalError.str
+          Type: 317 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 306 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 316 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 316
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 512
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4243,11 +4243,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 352
+      ID: 362
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 560
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4263,11 +4263,11 @@ Types:
       GoRuntimeType: 585408
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 544
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 536
+      ID: 546
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4301,7 +4301,7 @@ Types:
       GoRuntimeType: 1003296
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 415
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4311,7 +4311,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 397
+      ID: 407
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1724000
@@ -4319,7 +4319,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 691 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 701 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4327,25 +4327,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 399
+      ID: 409
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 706
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 403
+      ID: 413
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1113408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 708
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 281
+      ID: 291
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 836672
@@ -4353,18 +4353,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 283 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 293 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 282 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 292 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 282
+      ID: 292
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 691
+      ID: 701
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2212896
@@ -4372,13 +4372,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 692 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 702 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4387,7 +4387,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 694 GoSliceHeaderType []float64
+          Type: 704 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4396,13 +4396,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 695 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 705 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 697 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 707 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4413,13 +4413,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 692
+      ID: 702
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 587008
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 278
+      ID: 288
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 836576
@@ -4427,18 +4427,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 280 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 290 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 279 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 279
+      ID: 289
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 294
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -4446,36 +4446,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 296 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 285 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 295
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 475
+      ID: 485
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1117248
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 300
+      ID: 310
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 839360
       GoKind: 2
     - __kind: StructureType
-      ID: 473
+      ID: 483
       Name: github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
       GoRuntimeType: 1117120
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 440
+      ID: 450
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1594080
@@ -4488,7 +4488,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 444
+      ID: 454
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1726688
@@ -4504,7 +4504,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 442
+      ID: 452
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1426912
@@ -4514,7 +4514,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 438
+      ID: 448
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1426592
@@ -4524,14 +4524,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 677
+      ID: 687
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1499872
       GoKind: 21
-      HeaderType: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 700
+      ID: 710
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1050464
@@ -4546,15 +4546,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 719
+      ID: 729
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 452
+      ID: 462
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1594400
@@ -4562,12 +4562,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 446
+      ID: 456
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1427072
@@ -4577,7 +4577,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 450
+      ID: 460
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1726880
@@ -4588,12 +4588,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 448
+      ID: 458
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1594240
@@ -4606,7 +4606,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 454
+      ID: 464
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1427232
@@ -4614,9 +4614,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 145 StructureType time.Time
+          Type: 145 GoTimeType time.Time
     - __kind: StructureType
-      ID: 460
+      ID: 470
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1594720
@@ -4629,7 +4629,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 462
+      ID: 472
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1427552
@@ -4639,7 +4639,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 458
+      ID: 468
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1594560
@@ -4652,7 +4652,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 456
+      ID: 466
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1427392
@@ -4662,7 +4662,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 464
+      ID: 474
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1594880
@@ -4697,7 +4697,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 485
+      ID: 495
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1433472
@@ -4711,7 +4711,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 487
+      ID: 497
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1433632
@@ -4719,7 +4719,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 485 StructureType github.com/cihub/seelog.baseError
+          Type: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 784
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -4742,7 +4742,7 @@ Types:
           Offset: 8
           Type: 793 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1433952
@@ -4750,7 +4750,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 485 StructureType github.com/cihub/seelog.baseError
+          Type: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 788
       Name: github.com/cihub/seelog.splitDispatcher
@@ -4766,7 +4766,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 489
+      ID: 499
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1433792
@@ -4774,9 +4774,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 485 StructureType github.com/cihub/seelog.baseError
+          Type: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 493
+      ID: 503
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1434112
@@ -4784,7 +4784,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 485 StructureType github.com/cihub/seelog.baseError
+          Type: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 919
       Name: github.com/cihub/seelog/archive.Reader
@@ -4813,30 +4813,30 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 593
+      ID: 603
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 605
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 595
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 408
+      ID: 418
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1420672
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 599
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 635
+      ID: 645
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1845280
@@ -4852,11 +4852,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 639
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 569
+      ID: 579
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1696256
@@ -4869,7 +4869,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 641
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1845728
@@ -4885,13 +4885,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 532
+      ID: 542
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 988704
       GoKind: 8
     - __kind: StructureType
-      ID: 633
+      ID: 643
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1845056
@@ -4907,13 +4907,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 703
+      ID: 713
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 836192
       GoKind: 8
     - __kind: StructureType
-      ID: 631
+      ID: 641
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1844832
@@ -4921,15 +4921,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 639
+      ID: 649
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1759488
@@ -4942,7 +4942,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 637
+      ID: 647
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1845504
@@ -4958,7 +4958,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 645
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1630304
@@ -4968,19 +4968,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 573
+      ID: 583
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1279808
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 571
+      ID: 581
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1279680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 643
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1759680
@@ -4993,7 +4993,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 308
+      ID: 318
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 841472
@@ -5001,22 +5001,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 310 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 320 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 309 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 309
+      ID: 319
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 694
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 599
+      ID: 609
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1443232
@@ -5026,19 +5026,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 311
+      ID: 321
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 842048
       GoKind: 10
     - __kind: BaseType
-      ID: 682
+      ID: 692
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1000320
       GoKind: 10
     - __kind: StructureType
-      ID: 653
+      ID: 663
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1877760
@@ -5049,12 +5049,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 682 BaseType golang.org/x/net/http2.ErrCode
+          Type: 692 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 516
+      ID: 526
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1601600
@@ -5062,12 +5062,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 682 BaseType golang.org/x/net/http2.ErrCode
+          Type: 692 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 315
+      ID: 325
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 842240
@@ -5075,18 +5075,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 317 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 327 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 316 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 316
+      ID: 326
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 321
+      ID: 331
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 842432
@@ -5094,18 +5094,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 323 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 333 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 322 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 322
+      ID: 332
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 318
+      ID: 328
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 842336
@@ -5113,18 +5113,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 320 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 330 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 319 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 319
+      ID: 329
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 312
+      ID: 322
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 842144
@@ -5132,18 +5132,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 314 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 324 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 313 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 313
+      ID: 323
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 520
+      ID: 530
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1444512
@@ -5153,13 +5153,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 324
+      ID: 334
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 842528
       GoKind: 2
     - __kind: StructureType
-      ID: 495
+      ID: 505
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1438912
@@ -5169,11 +5169,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 661
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 671
+      ID: 681
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1904832
@@ -5189,7 +5189,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 506
+      ID: 516
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1600640
@@ -5206,7 +5206,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 597
+      ID: 607
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1561568
@@ -5220,25 +5220,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 477
+      ID: 487
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 601
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 659
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 647
+      ID: 657
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1508032
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 392
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -5484,16 +5484,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 232 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 238 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 237 GoMapType map[string]interface {}
+          Type: 243 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 741
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 247
+      ID: 257
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1912128
@@ -5592,11 +5592,11 @@ Types:
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 434
+      ID: 444
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 479
+      ID: 489
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1430752
@@ -5606,7 +5606,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 481
+      ID: 491
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1430912
@@ -5616,7 +5616,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 514
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5648,19 +5648,19 @@ Types:
       GroupType: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 822 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 241
+      ID: 251
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 242 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 252 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 243 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 979
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5690,63 +5690,63 @@ Types:
       GroupType: 844 StructureType noalg.map.group[string][]string
       GroupSliceType: 848 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 229
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[string]float64
+          Type: 230 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[string]float64
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 231 StructureType noalg.map.group[string]float64
+      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 708
+      ID: 718
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 709 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 719 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 714 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 724 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 221
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[string]interface {}
+          Type: 222 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 223 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 227 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 213
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[string]string
+          Type: 214 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 215 StructureType noalg.map.group[string]string
+      GroupSliceType: 219 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 533
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5793,11 +5793,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 683
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 423
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5823,11 +5823,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 411
+      ID: 421
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 637
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5835,13 +5835,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 625
+      ID: 635
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1475392
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 364
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5922,7 +5922,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 298
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 837440
@@ -5930,18 +5930,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 300 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 299 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 299
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 577
+      ID: 587
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1553248
@@ -5949,7 +5949,7 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 672 PointerType *internal/abi.Type
+          Type: 682 PointerType *internal/abi.Type
     - __kind: StructureType
       ID: 134
       Name: internal/sync.Mutex
@@ -6031,7 +6031,7 @@ Types:
           Offset: 0
           Type: 910 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 633
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6105,7 +6105,7 @@ Types:
       TablePtrSliceType: 821 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 234
+      ID: 240
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6118,7 +6118,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 235 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 241 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6137,8 +6137,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 243 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 258 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 975
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6242,10 +6242,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<string,float64>.array
-      GroupType: 225 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 234 GoSliceDataType []*table<string,float64>.array
+      GroupType: 231 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 679
+      ID: 689
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6258,7 +6258,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 680 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 690 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6277,8 +6277,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 713 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 723 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 166
       Name: map<string,interface {}>
@@ -6312,8 +6312,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 217 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 226 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 223 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 161
       Name: map<string,string>
@@ -6347,8 +6347,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 209 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 218 GoSliceDataType []*table<string,string>.array
+      GroupType: 215 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 137
       Name: map[context.canceler]struct {}
@@ -6364,12 +6364,12 @@ Types:
       GoKind: 21
       HeaderType: 795 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 232
+      ID: 238
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1133344
       GoKind: 21
-      HeaderType: 234 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 240 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 973
       Name: map[string][]*mime/multipart.FileHeader
@@ -6392,7 +6392,7 @@ Types:
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 237
+      ID: 243
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1126592
@@ -6406,7 +6406,7 @@ Types:
       GoKind: 21
       HeaderType: 161 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 432
+      ID: 442
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1423552
@@ -6450,11 +6450,11 @@ Types:
           Offset: 8
           Type: 920 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 619
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 690
+      ID: 700
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1590880
@@ -6467,7 +6467,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 668
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6475,11 +6475,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 666
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 621
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6495,7 +6495,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 602
+      ID: 612
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1108288
@@ -6503,18 +6503,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 604 PointerType *net.UnknownNetworkError.str
+          Type: 614 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 603 GoStringDataType net.UnknownNetworkError.str
+      Data: 613 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 603
+      ID: 613
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 538
+      ID: 548
       Name: net.canceledError
       GoRuntimeType: 1277248
       GoKind: 25
@@ -6524,7 +6524,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 712
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2101280
@@ -6532,7 +6532,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 690 GoInterfaceType net.Conn
+          Type: 700 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -6559,7 +6559,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 326
+      ID: 336
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6576,7 +6576,7 @@ Types:
           Offset: 16
           Type: 117 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 328
+      ID: 338
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1718240
@@ -6584,7 +6584,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 685 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 695 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6618,11 +6618,11 @@ Types:
           Offset: 0
           Type: 950 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 623
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 670
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6672,11 +6672,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 334
+      ID: 344
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 550
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6728,7 +6728,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6773,7 +6773,7 @@ Types:
           Type: 860 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 159 GoMapType map[string]string
@@ -6810,7 +6810,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6883,19 +6883,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 250
+      ID: 260
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 833312
       GoKind: 10
     - __kind: BaseType
-      ID: 674
+      ID: 684
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 984768
       GoKind: 10
     - __kind: StructureType
-      ID: 337
+      ID: 347
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1719968
@@ -6906,12 +6906,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 684 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 672
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1894848
@@ -6922,7 +6922,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 684 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
@@ -6931,7 +6931,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 343
+      ID: 353
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1591360
@@ -6939,12 +6939,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 684 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 254
+      ID: 264
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833504
@@ -6952,18 +6952,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 256 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 266 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 255 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 255
+      ID: 265
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 341
+      ID: 351
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1109568
       GoKind: 25
@@ -6973,7 +6973,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 260
+      ID: 270
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833696
@@ -6981,18 +6981,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 262 PointerType *net/http.http2headerFieldNameError.str
+          Type: 272 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 261 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 271 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 261
+      ID: 271
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 257
+      ID: 267
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 833600
@@ -7000,18 +7000,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 259 PointerType *net/http.http2headerFieldValueError.str
+          Type: 269 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 258 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 268 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 258
+      ID: 268
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 617
+      ID: 627
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -7027,13 +7027,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 546
+      ID: 556
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1277888
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 251
+      ID: 261
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833408
@@ -7041,13 +7041,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 253 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 263 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 252 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 262 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 252
+      ID: 262
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7090,7 +7090,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 542
+      ID: 552
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1545568
@@ -7130,7 +7130,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 347
+      ID: 357
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1412032
@@ -7205,7 +7205,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 828 StructureType sync/atomic.Bool
@@ -7244,7 +7244,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 332
+      ID: 342
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1591200
@@ -7257,17 +7257,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 674
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 615
+      ID: 625
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1462432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 544
+      ID: 554
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1545728
@@ -7285,12 +7285,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 690 GoInterfaceType net.Conn
+          Type: 700 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 690 GoInterfaceType net.Conn
+          Type: 700 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 330
+      ID: 340
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7300,7 +7300,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 362
+      ID: 372
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1722464
@@ -7316,7 +7316,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 360
+      ID: 370
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1592320
@@ -7329,11 +7329,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 387
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 274
+      ID: 284
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835712
@@ -7341,22 +7341,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 276 PointerType *net/textproto.ProtocolError.str
+          Type: 286 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 275 GoStringDataType net/textproto.ProtocolError.str
+      Data: 285 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 275
+      ID: 285
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 679
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 268
+      ID: 278
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 835520
@@ -7364,18 +7364,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 270 PointerType *net/url.EscapeError.str
+          Type: 280 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 269 GoStringDataType net/url.EscapeError.str
+      Data: 279 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 269
+      ID: 279
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 281
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 835616
@@ -7383,13 +7383,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *net/url.InvalidHostError.str
+          Type: 283 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 272 GoStringDataType net/url.InvalidHostError.str
+      Data: 282 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 282
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7463,14 +7463,14 @@ Types:
       HasCount: true
       Element: 819 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 244
+      ID: 254
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 703616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 245 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 255 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 982
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7490,41 +7490,41 @@ Types:
       HasCount: true
       Element: 846 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 226
+      ID: 232
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 703520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key string; elem float64 }
+      Element: 233 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 711
+      ID: 721
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 760672
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 712 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 722 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 218
+      ID: 224
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 681216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key string; elem interface {} }
+      Element: 225 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 210
+      ID: 216
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key string; elem string }
+      Element: 217 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 197
       Name: noalg.map.group[context.canceler]struct {}
@@ -7552,7 +7552,7 @@ Types:
           Offset: 8
           Type: 818 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 243
+      ID: 253
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1306048
@@ -7563,7 +7563,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 244 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 254 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 981
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7591,7 +7591,7 @@ Types:
           Offset: 8
           Type: 845 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 225
+      ID: 231
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1305792
@@ -7602,9 +7602,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 232 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 710
+      ID: 720
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1347648
@@ -7615,9 +7615,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 711 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 721 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 217
+      ID: 223
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1287872
@@ -7628,9 +7628,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 224 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 209
+      ID: 215
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1292864
@@ -7641,7 +7641,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 216 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 199
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7669,7 +7669,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 245
+      ID: 255
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1305920
@@ -7680,7 +7680,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 246 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 256 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 983
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7706,9 +7706,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 227
+      ID: 233
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1305664
@@ -7721,7 +7721,7 @@ Types:
           Offset: 16
           Type: 17 BaseType float64
     - __kind: StructureType
-      ID: 712
+      ID: 722
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1347520
@@ -7732,9 +7732,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 219
+      ID: 225
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1287744
@@ -7747,7 +7747,7 @@ Types:
           Offset: 16
           Type: 136 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 211
+      ID: 217
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1292736
@@ -7764,7 +7764,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 558
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7781,7 +7781,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 629
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7823,15 +7823,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 591
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 716
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 583
+      ID: 593
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1696448
@@ -7865,7 +7865,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 302
+      ID: 312
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 840128
@@ -7873,36 +7873,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 304 PointerType *os/user.UnknownGroupIdError.str
+          Type: 314 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 303 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 313 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 303
+      ID: 313
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 301
+      ID: 311
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 840032
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 356
+      ID: 366
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 436
+      ID: 446
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 556
+      ID: 566
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 570
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7914,7 +7914,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 558
+      ID: 568
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1884704
@@ -7931,9 +7931,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 704 BaseType runtime.boundsErrorCode
+          Type: 714 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 704
+      ID: 714
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585600
@@ -7953,7 +7953,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 621
+      ID: 631
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1754112
@@ -7966,7 +7966,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 524
+      ID: 534
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 986016
@@ -7974,13 +7974,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 526 PointerType *runtime.errorString.str
+          Type: 536 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 525 GoStringDataType runtime.errorString.str
+      Data: 535 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 525
+      ID: 535
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8643,7 +8643,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 527
+      ID: 537
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 986112
@@ -8651,13 +8651,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 529 PointerType *runtime.plainError.str
+          Type: 539 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 528 GoStringDataType runtime.plainError.str
+      Data: 538 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 528
+      ID: 538
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8698,7 +8698,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 358
+      ID: 368
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1592000
@@ -8756,7 +8756,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 552
+      ID: 562
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9127,7 +9127,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 654
+      ID: 664
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1278784
@@ -9187,7 +9187,7 @@ Types:
           Offset: 16
           Type: 815 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 240
+      ID: 250
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9209,7 +9209,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 241 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 251 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 978
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9259,7 +9259,7 @@ Types:
           Offset: 16
           Type: 842 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 222
+      ID: 228
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9281,9 +9281,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 229 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 707
+      ID: 717
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9305,9 +9305,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 708 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 718 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 214
+      ID: 220
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9329,9 +9329,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 221 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 206
+      ID: 212
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9353,9 +9353,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<string,string>
+          Type: 213 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 601
+      ID: 611
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1700672
@@ -9385,10 +9385,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 722 GoSliceHeaderType []time.zone
+          Type: 204 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 725 GoSliceHeaderType []time.zoneTrans
+          Type: 207 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9400,12 +9400,12 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 723 PointerType *time.zone
+          Type: 205 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 350
+      ID: 360
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 145
       Name: time.Time
       ByteSize: 24
@@ -9421,6 +9421,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 146 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 144
       Name: time.Timer
@@ -9430,12 +9438,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 721 GoChannelType <-chan time.Time
+          Type: 731 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 273
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 833792
@@ -9443,18 +9451,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *time.fileSizeError.str
+          Type: 275 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 264 GoStringDataType time.fileSizeError.str
+      Data: 274 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 274
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 724
+      ID: 206
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1613408
@@ -9470,7 +9478,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 727
+      ID: 209
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1750848
@@ -9531,7 +9539,7 @@ Types:
       GoRuntimeType: 585536
       GoKind: 26
     - __kind: StructureType
-      ID: 685
+      ID: 695
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2058368
@@ -9542,10 +9550,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 686 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 696 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 687 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 697 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9560,18 +9568,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 688 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 698 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 688
+      ID: 698
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 987168
       GoKind: 9
     - __kind: StructureType
-      ID: 686
+      ID: 696
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1914944
@@ -9596,17 +9604,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 374
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 687
+      ID: 697
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 586432
       GoKind: 8
     - __kind: StructureType
-      ID: 379
+      ID: 389
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1417472
@@ -9616,13 +9624,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 277
+      ID: 287
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835808
       GoKind: 2
     - __kind: StructureType
-      ID: 565
+      ID: 575
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1695872
@@ -9635,7 +9643,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 531
+      ID: 541
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 988032

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.26rc1.yaml
@@ -136,7 +136,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 685 PointerType *crypto/x509.Certificate
+      Pointee: 695 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 743
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -166,10 +166,10 @@ Types:
       ByteSize: 8
       Pointee: 807 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 245
+      ID: 251
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 246 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 252 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 986
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -186,10 +186,10 @@ Types:
       ByteSize: 8
       Pointee: 183 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 690
+      ID: 700
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 701 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '**table<string,interface {}>'
@@ -237,30 +237,30 @@ Types:
       ByteSize: 8
       Pointee: 1015 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 728
+      ID: 738
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 727 GoSliceDataType []float64.array
+      Pointee: 737 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 241
+      ID: 247
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Pointee: 246 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: PointerType
-      ID: 249
+      ID: 255
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 254 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1021
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1020 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 215
+      ID: 221
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []os.Signal.array
+      Pointee: 220 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -269,20 +269,20 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 726
+      ID: 736
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 725 GoSliceDataType []string.array
+      Pointee: 735 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 739
+      ID: 257
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 738 GoSliceDataType []time.zone.array
+      Pointee: 256 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 741
+      ID: 259
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 740 GoSliceDataType []time.zoneTrans.array
+      Pointee: 258 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1008
       Name: '*[]uint8'
@@ -301,17 +301,17 @@ Types:
       ByteSize: 8
       Pointee: 199 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 955616
       GoKind: 22
-      Pointee: 519 GoSliceHeaderType archive/tar.headerError
+      Pointee: 529 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 521
+      ID: 531
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 520 GoSliceDataType archive/tar.headerError.array
+      Pointee: 530 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 908
       Name: '*archive/zip.checksumReader'
@@ -369,24 +369,24 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 919520
       GoKind: 22
-      Pointee: 291 BaseType compress/flate.CorruptInputError
+      Pointee: 301 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 394
+      ID: 404
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 919616
       GoKind: 22
-      Pointee: 292 GoStringHeaderType compress/flate.InternalError
+      Pointee: 302 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 294
+      ID: 304
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 293 GoStringDataType compress/flate.InternalError.str
+      Pointee: 303 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 948
       Name: '*compress/flate.decompressor'
@@ -423,12 +423,12 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1190656
       GoKind: 22
-      Pointee: 616 StructureType context.deadlineExceededError
+      Pointee: 626 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1022
       Name: '*context.emptyCtx'
@@ -472,54 +472,54 @@ Types:
       GoKind: 22
       Pointee: 135 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 442
+      ID: 452
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928256
       GoKind: 22
-      Pointee: 310 BaseType crypto/aes.KeySizeError
+      Pointee: 320 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928448
       GoKind: 22
-      Pointee: 311 BaseType crypto/des.KeySizeError
+      Pointee: 321 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 444
+      ID: 454
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928736
       GoKind: 22
-      Pointee: 312 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 322 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 596
+      ID: 606
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1063008
       GoKind: 22
-      Pointee: 597 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 607 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929024
       GoKind: 22
-      Pointee: 313 BaseType crypto/rc4.KeySizeError
+      Pointee: 323 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 280 BaseType crypto/tls.AlertError
+      Pointee: 290 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1047392
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 583 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 978
       Name: '*crypto/tls.Conn'
@@ -535,187 +535,187 @@ Types:
       GoKind: 22
       Pointee: 866 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 383
+      ID: 393
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 917696
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 394 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 381 StructureType crypto/tls.RecordHeaderError
+      Pointee: 391 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 571
+      ID: 581
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1045728
       GoKind: 22
-      Pointee: 540 BaseType crypto/tls.alert
+      Pointee: 550 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 385
+      ID: 395
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 917792
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 396 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 676
+      ID: 686
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1426304
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 687 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 685
+      ID: 695
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2034784
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 696 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 927872
       GoKind: 22
-      Pointee: 439 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 449 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 433 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 443 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 927392
       GoKind: 22
-      Pointee: 435 StructureType crypto/x509.HostnameError
+      Pointee: 445 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 309 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 319 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 588
+      ID: 598
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1056096
       GoKind: 22
-      Pointee: 589 StructureType crypto/x509.SystemRootsError
+      Pointee: 599 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 440
+      ID: 450
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 927968
       GoKind: 22
-      Pointee: 441 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 451 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 437 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 447 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 480
+      ID: 490
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 937952
       GoKind: 22
-      Pointee: 481 StructureType encoding/asn1.StructuralError
+      Pointee: 491 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 484
+      ID: 494
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 938144
       GoKind: 22
-      Pointee: 485 StructureType encoding/asn1.SyntaxError
+      Pointee: 495 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 482
+      ID: 492
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 938048
       GoKind: 22
-      Pointee: 483 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 493 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 917984
       GoKind: 22
-      Pointee: 281 BaseType encoding/base64.CorruptInputError
+      Pointee: 291 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 423
+      ID: 433
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 305 BaseType encoding/hex.InvalidByteError
+      Pointee: 315 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922016
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 419 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 584
+      ID: 594
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1052384
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 595 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 400
+      ID: 410
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 921632
       GoKind: 22
-      Pointee: 401 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 411 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 921920
       GoKind: 22
-      Pointee: 407 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 417 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 921824
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 415 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 921728
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 413 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 922400
       GoKind: 22
-      Pointee: 411 StructureType encoding/json.jsonError
+      Pointee: 421 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 949664
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 522 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -724,19 +724,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 365
+      ID: 375
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 912512
       GoKind: 22
-      Pointee: 366 UnresolvedPointeeType errors.errorString
+      Pointee: 376 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 559
+      ID: 569
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1038560
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType errors.joinError
+      Pointee: 570 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -752,26 +752,26 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 543
+      ID: 553
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1027936
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType fmt.wrapError
+      Pointee: 554 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 545
+      ID: 555
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1028064
       GoKind: 22
-      Pointee: 546 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 556 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 421
+      ID: 431
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 925088
       GoKind: 22
-      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 432 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 808
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -780,200 +780,200 @@ Types:
       GoKind: 22
       Pointee: 809 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 413
+      ID: 423
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 923744
       GoKind: 22
-      Pointee: 414 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 424 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 923840
       GoKind: 22
-      Pointee: 416 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 426 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 705
+      ID: 715
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 923552
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 716 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 419
+      ID: 429
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 924128
       GoKind: 22
-      Pointee: 420 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 430 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 707
+      ID: 717
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 923648
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 718 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 923936
       GoKind: 22
-      Pointee: 299 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 309 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 301
+      ID: 311
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 300 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 310 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 296 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 306 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 297 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 302 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 312 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 304
+      ID: 314
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 303 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 313 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 489
+      ID: 499
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 939104
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 500 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 938912
       GoKind: 22
-      Pointee: 314 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 324 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 487
+      ID: 497
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 939008
       GoKind: 22
-      Pointee: 488 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
+      Pointee: 498 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 454
+      ID: 464
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 934784
       GoKind: 22
-      Pointee: 455 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 465 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 458
+      ID: 468
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 934976
       GoKind: 22
-      Pointee: 459 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 469 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 456
+      ID: 466
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 934880
       GoKind: 22
-      Pointee: 457 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 467 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 934688
       GoKind: 22
-      Pointee: 453 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 463 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 730
+      ID: 740
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 739 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 935360
       GoKind: 22
-      Pointee: 467 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 477 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 460
+      ID: 470
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 935072
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 471 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 935264
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 475 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 462
+      ID: 472
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 935168
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 473 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 935456
       GoKind: 22
-      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 485 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 476
+      ID: 486
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 935840
       GoKind: 22
-      Pointee: 477 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 487 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 472
+      ID: 482
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 935648
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 483 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 935552
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 481 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 936032
       GoKind: 22
-      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 489 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 822
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1003,12 +1003,12 @@ Types:
       GoKind: 22
       Pointee: 821 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 499
+      ID: 509
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 947072
       GoKind: 22
-      Pointee: 500 StructureType github.com/cihub/seelog.baseError
+      Pointee: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 801
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1017,12 +1017,12 @@ Types:
       GoKind: 22
       Pointee: 802 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 947168
       GoKind: 22
-      Pointee: 502 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 512 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 793
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1045,12 +1045,12 @@ Types:
       GoKind: 22
       Pointee: 800 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 947360
       GoKind: 22
-      Pointee: 506 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 516 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 797
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1066,19 +1066,19 @@ Types:
       GoKind: 22
       Pointee: 815 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 947264
       GoKind: 22
-      Pointee: 504 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 514 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 947456
       GoKind: 22
-      Pointee: 508 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 518 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 906
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1094,268 +1094,268 @@ Types:
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 602
+      ID: 612
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1075424
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 613 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1075552
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 615 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 594
+      ID: 604
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1060192
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 605 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 925760
       GoKind: 22
-      Pointee: 425 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 435 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 598
+      ID: 608
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1063776
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 609 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 644
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1213952
       GoKind: 22
-      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1213568
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 649 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1051488
       GoKind: 22
-      Pointee: 579 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 650
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1214336
       GoKind: 22
-      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1051360
       GoKind: 22
-      Pointee: 542 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 552 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 642
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1213824
       GoKind: 22
-      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1213696
       GoKind: 22
-      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 648
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1214208
       GoKind: 22
-      Pointee: 649 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 646
+      ID: 656
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1214080
       GoKind: 22
-      Pointee: 647 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 654
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1214720
       GoKind: 22
-      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 582
+      ID: 592
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1051744
       GoKind: 22
-      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 580
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1051616
       GoKind: 22
-      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 652
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1214592
       GoKind: 22
-      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 954848
       GoKind: 22
-      Pointee: 319 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 329 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 321
+      ID: 331
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 693
+      ID: 703
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1677856
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 704 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1091680
       GoKind: 22
-      Pointee: 609 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 619 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 956864
       GoKind: 22
-      Pointee: 322 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 332 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 662
+      ID: 672
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1268096
       GoKind: 22
-      Pointee: 663 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 673 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 525
+      ID: 535
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 957152
       GoKind: 22
-      Pointee: 526 StructureType golang.org/x/net/http2.connError
+      Pointee: 536 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 524
+      ID: 534
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 957056
       GoKind: 22
-      Pointee: 326 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 336 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 327 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 528
+      ID: 538
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 957344
       GoKind: 22
-      Pointee: 332 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 342 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 334
+      ID: 344
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 333 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 527
+      ID: 537
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 957248
       GoKind: 22
-      Pointee: 329 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 339 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 330 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 956960
       GoKind: 22
-      Pointee: 323 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 333 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 325
+      ID: 335
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 324 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 957440
       GoKind: 22
-      Pointee: 530 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 540 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 531
+      ID: 541
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 957536
       GoKind: 22
-      Pointee: 335 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 345 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 509
+      ID: 519
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 949280
       GoKind: 22
-      Pointee: 510 StructureType google.golang.org/grpc.dropError
+      Pointee: 520 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 660
+      ID: 670
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1264896
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 671 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 680
+      ID: 690
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1451744
       GoKind: 22
-      Pointee: 681 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 691 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 515
+      ID: 525
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 953120
       GoKind: 22
-      Pointee: 516 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 526 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 937
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1364,12 +1364,12 @@ Types:
       GoKind: 22
       Pointee: 938 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 606
+      ID: 616
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1085920
       GoKind: 22
-      Pointee: 607 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 617 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 921
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1378,40 +1378,40 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 491
+      ID: 501
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 941312
       GoKind: 22
-      Pointee: 492 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 502 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1065184
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 611 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 658
+      ID: 668
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1231488
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 669 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 656
+      ID: 666
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1231232
       GoKind: 22
-      Pointee: 657 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 667 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 920672
       GoKind: 22
-      Pointee: 399 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 409 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 752
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
@@ -1469,12 +1469,12 @@ Types:
       GoKind: 22
       Pointee: 751 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 256
+      ID: 266
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1198336
       GoKind: 22
-      Pointee: 257 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 267 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 192
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
@@ -1511,40 +1511,40 @@ Types:
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 448
+      ID: 458
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 933056
       GoKind: 22
-      Pointee: 449 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 459 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 493
+      ID: 503
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 941888
       GoKind: 22
-      Pointee: 494 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 504 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 495
+      ID: 505
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 496 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 506 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 950432
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 524 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 532
+      ID: 542
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 958304
       GoKind: 22
-      Pointee: 533 UnresolvedPointeeType html/template.Error
+      Pointee: 543 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 106
       Name: '*int'
@@ -1581,33 +1581,33 @@ Types:
       GoKind: 22
       Pointee: 22 BaseType int8
     - __kind: PointerType
-      ID: 682
+      ID: 692
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2215712
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType internal/abi.Type
+      Pointee: 693 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 429
+      ID: 439
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 926432
       GoKind: 22
-      Pointee: 430 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 440 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 427
+      ID: 437
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 926336
       GoKind: 22
-      Pointee: 428 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 438 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 636
+      ID: 646
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1206528
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 647 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 976
       Name: '*internal/poll.FD'
@@ -1616,19 +1616,19 @@ Types:
       GoKind: 22
       Pointee: 977 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 634
+      ID: 644
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1206400
       GoKind: 22
-      Pointee: 635 StructureType internal/poll.errNetClosing
+      Pointee: 645 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 367
+      ID: 377
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 912896
       GoKind: 22
-      Pointee: 368 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 378 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -1637,31 +1637,31 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 926240
       GoKind: 22
-      Pointee: 306 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 316 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 308
+      ID: 318
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 317 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1054944
       GoKind: 22
-      Pointee: 587 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 597 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 279 BaseType internal/strconv.Error
+      Pointee: 289 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 941
       Name: '*io.PipeReader'
@@ -1691,12 +1691,12 @@ Types:
       GoKind: 22
       Pointee: 905 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 632
+      ID: 642
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1205376
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType io/fs.PathError
+      Pointee: 643 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 144
       Name: '*map<context.canceler,struct {}>'
@@ -1708,10 +1708,10 @@ Types:
       ByteSize: 8
       Pointee: 805 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 243
+      ID: 249
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 244 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 250 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 984
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1728,10 +1728,10 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 688
+      ID: 698
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 699 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 175
       Name: '*map<string,interface {}>'
@@ -1743,12 +1743,12 @@ Types:
       ByteSize: 8
       Pointee: 171 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 446
+      ID: 456
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 929792
       GoKind: 22
-      Pointee: 447 StructureType math/big.ErrNaN
+      Pointee: 457 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 996
       Name: '*mime/multipart.FileHeader'
@@ -1778,19 +1778,19 @@ Types:
       GoKind: 22
       Pointee: 926 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1191808
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType net.AddrError
+      Pointee: 629 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 667
+      ID: 677
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1419104
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType net.DNSError
+      Pointee: 678 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 952
       Name: '*net.IPConn'
@@ -1799,19 +1799,19 @@ Types:
       GoKind: 22
       Pointee: 953 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 665
+      ID: 675
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1418784
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType net.OpError
+      Pointee: 676 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1191936
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType net.ParseError
+      Pointee: 631 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 960
       Name: '*net.TCPConn'
@@ -1834,24 +1834,24 @@ Types:
       GoKind: 22
       Pointee: 959 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1191040
       GoKind: 22
-      Pointee: 612 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 622 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 614
+      ID: 624
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 613 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 623 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 547
+      ID: 557
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1028960
       GoKind: 22
-      Pointee: 548 StructureType net.canceledError
+      Pointee: 558 StructureType net.canceledError
     - __kind: PointerType
       ID: 950
       Name: '*net.conn'
@@ -1860,12 +1860,12 @@ Types:
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 711
+      ID: 721
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1851264
       GoKind: 22
-      Pointee: 712 StructureType net.dialResult·1
+      Pointee: 722 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 966
       Name: '*net.netFD'
@@ -1874,12 +1874,12 @@ Types:
       GoKind: 22
       Pointee: 967 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 905312
       GoKind: 22
-      Pointee: 337 UnresolvedPointeeType net.notFoundError
+      Pointee: 347 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1023
       Name: '*net.onlyValuesCtx'
@@ -1888,12 +1888,12 @@ Types:
       GoKind: 22
       Pointee: 1024 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 905984
       GoKind: 22
-      Pointee: 339 StructureType net.result·2
+      Pointee: 349 StructureType net.result·2
     - __kind: PointerType
       ID: 956
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1909,33 +1909,33 @@ Types:
       GoKind: 22
       Pointee: 955 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 622
+      ID: 632
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1192576
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net.temporaryError
+      Pointee: 633 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 669
+      ID: 679
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1419424
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType net.timeoutError
+      Pointee: 680 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 908576
       GoKind: 22
-      Pointee: 345 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 355 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1032672
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 560 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 118
       Name: '*net/http.Request'
@@ -1993,26 +1993,26 @@ Types:
       GoKind: 22
       Pointee: 919 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 908768
       GoKind: 22
-      Pointee: 260 BaseType net/http.http2ConnectionError
+      Pointee: 270 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 347
+      ID: 357
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 348 StructureType net/http.http2GoAwayError
+      Pointee: 358 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 671
+      ID: 681
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1420224
       GoKind: 22
-      Pointee: 672 StructureType net/http.http2StreamError
+      Pointee: 682 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 914
       Name: '*net/http.http2clientStream'
@@ -2021,31 +2021,31 @@ Types:
       GoKind: 22
       Pointee: 915 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 909920
       GoKind: 22
-      Pointee: 354 StructureType net/http.http2connError
+      Pointee: 364 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 909344
       GoKind: 22
-      Pointee: 264 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 274 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 266
+      ID: 276
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 275 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 351
+      ID: 361
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 909440
       GoKind: 22
-      Pointee: 352 StructureType net/http.http2goAwayFlowError
+      Pointee: 362 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 916
       Name: '*net/http.http2gzipReader'
@@ -2054,36 +2054,36 @@ Types:
       GoKind: 22
       Pointee: 917 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 270 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 280 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 272
+      ID: 282
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 281 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 910016
       GoKind: 22
-      Pointee: 267 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 277 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 269
+      ID: 279
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 278 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1196160
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 637 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 878
       Name: '*net/http.http2missingBody'
@@ -2099,24 +2099,24 @@ Types:
       GoKind: 22
       Pointee: 887 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1034848
       GoKind: 22
-      Pointee: 556 StructureType net/http.http2noCachedConnError
+      Pointee: 566 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 349
+      ID: 359
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 909248
       GoKind: 22
-      Pointee: 261 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 271 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 263
+      ID: 273
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 272 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 884
       Name: '*net/http.http2requestBody'
@@ -2160,12 +2160,12 @@ Types:
       GoKind: 22
       Pointee: 903 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 551
+      ID: 561
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1034592
       GoKind: 22
-      Pointee: 552 StructureType net/http.nothingWrittenError
+      Pointee: 562 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 870
       Name: '*net/http.pattern'
@@ -2188,12 +2188,12 @@ Types:
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 357
+      ID: 367
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 910304
       GoKind: 22
-      Pointee: 358 StructureType net/http.requestBodyReadError
+      Pointee: 368 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 791
       Name: '*net/http.response'
@@ -2209,33 +2209,33 @@ Types:
       GoKind: 22
       Pointee: 1019 StructureType net/http.segment
     - __kind: PointerType
-      ID: 342
+      ID: 352
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 908480
       GoKind: 22
-      Pointee: 343 StructureType net/http.statusError
+      Pointee: 353 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 673
+      ID: 683
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1421664
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 684 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 624
+      ID: 634
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1196032
       GoKind: 22
-      Pointee: 625 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 635 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 553
+      ID: 563
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1034720
       GoKind: 22
-      Pointee: 554 StructureType net/http.transportReadFromServerError
+      Pointee: 564 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 939
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2244,12 +2244,12 @@ Types:
       GoKind: 22
       Pointee: 940 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 907712
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 351 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 896
       Name: '*net/http/httputil.failureToReadBody'
@@ -2258,69 +2258,69 @@ Types:
       GoKind: 22
       Pointee: 897 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915776
       GoKind: 22
-      Pointee: 376 StructureType net/netip.parseAddrError
+      Pointee: 386 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915680
       GoKind: 22
-      Pointee: 374 StructureType net/netip.parsePrefixError
+      Pointee: 384 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 391
+      ID: 401
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 919232
       GoKind: 22
-      Pointee: 392 UnresolvedPointeeType net/textproto.Error
+      Pointee: 402 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 919136
       GoKind: 22
-      Pointee: 288 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 298 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 290
+      ID: 300
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 299 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 678
+      ID: 688
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1426624
       GoKind: 22
-      Pointee: 679 UnresolvedPointeeType net/url.Error
+      Pointee: 689 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 282 GoStringHeaderType net/url.EscapeError
+      Pointee: 292 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 284
+      ID: 294
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 283 GoStringDataType net/url.EscapeError.str
+      Pointee: 293 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 285 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 295 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 287
+      ID: 297
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 286 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 296 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 859
       Name: '*net/url.URL'
@@ -2346,10 +2346,10 @@ Types:
       ByteSize: 8
       Pointee: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 252
+      ID: 262
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 990
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2361,25 +2361,25 @@ Types:
       ByteSize: 8
       Pointee: 854 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 234
+      ID: 240
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 235 StructureType noalg.map.group[string]float64
+      Pointee: 241 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 719
+      ID: 729
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 226
+      ID: 232
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 227 StructureType noalg.map.group[string]interface {}
+      Pointee: 233 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 218
+      ID: 224
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 219 StructureType noalg.map.group[string]string
+      Pointee: 225 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 972
       Name: '*os.File'
@@ -2388,12 +2388,12 @@ Types:
       GoKind: 22
       Pointee: 973 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1037024
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType os.LinkError
+      Pointee: 568 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 162
       Name: '*os.Signal'
@@ -2402,12 +2402,12 @@ Types:
       GoKind: 22
       Pointee: 163 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 628
+      ID: 638
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1196544
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType os.SyscallError
+      Pointee: 639 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 970
       Name: '*os.fileWithoutReadFrom'
@@ -2423,26 +2423,26 @@ Types:
       GoKind: 22
       Pointee: 969 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 590
+      ID: 600
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1058784
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType os/exec.Error
+      Pointee: 601 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 715
+      ID: 725
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2111072
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 726 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 592
+      ID: 602
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1058912
       GoKind: 22
-      Pointee: 593 StructureType os/exec.wrappedError
+      Pointee: 603 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 136
       Name: '*os/signal.signalCtx'
@@ -2451,64 +2451,64 @@ Types:
       GoKind: 22
       Pointee: 137 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*os/signal.signalError'
       ByteSize: 8
       GoRuntimeType: 911072
       GoKind: 22
-      Pointee: 273 GoStringHeaderType os/signal.signalError
+      Pointee: 283 GoStringHeaderType os/signal.signalError
     - __kind: PointerType
-      ID: 275
+      ID: 285
       Name: '*os/signal.signalError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType os/signal.signalError.str
+      Pointee: 284 GoStringDataType os/signal.signalError.str
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 946112
       GoKind: 22
-      Pointee: 316 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 326 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 318
+      ID: 328
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 327 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 497
+      ID: 507
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 946016
       GoKind: 22
-      Pointee: 315 BaseType os/user.UnknownUserIdError
+      Pointee: 325 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 913664
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType reflect.ValueError
+      Pointee: 380 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 934016
       GoKind: 22
-      Pointee: 451 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 461 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1042912
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 576 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 569
+      ID: 579
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1043552
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 580 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -2524,12 +2524,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1043040
       GoKind: 22
-      Pointee: 568 StructureType runtime.boundsError
+      Pointee: 578 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -2545,24 +2545,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 630
+      ID: 640
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1204864
       GoKind: 22
-      Pointee: 631 StructureType runtime.errorAddressString
+      Pointee: 641 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 563
+      ID: 573
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1041248
       GoKind: 22
-      Pointee: 534 GoStringHeaderType runtime.errorString
+      Pointee: 544 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 536
+      ID: 546
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 535 GoStringDataType runtime.errorString.str
+      Pointee: 545 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -2585,17 +2585,17 @@ Types:
       GoKind: 22
       Pointee: 201 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1041376
       GoKind: 22
-      Pointee: 537 GoStringHeaderType runtime.plainError
+      Pointee: 547 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 538 GoStringDataType runtime.plainError.str
+      Pointee: 548 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -2611,12 +2611,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 915392
       GoKind: 22
-      Pointee: 372 StructureType runtime.synctestDeadlockError
+      Pointee: 382 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -2639,12 +2639,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 561
+      ID: 571
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1040864
       GoKind: 22
-      Pointee: 562 UnresolvedPointeeType strconv.NumError
+      Pointee: 572 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -2770,12 +2770,12 @@ Types:
       GoKind: 22
       Pointee: 899 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 675
+      ID: 685
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1425504
       GoKind: 22
-      Pointee: 664 BaseType syscall.Errno
+      Pointee: 674 BaseType syscall.Errno
     - __kind: PointerType
       ID: 748
       Name: '*syscall.Signal'
@@ -2794,10 +2794,10 @@ Types:
       ByteSize: 8
       Pointee: 824 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 246
+      ID: 252
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 250 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 260 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 987
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2812,29 +2812,29 @@ Types:
       ID: 183
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 232 StructureType table<string,float64>
+      Pointee: 238 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 691
+      ID: 701
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 717 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 727 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 178
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 224 StructureType table<string,interface {}>
+      Pointee: 230 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 173
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 216 StructureType table<string,string>
+      Pointee: 222 StructureType table<string,string>
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1096160
       GoKind: 22
-      Pointee: 611 StructureType text/template.ExecError
+      Pointee: 621 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 157
       Name: '*time.Location'
@@ -2843,12 +2843,12 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType time.Location
     - __kind: PointerType
-      ID: 363
+      ID: 373
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 911360
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType time.ParseError
+      Pointee: 374 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 154
       Name: '*time.Timer'
@@ -2857,38 +2857,38 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType time.Timer
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 911168
       GoKind: 22
-      Pointee: 276 GoStringHeaderType time.fileSizeError
+      Pointee: 286 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 278
+      ID: 288
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType time.fileSizeError.str
+      Pointee: 287 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 911264
       GoKind: 22
-      Pointee: 362 UnresolvedPointeeType time.parseDurationError
+      Pointee: 372 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 733
+      ID: 215
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 400064
       GoKind: 22
-      Pointee: 734 StructureType time.zone
+      Pointee: 216 StructureType time.zone
     - __kind: PointerType
-      ID: 736
+      ID: 218
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 400128
       GoKind: 22
-      Pointee: 737 StructureType time.zoneTrans
+      Pointee: 219 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -2932,47 +2932,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 916640
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 389 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 396 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 406 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 295 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 305 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 574
+      ID: 584
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1048928
       GoKind: 22
-      Pointee: 575 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 585 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 576
+      ID: 586
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1049056
       GoKind: 22
-      Pointee: 541 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 551 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 867
       Name: <-chan struct {}
       GoRuntimeType: 604000
       GoKind: 18
     - __kind: GoChannelType
-      ID: 731
+      ID: 741
       Name: <-chan time.Time
       GoRuntimeType: 609696
       GoKind: 18
@@ -3150,7 +3150,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 699
+      ID: 709
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 708032
@@ -3198,7 +3198,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 685 PointerType *crypto/x509.Certificate
+      Element: 695 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 742
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -3281,11 +3281,11 @@ Types:
       ByteSize: 8
       Element: 807 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 268
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 246 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 252 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 997
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3299,25 +3299,25 @@ Types:
       ByteSize: 8
       Element: 846 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 244
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 183 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 723
+      ID: 733
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 701 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 236
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 178 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 228
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3369,7 +3369,7 @@ Types:
       ByteSize: 24
       Element: 41 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 704
+      ID: 714
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 502208
@@ -3384,9 +3384,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 727 GoSliceDataType []float64.array
+      Data: 737 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 727
+      ID: 737
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3407,9 +3407,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 240 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 246 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 246
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3430,9 +3430,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 248 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 254 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 254
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3473,11 +3473,11 @@ Types:
       ByteSize: 24
       Element: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 269
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 998
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3491,29 +3491,29 @@ Types:
       ByteSize: 328
       Element: 854 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 245
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 235 StructureType noalg.map.group[string]float64
+      Element: 241 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 724
+      ID: 734
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 237
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 227 StructureType noalg.map.group[string]interface {}
+      Element: 233 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 229
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 219 StructureType noalg.map.group[string]string
+      Element: 225 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 161
       Name: '[]os.Signal'
@@ -3530,9 +3530,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 214 GoSliceDataType []os.Signal.array
+      Data: 220 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 220
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3542,7 +3542,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 703
+      ID: 713
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 502464
@@ -3557,15 +3557,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 725 GoSliceDataType []string.array
+      Data: 735 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 725
+      ID: 735
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 732
+      ID: 214
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 495456
@@ -3573,22 +3573,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 733 PointerType *time.zone
+          Type: 215 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 738 GoSliceDataType []time.zone.array
+      Data: 256 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 738
+      ID: 256
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 734 StructureType time.zone
+      Element: 216 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 735
+      ID: 217
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 495520
@@ -3596,20 +3596,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 736 PointerType *time.zoneTrans
+          Type: 218 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 740 GoSliceDataType []time.zoneTrans.array
+      Data: 258 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 740
+      ID: 258
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 737 StructureType time.zoneTrans
+      Element: 219 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 41
       Name: '[]uint8'
@@ -3657,7 +3657,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 519
+      ID: 529
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 955712
@@ -3672,9 +3672,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 520 GoSliceDataType archive/tar.headerError.array
+      Data: 530 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 530
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3732,13 +3732,13 @@ Types:
       GoRuntimeType: 591072
       GoKind: 15
     - __kind: BaseType
-      ID: 291
+      ID: 301
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 842816
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 292
+      ID: 302
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 842912
@@ -3746,13 +3746,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 294 PointerType *compress/flate.InternalError.str
+          Type: 304 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 293 GoStringDataType compress/flate.InternalError.str
+      Data: 303 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 293
+      ID: 303
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3860,7 +3860,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 616
+      ID: 626
       Name: context.deadlineExceededError
       GoRuntimeType: 1469184
       GoKind: 25
@@ -3904,7 +3904,7 @@ Types:
           Type: 154 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 156 StructureType time.Time
+          Type: 156 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3950,43 +3950,43 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 310
+      ID: 320
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845024
       GoKind: 2
     - __kind: BaseType
-      ID: 311
+      ID: 321
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845120
       GoKind: 2
     - __kind: BaseType
-      ID: 312
+      ID: 322
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845216
       GoKind: 2
     - __kind: StructureType
-      ID: 597
+      ID: 607
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1293888
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 313
+      ID: 323
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845312
       GoKind: 2
     - __kind: BaseType
-      ID: 280
+      ID: 290
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 842336
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 583
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4058,11 +4058,11 @@ Types:
       GoRuntimeType: 842048
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 394
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 381
+      ID: 391
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1740448
@@ -4073,10 +4073,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 699 ArrayType [5]uint8
+          Type: 709 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 700 GoInterfaceType net.Conn
+          Type: 710 GoInterfaceType net.Conn
     - __kind: BaseType
       ID: 1010
       Name: crypto/tls.SignatureScheme
@@ -4084,25 +4084,25 @@ Types:
       GoRuntimeType: 842144
       GoKind: 9
     - __kind: BaseType
-      ID: 540
+      ID: 550
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 996832
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 396
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 687
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 696
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 439
+      ID: 449
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1742560
@@ -4110,21 +4110,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 695 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 709 BaseType crypto/x509.InvalidReason
+          Type: 719 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 433
+      ID: 443
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1123328
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 435
+      ID: 445
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1608832
@@ -4132,24 +4132,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 695 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 309
+      ID: 319
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 844736
       GoKind: 2
     - __kind: BaseType
-      ID: 709
+      ID: 719
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 594016
       GoKind: 2
     - __kind: StructureType
-      ID: 589
+      ID: 599
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1568640
@@ -4159,13 +4159,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 441
+      ID: 451
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1123584
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 437
+      ID: 447
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1742368
@@ -4173,15 +4173,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 695 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 695 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 481
+      ID: 491
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1439584
@@ -4191,7 +4191,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 485
+      ID: 495
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1439744
@@ -4201,47 +4201,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 483
+      ID: 493
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 281
+      ID: 291
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 842432
       GoKind: 6
     - __kind: BaseType
-      ID: 305
+      ID: 315
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 844448
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 419
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 595
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 401
+      ID: 411
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 407
+      ID: 417
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 415
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 413
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1430304
@@ -4251,7 +4251,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 522
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4268,11 +4268,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 366
+      ID: 376
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 570
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4288,11 +4288,11 @@ Types:
       GoRuntimeType: 591264
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 554
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 546
+      ID: 556
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4326,7 +4326,7 @@ Types:
       GoRuntimeType: 1012672
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 422
+      ID: 432
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4336,7 +4336,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 414
+      ID: 424
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1741600
@@ -4344,7 +4344,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 701 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 711 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4352,25 +4352,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 416
+      ID: 426
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 716
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 420
+      ID: 430
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1122304
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 718
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 299
+      ID: 309
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 843872
@@ -4378,18 +4378,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 301 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 311 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 300 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 310 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 300
+      ID: 310
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 701
+      ID: 711
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2235776
@@ -4397,13 +4397,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 702 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 712 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4412,7 +4412,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 704 GoSliceHeaderType []float64
+          Type: 714 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4421,13 +4421,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 705 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 715 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 707 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 717 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4438,13 +4438,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 702
+      ID: 712
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 592800
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 296
+      ID: 306
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 843776
@@ -4452,18 +4452,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 298 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 308 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 297 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 297
+      ID: 307
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 302
+      ID: 312
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 843968
@@ -4471,36 +4471,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 304 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 314 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 303 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 313 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 303
+      ID: 313
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 490
+      ID: 500
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1126016
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 314
+      ID: 324
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 846464
       GoKind: 2
     - __kind: StructureType
-      ID: 488
+      ID: 498
       Name: github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
       GoRuntimeType: 1125888
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 455
+      ID: 465
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1609952
@@ -4513,7 +4513,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 459
+      ID: 469
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1744672
@@ -4529,7 +4529,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 457
+      ID: 467
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1438144
@@ -4539,7 +4539,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 453
+      ID: 463
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1437824
@@ -4549,14 +4549,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 687
+      ID: 697
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1513504
       GoKind: 21
-      HeaderType: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 699 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 710
+      ID: 720
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1059808
@@ -4571,15 +4571,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 739 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 729
+      ID: 739
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 467
+      ID: 477
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1610272
@@ -4587,12 +4587,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 697 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 697 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 461
+      ID: 471
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1438304
@@ -4602,7 +4602,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 465
+      ID: 475
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1744864
@@ -4613,12 +4613,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 463
+      ID: 473
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1610112
@@ -4631,7 +4631,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 469
+      ID: 479
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1438464
@@ -4639,9 +4639,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 156 StructureType time.Time
+          Type: 156 GoTimeType time.Time
     - __kind: StructureType
-      ID: 475
+      ID: 485
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1610592
@@ -4654,7 +4654,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 477
+      ID: 487
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1438784
@@ -4664,7 +4664,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 473
+      ID: 483
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1610432
@@ -4677,7 +4677,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 471
+      ID: 481
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1438624
@@ -4687,7 +4687,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 479
+      ID: 489
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1610752
@@ -4722,7 +4722,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 500
+      ID: 510
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1444704
@@ -4736,7 +4736,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 502
+      ID: 512
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1444864
@@ -4744,7 +4744,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 500 StructureType github.com/cihub/seelog.baseError
+          Type: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 794
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -4767,7 +4767,7 @@ Types:
           Offset: 8
           Type: 803 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 506
+      ID: 516
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1445184
@@ -4775,7 +4775,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 500 StructureType github.com/cihub/seelog.baseError
+          Type: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 798
       Name: github.com/cihub/seelog.splitDispatcher
@@ -4791,7 +4791,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 504
+      ID: 514
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1445024
@@ -4799,9 +4799,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 500 StructureType github.com/cihub/seelog.baseError
+          Type: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 508
+      ID: 518
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1445344
@@ -4809,7 +4809,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 500 StructureType github.com/cihub/seelog.baseError
+          Type: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 929
       Name: github.com/cihub/seelog/archive.Reader
@@ -4838,30 +4838,30 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 613
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 615
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 605
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1431584
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 609
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1864032
@@ -4877,11 +4877,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 649
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 579
+      ID: 589
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1713856
@@ -4894,7 +4894,7 @@ Types:
           Offset: 1
           Type: 22 BaseType int8
     - __kind: StructureType
-      ID: 651
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1864480
@@ -4910,13 +4910,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 542
+      ID: 552
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 997984
       GoKind: 8
     - __kind: StructureType
-      ID: 643
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1863808
@@ -4932,13 +4932,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 713
+      ID: 723
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 843392
       GoKind: 8
     - __kind: StructureType
-      ID: 641
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1863584
@@ -4946,15 +4946,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 723 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 723 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 649
+      ID: 659
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1778208
@@ -4967,7 +4967,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 647
+      ID: 657
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1864256
@@ -4983,7 +4983,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 655
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1646176
@@ -4993,19 +4993,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 593
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1290176
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 581
+      ID: 591
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1290048
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 653
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1778400
@@ -5018,7 +5018,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 329
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 848480
@@ -5026,22 +5026,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 331 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 320 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 330
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 704
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 609
+      ID: 619
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1454464
@@ -5051,19 +5051,19 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 322
+      ID: 332
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 849056
       GoKind: 10
     - __kind: BaseType
-      ID: 692
+      ID: 702
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1009696
       GoKind: 10
     - __kind: StructureType
-      ID: 663
+      ID: 673
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1896064
@@ -5074,12 +5074,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 692 BaseType golang.org/x/net/http2.ErrCode
+          Type: 702 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 526
+      ID: 536
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1617472
@@ -5087,12 +5087,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 692 BaseType golang.org/x/net/http2.ErrCode
+          Type: 702 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 326
+      ID: 336
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 849248
@@ -5100,18 +5100,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 328 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 338 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 327 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 327
+      ID: 337
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 332
+      ID: 342
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 849440
@@ -5119,18 +5119,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 334 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 344 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 333 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 333
+      ID: 343
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 329
+      ID: 339
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 849344
@@ -5138,18 +5138,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 331 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 341 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 330 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 330
+      ID: 340
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 323
+      ID: 333
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 849152
@@ -5157,18 +5157,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 325 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 335 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 324 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 324
+      ID: 334
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 530
+      ID: 540
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1455744
@@ -5178,13 +5178,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 335
+      ID: 345
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 849536
       GoKind: 2
     - __kind: StructureType
-      ID: 510
+      ID: 520
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1450144
@@ -5194,11 +5194,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 671
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 681
+      ID: 691
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1924224
@@ -5214,7 +5214,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 516
+      ID: 526
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1616512
@@ -5231,7 +5231,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 607
+      ID: 617
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1576320
@@ -5245,25 +5245,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 492
+      ID: 502
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 611
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 669
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 667
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1521984
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 399
+      ID: 409
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -5509,16 +5509,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 242 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 248 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 247 GoMapType map[string]interface {}
+          Type: 253 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 751
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 257
+      ID: 267
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1931264
@@ -5617,11 +5617,11 @@ Types:
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 449
+      ID: 459
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 494
+      ID: 504
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1441984
@@ -5631,7 +5631,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 496
+      ID: 506
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1442144
@@ -5641,7 +5641,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 524
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5673,19 +5673,19 @@ Types:
       GroupType: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 832 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 251
+      ID: 261
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 252 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 262 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 989
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5715,63 +5715,63 @@ Types:
       GroupType: 854 StructureType noalg.map.group[string][]string
       GroupSliceType: 858 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 233
+      ID: 239
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 234 PointerType *noalg.map.group[string]float64
+          Type: 240 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 235 StructureType noalg.map.group[string]float64
-      GroupSliceType: 239 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 241 StructureType noalg.map.group[string]float64
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 718
+      ID: 728
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 719 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 729 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 724 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 734 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 225
+      ID: 231
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 226 PointerType *noalg.map.group[string]interface {}
+          Type: 232 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 227 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 233 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 217
+      ID: 223
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 218 PointerType *noalg.map.group[string]string
+          Type: 224 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 219 StructureType noalg.map.group[string]string
-      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 225 StructureType noalg.map.group[string]string
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 533
+      ID: 543
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5818,17 +5818,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 714
+      ID: 724
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 593440
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 693
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 430
+      ID: 440
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5854,11 +5854,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 428
+      ID: 438
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 647
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5866,13 +5866,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 635
+      ID: 645
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1487584
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 368
+      ID: 378
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5944,7 +5944,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 316
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 844640
@@ -5952,18 +5952,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 318 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 317 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 317
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1567680
@@ -5971,9 +5971,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 682 PointerType *internal/abi.Type
+          Type: 692 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 279
+      ID: 289
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 841856
@@ -6059,7 +6059,7 @@ Types:
           Offset: 0
           Type: 920 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 643
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6133,7 +6133,7 @@ Types:
       TablePtrSliceType: 831 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 244
+      ID: 250
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6146,7 +6146,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 245 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 251 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6165,8 +6165,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 268 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 985
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6270,10 +6270,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 238 GoSliceDataType []*table<string,float64>.array
-      GroupType: 235 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,float64>.array
+      GroupType: 241 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 689
+      ID: 699
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6286,7 +6286,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 690 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 700 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6305,8 +6305,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 723 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 733 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 176
       Name: map<string,interface {}>
@@ -6340,8 +6340,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 230 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 227 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 233 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 171
       Name: map<string,string>
@@ -6375,8 +6375,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 222 GoSliceDataType []*table<string,string>.array
-      GroupType: 219 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 228 GoSliceDataType []*table<string,string>.array
+      GroupType: 225 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 143
       Name: map[context.canceler]struct {}
@@ -6392,12 +6392,12 @@ Types:
       GoKind: 21
       HeaderType: 805 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 242
+      ID: 248
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1142112
       GoKind: 21
-      HeaderType: 244 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 250 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 983
       Name: map[string][]*mime/multipart.FileHeader
@@ -6420,7 +6420,7 @@ Types:
       GoKind: 21
       HeaderType: 181 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 247
+      ID: 253
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1135360
@@ -6434,7 +6434,7 @@ Types:
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 447
+      ID: 457
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1434784
@@ -6478,11 +6478,11 @@ Types:
           Offset: 8
           Type: 930 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 629
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 700
+      ID: 710
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1606112
@@ -6495,7 +6495,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 678
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6503,11 +6503,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 676
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 631
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6523,7 +6523,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 612
+      ID: 622
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1116928
@@ -6531,18 +6531,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 614 PointerType *net.UnknownNetworkError.str
+          Type: 624 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 613 GoStringDataType net.UnknownNetworkError.str
+      Data: 623 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 613
+      ID: 623
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 548
+      ID: 558
       Name: net.canceledError
       GoRuntimeType: 1287488
       GoKind: 25
@@ -6552,7 +6552,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 712
+      ID: 722
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2123008
@@ -6560,7 +6560,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 700 GoInterfaceType net.Conn
+          Type: 710 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -6587,7 +6587,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 337
+      ID: 347
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6604,7 +6604,7 @@ Types:
           Offset: 16
           Type: 123 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 339
+      ID: 349
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1735456
@@ -6612,7 +6612,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 695 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6646,11 +6646,11 @@ Types:
           Offset: 0
           Type: 960 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 633
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 680
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6700,11 +6700,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 345
+      ID: 355
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 560
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6756,7 +6756,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6801,7 +6801,7 @@ Types:
           Type: 870 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 169 GoMapType map[string]string
@@ -6838,7 +6838,7 @@ Types:
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6911,19 +6911,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 260
+      ID: 270
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 840128
       GoKind: 10
     - __kind: BaseType
-      ID: 684
+      ID: 694
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 994048
       GoKind: 10
     - __kind: StructureType
-      ID: 348
+      ID: 358
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1737184
@@ -6934,12 +6934,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 694 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 672
+      ID: 682
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1912960
@@ -6950,7 +6950,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 694 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
@@ -6959,7 +6959,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 354
+      ID: 364
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1606592
@@ -6967,12 +6967,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 694 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 264
+      ID: 274
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840320
@@ -6980,18 +6980,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 266 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 276 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 275 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 265
+      ID: 275
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 352
+      ID: 362
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1118208
       GoKind: 25
@@ -7001,7 +7001,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 280
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840512
@@ -7009,18 +7009,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *net/http.http2headerFieldNameError.str
+          Type: 282 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 271 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 281 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 281
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 277
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840416
@@ -7028,18 +7028,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *net/http.http2headerFieldValueError.str
+          Type: 279 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 278 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 278
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 637
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -7055,13 +7055,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 556
+      ID: 566
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1288384
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 271
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -7069,13 +7069,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 273 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 262 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 272 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 272
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7118,7 +7118,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 552
+      ID: 562
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1559520
@@ -7158,7 +7158,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 358
+      ID: 368
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1422464
@@ -7233,7 +7233,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 149 StructureType sync/atomic.Bool
@@ -7272,7 +7272,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 343
+      ID: 353
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1606432
@@ -7285,17 +7285,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 684
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 625
+      ID: 635
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1473664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 554
+      ID: 564
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1559680
@@ -7313,12 +7313,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 700 GoInterfaceType net.Conn
+          Type: 710 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 700 GoInterfaceType net.Conn
+          Type: 710 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 351
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7328,7 +7328,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 376
+      ID: 386
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1740064
@@ -7344,7 +7344,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 374
+      ID: 384
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1607712
@@ -7357,11 +7357,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 392
+      ID: 402
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 298
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 842720
@@ -7369,22 +7369,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *net/textproto.ProtocolError.str
+          Type: 300 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType net/textproto.ProtocolError.str
+      Data: 299 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 299
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 679
+      ID: 689
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 282
+      ID: 292
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 842528
@@ -7392,18 +7392,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 284 PointerType *net/url.EscapeError.str
+          Type: 294 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 283 GoStringDataType net/url.EscapeError.str
+      Data: 293 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 283
+      ID: 293
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 285
+      ID: 295
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 842624
@@ -7411,13 +7411,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 287 PointerType *net/url.InvalidHostError.str
+          Type: 297 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 286 GoStringDataType net/url.InvalidHostError.str
+      Data: 296 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 286
+      ID: 296
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7491,14 +7491,14 @@ Types:
       HasCount: true
       Element: 829 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 254
+      ID: 264
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 255 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 265 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 992
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7518,41 +7518,41 @@ Types:
       HasCount: true
       Element: 856 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 236
+      ID: 242
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 237 StructureType noalg.struct { key string; elem float64 }
+      Element: 243 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 721
+      ID: 731
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 767680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 722 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 732 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 228
+      ID: 234
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 687584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 229 StructureType noalg.struct { key string; elem interface {} }
+      Element: 235 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 220
+      ID: 226
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 700928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 221 StructureType noalg.struct { key string; elem string }
+      Element: 227 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 207
       Name: noalg.map.group[context.canceler]struct {}
@@ -7580,7 +7580,7 @@ Types:
           Offset: 8
           Type: 828 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 253
+      ID: 263
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1317056
@@ -7591,7 +7591,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 254 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 264 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 991
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7619,7 +7619,7 @@ Types:
           Offset: 8
           Type: 855 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 235
+      ID: 241
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1316800
@@ -7630,9 +7630,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 236 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 242 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 720
+      ID: 730
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1358272
@@ -7643,9 +7643,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 721 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 731 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 227
+      ID: 233
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1298496
@@ -7656,9 +7656,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 228 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 234 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 219
+      ID: 225
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1303616
@@ -7669,7 +7669,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 220 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 226 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 209
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7697,7 +7697,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 255
+      ID: 265
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1316928
@@ -7708,7 +7708,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 256 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 266 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 993
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7734,9 +7734,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 237
+      ID: 243
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1316672
@@ -7749,7 +7749,7 @@ Types:
           Offset: 16
           Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 722
+      ID: 732
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1358144
@@ -7760,9 +7760,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 229
+      ID: 235
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1298368
@@ -7775,7 +7775,7 @@ Types:
           Offset: 16
           Type: 142 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 221
+      ID: 227
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1303488
@@ -7792,7 +7792,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 568
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7809,7 +7809,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 639
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7851,15 +7851,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 601
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 726
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 593
+      ID: 603
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1714048
@@ -7893,7 +7893,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 283
       Name: os/signal.signalError
       ByteSize: 16
       GoRuntimeType: 840608
@@ -7901,18 +7901,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *os/signal.signalError.str
+          Type: 285 PointerType *os/signal.signalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType os/signal.signalError.str
+      Data: 284 GoStringDataType os/signal.signalError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 284
       Name: os/signal.signalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 326
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 847232
@@ -7920,36 +7920,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *os/user.UnknownGroupIdError.str
+          Type: 328 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 327 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 327
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 315
+      ID: 325
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 847136
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 380
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 451
+      ID: 461
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 576
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 580
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7961,7 +7961,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 568
+      ID: 578
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1903008
@@ -7978,7 +7978,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 714 BaseType internal/abi.BoundsErrorCode
+          Type: 724 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -7994,7 +7994,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 631
+      ID: 641
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1772256
@@ -8007,7 +8007,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 534
+      ID: 544
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 995296
@@ -8015,13 +8015,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 536 PointerType *runtime.errorString.str
+          Type: 546 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 535 GoStringDataType runtime.errorString.str
+      Data: 545 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 535
+      ID: 545
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8706,7 +8706,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 537
+      ID: 547
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 995392
@@ -8714,13 +8714,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 539 PointerType *runtime.plainError.str
+          Type: 549 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 538 GoStringDataType runtime.plainError.str
+      Data: 548 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 538
+      ID: 548
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8761,7 +8761,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 372
+      ID: 382
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1607392
@@ -8833,7 +8833,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 562
+      ID: 572
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9220,7 +9220,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 664
+      ID: 674
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1289152
@@ -9280,7 +9280,7 @@ Types:
           Offset: 16
           Type: 825 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 250
+      ID: 260
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9302,7 +9302,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 251 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 261 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 988
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9352,7 +9352,7 @@ Types:
           Offset: 16
           Type: 852 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 232
+      ID: 238
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9374,9 +9374,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 233 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 239 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 717
+      ID: 727
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9398,9 +9398,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 718 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 728 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 224
+      ID: 230
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9422,9 +9422,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 225 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 231 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 216
+      ID: 222
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9446,9 +9446,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 217 GoSwissMapGroupsType groupReference<string,string>
+          Type: 223 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 611
+      ID: 621
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1718272
@@ -9478,10 +9478,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 732 GoSliceHeaderType []time.zone
+          Type: 214 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 735 GoSliceHeaderType []time.zoneTrans
+          Type: 217 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9493,12 +9493,12 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 733 PointerType *time.zone
+          Type: 215 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 374
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 156
       Name: time.Time
       ByteSize: 24
@@ -9514,6 +9514,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 157 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 155
       Name: time.Timer
@@ -9523,12 +9531,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 731 GoChannelType <-chan time.Time
+          Type: 741 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 286
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 840704
@@ -9536,22 +9544,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *time.fileSizeError.str
+          Type: 288 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType time.fileSizeError.str
+      Data: 287 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 287
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 362
+      ID: 372
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 734
+      ID: 216
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1628896
@@ -9567,7 +9575,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 737
+      ID: 219
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1768992
@@ -9628,7 +9636,7 @@ Types:
       GoRuntimeType: 591392
       GoKind: 26
     - __kind: StructureType
-      ID: 695
+      ID: 705
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2079808
@@ -9639,10 +9647,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 696 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 706 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 697 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9657,18 +9665,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 698 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 708 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 698
+      ID: 708
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 996448
       GoKind: 9
     - __kind: StructureType
-      ID: 696
+      ID: 706
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1934080
@@ -9693,17 +9701,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 389
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 697
+      ID: 707
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 592224
       GoKind: 8
     - __kind: StructureType
-      ID: 396
+      ID: 406
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1428384
@@ -9713,13 +9721,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 295
+      ID: 305
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 843008
       GoKind: 2
     - __kind: StructureType
-      ID: 575
+      ID: 585
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1713472
@@ -9732,7 +9740,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 541
+      ID: 551
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 997312

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -135,7 +135,7 @@ Types:
       ID: 911
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 618 PointerType *crypto/x509.Certificate
+      Pointee: 628 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 670
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -180,30 +180,30 @@ Types:
       ByteSize: 8
       Pointee: 922 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 654 GoSliceDataType []float64.array
+      Pointee: 664 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 200
+      ID: 206
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Pointee: 205 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: PointerType
-      ID: 208
+      ID: 214
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 213 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 928
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 927 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 191
+      ID: 197
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []os.Signal.array
+      Pointee: 196 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -212,20 +212,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 653
+      ID: 663
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 652 GoSliceDataType []string.array
+      Pointee: 662 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 666
+      ID: 216
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 665 GoSliceDataType []time.zone.array
+      Pointee: 215 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 668
+      ID: 218
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 667 GoSliceDataType []time.zoneTrans.array
+      Pointee: 217 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 915
       Name: '*[]uint8'
@@ -244,17 +244,17 @@ Types:
       ByteSize: 8
       Pointee: 182 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 872512
       GoKind: 22
-      Pointee: 458 GoSliceHeaderType archive/tar.headerError
+      Pointee: 468 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 460
+      ID: 470
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 459 GoSliceDataType archive/tar.headerError.array
+      Pointee: 469 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 830
       Name: '*archive/zip.checksumReader'
@@ -301,10 +301,10 @@ Types:
       ByteSize: 8
       Pointee: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 204
+      ID: 210
       Name: '*bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 900
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -321,10 +321,10 @@ Types:
       ByteSize: 8
       Pointee: 166 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 623
+      ID: 633
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 624 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 160
       Name: '*bucket<string,interface {}>'
@@ -350,24 +350,24 @@ Types:
       GoKind: 22
       Pointee: 108 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 846880
       GoKind: 22
-      Pointee: 255 BaseType compress/flate.CorruptInputError
+      Pointee: 265 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 846976
       GoKind: 22
-      Pointee: 256 GoStringHeaderType compress/flate.InternalError
+      Pointee: 266 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 258
+      ID: 268
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 257 GoStringDataType compress/flate.InternalError.str
+      Pointee: 267 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 862
       Name: '*compress/flate.decompressor'
@@ -397,12 +397,12 @@ Types:
       GoKind: 22
       Pointee: 112 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 550
+      ID: 560
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1095072
       GoKind: 22
-      Pointee: 551 StructureType context.deadlineExceededError
+      Pointee: 561 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 929
       Name: '*context.emptyCtx'
@@ -446,40 +446,40 @@ Types:
       GoKind: 22
       Pointee: 120 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 845920
       GoKind: 22
-      Pointee: 252 BaseType crypto/aes.KeySizeError
+      Pointee: 262 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 846112
       GoKind: 22
-      Pointee: 253 BaseType crypto/des.KeySizeError
+      Pointee: 263 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 379
+      ID: 389
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 846400
       GoKind: 22
-      Pointee: 254 BaseType crypto/rc4.KeySizeError
+      Pointee: 264 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 326
+      ID: 336
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 836608
       GoKind: 22
-      Pointee: 229 BaseType crypto/tls.AlertError
+      Pointee: 239 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 993792
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 522 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 892
       Name: '*crypto/tls.Conn'
@@ -495,206 +495,206 @@ Types:
       GoKind: 22
       Pointee: 782 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 324
+      ID: 334
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 836416
       GoKind: 22
-      Pointee: 325 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 335 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 322
+      ID: 332
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 836320
       GoKind: 22
-      Pointee: 323 StructureType crypto/tls.RecordHeaderError
+      Pointee: 333 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 510
+      ID: 520
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 992128
       GoKind: 22
-      Pointee: 479 BaseType crypto/tls.alert
+      Pointee: 489 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1233760
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 622 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1905824
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 629 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 845728
       GoKind: 22
-      Pointee: 374 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 384 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 367
+      ID: 377
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 845248
       GoKind: 22
-      Pointee: 368 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 378 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 845344
       GoKind: 22
-      Pointee: 370 StructureType crypto/x509.HostnameError
+      Pointee: 380 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 845152
       GoKind: 22
-      Pointee: 251 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 261 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 525
+      ID: 535
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1002752
       GoKind: 22
-      Pointee: 526 StructureType crypto/x509.SystemRootsError
+      Pointee: 536 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 845824
       GoKind: 22
-      Pointee: 376 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 386 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 845632
       GoKind: 22
-      Pointee: 372 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 382 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 855136
       GoKind: 22
-      Pointee: 417 StructureType encoding/asn1.StructuralError
+      Pointee: 427 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 855328
       GoKind: 22
-      Pointee: 421 StructureType encoding/asn1.SyntaxError
+      Pointee: 431 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 855232
       GoKind: 22
-      Pointee: 419 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 429 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 836704
       GoKind: 22
-      Pointee: 230 BaseType encoding/base64.CorruptInputError
+      Pointee: 240 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 844096
       GoKind: 22
-      Pointee: 250 BaseType encoding/hex.InvalidByteError
+      Pointee: 260 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 840448
       GoKind: 22
-      Pointee: 347 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 357 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 998784
       GoKind: 22
-      Pointee: 524 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 534 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 840064
       GoKind: 22
-      Pointee: 339 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 349 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 840352
       GoKind: 22
-      Pointee: 345 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 355 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 342
+      ID: 352
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 840256
       GoKind: 22
-      Pointee: 343 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 353 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 840160
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 351 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 840832
       GoKind: 22
-      Pointee: 349 StructureType encoding/json.jsonError
+      Pointee: 359 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 866368
       GoKind: 22
-      Pointee: 448 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 458 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 866272
       GoKind: 22
-      Pointee: 446 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 456 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 866464
       GoKind: 22
-      Pointee: 264 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 274 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 266
+      ID: 276
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 265 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 275 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 866560
       GoKind: 22
-      Pointee: 451 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 461 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -703,19 +703,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 310
+      ID: 320
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 831808
       GoKind: 22
-      Pointee: 311 UnresolvedPointeeType errors.errorString
+      Pointee: 321 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 985088
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType errors.joinError
+      Pointee: 509 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -731,26 +731,26 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 482
+      ID: 492
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 975104
       GoKind: 22
-      Pointee: 483 UnresolvedPointeeType fmt.wrapError
+      Pointee: 493 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 484
+      ID: 494
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 975232
       GoKind: 22
-      Pointee: 485 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 495 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 843616
       GoKind: 22
-      Pointee: 360 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 370 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 735
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -759,193 +759,193 @@ Types:
       GoKind: 22
       Pointee: 736 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 351
+      ID: 361
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 842176
       GoKind: 22
-      Pointee: 352 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 362 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 842272
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 364 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 841984
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 649 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 357
+      ID: 367
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 842560
       GoKind: 22
-      Pointee: 358 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 368 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 842080
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 651 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 842368
       GoKind: 22
-      Pointee: 244 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 254 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 246
+      ID: 256
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 245 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 255 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 841888
       GoKind: 22
-      Pointee: 241 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 251 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 243
+      ID: 253
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 242 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 252 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 842464
       GoKind: 22
-      Pointee: 247 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 257 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 249
+      ID: 259
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 248 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 258 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 423
+      ID: 433
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 855808
       GoKind: 22
-      Pointee: 424 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 434 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 855712
       GoKind: 22
-      Pointee: 259 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 269 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 852544
       GoKind: 22
-      Pointee: 391 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 401 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 394
+      ID: 404
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 852736
       GoKind: 22
-      Pointee: 395 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 405 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 392
+      ID: 402
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 852640
       GoKind: 22
-      Pointee: 393 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 403 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 852448
       GoKind: 22
-      Pointee: 389 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 399 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 656 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 666 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 853120
       GoKind: 22
-      Pointee: 403 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 413 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 396
+      ID: 406
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 852832
       GoKind: 22
-      Pointee: 397 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 407 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 400
+      ID: 410
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 853024
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 411 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 852928
       GoKind: 22
-      Pointee: 399 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 409 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 853216
       GoKind: 22
-      Pointee: 405 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 415 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 853504
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 421 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 853600
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 423 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 853408
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 419 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 853312
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 417 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 853792
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 425 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 749
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -975,12 +975,12 @@ Types:
       GoKind: 22
       Pointee: 748 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 433
+      ID: 443
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 863584
       GoKind: 22
-      Pointee: 434 StructureType github.com/cihub/seelog.baseError
+      Pointee: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 728
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -989,12 +989,12 @@ Types:
       GoKind: 22
       Pointee: 729 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 435
+      ID: 445
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 863680
       GoKind: 22
-      Pointee: 436 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 446 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 720
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1017,12 +1017,12 @@ Types:
       GoKind: 22
       Pointee: 727 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 439
+      ID: 449
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 863872
       GoKind: 22
-      Pointee: 440 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 450 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 724
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1038,19 +1038,19 @@ Types:
       GoKind: 22
       Pointee: 742 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 437
+      ID: 447
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 863776
       GoKind: 22
-      Pointee: 438 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 448 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 441
+      ID: 451
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 863968
       GoKind: 22
-      Pointee: 442 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 452 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 828
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1066,268 +1066,268 @@ Types:
       GoKind: 22
       Pointee: 848 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 537
+      ID: 547
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1022976
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 548 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1023104
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 550 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 531
+      ID: 541
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1007744
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 542 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 844288
       GoKind: 22
-      Pointee: 363 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 373 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 533
+      ID: 543
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1010688
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 544 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 579
+      ID: 589
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1118112
       GoKind: 22
-      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 573
+      ID: 583
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1117728
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 584 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 997760
       GoKind: 22
-      Pointee: 518 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 528 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 585
+      ID: 595
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1118496
       GoKind: 22
-      Pointee: 586 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 596 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 516
+      ID: 526
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 997632
       GoKind: 22
-      Pointee: 481 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 491 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1117984
       GoKind: 22
-      Pointee: 578 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 588 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 575
+      ID: 585
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1117856
       GoKind: 22
-      Pointee: 576 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 586 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 583
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1118368
       GoKind: 22
-      Pointee: 584 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 581
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1118240
       GoKind: 22
-      Pointee: 582 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 589
+      ID: 599
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1118880
       GoKind: 22
-      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 600 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 521
+      ID: 531
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 998016
       GoKind: 22
-      Pointee: 522 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 532 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 519
+      ID: 529
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 997888
       GoKind: 22
-      Pointee: 520 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 530 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 587
+      ID: 597
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1118752
       GoKind: 22
-      Pointee: 588 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 598 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 456
+      ID: 466
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871744
       GoKind: 22
-      Pointee: 267 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 277 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 269
+      ID: 279
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 278 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1468608
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 637 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 543
+      ID: 553
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1039872
       GoKind: 22
-      Pointee: 544 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 554 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 873760
       GoKind: 22
-      Pointee: 270 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 280 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 597
+      ID: 607
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1170208
       GoKind: 22
-      Pointee: 598 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 608 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 22
-      Pointee: 465 StructureType golang.org/x/net/http2.connError
+      Pointee: 475 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 22
-      Pointee: 274 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 284 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 276
+      ID: 286
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 275 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 285 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 22
-      Pointee: 280 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 290 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 282
+      ID: 292
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 291 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 22
-      Pointee: 277 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 287 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 279
+      ID: 289
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 288 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 462
+      ID: 472
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 22
-      Pointee: 271 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 281 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 273
+      ID: 283
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 282 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 22
-      Pointee: 469 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 479 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 874432
       GoKind: 22
-      Pointee: 283 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 293 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 865792
       GoKind: 22
-      Pointee: 444 StructureType google.golang.org/grpc.dropError
+      Pointee: 454 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 595
+      ID: 605
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1166880
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 606 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1257760
       GoKind: 22
-      Pointee: 616 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 626 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 454
+      ID: 464
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 870016
       GoKind: 22
-      Pointee: 455 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 465 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 853
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1336,12 +1336,12 @@ Types:
       GoKind: 22
       Pointee: 854 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 541
+      ID: 551
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1034112
       GoKind: 22
-      Pointee: 542 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 552 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 837
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1350,40 +1350,40 @@ Types:
       GoKind: 22
       Pointee: 838 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 425
+      ID: 435
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 858016
       GoKind: 22
-      Pointee: 426 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 436 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 535
+      ID: 545
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1012224
       GoKind: 22
-      Pointee: 536 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 546 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1133344
       GoKind: 22
-      Pointee: 594 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 604 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1133088
       GoKind: 22
-      Pointee: 592 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 602 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 839104
       GoKind: 22
-      Pointee: 337 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 347 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 679
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
@@ -1441,12 +1441,12 @@ Types:
       GoKind: 22
       Pointee: 678 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 210
+      ID: 220
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1103392
       GoKind: 22
-      Pointee: 211 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 221 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 175
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
@@ -1483,33 +1483,33 @@ Types:
       GoKind: 22
       Pointee: 811 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 850816
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 395 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 427
+      ID: 437
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 858592
       GoKind: 22
-      Pointee: 428 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 438 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 429
+      ID: 439
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 858688
       GoKind: 22
-      Pointee: 430 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 440 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 867328
       GoKind: 22
-      Pointee: 453 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 463 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
       ID: 129
       Name: '*hash<context.canceler,struct {}>'
@@ -1521,10 +1521,10 @@ Types:
       ByteSize: 8
       Pointee: 732 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 202
+      ID: 208
       Name: '*hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 203 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 209 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 898
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
@@ -1541,10 +1541,10 @@ Types:
       ByteSize: 8
       Pointee: 164 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 621
+      ID: 631
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 622 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 632 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 158
       Name: '*hash<string,interface {}>'
@@ -1556,12 +1556,12 @@ Types:
       ByteSize: 8
       Pointee: 154 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 875200
       GoKind: 22
-      Pointee: 472 UnresolvedPointeeType html/template.Error
+      Pointee: 482 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 96
       Name: '*int'
@@ -1598,19 +1598,19 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 844672
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 375 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 571
+      ID: 581
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1111840
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 582 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 890
       Name: '*internal/poll.FD'
@@ -1619,19 +1619,19 @@ Types:
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 569
+      ID: 579
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1111712
       GoKind: 22
-      Pointee: 570 StructureType internal/poll.errNetClosing
+      Pointee: 580 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 312
+      ID: 322
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 832192
       GoKind: 22
-      Pointee: 313 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 323 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 855
       Name: '*io.PipeReader'
@@ -1661,19 +1661,19 @@ Types:
       GoKind: 22
       Pointee: 827 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1110944
       GoKind: 22
-      Pointee: 568 UnresolvedPointeeType io/fs.PathError
+      Pointee: 578 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 847552
       GoKind: 22
-      Pointee: 383 StructureType math/big.ErrNaN
+      Pointee: 393 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 905
       Name: '*mime/multipart.FileHeader'
@@ -1703,19 +1703,19 @@ Types:
       GoKind: 22
       Pointee: 842 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 553
+      ID: 563
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1096224
       GoKind: 22
-      Pointee: 554 UnresolvedPointeeType net.AddrError
+      Pointee: 564 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 602
+      ID: 612
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1226880
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType net.DNSError
+      Pointee: 613 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 866
       Name: '*net.IPConn'
@@ -1724,19 +1724,19 @@ Types:
       GoKind: 22
       Pointee: 867 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1226560
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType net.OpError
+      Pointee: 611 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1096352
       GoKind: 22
-      Pointee: 556 UnresolvedPointeeType net.ParseError
+      Pointee: 566 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 874
       Name: '*net.TCPConn'
@@ -1759,24 +1759,24 @@ Types:
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1095456
       GoKind: 22
-      Pointee: 547 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 557 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 548 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 558 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 976128
       GoKind: 22
-      Pointee: 487 StructureType net.canceledError
+      Pointee: 497 StructureType net.canceledError
     - __kind: PointerType
       ID: 864
       Name: '*net.conn'
@@ -1785,12 +1785,12 @@ Types:
       GoKind: 22
       Pointee: 865 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 644
+      ID: 654
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1701216
       GoKind: 22
-      Pointee: 645 StructureType net.dialResult·1
+      Pointee: 655 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 880
       Name: '*net.netFD'
@@ -1799,12 +1799,12 @@ Types:
       GoKind: 22
       Pointee: 881 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 284
+      ID: 294
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 824992
       GoKind: 22
-      Pointee: 285 UnresolvedPointeeType net.notFoundError
+      Pointee: 295 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 930
       Name: '*net.onlyValuesCtx'
@@ -1813,12 +1813,12 @@ Types:
       GoKind: 22
       Pointee: 931 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 286
+      ID: 296
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 825664
       GoKind: 22
-      Pointee: 287 StructureType net.result·2
+      Pointee: 297 StructureType net.result·2
     - __kind: PointerType
       ID: 870
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1834,33 +1834,33 @@ Types:
       GoKind: 22
       Pointee: 869 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1096992
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType net.temporaryError
+      Pointee: 568 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1227200
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType net.timeoutError
+      Pointee: 615 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 292
+      ID: 302
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 828256
       GoKind: 22
-      Pointee: 293 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 303 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 979456
       GoKind: 22
-      Pointee: 489 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 499 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 105
       Name: '*net/http.Request'
@@ -1918,26 +1918,26 @@ Types:
       GoKind: 22
       Pointee: 805 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 294
+      ID: 304
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 828448
       GoKind: 22
-      Pointee: 213 BaseType net/http.http2ConnectionError
+      Pointee: 223 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 295
+      ID: 305
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 828544
       GoKind: 22
-      Pointee: 296 StructureType net/http.http2GoAwayError
+      Pointee: 306 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 606
+      ID: 616
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1228160
       GoKind: 22
-      Pointee: 607 StructureType net/http.http2StreamError
+      Pointee: 617 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 834
       Name: '*net/http.http2clientStream'
@@ -1946,31 +1946,31 @@ Types:
       GoKind: 22
       Pointee: 835 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 301
+      ID: 311
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 829408
       GoKind: 22
-      Pointee: 302 StructureType net/http.http2connError
+      Pointee: 312 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 828928
       GoKind: 22
-      Pointee: 217 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 227 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 219
+      ID: 229
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 218 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 228 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 299
+      ID: 309
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 829024
       GoKind: 22
-      Pointee: 300 StructureType net/http.http2goAwayFlowError
+      Pointee: 310 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 798
       Name: '*net/http.http2gzipReader'
@@ -1979,36 +1979,36 @@ Types:
       GoKind: 22
       Pointee: 799 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 304
+      ID: 314
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 829600
       GoKind: 22
-      Pointee: 223 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 233 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 225
+      ID: 235
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 224 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 234 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 303
+      ID: 313
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 829504
       GoKind: 22
-      Pointee: 220 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 230 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 222
+      ID: 232
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 221 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 231 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 561
+      ID: 571
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1101216
       GoKind: 22
-      Pointee: 562 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 572 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 794
       Name: '*net/http.http2missingBody'
@@ -2024,24 +2024,24 @@ Types:
       GoKind: 22
       Pointee: 807 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 981504
       GoKind: 22
-      Pointee: 495 StructureType net/http.http2noCachedConnError
+      Pointee: 505 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 297
+      ID: 307
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 828832
       GoKind: 22
-      Pointee: 214 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 224 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 216
+      ID: 226
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 215 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 225 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 802
       Name: '*net/http.http2requestBody'
@@ -2085,12 +2085,12 @@ Types:
       GoKind: 22
       Pointee: 825 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 981120
       GoKind: 22
-      Pointee: 491 StructureType net/http.nothingWrittenError
+      Pointee: 501 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 786
       Name: '*net/http.pattern'
@@ -2113,12 +2113,12 @@ Types:
       GoKind: 22
       Pointee: 823 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 305
+      ID: 315
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 829792
       GoKind: 22
-      Pointee: 306 StructureType net/http.requestBodyReadError
+      Pointee: 316 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 718
       Name: '*net/http.response'
@@ -2134,40 +2134,40 @@ Types:
       GoKind: 22
       Pointee: 926 StructureType net/http.segment
     - __kind: PointerType
-      ID: 290
+      ID: 300
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 828160
       GoKind: 22
-      Pointee: 291 StructureType net/http.statusError
+      Pointee: 301 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1229600
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 619 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 559
+      ID: 569
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1101088
       GoKind: 22
-      Pointee: 560 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 570 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 981248
       GoKind: 22
-      Pointee: 493 StructureType net/http.transportReadFromServerError
+      Pointee: 503 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 288
+      ID: 298
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 827392
       GoKind: 22
-      Pointee: 289 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 299 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 816
       Name: '*net/http/httputil.failureToReadBody'
@@ -2176,69 +2176,69 @@ Types:
       GoKind: 22
       Pointee: 817 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 318
+      ID: 328
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 834688
       GoKind: 22
-      Pointee: 319 StructureType net/netip.parseAddrError
+      Pointee: 329 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 316
+      ID: 326
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 834592
       GoKind: 22
-      Pointee: 317 StructureType net/netip.parsePrefixError
+      Pointee: 327 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 837952
       GoKind: 22
-      Pointee: 332 UnresolvedPointeeType net/textproto.Error
+      Pointee: 342 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 837856
       GoKind: 22
-      Pointee: 237 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 247 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 239
+      ID: 249
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 238 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 248 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1234240
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType net/url.Error
+      Pointee: 624 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836800
       GoKind: 22
-      Pointee: 231 GoStringHeaderType net/url.EscapeError
+      Pointee: 241 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 233
+      ID: 243
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 232 GoStringDataType net/url.EscapeError.str
+      Pointee: 242 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 329
+      ID: 339
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 22
-      Pointee: 234 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 244 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 236
+      ID: 246
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 235 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 245 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 775
       Name: '*net/url.URL'
@@ -2261,12 +2261,12 @@ Types:
       GoKind: 22
       Pointee: 887 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 983424
       GoKind: 22
-      Pointee: 497 UnresolvedPointeeType os.LinkError
+      Pointee: 507 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 144
       Name: '*os.Signal'
@@ -2275,12 +2275,12 @@ Types:
       GoKind: 22
       Pointee: 145 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 563
+      ID: 573
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1101728
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType os.SyscallError
+      Pointee: 574 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 884
       Name: '*os.fileWithoutReadFrom'
@@ -2296,26 +2296,26 @@ Types:
       GoKind: 22
       Pointee: 883 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 527
+      ID: 537
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1006080
       GoKind: 22
-      Pointee: 528 UnresolvedPointeeType os/exec.Error
+      Pointee: 538 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 648
+      ID: 658
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1951872
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 659 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1006208
       GoKind: 22
-      Pointee: 530 StructureType os/exec.wrappedError
+      Pointee: 540 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 121
       Name: '*os/signal.signalCtx'
@@ -2324,52 +2324,52 @@ Types:
       GoKind: 22
       Pointee: 122 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 862624
       GoKind: 22
-      Pointee: 261 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 271 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 263
+      ID: 273
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 272 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 862528
       GoKind: 22
-      Pointee: 260 BaseType os/user.UnknownUserIdError
+      Pointee: 270 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 314
+      ID: 324
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 833056
       GoKind: 22
-      Pointee: 315 UnresolvedPointeeType reflect.ValueError
+      Pointee: 325 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 851776
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 397 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 988032
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 514 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 989952
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 519 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2385,12 +2385,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 988160
       GoKind: 22
-      Pointee: 506 StructureType runtime.boundsError
+      Pointee: 516 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -2406,24 +2406,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1109792
       GoKind: 22
-      Pointee: 566 StructureType runtime.errorAddressString
+      Pointee: 576 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 987776
       GoKind: 22
-      Pointee: 473 GoStringHeaderType runtime.errorString
+      Pointee: 483 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 475
+      ID: 485
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 474 GoStringDataType runtime.errorString.str
+      Pointee: 484 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -2446,17 +2446,17 @@ Types:
       GoKind: 22
       Pointee: 134 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 989696
       GoKind: 22
-      Pointee: 476 GoStringHeaderType runtime.plainError
+      Pointee: 486 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 477 GoStringDataType runtime.plainError.str
+      Pointee: 487 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2479,12 +2479,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 987392
       GoKind: 22
-      Pointee: 501 UnresolvedPointeeType strconv.NumError
+      Pointee: 511 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -2610,12 +2610,12 @@ Types:
       GoKind: 22
       Pointee: 819 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1233120
       GoKind: 22
-      Pointee: 599 BaseType syscall.Errno
+      Pointee: 609 BaseType syscall.Errno
     - __kind: PointerType
       ID: 675
       Name: '*syscall.Signal'
@@ -2624,12 +2624,12 @@ Types:
       GoKind: 22
       Pointee: 674 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 545
+      ID: 555
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1044352
       GoKind: 22
-      Pointee: 546 StructureType text/template.ExecError
+      Pointee: 556 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 139
       Name: '*time.Location'
@@ -2638,12 +2638,12 @@ Types:
       GoKind: 22
       Pointee: 140 StructureType time.Location
     - __kind: PointerType
-      ID: 308
+      ID: 318
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 830656
       GoKind: 22
-      Pointee: 309 UnresolvedPointeeType time.ParseError
+      Pointee: 319 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 136
       Name: '*time.Timer'
@@ -2652,31 +2652,31 @@ Types:
       GoKind: 22
       Pointee: 137 StructureType time.Timer
     - __kind: PointerType
-      ID: 307
+      ID: 317
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 830560
       GoKind: 22
-      Pointee: 226 GoStringHeaderType time.fileSizeError
+      Pointee: 236 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 228
+      ID: 238
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 227 GoStringDataType time.fileSizeError.str
+      Pointee: 237 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 660
+      ID: 191
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 661 StructureType time.zone
+      Pointee: 192 StructureType time.zone
     - __kind: PointerType
-      ID: 663
+      ID: 194
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367200
       GoKind: 22
-      Pointee: 664 StructureType time.zoneTrans
+      Pointee: 195 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -2720,47 +2720,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 320
+      ID: 330
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 835456
       GoKind: 22
-      Pointee: 321 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 331 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 333
+      ID: 343
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 838336
       GoKind: 22
-      Pointee: 334 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 344 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 838432
       GoKind: 22
-      Pointee: 240 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 250 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 995200
       GoKind: 22
-      Pointee: 514 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 524 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 515
+      ID: 525
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 995328
       GoKind: 22
-      Pointee: 480 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 490 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 783
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: GoChannelType
-      ID: 658
+      ID: 668
       Name: <-chan time.Time
       GoRuntimeType: 550144
       GoKind: 18
@@ -2929,7 +2929,7 @@ Types:
       HasCount: true
       Element: 12 BaseType uint64
     - __kind: ArrayType
-      ID: 632
+      ID: 642
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 642080
@@ -2986,7 +2986,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 618 PointerType *crypto/x509.Certificate
+      Element: 628 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 669
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -3092,11 +3092,11 @@ Types:
       ByteSize: 32
       Element: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 222
       Name: '[]bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 906
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
@@ -3110,31 +3110,31 @@ Types:
       ByteSize: 336
       Element: 768 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 204
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 166 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 651
+      ID: 661
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 624 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 202
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
       Element: 161 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 200
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
       Element: 156 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 637
+      ID: 647
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 464512
@@ -3149,9 +3149,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 654 GoSliceDataType []float64.array
+      Data: 664 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 654
+      ID: 664
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3172,9 +3172,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 199 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 205 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 205
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3195,9 +3195,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 207 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 213 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 213
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3217,7 +3217,7 @@ Types:
       HasCount: true
       Element: 752 BaseType github.com/cihub/seelog.LogLevel
     - __kind: ArrayType
-      ID: 192
+      ID: 198
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -3262,9 +3262,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 190 GoSliceDataType []os.Signal.array
+      Data: 196 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 196
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3274,7 +3274,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 636
+      ID: 646
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -3289,15 +3289,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 652 GoSliceDataType []string.array
+      Data: 662 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 652
+      ID: 662
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 659
+      ID: 190
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -3305,22 +3305,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 660 PointerType *time.zone
+          Type: 191 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 665 GoSliceDataType []time.zone.array
+      Data: 215 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 215
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 661 StructureType time.zone
+      Element: 192 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 662
+      ID: 193
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459232
@@ -3328,20 +3328,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 663 PointerType *time.zoneTrans
+          Type: 194 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 667 GoSliceDataType []time.zoneTrans.array
+      Data: 217 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 667
+      ID: 217
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 664 StructureType time.zoneTrans
+      Element: 195 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3389,12 +3389,12 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 209
+      ID: 219
       Name: '[]val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 210 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 220 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
       ID: 902
       Name: '[]val<[]*mime/multipart.FileHeader>'
@@ -3408,7 +3408,7 @@ Types:
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 636 GoSliceHeaderType []string
+      Element: 646 GoSliceHeaderType []string
     - __kind: ArrayType
       ID: 753
       Name: '[]val<bool>'
@@ -3417,28 +3417,28 @@ Types:
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 197
+      ID: 203
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 650
+      ID: 660
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 643 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 195
+      ID: 201
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 127 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 193
+      ID: 199
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -3451,7 +3451,7 @@ Types:
       HasCount: true
       Element: 188 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 458
+      ID: 468
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 872608
@@ -3466,9 +3466,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 459 GoSliceDataType archive/tar.headerError.array
+      Data: 469 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 469
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3534,7 +3534,7 @@ Types:
       KeyType: 752 BaseType github.com/cihub/seelog.LogLevel
       ValueType: 6 BaseType bool
     - __kind: GoHMapBucketType
-      ID: 205
+      ID: 211
       Name: bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
@@ -3543,15 +3543,15 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 209 ArrayType []val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 219 ArrayType []val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 210 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      ValueType: 220 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 901
       Name: bucket<string,[]*mime/multipart.FileHeader>
@@ -3562,7 +3562,7 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
           Type: 902 ArrayType []val<[]*mime/multipart.FileHeader>
@@ -3581,7 +3581,7 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
           Type: 773 ArrayType []val<[]string>
@@ -3589,7 +3589,7 @@ Types:
           Offset: 328
           Type: 767 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 636 GoSliceHeaderType []string
+      ValueType: 646 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
       ID: 166
       Name: bucket<string,float64>
@@ -3600,17 +3600,17 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 197 ArrayType []val<float64>
+          Type: 203 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
           Type: 165 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 624
+      ID: 634
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
@@ -3619,15 +3619,15 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 650 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 660 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 623 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 643 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 161
       Name: bucket<string,interface {}>
@@ -3638,10 +3638,10 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 195 ArrayType []val<interface {}>
+          Type: 201 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
           Type: 160 PointerType *bucket<string,interface {}>
@@ -3657,10 +3657,10 @@ Types:
           Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 192 ArrayType []key<string>
+          Type: 198 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 193 ArrayType []val<string>
+          Type: 199 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 155 PointerType *bucket<string,string>
@@ -3697,13 +3697,13 @@ Types:
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: BaseType
-      ID: 255
+      ID: 265
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 768928
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 256
+      ID: 266
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 769024
@@ -3711,13 +3711,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 258 PointerType *compress/flate.InternalError.str
+          Type: 268 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 257 GoStringDataType compress/flate.InternalError.str
+      Data: 267 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 257
+      ID: 267
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3801,7 +3801,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 551
+      ID: 561
       Name: context.deadlineExceededError
       GoRuntimeType: 1275008
       GoKind: 25
@@ -3845,7 +3845,7 @@ Types:
           Type: 136 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 138 StructureType time.Time
+          Type: 138 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3891,31 +3891,31 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 252
+      ID: 262
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768640
       GoKind: 2
     - __kind: BaseType
-      ID: 253
+      ID: 263
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768736
       GoKind: 2
     - __kind: BaseType
-      ID: 254
+      ID: 264
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768832
       GoKind: 2
     - __kind: BaseType
-      ID: 229
+      ID: 239
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 766336
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 522
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3984,11 +3984,11 @@ Types:
       GoRuntimeType: 766144
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 325
+      ID: 335
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 323
+      ID: 333
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1596064
@@ -3999,26 +3999,26 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 632 ArrayType [5]uint8
+          Type: 642 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 633 GoInterfaceType net.Conn
+          Type: 643 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 479
+      ID: 489
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 945088
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 622
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 629
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 374
+      ID: 384
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1598944
@@ -4026,21 +4026,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 618 PointerType *crypto/x509.Certificate
+          Type: 628 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 642 BaseType crypto/x509.InvalidReason
+          Type: 652 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 368
+      ID: 378
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1071040
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 370
+      ID: 380
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1401728
@@ -4048,24 +4048,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 618 PointerType *crypto/x509.Certificate
+          Type: 628 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 251
+      ID: 261
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: BaseType
-      ID: 642
+      ID: 652
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537536
       GoKind: 2
     - __kind: StructureType
-      ID: 526
+      ID: 536
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1365216
@@ -4075,13 +4075,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 376
+      ID: 386
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1071296
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 372
+      ID: 382
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1598752
@@ -4089,15 +4089,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 618 PointerType *crypto/x509.Certificate
+          Type: 628 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 618 PointerType *crypto/x509.Certificate
+          Type: 628 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 417
+      ID: 427
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1245600
@@ -4107,7 +4107,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 421
+      ID: 431
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1245760
@@ -4117,47 +4117,47 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 419
+      ID: 429
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 230
+      ID: 240
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 766432
       GoKind: 6
     - __kind: BaseType
-      ID: 250
+      ID: 260
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 768256
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 347
+      ID: 357
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 524
+      ID: 534
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 339
+      ID: 349
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 345
+      ID: 355
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 343
+      ID: 353
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 351
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 349
+      ID: 359
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1237280
@@ -4167,15 +4167,15 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 448
+      ID: 458
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 446
+      ID: 456
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 264
+      ID: 274
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 771616
@@ -4183,18 +4183,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 266 PointerType *encoding/xml.UnmarshalError.str
+          Type: 276 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 265 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 275 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 265
+      ID: 275
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 451
+      ID: 461
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4211,11 +4211,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 311
+      ID: 321
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 509
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4231,11 +4231,11 @@ Types:
       GoRuntimeType: 534720
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 483
+      ID: 493
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 485
+      ID: 495
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4269,7 +4269,7 @@ Types:
       GoRuntimeType: 960448
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 360
+      ID: 370
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4279,7 +4279,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 352
+      ID: 362
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1597408
@@ -4287,7 +4287,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 634 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 644 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -4295,25 +4295,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 364
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 649
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 358
+      ID: 368
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1070016
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 651
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 244
+      ID: 254
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 767680
@@ -4321,18 +4321,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 246 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 256 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 245 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 255 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 245
+      ID: 255
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 634
+      ID: 644
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2068064
@@ -4340,13 +4340,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 635 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 645 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 13 GoStringHeaderType string
@@ -4355,7 +4355,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 637 GoSliceHeaderType []float64
+          Type: 647 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 16 BaseType int64
@@ -4364,13 +4364,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 638 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 648 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 640 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 650 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 13 GoStringHeaderType string
@@ -4381,13 +4381,13 @@ Types:
           Offset: 184
           Type: 16 BaseType int64
     - __kind: BaseType
-      ID: 635
+      ID: 645
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 536320
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 241
+      ID: 251
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 767584
@@ -4395,18 +4395,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 243 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 253 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 242 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 252 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 242
+      ID: 252
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 247
+      ID: 257
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 767776
@@ -4414,30 +4414,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 249 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 259 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 248 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 258 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 248
+      ID: 258
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 424
+      ID: 434
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1073856
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 259
+      ID: 269
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 770176
       GoKind: 2
     - __kind: StructureType
-      ID: 391
+      ID: 401
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1402688
@@ -4450,7 +4450,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 395
+      ID: 405
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1600672
@@ -4466,7 +4466,7 @@ Types:
           Offset: 24
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 393
+      ID: 403
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1244160
@@ -4476,7 +4476,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 389
+      ID: 399
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1243840
@@ -4486,14 +4486,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 620
+      ID: 630
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1129760
       GoKind: 21
-      HeaderType: 622 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 632 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 643
+      ID: 653
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1007104
@@ -4508,15 +4508,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 656 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 666 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 656
+      ID: 666
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 403
+      ID: 413
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1403008
@@ -4524,12 +4524,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 620 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 630 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 620 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 630 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 397
+      ID: 407
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1244320
@@ -4539,7 +4539,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 401
+      ID: 411
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1600864
@@ -4550,12 +4550,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 643 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 643 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 399
+      ID: 409
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1402848
@@ -4568,7 +4568,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 405
+      ID: 415
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1244480
@@ -4576,9 +4576,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 138 StructureType time.Time
+          Type: 138 GoTimeType time.Time
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1403328
@@ -4591,7 +4591,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 413
+      ID: 423
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1244800
@@ -4601,7 +4601,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 409
+      ID: 419
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1403168
@@ -4614,7 +4614,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 407
+      ID: 417
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1244640
@@ -4624,7 +4624,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 415
+      ID: 425
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1403488
@@ -4659,7 +4659,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 434
+      ID: 444
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1250720
@@ -4673,7 +4673,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 436
+      ID: 446
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1250880
@@ -4681,7 +4681,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 434 StructureType github.com/cihub/seelog.baseError
+          Type: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 721
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -4704,7 +4704,7 @@ Types:
           Offset: 8
           Type: 730 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 440
+      ID: 450
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1251200
@@ -4712,7 +4712,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 434 StructureType github.com/cihub/seelog.baseError
+          Type: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 725
       Name: github.com/cihub/seelog.splitDispatcher
@@ -4728,7 +4728,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 438
+      ID: 448
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1251040
@@ -4736,9 +4736,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 434 StructureType github.com/cihub/seelog.baseError
+          Type: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 442
+      ID: 452
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1251360
@@ -4746,7 +4746,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 434 StructureType github.com/cihub/seelog.baseError
+          Type: 444 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 845
       Name: github.com/cihub/seelog/archive.Reader
@@ -4775,30 +4775,30 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 548
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 550
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 542
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 363
+      ID: 373
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1238560
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 544
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 590
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1713312
@@ -4814,11 +4814,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 584
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 518
+      ID: 528
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1503648
@@ -4831,7 +4831,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 586
+      ID: 596
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1713760
@@ -4847,13 +4847,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 481
+      ID: 491
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 946240
       GoKind: 8
     - __kind: StructureType
-      ID: 578
+      ID: 588
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1713088
@@ -4869,13 +4869,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 646
+      ID: 656
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 767200
       GoKind: 8
     - __kind: StructureType
-      ID: 576
+      ID: 586
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1712864
@@ -4883,15 +4883,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 646 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 656 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 646 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 656 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 584
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1632896
@@ -4904,7 +4904,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 582
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1713536
@@ -4920,7 +4920,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 590
+      ID: 600
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1438464
@@ -4930,19 +4930,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 522
+      ID: 532
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1189984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 520
+      ID: 530
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1189856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 588
+      ID: 598
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1633088
@@ -4955,7 +4955,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 277
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 772288
@@ -4963,22 +4963,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 279 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 268 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 278 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 278
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 637
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 544
+      ID: 554
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1260480
@@ -4988,19 +4988,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 270
+      ID: 280
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 772864
       GoKind: 10
     - __kind: BaseType
-      ID: 625
+      ID: 635
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 957760
       GoKind: 10
     - __kind: StructureType
-      ID: 598
+      ID: 608
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1746016
@@ -5011,12 +5011,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 625 BaseType golang.org/x/net/http2.ErrCode
+          Type: 635 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 465
+      ID: 475
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1410208
@@ -5024,12 +5024,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 625 BaseType golang.org/x/net/http2.ErrCode
+          Type: 635 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 274
+      ID: 284
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 773056
@@ -5037,18 +5037,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 276 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 286 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 275 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 285 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 275
+      ID: 285
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 290
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 773248
@@ -5056,18 +5056,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 292 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 281 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 291 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 291
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 287
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 773152
@@ -5075,18 +5075,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 289 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 278 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 288 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 288
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 281
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 772960
@@ -5094,18 +5094,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 283 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 272 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 282 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 282
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 469
+      ID: 479
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1261760
@@ -5115,13 +5115,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 283
+      ID: 293
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 773344
       GoKind: 2
     - __kind: StructureType
-      ID: 444
+      ID: 454
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1256160
@@ -5131,11 +5131,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 606
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 616
+      ID: 626
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1770592
@@ -5151,7 +5151,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 455
+      ID: 465
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1409248
@@ -5168,7 +5168,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 542
+      ID: 552
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1372096
@@ -5182,25 +5182,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 426
+      ID: 436
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 536
+      ID: 546
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 594
+      ID: 604
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 592
+      ID: 602
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1321248
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 337
+      ID: 347
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -5446,16 +5446,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 201 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 207 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 206 GoMapType map[string]interface {}
+          Type: 212 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 678
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 211
+      ID: 221
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1777408
@@ -5554,11 +5554,11 @@ Types:
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 395
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 428
+      ID: 438
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1248000
@@ -5568,7 +5568,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 430
+      ID: 440
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1248160
@@ -5578,7 +5578,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 453
+      ID: 463
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -5650,7 +5650,7 @@ Types:
       BucketType: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
       BucketsType: 754 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
     - __kind: GoHMapHeaderType
-      ID: 203
+      ID: 209
       Name: hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -5671,18 +5671,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
-      BucketType: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 212 GoSliceDataType []bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 222 GoSliceDataType []bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
       ID: 899
       Name: hash<string,[]*mime/multipart.FileHeader>
@@ -5784,9 +5784,9 @@ Types:
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
       BucketType: 166 GoHMapBucketType bucket<string,float64>
-      BucketsType: 198 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 204 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 622
+      ID: 632
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -5807,18 +5807,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 623 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 623 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
-      BucketType: 624 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 651 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 661 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 159
       Name: hash<string,interface {}>
@@ -5852,7 +5852,7 @@ Types:
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
       BucketType: 161 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 196 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 202 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 154
       Name: hash<string,string>
@@ -5886,9 +5886,9 @@ Types:
           Offset: 40
           Type: 133 PointerType *runtime.mapextra
       BucketType: 156 GoHMapBucketType bucket<string,string>
-      BucketsType: 194 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 200 GoSliceDataType []bucket<string,string>.array
     - __kind: UnresolvedPointeeType
-      ID: 472
+      ID: 482
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5935,7 +5935,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 375
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5961,7 +5961,7 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 582
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5969,13 +5969,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 570
+      ID: 580
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1291808
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 313
+      ID: 323
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6123,7 +6123,7 @@ Types:
           Offset: 0
           Type: 836 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 568
+      ID: 578
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoMapType
@@ -6141,12 +6141,12 @@ Types:
       GoKind: 21
       HeaderType: 732 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 201
+      ID: 207
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 888448
       GoKind: 21
-      HeaderType: 203 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 209 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 897
       Name: map[string][]*mime/multipart.FileHeader
@@ -6169,7 +6169,7 @@ Types:
       GoKind: 21
       HeaderType: 164 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 206
+      ID: 212
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 880192
@@ -6183,7 +6183,7 @@ Types:
       GoKind: 21
       HeaderType: 154 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 383
+      ID: 393
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1240960
@@ -6227,11 +6227,11 @@ Types:
           Offset: 8
           Type: 846 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 554
+      ID: 564
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 633
+      ID: 643
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1399968
@@ -6244,7 +6244,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 613
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6252,11 +6252,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 611
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 556
+      ID: 566
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6272,7 +6272,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 547
+      ID: 557
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1065152
@@ -6280,18 +6280,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 549 PointerType *net.UnknownNetworkError.str
+          Type: 559 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 548 GoStringDataType net.UnknownNetworkError.str
+      Data: 558 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 548
+      ID: 558
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 487
+      ID: 497
       Name: net.canceledError
       GoRuntimeType: 1187552
       GoKind: 25
@@ -6301,7 +6301,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 655
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1962752
@@ -6309,7 +6309,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 633 GoInterfaceType net.Conn
+          Type: 643 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -6336,7 +6336,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 285
+      ID: 295
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6353,7 +6353,7 @@ Types:
           Offset: 16
           Type: 110 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 287
+      ID: 297
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1590880
@@ -6361,7 +6361,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 628 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 638 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -6395,11 +6395,11 @@ Types:
           Offset: 0
           Type: 874 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 568
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 615
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6449,11 +6449,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 293
+      ID: 303
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 489
+      ID: 499
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6505,7 +6505,7 @@ Types:
           Type: 16 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6550,7 +6550,7 @@ Types:
           Type: 786 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 152 GoMapType map[string]string
@@ -6587,7 +6587,7 @@ Types:
           Type: 16 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6660,19 +6660,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 213
+      ID: 223
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 764224
       GoKind: 10
     - __kind: BaseType
-      ID: 617
+      ID: 627
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 942400
       GoKind: 10
     - __kind: StructureType
-      ID: 296
+      ID: 306
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1592416
@@ -6683,12 +6683,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 617 BaseType net/http.http2ErrCode
+          Type: 627 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 617
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1760608
@@ -6699,7 +6699,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 617 BaseType net/http.http2ErrCode
+          Type: 627 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
@@ -6708,7 +6708,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 302
+      ID: 312
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1400448
@@ -6716,12 +6716,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 617 BaseType net/http.http2ErrCode
+          Type: 627 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 217
+      ID: 227
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 764416
@@ -6729,18 +6729,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 219 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 229 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 218 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 228 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 218
+      ID: 228
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 300
+      ID: 310
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1066432
       GoKind: 25
@@ -6750,7 +6750,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 223
+      ID: 233
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 764608
@@ -6758,18 +6758,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 225 PointerType *net/http.http2headerFieldNameError.str
+          Type: 235 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 224 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 234 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 224
+      ID: 234
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 220
+      ID: 230
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 764512
@@ -6777,18 +6777,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 222 PointerType *net/http.http2headerFieldValueError.str
+          Type: 232 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 221 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 231 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 221
+      ID: 231
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 562
+      ID: 572
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -6804,13 +6804,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 495
+      ID: 505
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1188192
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 214
+      ID: 224
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 764320
@@ -6818,13 +6818,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 216 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 226 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 215 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 225 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 215
+      ID: 225
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -6867,7 +6867,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1357216
@@ -6907,7 +6907,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 306
+      ID: 316
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1230400
@@ -6982,7 +6982,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 636 GoSliceHeaderType []string
+          Type: 646 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 760 StructureType sync/atomic.Bool
@@ -7018,7 +7018,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 291
+      ID: 301
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1400288
@@ -7031,17 +7031,17 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 619
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 560
+      ID: 570
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1279488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 493
+      ID: 503
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1357376
@@ -7051,7 +7051,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 289
+      ID: 299
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7061,7 +7061,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 319
+      ID: 329
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1595488
@@ -7077,7 +7077,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 317
+      ID: 327
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1400768
@@ -7090,11 +7090,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 332
+      ID: 342
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 237
+      ID: 247
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 766720
@@ -7102,22 +7102,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 239 PointerType *net/textproto.ProtocolError.str
+          Type: 249 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 238 GoStringDataType net/textproto.ProtocolError.str
+      Data: 248 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 238
+      ID: 248
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 624
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 231
+      ID: 241
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 766528
@@ -7125,18 +7125,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 233 PointerType *net/url.EscapeError.str
+          Type: 243 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 232 GoStringDataType net/url.EscapeError.str
+      Data: 242 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 232
+      ID: 242
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 234
+      ID: 244
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 766624
@@ -7144,13 +7144,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 236 PointerType *net/url.InvalidHostError.str
+          Type: 246 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 235 GoStringDataType net/url.InvalidHostError.str
+      Data: 245 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 235
+      ID: 245
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7210,7 +7210,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 497
+      ID: 507
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7227,7 +7227,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 574
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7269,15 +7269,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 528
+      ID: 538
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 659
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 530
+      ID: 540
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1503840
@@ -7311,7 +7311,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 271
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 770944
@@ -7319,36 +7319,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *os/user.UnknownGroupIdError.str
+          Type: 273 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 262 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 272 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 272
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 260
+      ID: 270
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 770848
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 315
+      ID: 325
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 397
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 514
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 519
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7360,7 +7360,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 506
+      ID: 516
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1751168
@@ -7377,9 +7377,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 647 BaseType runtime.boundsErrorCode
+          Type: 657 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 647
+      ID: 657
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 534912
@@ -7399,7 +7399,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 566
+      ID: 576
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1627136
@@ -7412,7 +7412,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 473
+      ID: 483
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 943648
@@ -7420,13 +7420,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 475 PointerType *runtime.errorString.str
+          Type: 485 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 474 GoStringDataType runtime.errorString.str
+      Data: 484 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 474
+      ID: 484
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8052,7 +8052,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 476
+      ID: 486
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 944224
@@ -8060,13 +8060,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 478 PointerType *runtime.plainError.str
+          Type: 488 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 477 GoStringDataType runtime.plainError.str
+      Data: 487 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 477
+      ID: 487
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8148,7 +8148,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 501
+      ID: 511
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8513,7 +8513,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 599
+      ID: 609
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1188832
@@ -8525,7 +8525,7 @@ Types:
       GoRuntimeType: 944416
       GoKind: 2
     - __kind: StructureType
-      ID: 546
+      ID: 556
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1508064
@@ -8555,10 +8555,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 659 GoSliceHeaderType []time.zone
+          Type: 190 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 662 GoSliceHeaderType []time.zoneTrans
+          Type: 193 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -8570,12 +8570,12 @@ Types:
           Type: 16 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 660 PointerType *time.zone
+          Type: 191 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 309
+      ID: 319
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 138
       Name: time.Time
       ByteSize: 24
@@ -8591,6 +8591,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 139 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 137
       Name: time.Timer
@@ -8600,12 +8608,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 658 GoChannelType <-chan time.Time
+          Type: 668 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 226
+      ID: 236
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 764704
@@ -8613,18 +8621,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 228 PointerType *time.fileSizeError.str
+          Type: 238 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 227 GoStringDataType time.fileSizeError.str
+      Data: 237 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 227
+      ID: 237
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 661
+      ID: 192
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1421376
@@ -8640,7 +8648,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 664
+      ID: 195
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1623872
@@ -8701,7 +8709,7 @@ Types:
       GoRuntimeType: 534848
       GoKind: 26
     - __kind: StructureType
-      ID: 628
+      ID: 638
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1921504
@@ -8712,10 +8720,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 629 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 639 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 630 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 640 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -8730,18 +8738,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 631 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 641 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 631
+      ID: 641
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 944704
       GoKind: 9
     - __kind: StructureType
-      ID: 629
+      ID: 639
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1779968
@@ -8766,17 +8774,17 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 321
+      ID: 331
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 630
+      ID: 640
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 535744
       GoKind: 8
     - __kind: StructureType
-      ID: 334
+      ID: 344
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1235360
@@ -8786,13 +8794,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 240
+      ID: 250
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 766816
       GoKind: 2
     - __kind: StructureType
-      ID: 514
+      ID: 524
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1503264
@@ -8805,7 +8813,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 480
+      ID: 490
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 945568

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -136,7 +136,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 654 PointerType *crypto/x509.Certificate
+      Pointee: 664 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 712
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -160,10 +160,10 @@ Types:
       ByteSize: 8
       Pointee: 776 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 230
+      ID: 236
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 231 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 237 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 955
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -180,10 +180,10 @@ Types:
       ByteSize: 8
       Pointee: 171 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 660 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 670 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 165
       Name: '**table<string,interface {}>'
@@ -226,30 +226,30 @@ Types:
       ByteSize: 8
       Pointee: 983 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 697
+      ID: 707
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 696 GoSliceDataType []float64.array
+      Pointee: 706 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 226
+      ID: 232
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Pointee: 231 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: PointerType
-      ID: 234
+      ID: 240
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 239 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 989
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 988 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 200
+      ID: 206
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []os.Signal.array
+      Pointee: 205 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -258,20 +258,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 695
+      ID: 705
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 694 GoSliceDataType []string.array
+      Pointee: 704 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 708
+      ID: 242
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 707 GoSliceDataType []time.zone.array
+      Pointee: 241 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 710
+      ID: 244
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 709 GoSliceDataType []time.zoneTrans.array
+      Pointee: 243 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 976
       Name: '*[]uint8'
@@ -290,17 +290,17 @@ Types:
       ByteSize: 8
       Pointee: 187 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 493
+      ID: 503
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 938400
       GoKind: 22
-      Pointee: 494 GoSliceHeaderType archive/tar.headerError
+      Pointee: 504 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 495 GoSliceDataType archive/tar.headerError.array
+      Pointee: 505 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 883
       Name: '*archive/zip.checksumReader'
@@ -351,24 +351,24 @@ Types:
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 416
+      ID: 426
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 911904
       GoKind: 22
-      Pointee: 288 BaseType compress/flate.CorruptInputError
+      Pointee: 298 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 912000
       GoKind: 22
-      Pointee: 289 GoStringHeaderType compress/flate.InternalError
+      Pointee: 299 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 291
+      ID: 301
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 290 GoStringDataType compress/flate.InternalError.str
+      Pointee: 300 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 917
       Name: '*compress/flate.decompressor'
@@ -398,12 +398,12 @@ Types:
       GoKind: 22
       Pointee: 117 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1173024
       GoKind: 22
-      Pointee: 587 StructureType context.deadlineExceededError
+      Pointee: 597 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 990
       Name: '*context.emptyCtx'
@@ -447,47 +447,47 @@ Types:
       GoKind: 22
       Pointee: 125 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 910656
       GoKind: 22
-      Pointee: 284 BaseType crypto/aes.KeySizeError
+      Pointee: 294 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 413
+      ID: 423
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 910848
       GoKind: 22
-      Pointee: 285 BaseType crypto/des.KeySizeError
+      Pointee: 295 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 286 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 296 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911424
       GoKind: 22
-      Pointee: 287 BaseType crypto/rc4.KeySizeError
+      Pointee: 297 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 901440
       GoKind: 22
-      Pointee: 261 BaseType crypto/tls.AlertError
+      Pointee: 271 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 547
+      ID: 557
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1028768
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 558 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 947
       Name: '*crypto/tls.Conn'
@@ -503,206 +503,206 @@ Types:
       GoKind: 22
       Pointee: 835 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 357
+      ID: 367
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 901248
       GoKind: 22
-      Pointee: 358 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 368 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 901152
       GoKind: 22
-      Pointee: 356 StructureType crypto/tls.RecordHeaderError
+      Pointee: 366 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 546
+      ID: 556
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1027104
       GoKind: 22
-      Pointee: 515 BaseType crypto/tls.alert
+      Pointee: 525 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 647
+      ID: 657
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1405536
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 658 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 654
+      ID: 664
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2030304
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 665 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 910464
       GoKind: 22
-      Pointee: 409 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 419 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 403 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 413 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 405 StructureType crypto/x509.HostnameError
+      Pointee: 415 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 283 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 293 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 561
+      ID: 571
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1037088
       GoKind: 22
-      Pointee: 562 StructureType crypto/x509.SystemRootsError
+      Pointee: 572 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 910560
       GoKind: 22
-      Pointee: 411 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 421 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 910368
       GoKind: 22
-      Pointee: 407 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 417 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 453 StructureType encoding/asn1.StructuralError
+      Pointee: 463 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 456
+      ID: 466
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 920928
       GoKind: 22
-      Pointee: 457 StructureType encoding/asn1.SyntaxError
+      Pointee: 467 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 454
+      ID: 464
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 920832
       GoKind: 22
-      Pointee: 455 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 465 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 901536
       GoKind: 22
-      Pointee: 262 BaseType encoding/base64.CorruptInputError
+      Pointee: 272 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 394
+      ID: 404
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 282 BaseType encoding/hex.InvalidByteError
+      Pointee: 292 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 379
+      ID: 389
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 390 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 559
+      ID: 569
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1033760
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 570 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 904704
       GoKind: 22
-      Pointee: 372 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 382 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 22
-      Pointee: 378 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 388 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 376 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 386 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 374 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 384 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 382 StructureType encoding/json.jsonError
+      Pointee: 392 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 483
+      ID: 493
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932256
       GoKind: 22
-      Pointee: 484 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 494 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 481
+      ID: 491
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 932160
       GoKind: 22
-      Pointee: 482 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 492 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 485
+      ID: 495
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 932352
       GoKind: 22
-      Pointee: 297 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 307 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 299
+      ID: 309
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 308 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 932448
       GoKind: 22
-      Pointee: 487 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 497 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -711,19 +711,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 343
+      ID: 353
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896736
       GoKind: 22
-      Pointee: 344 UnresolvedPointeeType errors.errorString
+      Pointee: 354 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 534
+      ID: 544
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1020064
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType errors.joinError
+      Pointee: 545 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -739,26 +739,26 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1009824
       GoKind: 22
-      Pointee: 519 UnresolvedPointeeType fmt.wrapError
+      Pointee: 529 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 520
+      ID: 530
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1009952
       GoKind: 22
-      Pointee: 521 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 531 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 392
+      ID: 402
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 393 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 403 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 777
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -767,193 +767,193 @@ Types:
       GoKind: 22
       Pointee: 778 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 384
+      ID: 394
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 906816
       GoKind: 22
-      Pointee: 385 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 395 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 386
+      ID: 396
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 906912
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 397 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 674
+      ID: 684
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 685 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 907200
       GoKind: 22
-      Pointee: 391 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 401 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 676
+      ID: 686
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 906720
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 687 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 276 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 286 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 278
+      ID: 288
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 287 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 383
+      ID: 393
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 906528
       GoKind: 22
-      Pointee: 273 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 283 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 275
+      ID: 285
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 907104
       GoKind: 22
-      Pointee: 279 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 289 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 281
+      ID: 291
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 280 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 290 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 921504
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 470 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 458
+      ID: 468
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 921408
       GoKind: 22
-      Pointee: 292 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 302 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 437 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 917760
       GoKind: 22
-      Pointee: 431 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 441 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 917664
       GoKind: 22
-      Pointee: 429 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 439 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 435 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 699
+      ID: 709
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 698 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 708 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 918144
       GoKind: 22
-      Pointee: 439 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 449 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 917856
       GoKind: 22
-      Pointee: 433 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 443 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 918048
       GoKind: 22
-      Pointee: 437 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 447 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 917952
       GoKind: 22
-      Pointee: 435 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 445 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 440
+      ID: 450
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 918240
       GoKind: 22
-      Pointee: 441 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 451 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 446
+      ID: 456
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 918528
       GoKind: 22
-      Pointee: 447 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 457 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 448
+      ID: 458
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 918624
       GoKind: 22
-      Pointee: 449 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 459 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 444
+      ID: 454
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 918432
       GoKind: 22
-      Pointee: 445 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 455 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 442
+      ID: 452
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 918336
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 453 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 918816
       GoKind: 22
-      Pointee: 451 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 461 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 791
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -983,12 +983,12 @@ Types:
       GoKind: 22
       Pointee: 790 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 469
+      ID: 479
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 929472
       GoKind: 22
-      Pointee: 470 StructureType github.com/cihub/seelog.baseError
+      Pointee: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 770
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -997,12 +997,12 @@ Types:
       GoKind: 22
       Pointee: 771 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 929568
       GoKind: 22
-      Pointee: 472 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 482 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 762
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1025,12 +1025,12 @@ Types:
       GoKind: 22
       Pointee: 769 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 475
+      ID: 485
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 929760
       GoKind: 22
-      Pointee: 476 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 486 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 766
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1046,19 +1046,19 @@ Types:
       GoKind: 22
       Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 473
+      ID: 483
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 929664
       GoKind: 22
-      Pointee: 474 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 484 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 477
+      ID: 487
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 929856
       GoKind: 22
-      Pointee: 478 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 488 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 881
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1074,268 +1074,268 @@ Types:
       GoKind: 22
       Pointee: 901 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 573
+      ID: 583
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1056544
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 584 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 575
+      ID: 585
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1056672
       GoKind: 22
-      Pointee: 576 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 586 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1041440
       GoKind: 22
-      Pointee: 568 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 578 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 908928
       GoKind: 22
-      Pointee: 396 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 406 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 569
+      ID: 579
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1044896
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 580 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1195424
       GoKind: 22
-      Pointee: 616 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 626 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 609
+      ID: 619
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1195040
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 620 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 553
+      ID: 563
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1032864
       GoKind: 22
-      Pointee: 554 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 564 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 621
+      ID: 631
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1195808
       GoKind: 22
-      Pointee: 622 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 632 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 552
+      ID: 562
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1032736
       GoKind: 22
-      Pointee: 517 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 527 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 613
+      ID: 623
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1195296
       GoKind: 22
-      Pointee: 614 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 624 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 611
+      ID: 621
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1195168
       GoKind: 22
-      Pointee: 612 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 622 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 619
+      ID: 629
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1195680
       GoKind: 22
-      Pointee: 620 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 630 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1195552
       GoKind: 22
-      Pointee: 618 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 628 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 625
+      ID: 635
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1196192
       GoKind: 22
-      Pointee: 626 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 636 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1033120
       GoKind: 22
-      Pointee: 558 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 568 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1032992
       GoKind: 22
-      Pointee: 556 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 566 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 623
+      ID: 633
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1196064
       GoKind: 22
-      Pointee: 624 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 634 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 300 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 310 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 302
+      ID: 312
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 301 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 311 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 662
+      ID: 672
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1648864
       GoKind: 22
-      Pointee: 663 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 673 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 579
+      ID: 589
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1073312
       GoKind: 22
-      Pointee: 580 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 590 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 497
+      ID: 507
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 939648
       GoKind: 22
-      Pointee: 303 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 313 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 633
+      ID: 643
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1248672
       GoKind: 22
-      Pointee: 634 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 644 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 939936
       GoKind: 22
-      Pointee: 501 StructureType golang.org/x/net/http2.connError
+      Pointee: 511 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 499
+      ID: 509
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 939840
       GoKind: 22
-      Pointee: 307 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 317 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 309
+      ID: 319
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 318 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 940128
       GoKind: 22
-      Pointee: 313 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 323 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 315
+      ID: 325
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 324 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 502
+      ID: 512
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 310 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 320 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 312
+      ID: 322
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 321 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 939744
       GoKind: 22
-      Pointee: 304 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 314 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 306
+      ID: 316
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 305 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 315 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 504
+      ID: 514
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 940224
       GoKind: 22
-      Pointee: 505 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 515 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 506
+      ID: 516
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 940320
       GoKind: 22
-      Pointee: 316 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 326 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 479
+      ID: 489
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 480 StructureType google.golang.org/grpc.dropError
+      Pointee: 490 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 631
+      ID: 641
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1245472
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 642 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 651
+      ID: 661
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1430336
       GoKind: 22
-      Pointee: 652 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 662 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 935904
       GoKind: 22
-      Pointee: 491 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 501 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 906
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1344,12 +1344,12 @@ Types:
       GoKind: 22
       Pointee: 907 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1067552
       GoKind: 22
-      Pointee: 578 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 588 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 890
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1358,40 +1358,40 @@ Types:
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 462 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 472 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 571
+      ID: 581
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1046304
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 582 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 629
+      ID: 639
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1211680
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 640 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 627
+      ID: 637
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1211424
       GoKind: 22
-      Pointee: 628 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 638 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 903744
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 380 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 721
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
@@ -1449,12 +1449,12 @@ Types:
       GoKind: 22
       Pointee: 720 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 241
+      ID: 251
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1181088
       GoKind: 22
-      Pointee: 242 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 252 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 180
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
@@ -1491,40 +1491,40 @@ Types:
       GoKind: 22
       Pointee: 864 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 420
+      ID: 430
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 915840
       GoKind: 22
-      Pointee: 421 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 431 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 924288
       GoKind: 22
-      Pointee: 464 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 474 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 465
+      ID: 475
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 924384
       GoKind: 22
-      Pointee: 466 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 476 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 933216
       GoKind: 22
-      Pointee: 489 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 499 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 941088
       GoKind: 22
-      Pointee: 508 UnresolvedPointeeType html/template.Error
+      Pointee: 518 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -1561,26 +1561,26 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
-      ID: 399
+      ID: 409
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 410 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 398 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 408 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 607
+      ID: 617
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1188896
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 618 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 945
       Name: '*internal/poll.FD'
@@ -1589,19 +1589,19 @@ Types:
       GoKind: 22
       Pointee: 946 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 605
+      ID: 615
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1188768
       GoKind: 22
-      Pointee: 606 StructureType internal/poll.errNetClosing
+      Pointee: 616 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 897120
       GoKind: 22
-      Pointee: 346 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 356 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 910
       Name: '*io.PipeReader'
@@ -1631,12 +1631,12 @@ Types:
       GoKind: 22
       Pointee: 880 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 603
+      ID: 613
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1188000
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType io/fs.PathError
+      Pointee: 614 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 136
       Name: '*map<context.canceler,struct {}>'
@@ -1648,10 +1648,10 @@ Types:
       ByteSize: 8
       Pointee: 774 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 228
+      ID: 234
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 229 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 235 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 953
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1668,10 +1668,10 @@ Types:
       ByteSize: 8
       Pointee: 169 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 658 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 668 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 163
       Name: '*map<string,interface {}>'
@@ -1683,12 +1683,12 @@ Types:
       ByteSize: 8
       Pointee: 159 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 419 StructureType math/big.ErrNaN
+      Pointee: 429 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 965
       Name: '*mime/multipart.FileHeader'
@@ -1718,19 +1718,19 @@ Types:
       GoKind: 22
       Pointee: 895 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 589
+      ID: 599
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1174176
       GoKind: 22
-      Pointee: 590 UnresolvedPointeeType net.AddrError
+      Pointee: 600 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1398656
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType net.DNSError
+      Pointee: 649 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 921
       Name: '*net.IPConn'
@@ -1739,19 +1739,19 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 636
+      ID: 646
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1398336
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType net.OpError
+      Pointee: 647 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 591
+      ID: 601
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1174304
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType net.ParseError
+      Pointee: 602 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 929
       Name: '*net.TCPConn'
@@ -1774,24 +1774,24 @@ Types:
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 588
+      ID: 598
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1173408
       GoKind: 22
-      Pointee: 583 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 593 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 585
+      ID: 595
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 584 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 594 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1010848
       GoKind: 22
-      Pointee: 523 StructureType net.canceledError
+      Pointee: 533 StructureType net.canceledError
     - __kind: PointerType
       ID: 919
       Name: '*net.conn'
@@ -1800,12 +1800,12 @@ Types:
       GoKind: 22
       Pointee: 920 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 680
+      ID: 690
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1817216
       GoKind: 22
-      Pointee: 681 StructureType net.dialResult·1
+      Pointee: 691 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 935
       Name: '*net.netFD'
@@ -1814,12 +1814,12 @@ Types:
       GoKind: 22
       Pointee: 936 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 317
+      ID: 327
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 889728
       GoKind: 22
-      Pointee: 318 UnresolvedPointeeType net.notFoundError
+      Pointee: 328 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 991
       Name: '*net.onlyValuesCtx'
@@ -1828,12 +1828,12 @@ Types:
       GoKind: 22
       Pointee: 992 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 319
+      ID: 329
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 890400
       GoKind: 22
-      Pointee: 320 StructureType net.result·2
+      Pointee: 330 StructureType net.result·2
     - __kind: PointerType
       ID: 925
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1849,33 +1849,33 @@ Types:
       GoKind: 22
       Pointee: 924 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 593
+      ID: 603
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1174944
       GoKind: 22
-      Pointee: 594 UnresolvedPointeeType net.temporaryError
+      Pointee: 604 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1398976
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType net.timeoutError
+      Pointee: 651 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 325
+      ID: 335
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 892992
       GoKind: 22
-      Pointee: 326 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 336 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 524
+      ID: 534
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1014304
       GoKind: 22
-      Pointee: 525 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 535 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -1933,26 +1933,26 @@ Types:
       GoKind: 22
       Pointee: 858 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 893184
       GoKind: 22
-      Pointee: 245 BaseType net/http.http2ConnectionError
+      Pointee: 255 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 893280
       GoKind: 22
-      Pointee: 329 StructureType net/http.http2GoAwayError
+      Pointee: 339 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 642
+      ID: 652
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1399936
       GoKind: 22
-      Pointee: 643 StructureType net/http.http2StreamError
+      Pointee: 653 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 887
       Name: '*net/http.http2clientStream'
@@ -1961,31 +1961,31 @@ Types:
       GoKind: 22
       Pointee: 888 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 334
+      ID: 344
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 894336
       GoKind: 22
-      Pointee: 335 StructureType net/http.http2connError
+      Pointee: 345 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 893760
       GoKind: 22
-      Pointee: 249 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 259 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 251
+      ID: 261
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 250 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 260 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 332
+      ID: 342
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 893856
       GoKind: 22
-      Pointee: 333 StructureType net/http.http2goAwayFlowError
+      Pointee: 343 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 851
       Name: '*net/http.http2gzipReader'
@@ -1994,36 +1994,36 @@ Types:
       GoKind: 22
       Pointee: 852 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 337
+      ID: 347
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 894528
       GoKind: 22
-      Pointee: 255 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 265 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 257
+      ID: 267
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 256 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 266 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 894432
       GoKind: 22
-      Pointee: 252 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 262 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 254
+      ID: 264
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 253 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 263 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 597
+      ID: 607
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1178912
       GoKind: 22
-      Pointee: 598 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 608 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 847
       Name: '*net/http.http2missingBody'
@@ -2039,24 +2039,24 @@ Types:
       GoKind: 22
       Pointee: 860 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 530
+      ID: 540
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1016608
       GoKind: 22
-      Pointee: 531 StructureType net/http.http2noCachedConnError
+      Pointee: 541 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 330
+      ID: 340
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 893664
       GoKind: 22
-      Pointee: 246 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 256 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 248
+      ID: 258
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 247 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 257 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 855
       Name: '*net/http.http2requestBody'
@@ -2100,12 +2100,12 @@ Types:
       GoKind: 22
       Pointee: 878 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 526
+      ID: 536
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1016224
       GoKind: 22
-      Pointee: 527 StructureType net/http.nothingWrittenError
+      Pointee: 537 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 839
       Name: '*net/http.pattern'
@@ -2128,12 +2128,12 @@ Types:
       GoKind: 22
       Pointee: 876 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 894720
       GoKind: 22
-      Pointee: 339 StructureType net/http.requestBodyReadError
+      Pointee: 349 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 760
       Name: '*net/http.response'
@@ -2149,33 +2149,33 @@ Types:
       GoKind: 22
       Pointee: 987 StructureType net/http.segment
     - __kind: PointerType
-      ID: 323
+      ID: 333
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 892896
       GoKind: 22
-      Pointee: 324 StructureType net/http.statusError
+      Pointee: 334 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 644
+      ID: 654
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1401376
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 655 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 595
+      ID: 605
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1178784
       GoKind: 22
-      Pointee: 596 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 606 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 528
+      ID: 538
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1016352
       GoKind: 22
-      Pointee: 529 StructureType net/http.transportReadFromServerError
+      Pointee: 539 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 908
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2184,12 +2184,12 @@ Types:
       GoKind: 22
       Pointee: 909 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 321
+      ID: 331
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 892128
       GoKind: 22
-      Pointee: 322 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 332 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 869
       Name: '*net/http/httputil.failureToReadBody'
@@ -2198,69 +2198,69 @@ Types:
       GoKind: 22
       Pointee: 870 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 351
+      ID: 361
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 899520
       GoKind: 22
-      Pointee: 352 StructureType net/netip.parseAddrError
+      Pointee: 362 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 349
+      ID: 359
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 899424
       GoKind: 22
-      Pointee: 350 StructureType net/netip.parsePrefixError
+      Pointee: 360 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 364
+      ID: 374
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 902784
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType net/textproto.Error
+      Pointee: 375 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 363
+      ID: 373
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 269 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 279 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 271
+      ID: 281
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 270 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 280 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 649
+      ID: 659
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1406016
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType net/url.Error
+      Pointee: 660 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 901632
       GoKind: 22
-      Pointee: 263 GoStringHeaderType net/url.EscapeError
+      Pointee: 273 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 265
+      ID: 275
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType net/url.EscapeError.str
+      Pointee: 274 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 362
+      ID: 372
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 266 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 276 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 268
+      ID: 278
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 277 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 828
       Name: '*net/url.URL'
@@ -2286,10 +2286,10 @@ Types:
       ByteSize: 8
       Pointee: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 237
+      ID: 247
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 238 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 959
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2301,25 +2301,25 @@ Types:
       ByteSize: 8
       Pointee: 823 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 219
+      ID: 225
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 220 StructureType noalg.map.group[string]float64
+      Pointee: 226 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 688
+      ID: 698
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 689 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 211
+      ID: 217
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 212 StructureType noalg.map.group[string]interface {}
+      Pointee: 218 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 203
+      ID: 209
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[string]string
+      Pointee: 210 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 941
       Name: '*os.File'
@@ -2328,12 +2328,12 @@ Types:
       GoKind: 22
       Pointee: 942 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 532
+      ID: 542
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1018528
       GoKind: 22
-      Pointee: 533 UnresolvedPointeeType os.LinkError
+      Pointee: 543 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 149
       Name: '*os.Signal'
@@ -2342,12 +2342,12 @@ Types:
       GoKind: 22
       Pointee: 150 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 599
+      ID: 609
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1179424
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType os.SyscallError
+      Pointee: 610 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 939
       Name: '*os.fileWithoutReadFrom'
@@ -2363,26 +2363,26 @@ Types:
       GoKind: 22
       Pointee: 938 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 563
+      ID: 573
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1040032
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType os/exec.Error
+      Pointee: 574 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 684
+      ID: 694
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2074368
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 695 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1040160
       GoKind: 22
-      Pointee: 566 StructureType os/exec.wrappedError
+      Pointee: 576 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 126
       Name: '*os/signal.signalCtx'
@@ -2391,52 +2391,52 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 928512
       GoKind: 22
-      Pointee: 294 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 304 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 296
+      ID: 306
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 295 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 305 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 928416
       GoKind: 22
-      Pointee: 293 BaseType os/user.UnknownUserIdError
+      Pointee: 303 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 347
+      ID: 357
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 897888
       GoKind: 22
-      Pointee: 348 UnresolvedPointeeType reflect.ValueError
+      Pointee: 358 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 422
+      ID: 432
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 423 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 433 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 540
+      ID: 550
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1023136
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 551 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 544
+      ID: 554
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1024928
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 555 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2452,12 +2452,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 542
+      ID: 552
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1023264
       GoKind: 22
-      Pointee: 543 StructureType runtime.boundsError
+      Pointee: 553 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -2473,24 +2473,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 601
+      ID: 611
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1187360
       GoKind: 22
-      Pointee: 602 StructureType runtime.errorAddressString
+      Pointee: 612 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 538
+      ID: 548
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1022752
       GoKind: 22
-      Pointee: 509 GoStringHeaderType runtime.errorString
+      Pointee: 519 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 510 GoStringDataType runtime.errorString.str
+      Pointee: 520 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2506,17 +2506,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1022880
       GoKind: 22
-      Pointee: 512 GoStringHeaderType runtime.plainError
+      Pointee: 522 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 513 GoStringDataType runtime.plainError.str
+      Pointee: 523 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2546,12 +2546,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 536
+      ID: 546
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1022368
       GoKind: 22
-      Pointee: 537 UnresolvedPointeeType strconv.NumError
+      Pointee: 547 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -2677,12 +2677,12 @@ Types:
       GoKind: 22
       Pointee: 872 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 646
+      ID: 656
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1404896
       GoKind: 22
-      Pointee: 635 BaseType syscall.Errno
+      Pointee: 645 BaseType syscall.Errno
     - __kind: PointerType
       ID: 717
       Name: '*syscall.Signal'
@@ -2701,10 +2701,10 @@ Types:
       ByteSize: 8
       Pointee: 793 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 231
+      ID: 237
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 235 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 245 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 956
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2719,29 +2719,29 @@ Types:
       ID: 171
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 217 StructureType table<string,float64>
+      Pointee: 223 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 660
+      ID: 670
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 686 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 696 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 166
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 209 StructureType table<string,interface {}>
+      Pointee: 215 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 161
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 201 StructureType table<string,string>
+      Pointee: 207 StructureType table<string,string>
     - __kind: PointerType
-      ID: 581
+      ID: 591
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1077792
       GoKind: 22
-      Pointee: 582 StructureType text/template.ExecError
+      Pointee: 592 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 144
       Name: '*time.Location'
@@ -2750,12 +2750,12 @@ Types:
       GoKind: 22
       Pointee: 145 StructureType time.Location
     - __kind: PointerType
-      ID: 341
+      ID: 351
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 895584
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType time.ParseError
+      Pointee: 352 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 141
       Name: '*time.Timer'
@@ -2764,31 +2764,31 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType time.Timer
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 895488
       GoKind: 22
-      Pointee: 258 GoStringHeaderType time.fileSizeError
+      Pointee: 268 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 260
+      ID: 270
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 259 GoStringDataType time.fileSizeError.str
+      Pointee: 269 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 702
+      ID: 200
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391680
       GoKind: 22
-      Pointee: 703 StructureType time.zone
+      Pointee: 201 StructureType time.zone
     - __kind: PointerType
-      ID: 705
+      ID: 203
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391744
       GoKind: 22
-      Pointee: 706 StructureType time.zoneTrans
+      Pointee: 204 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -2832,47 +2832,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 900288
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 364 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 366
+      ID: 376
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 902976
       GoKind: 22
-      Pointee: 367 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 377 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 368
+      ID: 378
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 903072
       GoKind: 22
-      Pointee: 272 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 282 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1030304
       GoKind: 22
-      Pointee: 550 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 560 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 551
+      ID: 561
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1030432
       GoKind: 22
-      Pointee: 516 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 526 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 836
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: GoChannelType
-      ID: 700
+      ID: 710
       Name: <-chan time.Time
       GoRuntimeType: 595936
       GoKind: 18
@@ -3057,7 +3057,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 668
+      ID: 678
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 695616
@@ -3105,7 +3105,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 654 PointerType *crypto/x509.Certificate
+      Element: 664 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 711
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -3165,11 +3165,11 @@ Types:
       ByteSize: 8
       Element: 776 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 253
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 231 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 237 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 966
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3183,25 +3183,25 @@ Types:
       ByteSize: 8
       Element: 815 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 229
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 171 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 692
+      ID: 702
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 660 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 670 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 221
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 166 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 213
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3253,7 +3253,7 @@ Types:
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 673
+      ID: 683
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 492416
@@ -3268,9 +3268,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 696 GoSliceDataType []float64.array
+      Data: 706 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 696
+      ID: 706
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3291,9 +3291,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 225 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 231 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 231
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3314,9 +3314,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 233 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 239 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 239
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3357,11 +3357,11 @@ Types:
       ByteSize: 24
       Element: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 254
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 238 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 967
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3375,29 +3375,29 @@ Types:
       ByteSize: 328
       Element: 823 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 230
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 220 StructureType noalg.map.group[string]float64
+      Element: 226 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 693
+      ID: 703
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 689 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 222
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 212 StructureType noalg.map.group[string]interface {}
+      Element: 218 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 214
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 204 StructureType noalg.map.group[string]string
+      Element: 210 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 148
       Name: '[]os.Signal'
@@ -3414,9 +3414,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 199 GoSliceDataType []os.Signal.array
+      Data: 205 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 205
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3426,7 +3426,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 672
+      ID: 682
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -3441,15 +3441,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 694 GoSliceDataType []string.array
+      Data: 704 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 694
+      ID: 704
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 701
+      ID: 199
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -3457,22 +3457,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 702 PointerType *time.zone
+          Type: 200 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 707 GoSliceDataType []time.zone.array
+      Data: 241 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 707
+      ID: 241
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 703 StructureType time.zone
+      Element: 201 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 704
+      ID: 202
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485856
@@ -3480,20 +3480,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 705 PointerType *time.zoneTrans
+          Type: 203 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 709 GoSliceDataType []time.zoneTrans.array
+      Data: 243 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 709
+      ID: 243
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 706 StructureType time.zoneTrans
+      Element: 204 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3541,7 +3541,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 494
+      ID: 504
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 938496
@@ -3556,9 +3556,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 495 GoSliceDataType archive/tar.headerError.array
+      Data: 505 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 505
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3616,13 +3616,13 @@ Types:
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: BaseType
-      ID: 288
+      ID: 298
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831936
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 289
+      ID: 299
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 832032
@@ -3630,13 +3630,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 291 PointerType *compress/flate.InternalError.str
+          Type: 301 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 290 GoStringDataType compress/flate.InternalError.str
+      Data: 300 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 290
+      ID: 300
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3720,7 +3720,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: context.deadlineExceededError
       GoRuntimeType: 1447584
       GoKind: 25
@@ -3764,7 +3764,7 @@ Types:
           Type: 141 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 143 StructureType time.Time
+          Type: 143 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3810,37 +3810,37 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 284
+      ID: 294
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 831552
       GoKind: 2
     - __kind: BaseType
-      ID: 285
+      ID: 295
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 831648
       GoKind: 2
     - __kind: BaseType
-      ID: 286
+      ID: 296
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 831744
       GoKind: 2
     - __kind: BaseType
-      ID: 287
+      ID: 297
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 831840
       GoKind: 2
     - __kind: BaseType
-      ID: 261
+      ID: 271
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 829248
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 558
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3909,11 +3909,11 @@ Types:
       GoRuntimeType: 829056
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 358
+      ID: 368
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 356
+      ID: 366
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1709536
@@ -3924,26 +3924,26 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 668 ArrayType [5]uint8
+          Type: 678 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 669 GoInterfaceType net.Conn
+          Type: 679 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 515
+      ID: 525
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 979104
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 658
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 665
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 409
+      ID: 419
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1711648
@@ -3951,21 +3951,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 654 PointerType *crypto/x509.Certificate
+          Type: 664 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 678 BaseType crypto/x509.InvalidReason
+          Type: 688 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 403
+      ID: 413
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1104416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 405
+      ID: 415
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1582240
@@ -3973,24 +3973,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 654 PointerType *crypto/x509.Certificate
+          Type: 664 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 283
+      ID: 293
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 831360
       GoKind: 2
     - __kind: BaseType
-      ID: 678
+      ID: 688
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 583200
       GoKind: 2
     - __kind: StructureType
-      ID: 562
+      ID: 572
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1542880
@@ -4000,13 +4000,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1104672
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 407
+      ID: 417
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1711456
@@ -4014,15 +4014,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 654 PointerType *crypto/x509.Certificate
+          Type: 664 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 654 PointerType *crypto/x509.Certificate
+          Type: 664 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 453
+      ID: 463
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1418176
@@ -4032,7 +4032,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 457
+      ID: 467
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1418336
@@ -4042,47 +4042,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 455
+      ID: 465
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 262
+      ID: 272
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 829344
       GoKind: 6
     - __kind: BaseType
-      ID: 282
+      ID: 292
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 831168
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 390
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 570
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 372
+      ID: 382
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 378
+      ID: 388
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 376
+      ID: 386
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 374
+      ID: 384
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 382
+      ID: 392
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1409056
@@ -4092,15 +4092,15 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 484
+      ID: 494
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 482
+      ID: 492
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 307
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 834624
@@ -4108,18 +4108,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *encoding/xml.UnmarshalError.str
+          Type: 309 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 308 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 308
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 487
+      ID: 497
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4136,11 +4136,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 344
+      ID: 354
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 545
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4156,11 +4156,11 @@ Types:
       GoRuntimeType: 580384
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 519
+      ID: 529
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 521
+      ID: 531
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4194,7 +4194,7 @@ Types:
       GoRuntimeType: 994848
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 393
+      ID: 403
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4204,7 +4204,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 385
+      ID: 395
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1710688
@@ -4212,7 +4212,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 670 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 680 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4220,25 +4220,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 397
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 685
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 391
+      ID: 401
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1103520
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 687
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 286
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 830592
@@ -4246,18 +4246,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 288 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 287 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 287
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 670
+      ID: 680
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2198176
@@ -4265,13 +4265,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 671 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 681 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4280,7 +4280,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 673 GoSliceHeaderType []float64
+          Type: 683 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4289,13 +4289,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 674 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 684 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 676 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 686 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4306,13 +4306,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 671
+      ID: 681
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 581984
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 283
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 830496
@@ -4320,18 +4320,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 285 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 284
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 279
+      ID: 289
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 830688
@@ -4339,30 +4339,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 281 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 291 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 280 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 290 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 280
+      ID: 290
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 460
+      ID: 470
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1107232
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 292
+      ID: 302
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 833184
       GoKind: 2
     - __kind: StructureType
-      ID: 427
+      ID: 437
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1583040
@@ -4375,7 +4375,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 431
+      ID: 441
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1713376
@@ -4391,7 +4391,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 429
+      ID: 439
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1416736
@@ -4401,7 +4401,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1416416
@@ -4411,14 +4411,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 656
+      ID: 666
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1489024
       GoKind: 21
-      HeaderType: 658 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 668 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 679
+      ID: 689
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1041056
@@ -4433,15 +4433,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 698 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 708 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 698
+      ID: 708
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 439
+      ID: 449
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1583360
@@ -4449,12 +4449,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 656 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 666 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 656 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 666 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 433
+      ID: 443
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1416896
@@ -4464,7 +4464,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 437
+      ID: 447
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1713568
@@ -4475,12 +4475,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 679 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 679 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 435
+      ID: 445
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1583200
@@ -4493,7 +4493,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 441
+      ID: 451
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1417056
@@ -4501,9 +4501,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 143 StructureType time.Time
+          Type: 143 GoTimeType time.Time
     - __kind: StructureType
-      ID: 447
+      ID: 457
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1583680
@@ -4516,7 +4516,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 449
+      ID: 459
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1417376
@@ -4526,7 +4526,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 445
+      ID: 455
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1583520
@@ -4539,7 +4539,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 443
+      ID: 453
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1417216
@@ -4549,7 +4549,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 451
+      ID: 461
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1583840
@@ -4584,7 +4584,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 470
+      ID: 480
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1423296
@@ -4598,7 +4598,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 472
+      ID: 482
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1423456
@@ -4606,7 +4606,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 470 StructureType github.com/cihub/seelog.baseError
+          Type: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 763
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -4629,7 +4629,7 @@ Types:
           Offset: 8
           Type: 772 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 476
+      ID: 486
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1423776
@@ -4637,7 +4637,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 470 StructureType github.com/cihub/seelog.baseError
+          Type: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 767
       Name: github.com/cihub/seelog.splitDispatcher
@@ -4653,7 +4653,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 474
+      ID: 484
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1423616
@@ -4661,9 +4661,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 470 StructureType github.com/cihub/seelog.baseError
+          Type: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 478
+      ID: 488
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1423936
@@ -4671,7 +4671,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 470 StructureType github.com/cihub/seelog.baseError
+          Type: 480 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 898
       Name: github.com/cihub/seelog/archive.Reader
@@ -4700,30 +4700,30 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 584
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 576
+      ID: 586
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 568
+      ID: 578
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 396
+      ID: 406
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1410336
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 580
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 616
+      ID: 626
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1830208
@@ -4739,11 +4739,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 620
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 554
+      ID: 564
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1684288
@@ -4756,7 +4756,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 622
+      ID: 632
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1830656
@@ -4772,13 +4772,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 517
+      ID: 527
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 980256
       GoKind: 8
     - __kind: StructureType
-      ID: 614
+      ID: 624
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1829984
@@ -4794,13 +4794,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 682
+      ID: 692
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 830112
       GoKind: 8
     - __kind: StructureType
-      ID: 612
+      ID: 622
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1829760
@@ -4808,15 +4808,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 682 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 692 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 682 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 692 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 620
+      ID: 630
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1745216
@@ -4829,7 +4829,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 618
+      ID: 628
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1830432
@@ -4845,7 +4845,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 626
+      ID: 636
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1618912
@@ -4855,19 +4855,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 558
+      ID: 568
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1269728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 556
+      ID: 566
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1269600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 624
+      ID: 634
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1745408
@@ -4880,7 +4880,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 300
+      ID: 310
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835296
@@ -4888,22 +4888,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 302 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 312 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 301 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 311 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 301
+      ID: 311
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 663
+      ID: 673
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 590
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1433056
@@ -4913,19 +4913,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 303
+      ID: 313
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 835872
       GoKind: 10
     - __kind: BaseType
-      ID: 661
+      ID: 671
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 991872
       GoKind: 10
     - __kind: StructureType
-      ID: 634
+      ID: 644
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1863136
@@ -4936,12 +4936,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 661 BaseType golang.org/x/net/http2.ErrCode
+          Type: 671 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 501
+      ID: 511
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1590560
@@ -4949,12 +4949,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 661 BaseType golang.org/x/net/http2.ErrCode
+          Type: 671 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 317
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836064
@@ -4962,18 +4962,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 319 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 318 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 318
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 323
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836256
@@ -4981,18 +4981,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 325 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 314 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 324 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 324
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 320
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836160
@@ -5000,18 +5000,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 322 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 311 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 321 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 321
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 304
+      ID: 314
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 835968
@@ -5019,18 +5019,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 306 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 316 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 305 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 315 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 305
+      ID: 315
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 505
+      ID: 515
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1434336
@@ -5040,13 +5040,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 316
+      ID: 326
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836352
       GoKind: 2
     - __kind: StructureType
-      ID: 480
+      ID: 490
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1428736
@@ -5056,11 +5056,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 642
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 652
+      ID: 662
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1889888
@@ -5076,7 +5076,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1589600
@@ -5093,7 +5093,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 578
+      ID: 588
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1550400
@@ -5107,25 +5107,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 462
+      ID: 472
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 582
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 640
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 638
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1497184
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 380
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -5371,16 +5371,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 227 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 233 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 232 GoMapType map[string]interface {}
+          Type: 238 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 720
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 242
+      ID: 252
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1896704
@@ -5479,11 +5479,11 @@ Types:
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 421
+      ID: 431
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 464
+      ID: 474
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1420576
@@ -5493,7 +5493,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 466
+      ID: 476
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1420736
@@ -5503,7 +5503,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 489
+      ID: 499
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5535,19 +5535,19 @@ Types:
       GroupType: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 801 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 236
+      ID: 246
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 237 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 247 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 238 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 958
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5577,63 +5577,63 @@ Types:
       GroupType: 823 StructureType noalg.map.group[string][]string
       GroupSliceType: 827 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 218
+      ID: 224
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 219 PointerType *noalg.map.group[string]float64
+          Type: 225 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 220 StructureType noalg.map.group[string]float64
-      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 226 StructureType noalg.map.group[string]float64
+      GroupSliceType: 230 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 687
+      ID: 697
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 688 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 698 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 689 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 693 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 703 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 210
+      ID: 216
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 211 PointerType *noalg.map.group[string]interface {}
+          Type: 217 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 212 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 218 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 208
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[string]string
+          Type: 209 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[string]string
-      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 210 StructureType noalg.map.group[string]string
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 508
+      ID: 518
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5680,7 +5680,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 410
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5706,11 +5706,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 398
+      ID: 408
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 618
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5718,13 +5718,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 606
+      ID: 616
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1464384
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 346
+      ID: 356
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5885,7 +5885,7 @@ Types:
           Offset: 0
           Type: 889 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 614
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -5953,7 +5953,7 @@ Types:
       TablePtrSliceType: 800 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 229
+      ID: 235
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -5966,7 +5966,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 230 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 236 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5982,8 +5982,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 238 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 253 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 954
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6078,10 +6078,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 223 GoSliceDataType []*table<string,float64>.array
-      GroupType: 220 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 229 GoSliceDataType []*table<string,float64>.array
+      GroupType: 226 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 658
+      ID: 668
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6094,7 +6094,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 659 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 669 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6110,8 +6110,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 692 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 689 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 702 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 164
       Name: map<string,interface {}>
@@ -6142,8 +6142,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 215 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 212 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 218 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 159
       Name: map<string,string>
@@ -6174,8 +6174,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 207 GoSliceDataType []*table<string,string>.array
-      GroupType: 204 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
+      GroupType: 210 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 135
       Name: map[context.canceler]struct {}
@@ -6191,12 +6191,12 @@ Types:
       GoKind: 21
       HeaderType: 774 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 227
+      ID: 233
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1123584
       GoKind: 21
-      HeaderType: 229 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 235 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 952
       Name: map[string][]*mime/multipart.FileHeader
@@ -6219,7 +6219,7 @@ Types:
       GoKind: 21
       HeaderType: 169 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 232
+      ID: 238
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1116576
@@ -6233,7 +6233,7 @@ Types:
       GoKind: 21
       HeaderType: 159 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 419
+      ID: 429
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1413536
@@ -6277,11 +6277,11 @@ Types:
           Offset: 8
           Type: 899 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 590
+      ID: 600
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 669
+      ID: 679
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1580320
@@ -6294,7 +6294,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 649
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6302,11 +6302,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 647
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 602
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6322,7 +6322,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 583
+      ID: 593
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1098400
@@ -6330,18 +6330,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 585 PointerType *net.UnknownNetworkError.str
+          Type: 595 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 584 GoStringDataType net.UnknownNetworkError.str
+      Data: 594 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 584
+      ID: 594
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 523
+      ID: 533
       Name: net.canceledError
       GoRuntimeType: 1267168
       GoKind: 25
@@ -6351,7 +6351,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 681
+      ID: 691
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2087008
@@ -6359,7 +6359,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 669 GoInterfaceType net.Conn
+          Type: 679 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -6386,7 +6386,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 318
+      ID: 328
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6403,7 +6403,7 @@ Types:
           Offset: 16
           Type: 115 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 320
+      ID: 330
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1704928
@@ -6411,7 +6411,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 664 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 674 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6445,11 +6445,11 @@ Types:
           Offset: 0
           Type: 929 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 594
+      ID: 604
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 651
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6499,11 +6499,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 326
+      ID: 336
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 525
+      ID: 535
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6555,7 +6555,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6600,7 +6600,7 @@ Types:
           Type: 839 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 157 GoMapType map[string]string
@@ -6637,7 +6637,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6710,19 +6710,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 245
+      ID: 255
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 827136
       GoKind: 10
     - __kind: BaseType
-      ID: 653
+      ID: 663
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 976416
       GoKind: 10
     - __kind: StructureType
-      ID: 329
+      ID: 339
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1706656
@@ -6733,12 +6733,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 653 BaseType net/http.http2ErrCode
+          Type: 663 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 643
+      ID: 653
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1880672
@@ -6749,7 +6749,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 653 BaseType net/http.http2ErrCode
+          Type: 663 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
@@ -6758,7 +6758,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 335
+      ID: 345
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1580800
@@ -6766,12 +6766,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 653 BaseType net/http.http2ErrCode
+          Type: 663 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 249
+      ID: 259
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 827328
@@ -6779,18 +6779,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 251 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 261 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 250 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 260 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 250
+      ID: 260
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 333
+      ID: 343
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1099680
       GoKind: 25
@@ -6800,7 +6800,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 255
+      ID: 265
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 827520
@@ -6808,18 +6808,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 257 PointerType *net/http.http2headerFieldNameError.str
+          Type: 267 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 256 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 266 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 256
+      ID: 266
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 252
+      ID: 262
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 827424
@@ -6827,18 +6827,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 254 PointerType *net/http.http2headerFieldValueError.str
+          Type: 264 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 253 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 263 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 253
+      ID: 263
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 598
+      ID: 608
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -6854,13 +6854,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 531
+      ID: 541
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1267808
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 246
+      ID: 256
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 827232
@@ -6868,13 +6868,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 248 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 258 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 247 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 257 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 247
+      ID: 257
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -6917,7 +6917,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 527
+      ID: 537
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1534400
@@ -6957,7 +6957,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 339
+      ID: 349
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1402176
@@ -7032,7 +7032,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 807 StructureType sync/atomic.Bool
@@ -7068,7 +7068,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 324
+      ID: 334
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1580640
@@ -7081,17 +7081,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 655
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 596
+      ID: 606
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1452224
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 529
+      ID: 539
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1534560
@@ -7109,12 +7109,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 669 GoInterfaceType net.Conn
+          Type: 679 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 669 GoInterfaceType net.Conn
+          Type: 679 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 322
+      ID: 332
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7124,7 +7124,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 352
+      ID: 362
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1709152
@@ -7140,7 +7140,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 350
+      ID: 360
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1581280
@@ -7153,11 +7153,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 375
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 269
+      ID: 279
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 829632
@@ -7165,22 +7165,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 271 PointerType *net/textproto.ProtocolError.str
+          Type: 281 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 270 GoStringDataType net/textproto.ProtocolError.str
+      Data: 280 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 270
+      ID: 280
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 660
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 273
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 829440
@@ -7188,18 +7188,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *net/url.EscapeError.str
+          Type: 275 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 264 GoStringDataType net/url.EscapeError.str
+      Data: 274 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 274
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 276
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 829536
@@ -7207,13 +7207,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *net/url.InvalidHostError.str
+          Type: 278 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 267 GoStringDataType net/url.InvalidHostError.str
+      Data: 277 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 277
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7287,14 +7287,14 @@ Types:
       HasCount: true
       Element: 798 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 239
+      ID: 249
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 698496
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 240 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 250 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 961
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7314,41 +7314,41 @@ Types:
       HasCount: true
       Element: 825 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 221
+      ID: 227
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 698400
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem float64 }
+      Element: 228 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 690
+      ID: 700
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 753568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 691 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 701 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 213
+      ID: 219
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 675616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 214 StructureType noalg.struct { key string; elem interface {} }
+      Element: 220 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 205
+      ID: 211
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key string; elem string }
+      Element: 212 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 192
       Name: noalg.map.group[context.canceler]struct {}
@@ -7376,7 +7376,7 @@ Types:
           Offset: 8
           Type: 797 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 238
+      ID: 248
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1296352
@@ -7387,7 +7387,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 239 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 249 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 960
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7415,7 +7415,7 @@ Types:
           Offset: 8
           Type: 824 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 220
+      ID: 226
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1296096
@@ -7426,9 +7426,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 227 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 689
+      ID: 699
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1337824
@@ -7439,9 +7439,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 690 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 700 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 212
+      ID: 218
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1277792
@@ -7452,9 +7452,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 213 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 219 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 204
+      ID: 210
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1282656
@@ -7465,7 +7465,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 211 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 194
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7493,7 +7493,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 240
+      ID: 250
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1296224
@@ -7504,7 +7504,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 241 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 251 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 962
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7530,9 +7530,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 672 GoSliceHeaderType []string
+          Type: 682 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 222
+      ID: 228
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1295968
@@ -7545,7 +7545,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 691
+      ID: 701
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1337696
@@ -7556,9 +7556,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 679 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 214
+      ID: 220
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1277664
@@ -7571,7 +7571,7 @@ Types:
           Offset: 16
           Type: 134 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 206
+      ID: 212
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1282528
@@ -7588,7 +7588,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 533
+      ID: 543
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7605,7 +7605,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 610
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7647,15 +7647,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 574
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 695
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 566
+      ID: 576
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1684480
@@ -7689,7 +7689,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 294
+      ID: 304
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 833952
@@ -7697,36 +7697,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 296 PointerType *os/user.UnknownGroupIdError.str
+          Type: 306 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 295 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 305 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 295
+      ID: 305
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 293
+      ID: 303
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 348
+      ID: 358
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 423
+      ID: 433
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 551
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 555
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7738,7 +7738,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 543
+      ID: 553
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1870080
@@ -7755,9 +7755,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 683 BaseType runtime.boundsErrorCode
+          Type: 693 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 683
+      ID: 693
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 580576
@@ -7777,7 +7777,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 602
+      ID: 612
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1739648
@@ -7790,7 +7790,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 509
+      ID: 519
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 977664
@@ -7798,13 +7798,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 511 PointerType *runtime.errorString.str
+          Type: 521 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 510 GoStringDataType runtime.errorString.str
+      Data: 520 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 510
+      ID: 520
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8460,7 +8460,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 512
+      ID: 522
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 977760
@@ -8468,13 +8468,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 514 PointerType *runtime.plainError.str
+          Type: 524 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 513 GoStringDataType runtime.plainError.str
+      Data: 523 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 513
+      ID: 523
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8560,7 +8560,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 537
+      ID: 547
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8931,7 +8931,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 635
+      ID: 645
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1268704
@@ -8991,7 +8991,7 @@ Types:
           Offset: 16
           Type: 794 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 235
+      ID: 245
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9013,7 +9013,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 236 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 246 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 957
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9063,7 +9063,7 @@ Types:
           Offset: 16
           Type: 821 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 217
+      ID: 223
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9085,9 +9085,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 218 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 224 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 686
+      ID: 696
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9109,9 +9109,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 687 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 697 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 209
+      ID: 215
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9133,9 +9133,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 210 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 216 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 201
+      ID: 207
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9157,9 +9157,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<string,string>
+          Type: 208 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 582
+      ID: 592
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1688704
@@ -9189,10 +9189,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 701 GoSliceHeaderType []time.zone
+          Type: 199 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 704 GoSliceHeaderType []time.zoneTrans
+          Type: 202 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9204,12 +9204,12 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 702 PointerType *time.zone
+          Type: 200 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 352
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 143
       Name: time.Time
       ByteSize: 24
@@ -9225,6 +9225,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 144 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 142
       Name: time.Timer
@@ -9234,12 +9242,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 700 GoChannelType <-chan time.Time
+          Type: 710 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 258
+      ID: 268
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 827616
@@ -9247,18 +9255,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 260 PointerType *time.fileSizeError.str
+          Type: 270 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 259 GoStringDataType time.fileSizeError.str
+      Data: 269 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 259
+      ID: 269
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 703
+      ID: 201
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1602208
@@ -9274,7 +9282,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 706
+      ID: 204
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1736576
@@ -9335,7 +9343,7 @@ Types:
       GoRuntimeType: 580512
       GoKind: 26
     - __kind: StructureType
-      ID: 664
+      ID: 674
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2044384
@@ -9346,10 +9354,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 665 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 675 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 666 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 676 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9364,18 +9372,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 667 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 677 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 667
+      ID: 677
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 978720
       GoKind: 9
     - __kind: StructureType
-      ID: 665
+      ID: 675
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1899008
@@ -9400,17 +9408,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 364
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 666
+      ID: 676
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 581408
       GoKind: 8
     - __kind: StructureType
-      ID: 367
+      ID: 377
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1407136
@@ -9420,13 +9428,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 272
+      ID: 282
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 829728
       GoKind: 2
     - __kind: StructureType
-      ID: 550
+      ID: 560
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1683904
@@ -9439,7 +9447,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 516
+      ID: 526
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 979584

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -130,7 +130,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 675 PointerType *crypto/x509.Certificate
+      Pointee: 685 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 733
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -160,10 +160,10 @@ Types:
       ByteSize: 8
       Pointee: 797 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 235
+      ID: 241
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 236 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 242 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 976
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -180,10 +180,10 @@ Types:
       ByteSize: 8
       Pointee: 173 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 680
+      ID: 690
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 167
       Name: '**table<string,interface {}>'
@@ -231,30 +231,30 @@ Types:
       ByteSize: 8
       Pointee: 1005 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 718
+      ID: 728
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 717 GoSliceDataType []float64.array
+      Pointee: 727 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 231
+      ID: 237
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Pointee: 236 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: PointerType
-      ID: 239
+      ID: 245
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 244 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1011
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1010 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 205
+      ID: 211
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []os.Signal.array
+      Pointee: 210 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -263,20 +263,20 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 716
+      ID: 726
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 715 GoSliceDataType []string.array
+      Pointee: 725 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 729
+      ID: 247
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 728 GoSliceDataType []time.zone.array
+      Pointee: 246 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 731
+      ID: 249
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 730 GoSliceDataType []time.zoneTrans.array
+      Pointee: 248 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 998
       Name: '*[]uint8'
@@ -295,17 +295,17 @@ Types:
       ByteSize: 8
       Pointee: 189 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 508
+      ID: 518
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 945472
       GoKind: 22
-      Pointee: 509 GoSliceHeaderType archive/tar.headerError
+      Pointee: 519 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 510 GoSliceDataType archive/tar.headerError.array
+      Pointee: 520 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 902
       Name: '*archive/zip.checksumReader'
@@ -356,24 +356,24 @@ Types:
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 429
+      ID: 439
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 296 BaseType compress/flate.CorruptInputError
+      Pointee: 306 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 430
+      ID: 440
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 297 GoStringHeaderType compress/flate.InternalError
+      Pointee: 307 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 299
+      ID: 309
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType compress/flate.InternalError.str
+      Pointee: 308 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 938
       Name: '*compress/flate.decompressor'
@@ -403,12 +403,12 @@ Types:
       GoKind: 22
       Pointee: 119 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 605
+      ID: 615
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1181760
       GoKind: 22
-      Pointee: 606 StructureType context.deadlineExceededError
+      Pointee: 616 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1012
       Name: '*context.emptyCtx'
@@ -452,54 +452,54 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 425
+      ID: 435
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 917632
       GoKind: 22
-      Pointee: 292 BaseType crypto/aes.KeySizeError
+      Pointee: 302 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 917824
       GoKind: 22
-      Pointee: 293 BaseType crypto/des.KeySizeError
+      Pointee: 303 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 427
+      ID: 437
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 294 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 304 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1052960
       GoKind: 22
-      Pointee: 587 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 597 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 428
+      ID: 438
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918400
       GoKind: 22
-      Pointee: 295 BaseType crypto/rc4.KeySizeError
+      Pointee: 305 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 908416
       GoKind: 22
-      Pointee: 266 BaseType crypto/tls.AlertError
+      Pointee: 276 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 562
+      ID: 572
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1037216
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 573 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 968
       Name: '*crypto/tls.Conn'
@@ -515,213 +515,213 @@ Types:
       GoKind: 22
       Pointee: 856 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 367
+      ID: 377
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 908128
       GoKind: 22
-      Pointee: 368 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 378 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 365
+      ID: 375
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 908032
       GoKind: 22
-      Pointee: 366 StructureType crypto/tls.RecordHeaderError
+      Pointee: 376 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 561
+      ID: 571
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1035552
       GoKind: 22
-      Pointee: 530 BaseType crypto/tls.alert
+      Pointee: 540 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 380 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 666
+      ID: 676
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1415328
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 677 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 675
+      ID: 685
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2043200
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 686 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 421
+      ID: 431
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 917440
       GoKind: 22
-      Pointee: 422 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 432 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 916960
       GoKind: 22
-      Pointee: 416 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 426 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 917056
       GoKind: 22
-      Pointee: 418 StructureType crypto/x509.HostnameError
+      Pointee: 428 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 414
+      ID: 424
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 916864
       GoKind: 22
-      Pointee: 291 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 301 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1045792
       GoKind: 22
-      Pointee: 579 StructureType crypto/x509.SystemRootsError
+      Pointee: 589 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 423
+      ID: 433
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 424 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 434 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 419
+      ID: 429
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 917344
       GoKind: 22
-      Pointee: 420 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 430 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 465
+      ID: 475
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 927712
       GoKind: 22
-      Pointee: 466 StructureType encoding/asn1.StructuralError
+      Pointee: 476 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 469
+      ID: 479
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927904
       GoKind: 22
-      Pointee: 470 StructureType encoding/asn1.SyntaxError
+      Pointee: 480 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 467
+      ID: 477
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927808
       GoKind: 22
-      Pointee: 468 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 478 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 372
+      ID: 382
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 267 BaseType encoding/base64.CorruptInputError
+      Pointee: 277 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 915616
       GoKind: 22
-      Pointee: 287 BaseType encoding/hex.InvalidByteError
+      Pointee: 297 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 391
+      ID: 401
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 912064
       GoKind: 22
-      Pointee: 392 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 402 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 574
+      ID: 584
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1042208
       GoKind: 22
-      Pointee: 575 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 585 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 383
+      ID: 393
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 394 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 911968
       GoKind: 22
-      Pointee: 390 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 400 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 398 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 385
+      ID: 395
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 911776
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 396 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 912448
       GoKind: 22
-      Pointee: 394 StructureType encoding/json.jsonError
+      Pointee: 404 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 509 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 496
+      ID: 506
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 939232
       GoKind: 22
-      Pointee: 497 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 507 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 500
+      ID: 510
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 939424
       GoKind: 22
-      Pointee: 305 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 315 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 307
+      ID: 317
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 316 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 939520
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 512 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -730,19 +730,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 351
+      ID: 361
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 903328
       GoKind: 22
-      Pointee: 352 UnresolvedPointeeType errors.errorString
+      Pointee: 362 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1028512
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType errors.joinError
+      Pointee: 560 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -758,26 +758,26 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 533
+      ID: 543
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1018144
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType fmt.wrapError
+      Pointee: 544 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 535
+      ID: 545
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1018272
       GoKind: 22
-      Pointee: 536 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 546 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915136
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 415 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 798
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -786,200 +786,200 @@ Types:
       GoKind: 22
       Pointee: 799 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 396
+      ID: 406
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 913792
       GoKind: 22
-      Pointee: 397 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 407 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 913888
       GoKind: 22
-      Pointee: 399 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 409 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 695
+      ID: 705
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 913600
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 706 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 914176
       GoKind: 22
-      Pointee: 403 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 413 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 697
+      ID: 707
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 913696
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 400
+      ID: 410
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 913984
       GoKind: 22
-      Pointee: 281 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 291 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 283
+      ID: 293
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 282 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 292 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 913504
       GoKind: 22
-      Pointee: 278 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 288 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 280
+      ID: 290
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 279 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 401
+      ID: 411
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 914080
       GoKind: 22
-      Pointee: 284 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 294 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 286
+      ID: 296
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 928576
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 485 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 471
+      ID: 481
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 928384
       GoKind: 22
-      Pointee: 300 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 310 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 472
+      ID: 482
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 928480
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
+      Pointee: 483 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 439
+      ID: 449
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 924544
       GoKind: 22
-      Pointee: 440 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 450 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 924736
       GoKind: 22
-      Pointee: 444 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 454 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 441
+      ID: 451
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 924640
       GoKind: 22
-      Pointee: 442 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 452 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 437
+      ID: 447
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 438 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 448 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 720
+      ID: 730
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 451
+      ID: 461
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 452 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 462 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 924832
       GoKind: 22
-      Pointee: 446 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 456 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 449
+      ID: 459
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 925024
       GoKind: 22
-      Pointee: 450 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 460 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 447
+      ID: 457
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 448 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 458 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 453
+      ID: 463
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 925216
       GoKind: 22
-      Pointee: 454 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 464 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 459
+      ID: 469
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 925504
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 470 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 461
+      ID: 471
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 925600
       GoKind: 22
-      Pointee: 462 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 472 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 457
+      ID: 467
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 925408
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 468 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 455
+      ID: 465
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 925312
       GoKind: 22
-      Pointee: 456 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 466 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 463
+      ID: 473
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 464 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 474 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 812
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -1009,12 +1009,12 @@ Types:
       GoKind: 22
       Pointee: 811 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 484
+      ID: 494
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 936544
       GoKind: 22
-      Pointee: 485 StructureType github.com/cihub/seelog.baseError
+      Pointee: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 791
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1023,12 +1023,12 @@ Types:
       GoKind: 22
       Pointee: 792 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 936640
       GoKind: 22
-      Pointee: 487 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 497 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 783
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1051,12 +1051,12 @@ Types:
       GoKind: 22
       Pointee: 790 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 490
+      ID: 500
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 936832
       GoKind: 22
-      Pointee: 491 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 501 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 787
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1072,19 +1072,19 @@ Types:
       GoKind: 22
       Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 488
+      ID: 498
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 936736
       GoKind: 22
-      Pointee: 489 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 499 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 492
+      ID: 502
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 936928
       GoKind: 22
-      Pointee: 493 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 503 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 900
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1100,268 +1100,268 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 592
+      ID: 602
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1065376
       GoKind: 22
-      Pointee: 593 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 603 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 594
+      ID: 604
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1065504
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 605 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 584
+      ID: 594
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1050144
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 595 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 407
+      ID: 417
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 915808
       GoKind: 22
-      Pointee: 408 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 418 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 588
+      ID: 598
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1053728
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 599 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 634
+      ID: 644
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1204032
       GoKind: 22
-      Pointee: 635 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 628
+      ID: 638
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1203648
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 639 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 568
+      ID: 578
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1041312
       GoKind: 22
-      Pointee: 569 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 579 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1204416
       GoKind: 22
-      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1041184
       GoKind: 22
-      Pointee: 532 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 542 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 632
+      ID: 642
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1203904
       GoKind: 22
-      Pointee: 633 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 630
+      ID: 640
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1203776
       GoKind: 22
-      Pointee: 631 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1204288
       GoKind: 22
-      Pointee: 639 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 649 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 636
+      ID: 646
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1204160
       GoKind: 22
-      Pointee: 637 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 647 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 644
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1204800
       GoKind: 22
-      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1041568
       GoKind: 22
-      Pointee: 573 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 570
+      ID: 580
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1041440
       GoKind: 22
-      Pointee: 571 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 642
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1204672
       GoKind: 22
-      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944704
       GoKind: 22
-      Pointee: 308 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 318 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 310
+      ID: 320
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 309 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 683
+      ID: 693
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1659904
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 694 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 598
+      ID: 608
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1082144
       GoKind: 22
-      Pointee: 599 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 609 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 512
+      ID: 522
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 946720
       GoKind: 22
-      Pointee: 311 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 321 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 652
+      ID: 662
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1257664
       GoKind: 22
-      Pointee: 653 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 663 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 515
+      ID: 525
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 947008
       GoKind: 22
-      Pointee: 516 StructureType golang.org/x/net/http2.connError
+      Pointee: 526 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 514
+      ID: 524
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946912
       GoKind: 22
-      Pointee: 315 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 325 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 317
+      ID: 327
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 316 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 947200
       GoKind: 22
-      Pointee: 321 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 331 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 323
+      ID: 333
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 322 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 947104
       GoKind: 22
-      Pointee: 318 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 328 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 320
+      ID: 330
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 319 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946816
       GoKind: 22
-      Pointee: 312 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 314
+      ID: 324
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 313 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 519
+      ID: 529
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 947296
       GoKind: 22
-      Pointee: 520 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 530 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 521
+      ID: 531
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 947392
       GoKind: 22
-      Pointee: 324 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 334 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 494
+      ID: 504
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 938752
       GoKind: 22
-      Pointee: 495 StructureType google.golang.org/grpc.dropError
+      Pointee: 505 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 650
+      ID: 660
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1254464
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 661 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 670
+      ID: 680
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1439808
       GoKind: 22
-      Pointee: 671 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 681 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942976
       GoKind: 22
-      Pointee: 506 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 516 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 927
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1370,12 +1370,12 @@ Types:
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 596
+      ID: 606
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1076384
       GoKind: 22
-      Pointee: 597 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 607 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 911
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1384,40 +1384,40 @@ Types:
       GoKind: 22
       Pointee: 912 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 476
+      ID: 486
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 930784
       GoKind: 22
-      Pointee: 477 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 487 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 590
+      ID: 600
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1055136
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 601 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 648
+      ID: 658
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1220672
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 659 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 646
+      ID: 656
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1220416
       GoKind: 22
-      Pointee: 647 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 657 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 381
+      ID: 391
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 910720
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 392 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 742
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
@@ -1475,12 +1475,12 @@ Types:
       GoKind: 22
       Pointee: 741 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 246
+      ID: 256
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1189696
       GoKind: 22
-      Pointee: 247 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 257 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 182
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
@@ -1517,40 +1517,40 @@ Types:
       GoKind: 22
       Pointee: 885 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 433
+      ID: 443
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 434 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 444 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 931360
       GoKind: 22
-      Pointee: 479 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 489 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 480
+      ID: 490
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 931456
       GoKind: 22
-      Pointee: 481 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 491 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 940288
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 514 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 948160
       GoKind: 22
-      Pointee: 523 UnresolvedPointeeType html/template.Error
+      Pointee: 533 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 102
       Name: '*int'
@@ -1587,33 +1587,33 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType int8
     - __kind: PointerType
-      ID: 672
+      ID: 682
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2204960
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType internal/abi.Type
+      Pointee: 683 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 916480
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 423 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 916384
       GoKind: 22
-      Pointee: 411 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 421 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1197504
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 637 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 966
       Name: '*internal/poll.FD'
@@ -1622,38 +1622,38 @@ Types:
       GoKind: 22
       Pointee: 967 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 624
+      ID: 634
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1197376
       GoKind: 22
-      Pointee: 625 StructureType internal/poll.errNetClosing
+      Pointee: 635 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 903712
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 364 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 409
+      ID: 419
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 916288
       GoKind: 22
-      Pointee: 288 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 298 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 290
+      ID: 300
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 299 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 576
+      ID: 586
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1044768
       GoKind: 22
-      Pointee: 577 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 587 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
       ID: 931
       Name: '*io.PipeReader'
@@ -1683,12 +1683,12 @@ Types:
       GoKind: 22
       Pointee: 899 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 622
+      ID: 632
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1196352
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType io/fs.PathError
+      Pointee: 633 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 138
       Name: '*map<context.canceler,struct {}>'
@@ -1700,10 +1700,10 @@ Types:
       ByteSize: 8
       Pointee: 795 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 233
+      ID: 239
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 234 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 240 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 974
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1720,10 +1720,10 @@ Types:
       ByteSize: 8
       Pointee: 171 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 678
+      ID: 688
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 165
       Name: '*map<string,interface {}>'
@@ -1735,12 +1735,12 @@ Types:
       ByteSize: 8
       Pointee: 161 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 919552
       GoKind: 22
-      Pointee: 432 StructureType math/big.ErrNaN
+      Pointee: 442 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 986
       Name: '*mime/multipart.FileHeader'
@@ -1770,19 +1770,19 @@ Types:
       GoKind: 22
       Pointee: 916 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1182912
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType net.AddrError
+      Pointee: 619 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 657
+      ID: 667
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1407648
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType net.DNSError
+      Pointee: 668 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 942
       Name: '*net.IPConn'
@@ -1791,19 +1791,19 @@ Types:
       GoKind: 22
       Pointee: 943 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 655
+      ID: 665
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1407328
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType net.OpError
+      Pointee: 666 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1183040
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType net.ParseError
+      Pointee: 621 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 950
       Name: '*net.TCPConn'
@@ -1826,24 +1826,24 @@ Types:
       GoKind: 22
       Pointee: 949 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 607
+      ID: 617
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1182144
       GoKind: 22
-      Pointee: 602 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 612 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 603 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 613 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 537
+      ID: 547
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1019168
       GoKind: 22
-      Pointee: 538 StructureType net.canceledError
+      Pointee: 548 StructureType net.canceledError
     - __kind: PointerType
       ID: 940
       Name: '*net.conn'
@@ -1852,12 +1852,12 @@ Types:
       GoKind: 22
       Pointee: 941 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 701
+      ID: 711
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1832192
       GoKind: 22
-      Pointee: 702 StructureType net.dialResult·1
+      Pointee: 712 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 956
       Name: '*net.netFD'
@@ -1866,12 +1866,12 @@ Types:
       GoKind: 22
       Pointee: 957 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 325
+      ID: 335
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 896320
       GoKind: 22
-      Pointee: 326 UnresolvedPointeeType net.notFoundError
+      Pointee: 336 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1013
       Name: '*net.onlyValuesCtx'
@@ -1880,12 +1880,12 @@ Types:
       GoKind: 22
       Pointee: 1014 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 327
+      ID: 337
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 896992
       GoKind: 22
-      Pointee: 328 StructureType net.result·2
+      Pointee: 338 StructureType net.result·2
     - __kind: PointerType
       ID: 946
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1901,33 +1901,33 @@ Types:
       GoKind: 22
       Pointee: 945 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 612
+      ID: 622
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1183680
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType net.temporaryError
+      Pointee: 623 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 659
+      ID: 669
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1407968
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType net.timeoutError
+      Pointee: 670 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 333
+      ID: 343
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 899584
       GoKind: 22
-      Pointee: 334 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 344 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1022624
       GoKind: 22
-      Pointee: 540 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 550 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 112
       Name: '*net/http.Request'
@@ -1985,26 +1985,26 @@ Types:
       GoKind: 22
       Pointee: 879 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 335
+      ID: 345
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 899776
       GoKind: 22
-      Pointee: 250 BaseType net/http.http2ConnectionError
+      Pointee: 260 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 899872
       GoKind: 22
-      Pointee: 337 StructureType net/http.http2GoAwayError
+      Pointee: 347 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 661
+      ID: 671
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1408928
       GoKind: 22
-      Pointee: 662 StructureType net/http.http2StreamError
+      Pointee: 672 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 908
       Name: '*net/http.http2clientStream'
@@ -2013,31 +2013,31 @@ Types:
       GoKind: 22
       Pointee: 909 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 342
+      ID: 352
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 900928
       GoKind: 22
-      Pointee: 343 StructureType net/http.http2connError
+      Pointee: 353 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 339
+      ID: 349
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900352
       GoKind: 22
-      Pointee: 254 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 264 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 256
+      ID: 266
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 255 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 900448
       GoKind: 22
-      Pointee: 341 StructureType net/http.http2goAwayFlowError
+      Pointee: 351 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 872
       Name: '*net/http.http2gzipReader'
@@ -2046,36 +2046,36 @@ Types:
       GoKind: 22
       Pointee: 873 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 345
+      ID: 355
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 901120
       GoKind: 22
-      Pointee: 260 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 270 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 262
+      ID: 272
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 261 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 271 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 901024
       GoKind: 22
-      Pointee: 257 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 267 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 259
+      ID: 269
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 258 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 268 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 616
+      ID: 626
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1187520
       GoKind: 22
-      Pointee: 617 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 627 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 868
       Name: '*net/http.http2missingBody'
@@ -2091,24 +2091,24 @@ Types:
       GoKind: 22
       Pointee: 881 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 545
+      ID: 555
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1024928
       GoKind: 22
-      Pointee: 546 StructureType net/http.http2noCachedConnError
+      Pointee: 556 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900256
       GoKind: 22
-      Pointee: 251 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 261 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 253
+      ID: 263
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 252 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 262 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 876
       Name: '*net/http.http2requestBody'
@@ -2152,12 +2152,12 @@ Types:
       GoKind: 22
       Pointee: 897 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 541
+      ID: 551
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1024544
       GoKind: 22
-      Pointee: 542 StructureType net/http.nothingWrittenError
+      Pointee: 552 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 860
       Name: '*net/http.pattern'
@@ -2180,12 +2180,12 @@ Types:
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 901312
       GoKind: 22
-      Pointee: 347 StructureType net/http.requestBodyReadError
+      Pointee: 357 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 781
       Name: '*net/http.response'
@@ -2201,33 +2201,33 @@ Types:
       GoKind: 22
       Pointee: 1009 StructureType net/http.segment
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 899488
       GoKind: 22
-      Pointee: 332 StructureType net/http.statusError
+      Pointee: 342 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 663
+      ID: 673
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1410528
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 674 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 614
+      ID: 624
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1187392
       GoKind: 22
-      Pointee: 615 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 625 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 543
+      ID: 553
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1024672
       GoKind: 22
-      Pointee: 544 StructureType net/http.transportReadFromServerError
+      Pointee: 554 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 929
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2236,12 +2236,12 @@ Types:
       GoKind: 22
       Pointee: 930 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 329
+      ID: 339
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 898720
       GoKind: 22
-      Pointee: 330 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 340 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 890
       Name: '*net/http/httputil.failureToReadBody'
@@ -2250,69 +2250,69 @@ Types:
       GoKind: 22
       Pointee: 891 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 906400
       GoKind: 22
-      Pointee: 362 StructureType net/netip.parseAddrError
+      Pointee: 372 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 906304
       GoKind: 22
-      Pointee: 360 StructureType net/netip.parsePrefixError
+      Pointee: 370 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 376
+      ID: 386
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 909760
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType net/textproto.Error
+      Pointee: 387 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 909664
       GoKind: 22
-      Pointee: 274 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 284 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 276
+      ID: 286
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 275 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 285 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 668
+      ID: 678
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1415648
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType net/url.Error
+      Pointee: 679 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 268 GoStringHeaderType net/url.EscapeError
+      Pointee: 278 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 270
+      ID: 280
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 269 GoStringDataType net/url.EscapeError.str
+      Pointee: 279 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 374
+      ID: 384
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 271 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 281 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 273
+      ID: 283
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 282 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 849
       Name: '*net/url.URL'
@@ -2338,10 +2338,10 @@ Types:
       ByteSize: 8
       Pointee: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 242
+      ID: 252
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 243 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 980
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2353,25 +2353,25 @@ Types:
       ByteSize: 8
       Pointee: 844 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 224
+      ID: 230
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[string]float64
+      Pointee: 231 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 709
+      ID: 719
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 216
+      ID: 222
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[string]interface {}
+      Pointee: 223 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 208
+      ID: 214
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[string]string
+      Pointee: 215 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 962
       Name: '*os.File'
@@ -2380,12 +2380,12 @@ Types:
       GoKind: 22
       Pointee: 963 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 547
+      ID: 557
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1026976
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType os.LinkError
+      Pointee: 558 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 151
       Name: '*os.Signal'
@@ -2394,12 +2394,12 @@ Types:
       GoKind: 22
       Pointee: 152 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1187904
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType os.SyscallError
+      Pointee: 629 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 960
       Name: '*os.fileWithoutReadFrom'
@@ -2415,26 +2415,26 @@ Types:
       GoKind: 22
       Pointee: 959 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 580
+      ID: 590
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1048736
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType os/exec.Error
+      Pointee: 591 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 705
+      ID: 715
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2088576
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 716 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 582
+      ID: 592
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1048864
       GoKind: 22
-      Pointee: 583 StructureType os/exec.wrappedError
+      Pointee: 593 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 128
       Name: '*os/signal.signalCtx'
@@ -2443,52 +2443,52 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 483
+      ID: 493
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 935584
       GoKind: 22
-      Pointee: 302 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 312 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 304
+      ID: 314
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 303 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 313 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 482
+      ID: 492
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 935488
       GoKind: 22
-      Pointee: 301 BaseType os/user.UnknownUserIdError
+      Pointee: 311 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 904480
       GoKind: 22
-      Pointee: 356 UnresolvedPointeeType reflect.ValueError
+      Pointee: 366 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 435
+      ID: 445
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 436 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 446 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1031584
       GoKind: 22
-      Pointee: 556 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 566 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 559
+      ID: 569
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1033376
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 570 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2504,12 +2504,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1031712
       GoKind: 22
-      Pointee: 558 StructureType runtime.boundsError
+      Pointee: 568 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -2525,24 +2525,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1195840
       GoKind: 22
-      Pointee: 621 StructureType runtime.errorAddressString
+      Pointee: 631 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 553
+      ID: 563
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1031200
       GoKind: 22
-      Pointee: 524 GoStringHeaderType runtime.errorString
+      Pointee: 534 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 526
+      ID: 536
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 525 GoStringDataType runtime.errorString.str
+      Pointee: 535 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2565,17 +2565,17 @@ Types:
       GoKind: 22
       Pointee: 191 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 554
+      ID: 564
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1031328
       GoKind: 22
-      Pointee: 527 GoStringHeaderType runtime.plainError
+      Pointee: 537 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 528 GoStringDataType runtime.plainError.str
+      Pointee: 538 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2591,12 +2591,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 357
+      ID: 367
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 906016
       GoKind: 22
-      Pointee: 358 StructureType runtime.synctestDeadlockError
+      Pointee: 368 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -2612,12 +2612,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 551
+      ID: 561
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1030816
       GoKind: 22
-      Pointee: 552 UnresolvedPointeeType strconv.NumError
+      Pointee: 562 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -2743,12 +2743,12 @@ Types:
       GoKind: 22
       Pointee: 893 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 665
+      ID: 675
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1414528
       GoKind: 22
-      Pointee: 654 BaseType syscall.Errno
+      Pointee: 664 BaseType syscall.Errno
     - __kind: PointerType
       ID: 738
       Name: '*syscall.Signal'
@@ -2767,10 +2767,10 @@ Types:
       ByteSize: 8
       Pointee: 814 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 236
+      ID: 242
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 240 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 250 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 977
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2785,29 +2785,29 @@ Types:
       ID: 173
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 222 StructureType table<string,float64>
+      Pointee: 228 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 681
+      ID: 691
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 707 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 717 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 168
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 214 StructureType table<string,interface {}>
+      Pointee: 220 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 163
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 206 StructureType table<string,string>
+      Pointee: 212 StructureType table<string,string>
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1086624
       GoKind: 22
-      Pointee: 601 StructureType text/template.ExecError
+      Pointee: 611 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 146
       Name: '*time.Location'
@@ -2816,12 +2816,12 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType time.Location
     - __kind: PointerType
-      ID: 349
+      ID: 359
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902176
       GoKind: 22
-      Pointee: 350 UnresolvedPointeeType time.ParseError
+      Pointee: 360 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 143
       Name: '*time.Timer'
@@ -2830,31 +2830,31 @@ Types:
       GoKind: 22
       Pointee: 144 StructureType time.Timer
     - __kind: PointerType
-      ID: 348
+      ID: 358
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902080
       GoKind: 22
-      Pointee: 263 GoStringHeaderType time.fileSizeError
+      Pointee: 273 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 265
+      ID: 275
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType time.fileSizeError.str
+      Pointee: 274 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 723
+      ID: 205
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394784
       GoKind: 22
-      Pointee: 724 StructureType time.zone
+      Pointee: 206 StructureType time.zone
     - __kind: PointerType
-      ID: 726
+      ID: 208
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394848
       GoKind: 22
-      Pointee: 727 StructureType time.zoneTrans
+      Pointee: 209 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -2898,47 +2898,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 363
+      ID: 373
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 907168
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 374 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 909952
       GoKind: 22
-      Pointee: 379 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 389 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 910048
       GoKind: 22
-      Pointee: 277 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 287 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1038752
       GoKind: 22
-      Pointee: 565 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 575 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 566
+      ID: 576
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1038880
       GoKind: 22
-      Pointee: 531 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 541 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 857
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
     - __kind: GoChannelType
-      ID: 721
+      ID: 731
       Name: <-chan time.Time
       GoRuntimeType: 600736
       GoKind: 18
@@ -3116,7 +3116,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 689
+      ID: 699
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 700800
@@ -3164,7 +3164,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 675 PointerType *crypto/x509.Certificate
+      Element: 685 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 732
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -3247,11 +3247,11 @@ Types:
       ByteSize: 8
       Element: 797 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 258
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 236 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 242 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 987
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3265,25 +3265,25 @@ Types:
       ByteSize: 8
       Element: 836 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 234
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 173 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 713
+      ID: 723
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 226
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 168 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 218
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3335,7 +3335,7 @@ Types:
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 694
+      ID: 704
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 496032
@@ -3350,9 +3350,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 717 GoSliceDataType []float64.array
+      Data: 727 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 717
+      ID: 727
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3373,9 +3373,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 230 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 236 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 236
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3396,9 +3396,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 238 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 244 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 244
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3439,11 +3439,11 @@ Types:
       ByteSize: 24
       Element: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 259
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 243 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 988
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3457,29 +3457,29 @@ Types:
       ByteSize: 328
       Element: 844 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 235
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 225 StructureType noalg.map.group[string]float64
+      Element: 231 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 724
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 227
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 217 StructureType noalg.map.group[string]interface {}
+      Element: 223 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 219
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 209 StructureType noalg.map.group[string]string
+      Element: 215 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 150
       Name: '[]os.Signal'
@@ -3496,9 +3496,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 204 GoSliceDataType []os.Signal.array
+      Data: 210 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 210
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3508,7 +3508,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 693
+      ID: 703
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -3523,15 +3523,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 715 GoSliceDataType []string.array
+      Data: 725 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 715
+      ID: 725
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 722
+      ID: 204
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489344
@@ -3539,22 +3539,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 723 PointerType *time.zone
+          Type: 205 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 728 GoSliceDataType []time.zone.array
+      Data: 246 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 728
+      ID: 246
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 724 StructureType time.zone
+      Element: 206 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 725
+      ID: 207
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489408
@@ -3562,20 +3562,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 726 PointerType *time.zoneTrans
+          Type: 208 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 730 GoSliceDataType []time.zoneTrans.array
+      Data: 248 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 730
+      ID: 248
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 727 StructureType time.zoneTrans
+      Element: 209 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3623,7 +3623,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 509
+      ID: 519
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 945568
@@ -3638,9 +3638,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 510 GoSliceDataType archive/tar.headerError.array
+      Data: 520 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 510
+      ID: 520
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3698,13 +3698,13 @@ Types:
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: BaseType
-      ID: 296
+      ID: 306
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 837504
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 307
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 837600
@@ -3712,13 +3712,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *compress/flate.InternalError.str
+          Type: 309 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType compress/flate.InternalError.str
+      Data: 308 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 308
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3802,7 +3802,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 606
+      ID: 616
       Name: context.deadlineExceededError
       GoRuntimeType: 1457088
       GoKind: 25
@@ -3846,7 +3846,7 @@ Types:
           Type: 143 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 145 StructureType time.Time
+          Type: 145 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3892,43 +3892,43 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 292
+      ID: 302
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 2
     - __kind: BaseType
-      ID: 293
+      ID: 303
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837216
       GoKind: 2
     - __kind: BaseType
-      ID: 294
+      ID: 304
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837312
       GoKind: 2
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1282560
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 295
+      ID: 305
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837408
       GoKind: 2
     - __kind: BaseType
-      ID: 266
+      ID: 276
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 834720
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 573
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4000,11 +4000,11 @@ Types:
       GoRuntimeType: 834432
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 368
+      ID: 378
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 366
+      ID: 376
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1722304
@@ -4015,10 +4015,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 689 ArrayType [5]uint8
+          Type: 699 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 690 GoInterfaceType net.Conn
+          Type: 700 GoInterfaceType net.Conn
     - __kind: BaseType
       ID: 1000
       Name: crypto/tls.SignatureScheme
@@ -4026,25 +4026,25 @@ Types:
       GoRuntimeType: 834528
       GoKind: 9
     - __kind: BaseType
-      ID: 530
+      ID: 540
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 986848
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 380
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 677
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 686
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 422
+      ID: 432
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1724416
@@ -4052,21 +4052,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 685 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 699 BaseType crypto/x509.InvalidReason
+          Type: 709 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 416
+      ID: 426
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1113600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 418
+      ID: 428
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1592736
@@ -4074,24 +4074,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 685 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 291
+      ID: 301
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 2
     - __kind: BaseType
-      ID: 699
+      ID: 709
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 588000
       GoKind: 2
     - __kind: StructureType
-      ID: 579
+      ID: 589
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1553664
@@ -4101,13 +4101,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 424
+      ID: 434
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1113856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 420
+      ID: 430
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1724224
@@ -4115,15 +4115,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 685 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 685 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 466
+      ID: 476
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1427648
@@ -4133,7 +4133,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 470
+      ID: 480
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1427808
@@ -4143,47 +4143,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 468
+      ID: 478
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 267
+      ID: 277
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834816
       GoKind: 6
     - __kind: BaseType
-      ID: 287
+      ID: 297
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 836640
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 392
+      ID: 402
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 575
+      ID: 585
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 394
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 390
+      ID: 400
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 398
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 396
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 394
+      ID: 404
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1418688
@@ -4193,15 +4193,15 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 509
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 497
+      ID: 507
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 305
+      ID: 315
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 840192
@@ -4209,18 +4209,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *encoding/xml.UnmarshalError.str
+          Type: 317 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 306 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 316 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 316
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 512
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4237,11 +4237,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 352
+      ID: 362
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 560
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4257,11 +4257,11 @@ Types:
       GoRuntimeType: 585184
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 544
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 536
+      ID: 546
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4295,7 +4295,7 @@ Types:
       GoRuntimeType: 1002592
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 415
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4305,7 +4305,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 397
+      ID: 407
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1723456
@@ -4313,7 +4313,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 691 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 701 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4321,25 +4321,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 399
+      ID: 409
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 706
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 403
+      ID: 413
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1112704
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 708
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 281
+      ID: 291
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 836064
@@ -4347,18 +4347,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 283 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 293 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 282 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 292 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 282
+      ID: 292
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 691
+      ID: 701
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2212128
@@ -4366,13 +4366,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 692 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 702 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4381,7 +4381,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 694 GoSliceHeaderType []float64
+          Type: 704 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4390,13 +4390,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 695 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 705 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 697 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 707 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4407,13 +4407,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 692
+      ID: 702
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586784
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 278
+      ID: 288
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 835968
@@ -4421,18 +4421,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 280 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 290 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 279 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 279
+      ID: 289
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 294
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 836160
@@ -4440,36 +4440,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 296 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 285 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 295
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 475
+      ID: 485
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1116544
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 300
+      ID: 310
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 838752
       GoKind: 2
     - __kind: StructureType
-      ID: 473
+      ID: 483
       Name: github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
       GoRuntimeType: 1116416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 440
+      ID: 450
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1593536
@@ -4482,7 +4482,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 444
+      ID: 454
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1726144
@@ -4498,7 +4498,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 442
+      ID: 452
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1426208
@@ -4508,7 +4508,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 438
+      ID: 448
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1425888
@@ -4518,14 +4518,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 677
+      ID: 687
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1499328
       GoKind: 21
-      HeaderType: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 700
+      ID: 710
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1049760
@@ -4540,15 +4540,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 719
+      ID: 729
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 452
+      ID: 462
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1593856
@@ -4556,12 +4556,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 446
+      ID: 456
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1426368
@@ -4571,7 +4571,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 450
+      ID: 460
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1726336
@@ -4582,12 +4582,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 448
+      ID: 458
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1593696
@@ -4600,7 +4600,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 454
+      ID: 464
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1426528
@@ -4608,9 +4608,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 145 StructureType time.Time
+          Type: 145 GoTimeType time.Time
     - __kind: StructureType
-      ID: 460
+      ID: 470
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1594176
@@ -4623,7 +4623,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 462
+      ID: 472
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1426848
@@ -4633,7 +4633,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 458
+      ID: 468
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1594016
@@ -4646,7 +4646,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 456
+      ID: 466
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1426688
@@ -4656,7 +4656,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 464
+      ID: 474
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1594336
@@ -4691,7 +4691,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 485
+      ID: 495
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1432768
@@ -4705,7 +4705,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 487
+      ID: 497
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1432928
@@ -4713,7 +4713,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 485 StructureType github.com/cihub/seelog.baseError
+          Type: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 784
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -4736,7 +4736,7 @@ Types:
           Offset: 8
           Type: 793 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 491
+      ID: 501
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1433248
@@ -4744,7 +4744,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 485 StructureType github.com/cihub/seelog.baseError
+          Type: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 788
       Name: github.com/cihub/seelog.splitDispatcher
@@ -4760,7 +4760,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 489
+      ID: 499
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1433088
@@ -4768,9 +4768,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 485 StructureType github.com/cihub/seelog.baseError
+          Type: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 493
+      ID: 503
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1433408
@@ -4778,7 +4778,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 485 StructureType github.com/cihub/seelog.baseError
+          Type: 495 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 919
       Name: github.com/cihub/seelog/archive.Reader
@@ -4807,30 +4807,30 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 593
+      ID: 603
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 605
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 595
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 408
+      ID: 418
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1419968
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 599
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 635
+      ID: 645
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1844736
@@ -4846,11 +4846,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 639
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 569
+      ID: 579
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1695712
@@ -4863,7 +4863,7 @@ Types:
           Offset: 1
           Type: 19 BaseType int8
     - __kind: StructureType
-      ID: 641
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1845184
@@ -4879,13 +4879,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 532
+      ID: 542
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 988000
       GoKind: 8
     - __kind: StructureType
-      ID: 633
+      ID: 643
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1844512
@@ -4901,13 +4901,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 703
+      ID: 713
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 835584
       GoKind: 8
     - __kind: StructureType
-      ID: 631
+      ID: 641
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1844288
@@ -4915,15 +4915,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 639
+      ID: 649
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1758944
@@ -4936,7 +4936,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 637
+      ID: 647
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1844960
@@ -4952,7 +4952,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 645
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1629760
@@ -4962,19 +4962,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 573
+      ID: 583
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1279104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 571
+      ID: 581
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1278976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 643
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1759136
@@ -4987,7 +4987,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 308
+      ID: 318
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 840864
@@ -4995,22 +4995,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 310 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 320 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 309 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 309
+      ID: 319
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 694
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 599
+      ID: 609
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1442528
@@ -5020,19 +5020,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 311
+      ID: 321
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 841440
       GoKind: 10
     - __kind: BaseType
-      ID: 682
+      ID: 692
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 999616
       GoKind: 10
     - __kind: StructureType
-      ID: 653
+      ID: 663
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1876992
@@ -5043,12 +5043,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 682 BaseType golang.org/x/net/http2.ErrCode
+          Type: 692 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 516
+      ID: 526
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1601056
@@ -5056,12 +5056,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 682 BaseType golang.org/x/net/http2.ErrCode
+          Type: 692 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 315
+      ID: 325
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841632
@@ -5069,18 +5069,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 317 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 327 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 316 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 316
+      ID: 326
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 321
+      ID: 331
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 841824
@@ -5088,18 +5088,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 323 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 333 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 322 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 322
+      ID: 332
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 318
+      ID: 328
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 841728
@@ -5107,18 +5107,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 320 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 330 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 319 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 319
+      ID: 329
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 312
+      ID: 322
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841536
@@ -5126,18 +5126,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 314 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 324 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 313 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 313
+      ID: 323
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 520
+      ID: 530
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1443808
@@ -5147,13 +5147,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 324
+      ID: 334
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 841920
       GoKind: 2
     - __kind: StructureType
-      ID: 495
+      ID: 505
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1438208
@@ -5163,11 +5163,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 661
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 671
+      ID: 681
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1904064
@@ -5183,7 +5183,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 506
+      ID: 516
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1600096
@@ -5200,7 +5200,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 597
+      ID: 607
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1561024
@@ -5214,25 +5214,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 477
+      ID: 487
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 601
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 659
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 647
+      ID: 657
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1507488
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 392
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -5478,16 +5478,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 232 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 238 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 237 GoMapType map[string]interface {}
+          Type: 243 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 741
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 247
+      ID: 257
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1911360
@@ -5586,11 +5586,11 @@ Types:
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 434
+      ID: 444
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 479
+      ID: 489
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1430048
@@ -5600,7 +5600,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 481
+      ID: 491
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1430208
@@ -5610,7 +5610,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 514
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5642,19 +5642,19 @@ Types:
       GroupType: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 822 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 241
+      ID: 251
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 242 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 252 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 243 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 979
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5684,63 +5684,63 @@ Types:
       GroupType: 844 StructureType noalg.map.group[string][]string
       GroupSliceType: 848 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 229
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[string]float64
+          Type: 230 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[string]float64
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 231 StructureType noalg.map.group[string]float64
+      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 708
+      ID: 718
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 709 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 719 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 714 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 724 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 221
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[string]interface {}
+          Type: 222 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 223 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 227 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 213
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[string]string
+          Type: 214 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 215 StructureType noalg.map.group[string]string
+      GroupSliceType: 219 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 523
+      ID: 533
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5787,11 +5787,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 683
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 423
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5817,11 +5817,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 411
+      ID: 421
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 637
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5829,13 +5829,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 625
+      ID: 635
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1474688
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 364
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5916,7 +5916,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 298
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 836832
@@ -5924,18 +5924,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 300 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 299 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 299
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 577
+      ID: 587
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1552704
@@ -5943,7 +5943,7 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 672 PointerType *internal/abi.Type
+          Type: 682 PointerType *internal/abi.Type
     - __kind: StructureType
       ID: 134
       Name: internal/sync.Mutex
@@ -6025,7 +6025,7 @@ Types:
           Offset: 0
           Type: 910 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 633
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6099,7 +6099,7 @@ Types:
       TablePtrSliceType: 821 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 234
+      ID: 240
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6112,7 +6112,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 235 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 241 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6131,8 +6131,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 243 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 258 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 975
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6236,10 +6236,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<string,float64>.array
-      GroupType: 225 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 234 GoSliceDataType []*table<string,float64>.array
+      GroupType: 231 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 679
+      ID: 689
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6252,7 +6252,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 680 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 690 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6271,8 +6271,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 713 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 723 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 166
       Name: map<string,interface {}>
@@ -6306,8 +6306,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 217 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 226 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 223 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 161
       Name: map<string,string>
@@ -6341,8 +6341,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 209 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 218 GoSliceDataType []*table<string,string>.array
+      GroupType: 215 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 137
       Name: map[context.canceler]struct {}
@@ -6358,12 +6358,12 @@ Types:
       GoKind: 21
       HeaderType: 795 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 232
+      ID: 238
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1132640
       GoKind: 21
-      HeaderType: 234 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 240 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 973
       Name: map[string][]*mime/multipart.FileHeader
@@ -6386,7 +6386,7 @@ Types:
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 237
+      ID: 243
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1125888
@@ -6400,7 +6400,7 @@ Types:
       GoKind: 21
       HeaderType: 161 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 432
+      ID: 442
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1422848
@@ -6444,11 +6444,11 @@ Types:
           Offset: 8
           Type: 920 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 619
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 690
+      ID: 700
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1590336
@@ -6461,7 +6461,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 668
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6469,11 +6469,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 666
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 621
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6489,7 +6489,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 602
+      ID: 612
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1107584
@@ -6497,18 +6497,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 604 PointerType *net.UnknownNetworkError.str
+          Type: 614 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 603 GoStringDataType net.UnknownNetworkError.str
+      Data: 613 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 603
+      ID: 613
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 538
+      ID: 548
       Name: net.canceledError
       GoRuntimeType: 1276544
       GoKind: 25
@@ -6518,7 +6518,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 712
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2100512
@@ -6526,7 +6526,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 690 GoInterfaceType net.Conn
+          Type: 700 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -6553,7 +6553,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 326
+      ID: 336
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6570,7 +6570,7 @@ Types:
           Offset: 16
           Type: 117 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 328
+      ID: 338
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1717696
@@ -6578,7 +6578,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 685 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 695 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6612,11 +6612,11 @@ Types:
           Offset: 0
           Type: 950 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 623
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 670
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6666,11 +6666,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 334
+      ID: 344
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 540
+      ID: 550
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6722,7 +6722,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6767,7 +6767,7 @@ Types:
           Type: 860 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 159 GoMapType map[string]string
@@ -6804,7 +6804,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6877,19 +6877,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 250
+      ID: 260
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832704
       GoKind: 10
     - __kind: BaseType
-      ID: 674
+      ID: 684
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 984064
       GoKind: 10
     - __kind: StructureType
-      ID: 337
+      ID: 347
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1719424
@@ -6900,12 +6900,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 684 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 672
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1894080
@@ -6916,7 +6916,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 684 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
@@ -6925,7 +6925,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 343
+      ID: 353
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1590816
@@ -6933,12 +6933,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 684 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 254
+      ID: 264
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832896
@@ -6946,18 +6946,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 256 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 266 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 255 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 255
+      ID: 265
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 341
+      ID: 351
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1108864
       GoKind: 25
@@ -6967,7 +6967,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 260
+      ID: 270
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833088
@@ -6975,18 +6975,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 262 PointerType *net/http.http2headerFieldNameError.str
+          Type: 272 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 261 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 271 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 261
+      ID: 271
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 257
+      ID: 267
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832992
@@ -6994,18 +6994,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 259 PointerType *net/http.http2headerFieldValueError.str
+          Type: 269 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 258 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 268 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 258
+      ID: 268
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 617
+      ID: 627
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -7021,13 +7021,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 546
+      ID: 556
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1277184
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 251
+      ID: 261
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832800
@@ -7035,13 +7035,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 253 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 263 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 252 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 262 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 252
+      ID: 262
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7084,7 +7084,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 542
+      ID: 552
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1545024
@@ -7124,7 +7124,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 347
+      ID: 357
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1411328
@@ -7199,7 +7199,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 828 StructureType sync/atomic.Bool
@@ -7238,7 +7238,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 332
+      ID: 342
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1590656
@@ -7251,17 +7251,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 674
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 615
+      ID: 625
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1461728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 544
+      ID: 554
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1545184
@@ -7279,12 +7279,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 690 GoInterfaceType net.Conn
+          Type: 700 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 690 GoInterfaceType net.Conn
+          Type: 700 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 330
+      ID: 340
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7294,7 +7294,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 362
+      ID: 372
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1721920
@@ -7310,7 +7310,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 360
+      ID: 370
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1591776
@@ -7323,11 +7323,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 387
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 274
+      ID: 284
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835104
@@ -7335,22 +7335,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 276 PointerType *net/textproto.ProtocolError.str
+          Type: 286 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 275 GoStringDataType net/textproto.ProtocolError.str
+      Data: 285 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 275
+      ID: 285
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 679
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 268
+      ID: 278
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 834912
@@ -7358,18 +7358,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 270 PointerType *net/url.EscapeError.str
+          Type: 280 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 269 GoStringDataType net/url.EscapeError.str
+      Data: 279 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 269
+      ID: 279
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 281
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 835008
@@ -7377,13 +7377,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *net/url.InvalidHostError.str
+          Type: 283 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 272 GoStringDataType net/url.InvalidHostError.str
+      Data: 282 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 282
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7457,14 +7457,14 @@ Types:
       HasCount: true
       Element: 819 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 244
+      ID: 254
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 703488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 245 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 255 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 982
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7484,41 +7484,41 @@ Types:
       HasCount: true
       Element: 846 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 226
+      ID: 232
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 703392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key string; elem float64 }
+      Element: 233 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 711
+      ID: 721
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 760160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 712 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 722 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 218
+      ID: 224
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 680992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key string; elem interface {} }
+      Element: 225 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 210
+      ID: 216
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key string; elem string }
+      Element: 217 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 197
       Name: noalg.map.group[context.canceler]struct {}
@@ -7546,7 +7546,7 @@ Types:
           Offset: 8
           Type: 818 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 243
+      ID: 253
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1305344
@@ -7557,7 +7557,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 244 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 254 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 981
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7585,7 +7585,7 @@ Types:
           Offset: 8
           Type: 845 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 225
+      ID: 231
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1305088
@@ -7596,9 +7596,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 232 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 710
+      ID: 720
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1346944
@@ -7609,9 +7609,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 711 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 721 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 217
+      ID: 223
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1287168
@@ -7622,9 +7622,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 224 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 209
+      ID: 215
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1292160
@@ -7635,7 +7635,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 216 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 199
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7663,7 +7663,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 245
+      ID: 255
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1305216
@@ -7674,7 +7674,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 246 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 256 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 983
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7700,9 +7700,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 693 GoSliceHeaderType []string
+          Type: 703 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 227
+      ID: 233
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1304960
@@ -7715,7 +7715,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 712
+      ID: 722
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1346816
@@ -7726,9 +7726,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 219
+      ID: 225
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1287040
@@ -7741,7 +7741,7 @@ Types:
           Offset: 16
           Type: 136 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 211
+      ID: 217
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1292032
@@ -7758,7 +7758,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 558
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7775,7 +7775,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 629
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7817,15 +7817,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 591
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 716
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 583
+      ID: 593
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1695904
@@ -7859,7 +7859,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 302
+      ID: 312
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 839520
@@ -7867,36 +7867,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 304 PointerType *os/user.UnknownGroupIdError.str
+          Type: 314 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 303 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 313 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 303
+      ID: 313
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 301
+      ID: 311
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 839424
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 356
+      ID: 366
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 436
+      ID: 446
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 556
+      ID: 566
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 570
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7908,7 +7908,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 558
+      ID: 568
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1883936
@@ -7925,9 +7925,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 704 BaseType runtime.boundsErrorCode
+          Type: 714 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 704
+      ID: 714
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585376
@@ -7947,7 +7947,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 621
+      ID: 631
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1753568
@@ -7960,7 +7960,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 524
+      ID: 534
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 985312
@@ -7968,13 +7968,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 526 PointerType *runtime.errorString.str
+          Type: 536 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 525 GoStringDataType runtime.errorString.str
+      Data: 535 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 525
+      ID: 535
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8637,7 +8637,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 527
+      ID: 537
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 985408
@@ -8645,13 +8645,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 529 PointerType *runtime.plainError.str
+          Type: 539 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 528 GoStringDataType runtime.plainError.str
+      Data: 538 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 528
+      ID: 538
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8692,7 +8692,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 358
+      ID: 368
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1591456
@@ -8750,7 +8750,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 552
+      ID: 562
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9121,7 +9121,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 654
+      ID: 664
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1278080
@@ -9181,7 +9181,7 @@ Types:
           Offset: 16
           Type: 815 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 240
+      ID: 250
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9203,7 +9203,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 241 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 251 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 978
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9253,7 +9253,7 @@ Types:
           Offset: 16
           Type: 842 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 222
+      ID: 228
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9275,9 +9275,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 229 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 707
+      ID: 717
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9299,9 +9299,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 708 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 718 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 214
+      ID: 220
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9323,9 +9323,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 221 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 206
+      ID: 212
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9347,9 +9347,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<string,string>
+          Type: 213 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 601
+      ID: 611
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1700128
@@ -9379,10 +9379,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 722 GoSliceHeaderType []time.zone
+          Type: 204 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 725 GoSliceHeaderType []time.zoneTrans
+          Type: 207 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9394,12 +9394,12 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 723 PointerType *time.zone
+          Type: 205 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 350
+      ID: 360
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 145
       Name: time.Time
       ByteSize: 24
@@ -9415,6 +9415,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 146 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 144
       Name: time.Timer
@@ -9424,12 +9432,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 721 GoChannelType <-chan time.Time
+          Type: 731 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 273
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 833184
@@ -9437,18 +9445,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *time.fileSizeError.str
+          Type: 275 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 264 GoStringDataType time.fileSizeError.str
+      Data: 274 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 274
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 724
+      ID: 206
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1612864
@@ -9464,7 +9472,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 727
+      ID: 209
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1750304
@@ -9525,7 +9533,7 @@ Types:
       GoRuntimeType: 585312
       GoKind: 26
     - __kind: StructureType
-      ID: 685
+      ID: 695
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2057600
@@ -9536,10 +9544,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 686 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 696 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 687 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 697 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9554,18 +9562,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 688 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 698 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 688
+      ID: 698
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 986464
       GoKind: 9
     - __kind: StructureType
-      ID: 686
+      ID: 696
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1914176
@@ -9590,17 +9598,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 374
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 687
+      ID: 697
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 586208
       GoKind: 8
     - __kind: StructureType
-      ID: 379
+      ID: 389
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1416768
@@ -9610,13 +9618,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 277
+      ID: 287
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835200
       GoKind: 2
     - __kind: StructureType
-      ID: 565
+      ID: 575
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1695328
@@ -9629,7 +9637,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 531
+      ID: 541
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 987328

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.26rc1.yaml
@@ -130,7 +130,7 @@ Types:
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 685 PointerType *crypto/x509.Certificate
+      Pointee: 695 PointerType *crypto/x509.Certificate
     - __kind: PointerType
       ID: 743
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -160,10 +160,10 @@ Types:
       ByteSize: 8
       Pointee: 807 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 245
+      ID: 251
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 246 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 252 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 986
       Name: '**table<string,[]*mime/multipart.FileHeader>'
@@ -180,10 +180,10 @@ Types:
       ByteSize: 8
       Pointee: 183 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 690
+      ID: 700
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 701 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '**table<string,interface {}>'
@@ -231,30 +231,30 @@ Types:
       ByteSize: 8
       Pointee: 1015 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 728
+      ID: 738
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 727 GoSliceDataType []float64.array
+      Pointee: 737 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 241
+      ID: 247
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Pointee: 246 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: PointerType
-      ID: 249
+      ID: 255
       Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 254 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 1021
       Name: '*[]net/http.segment.array'
       ByteSize: 8
       Pointee: 1020 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 215
+      ID: 221
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []os.Signal.array
+      Pointee: 220 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -263,20 +263,20 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 726
+      ID: 736
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 725 GoSliceDataType []string.array
+      Pointee: 735 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 739
+      ID: 257
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 738 GoSliceDataType []time.zone.array
+      Pointee: 256 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 741
+      ID: 259
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 740 GoSliceDataType []time.zoneTrans.array
+      Pointee: 258 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1008
       Name: '*[]uint8'
@@ -295,17 +295,17 @@ Types:
       ByteSize: 8
       Pointee: 199 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 518
+      ID: 528
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 954880
       GoKind: 22
-      Pointee: 519 GoSliceHeaderType archive/tar.headerError
+      Pointee: 529 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 521
+      ID: 531
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 520 GoSliceDataType archive/tar.headerError.array
+      Pointee: 530 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
       ID: 908
       Name: '*archive/zip.checksumReader'
@@ -363,24 +363,24 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 393
+      ID: 403
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 291 BaseType compress/flate.CorruptInputError
+      Pointee: 301 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 394
+      ID: 404
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 292 GoStringHeaderType compress/flate.InternalError
+      Pointee: 302 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 294
+      ID: 304
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 293 GoStringDataType compress/flate.InternalError.str
+      Pointee: 303 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
       ID: 948
       Name: '*compress/flate.decompressor'
@@ -417,12 +417,12 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 615
+      ID: 625
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1189920
       GoKind: 22
-      Pointee: 616 StructureType context.deadlineExceededError
+      Pointee: 626 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 1022
       Name: '*context.emptyCtx'
@@ -466,54 +466,54 @@ Types:
       GoKind: 22
       Pointee: 135 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 442
+      ID: 452
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927616
       GoKind: 22
-      Pointee: 310 BaseType crypto/aes.KeySizeError
+      Pointee: 320 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 443
+      ID: 453
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927808
       GoKind: 22
-      Pointee: 311 BaseType crypto/des.KeySizeError
+      Pointee: 321 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 444
+      ID: 454
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928096
       GoKind: 22
-      Pointee: 312 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 322 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 596
+      ID: 606
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1062272
       GoKind: 22
-      Pointee: 597 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 607 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 445
+      ID: 455
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928384
       GoKind: 22
-      Pointee: 313 BaseType crypto/rc4.KeySizeError
+      Pointee: 323 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 382
+      ID: 392
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 916960
       GoKind: 22
-      Pointee: 280 BaseType crypto/tls.AlertError
+      Pointee: 290 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 572
+      ID: 582
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1046656
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 583 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
       ID: 978
       Name: '*crypto/tls.Conn'
@@ -529,187 +529,187 @@ Types:
       GoKind: 22
       Pointee: 866 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 383
+      ID: 393
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 917056
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 394 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 380
+      ID: 390
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 916864
       GoKind: 22
-      Pointee: 381 StructureType crypto/tls.RecordHeaderError
+      Pointee: 391 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 571
+      ID: 581
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1044992
       GoKind: 22
-      Pointee: 540 BaseType crypto/tls.alert
+      Pointee: 550 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 385
+      ID: 395
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 917152
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 396 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 676
+      ID: 686
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1425568
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 687 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 685
+      ID: 695
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2033984
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 696 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 438
+      ID: 448
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 927232
       GoKind: 22
-      Pointee: 439 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 449 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 432
+      ID: 442
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 433 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 443 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 434
+      ID: 444
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 926752
       GoKind: 22
-      Pointee: 435 StructureType crypto/x509.HostnameError
+      Pointee: 445 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 431
+      ID: 441
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 926176
       GoKind: 22
-      Pointee: 309 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 319 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 588
+      ID: 598
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1055360
       GoKind: 22
-      Pointee: 589 StructureType crypto/x509.SystemRootsError
+      Pointee: 599 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 440
+      ID: 450
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 927328
       GoKind: 22
-      Pointee: 441 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 451 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 436
+      ID: 446
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 927136
       GoKind: 22
-      Pointee: 437 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 447 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 480
+      ID: 490
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 937216
       GoKind: 22
-      Pointee: 481 StructureType encoding/asn1.StructuralError
+      Pointee: 491 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 484
+      ID: 494
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 485 StructureType encoding/asn1.SyntaxError
+      Pointee: 495 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 482
+      ID: 492
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 937312
       GoKind: 22
-      Pointee: 483 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 493 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 387
+      ID: 397
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 917344
       GoKind: 22
-      Pointee: 281 BaseType encoding/base64.CorruptInputError
+      Pointee: 291 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 423
+      ID: 433
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 305 BaseType encoding/hex.InvalidByteError
+      Pointee: 315 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 408
+      ID: 418
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 419 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 584
+      ID: 594
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1051648
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 595 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 400
+      ID: 410
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 920992
       GoKind: 22
-      Pointee: 401 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 411 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 406
+      ID: 416
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 407 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 417 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 404
+      ID: 414
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 405 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 415 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 402
+      ID: 412
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 921088
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 413 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 410
+      ID: 420
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 411 StructureType encoding/json.jsonError
+      Pointee: 421 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 511
+      ID: 521
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 948928
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 522 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -718,19 +718,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 365
+      ID: 375
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 366 UnresolvedPointeeType errors.errorString
+      Pointee: 376 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 559
+      ID: 569
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1037824
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType errors.joinError
+      Pointee: 570 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -746,26 +746,26 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 543
+      ID: 553
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1027200
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType fmt.wrapError
+      Pointee: 554 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 545
+      ID: 555
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1027328
       GoKind: 22
-      Pointee: 546 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 556 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 421
+      ID: 431
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 432 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
       ID: 808
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
@@ -774,200 +774,200 @@ Types:
       GoKind: 22
       Pointee: 809 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 413
+      ID: 423
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 923104
       GoKind: 22
-      Pointee: 414 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 424 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 415
+      ID: 425
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 923200
       GoKind: 22
-      Pointee: 416 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 426 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 705
+      ID: 715
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 716 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 419
+      ID: 429
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 923488
       GoKind: 22
-      Pointee: 420 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 430 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 707
+      ID: 717
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 923008
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 718 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 417
+      ID: 427
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 923296
       GoKind: 22
-      Pointee: 299 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 309 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 301
+      ID: 311
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 300 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 310 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 412
+      ID: 422
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 296 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 306 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 298
+      ID: 308
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 297 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 418
+      ID: 428
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 923392
       GoKind: 22
-      Pointee: 302 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 312 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 304
+      ID: 314
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 303 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 313 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 489
+      ID: 499
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 938368
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 500 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 486
+      ID: 496
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 938176
       GoKind: 22
-      Pointee: 314 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 324 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 487
+      ID: 497
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 938272
       GoKind: 22
-      Pointee: 488 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
+      Pointee: 498 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 454
+      ID: 464
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 934048
       GoKind: 22
-      Pointee: 455 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 465 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 458
+      ID: 468
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 934240
       GoKind: 22
-      Pointee: 459 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 469 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 456
+      ID: 466
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 934144
       GoKind: 22
-      Pointee: 457 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 467 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 452
+      ID: 462
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 933952
       GoKind: 22
-      Pointee: 453 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 463 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 730
+      ID: 740
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 739 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 466
+      ID: 476
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 934624
       GoKind: 22
-      Pointee: 467 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 477 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 460
+      ID: 470
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 471 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 464
+      ID: 474
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 934528
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 475 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 462
+      ID: 472
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 934432
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 473 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 468
+      ID: 478
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 934720
       GoKind: 22
-      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 474
+      ID: 484
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 935008
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 485 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 476
+      ID: 486
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 935104
       GoKind: 22
-      Pointee: 477 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 487 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 472
+      ID: 482
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 934912
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 483 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 470
+      ID: 480
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 481 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 478
+      ID: 488
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 935296
       GoKind: 22
-      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 489 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
       ID: 822
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
@@ -997,12 +997,12 @@ Types:
       GoKind: 22
       Pointee: 821 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 499
+      ID: 509
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 946336
       GoKind: 22
-      Pointee: 500 StructureType github.com/cihub/seelog.baseError
+      Pointee: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 801
       Name: '*github.com/cihub/seelog.bufferedWriter'
@@ -1011,12 +1011,12 @@ Types:
       GoKind: 22
       Pointee: 802 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 501
+      ID: 511
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 946432
       GoKind: 22
-      Pointee: 502 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 512 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 793
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
@@ -1039,12 +1039,12 @@ Types:
       GoKind: 22
       Pointee: 800 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 505
+      ID: 515
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 946624
       GoKind: 22
-      Pointee: 506 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 516 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 797
       Name: '*github.com/cihub/seelog.splitDispatcher'
@@ -1060,19 +1060,19 @@ Types:
       GoKind: 22
       Pointee: 815 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 503
+      ID: 513
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 946528
       GoKind: 22
-      Pointee: 504 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 514 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 507
+      ID: 517
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 946720
       GoKind: 22
-      Pointee: 508 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 518 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 906
       Name: '*github.com/cihub/seelog/archive.nopCloser'
@@ -1088,268 +1088,268 @@ Types:
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 602
+      ID: 612
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1074688
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 613 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 604
+      ID: 614
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1074816
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 615 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 594
+      ID: 604
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1059456
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 605 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 424
+      ID: 434
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 425 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 435 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 598
+      ID: 608
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1063040
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 609 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 644
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1213216
       GoKind: 22
-      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 638
+      ID: 648
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1212832
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 649 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 578
+      ID: 588
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1050752
       GoKind: 22
-      Pointee: 579 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 650
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1213600
       GoKind: 22
-      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 577
+      ID: 587
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1050624
       GoKind: 22
-      Pointee: 542 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 552 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 642
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1213088
       GoKind: 22
-      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 640
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1212960
       GoKind: 22
-      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 648
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1213472
       GoKind: 22
-      Pointee: 649 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 646
+      ID: 656
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1213344
       GoKind: 22
-      Pointee: 647 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 654
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1213984
       GoKind: 22
-      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 582
+      ID: 592
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1051008
       GoKind: 22
-      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 580
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1050880
       GoKind: 22
-      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 652
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1213856
       GoKind: 22
-      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 517
+      ID: 527
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 954112
       GoKind: 22
-      Pointee: 319 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 329 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 321
+      ID: 331
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 693
+      ID: 703
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1677280
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 704 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 608
+      ID: 618
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1090944
       GoKind: 22
-      Pointee: 609 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 619 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 522
+      ID: 532
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 956128
       GoKind: 22
-      Pointee: 322 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 332 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 662
+      ID: 672
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1267360
       GoKind: 22
-      Pointee: 663 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 673 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 525
+      ID: 535
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 956416
       GoKind: 22
-      Pointee: 526 StructureType golang.org/x/net/http2.connError
+      Pointee: 536 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 524
+      ID: 534
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 956320
       GoKind: 22
-      Pointee: 326 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 336 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 328
+      ID: 338
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 327 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 528
+      ID: 538
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 956608
       GoKind: 22
-      Pointee: 332 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 342 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 334
+      ID: 344
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 333 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 527
+      ID: 537
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 956512
       GoKind: 22
-      Pointee: 329 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 339 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 331
+      ID: 341
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 330 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 523
+      ID: 533
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 956224
       GoKind: 22
-      Pointee: 323 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 333 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 325
+      ID: 335
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 324 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 529
+      ID: 539
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 956704
       GoKind: 22
-      Pointee: 530 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 540 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 531
+      ID: 541
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 956800
       GoKind: 22
-      Pointee: 335 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 345 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 509
+      ID: 519
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 948544
       GoKind: 22
-      Pointee: 510 StructureType google.golang.org/grpc.dropError
+      Pointee: 520 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 660
+      ID: 670
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1264160
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 671 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 680
+      ID: 690
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1451008
       GoKind: 22
-      Pointee: 681 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 691 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 515
+      ID: 525
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 952384
       GoKind: 22
-      Pointee: 516 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 526 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
       ID: 937
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
@@ -1358,12 +1358,12 @@ Types:
       GoKind: 22
       Pointee: 938 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 606
+      ID: 616
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1085184
       GoKind: 22
-      Pointee: 607 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 617 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
       ID: 921
       Name: '*google.golang.org/grpc/mem.sliceReader'
@@ -1372,40 +1372,40 @@ Types:
       GoKind: 22
       Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 491
+      ID: 501
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 940576
       GoKind: 22
-      Pointee: 492 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 502 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 600
+      ID: 610
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1064448
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 611 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 658
+      ID: 668
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1230752
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 669 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 656
+      ID: 666
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1230496
       GoKind: 22
-      Pointee: 657 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 667 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 398
+      ID: 408
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 920032
       GoKind: 22
-      Pointee: 399 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 409 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 752
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
@@ -1463,12 +1463,12 @@ Types:
       GoKind: 22
       Pointee: 751 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 256
+      ID: 266
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1197600
       GoKind: 22
-      Pointee: 257 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 267 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 192
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
@@ -1505,40 +1505,40 @@ Types:
       GoKind: 22
       Pointee: 891 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 448
+      ID: 458
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 932320
       GoKind: 22
-      Pointee: 449 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 459 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 493
+      ID: 503
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 941152
       GoKind: 22
-      Pointee: 494 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 504 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 495
+      ID: 505
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 941248
       GoKind: 22
-      Pointee: 496 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 506 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 513
+      ID: 523
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 949696
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 524 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 532
+      ID: 542
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 957568
       GoKind: 22
-      Pointee: 533 UnresolvedPointeeType html/template.Error
+      Pointee: 543 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 107
       Name: '*int'
@@ -1575,33 +1575,33 @@ Types:
       GoKind: 22
       Pointee: 21 BaseType int8
     - __kind: PointerType
-      ID: 682
+      ID: 692
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2214912
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType internal/abi.Type
+      Pointee: 693 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 429
+      ID: 439
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 430 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 440 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 427
+      ID: 437
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 925696
       GoKind: 22
-      Pointee: 428 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 438 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 636
+      ID: 646
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1205792
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 647 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
       ID: 976
       Name: '*internal/poll.FD'
@@ -1610,19 +1610,19 @@ Types:
       GoKind: 22
       Pointee: 977 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 634
+      ID: 644
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1205664
       GoKind: 22
-      Pointee: 635 StructureType internal/poll.errNetClosing
+      Pointee: 645 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 367
+      ID: 377
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 912256
       GoKind: 22
-      Pointee: 368 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 378 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -1631,31 +1631,31 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 426
+      ID: 436
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 925600
       GoKind: 22
-      Pointee: 306 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 316 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 308
+      ID: 318
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 317 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 586
+      ID: 596
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1054208
       GoKind: 22
-      Pointee: 587 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 597 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 377
+      ID: 387
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 279 BaseType internal/strconv.Error
+      Pointee: 289 BaseType internal/strconv.Error
     - __kind: PointerType
       ID: 941
       Name: '*io.PipeReader'
@@ -1685,12 +1685,12 @@ Types:
       GoKind: 22
       Pointee: 905 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 632
+      ID: 642
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1204640
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType io/fs.PathError
+      Pointee: 643 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
       ID: 144
       Name: '*map<context.canceler,struct {}>'
@@ -1702,10 +1702,10 @@ Types:
       ByteSize: 8
       Pointee: 805 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 243
+      ID: 249
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 244 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 250 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 984
       Name: '*map<string,[]*mime/multipart.FileHeader>'
@@ -1722,10 +1722,10 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 688
+      ID: 698
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 699 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 175
       Name: '*map<string,interface {}>'
@@ -1737,12 +1737,12 @@ Types:
       ByteSize: 8
       Pointee: 171 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 446
+      ID: 456
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 929056
       GoKind: 22
-      Pointee: 447 StructureType math/big.ErrNaN
+      Pointee: 457 StructureType math/big.ErrNaN
     - __kind: PointerType
       ID: 996
       Name: '*mime/multipart.FileHeader'
@@ -1772,19 +1772,19 @@ Types:
       GoKind: 22
       Pointee: 926 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 618
+      ID: 628
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1191072
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType net.AddrError
+      Pointee: 629 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 667
+      ID: 677
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1418368
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType net.DNSError
+      Pointee: 678 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
       ID: 952
       Name: '*net.IPConn'
@@ -1793,19 +1793,19 @@ Types:
       GoKind: 22
       Pointee: 953 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 665
+      ID: 675
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1418048
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType net.OpError
+      Pointee: 676 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 620
+      ID: 630
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1191200
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType net.ParseError
+      Pointee: 631 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 960
       Name: '*net.TCPConn'
@@ -1828,24 +1828,24 @@ Types:
       GoKind: 22
       Pointee: 959 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 617
+      ID: 627
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1190304
       GoKind: 22
-      Pointee: 612 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 622 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 614
+      ID: 624
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 613 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 623 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 547
+      ID: 557
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1028224
       GoKind: 22
-      Pointee: 548 StructureType net.canceledError
+      Pointee: 558 StructureType net.canceledError
     - __kind: PointerType
       ID: 950
       Name: '*net.conn'
@@ -1854,12 +1854,12 @@ Types:
       GoKind: 22
       Pointee: 951 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 711
+      ID: 721
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1850688
       GoKind: 22
-      Pointee: 712 StructureType net.dialResult·1
+      Pointee: 722 StructureType net.dialResult·1
     - __kind: PointerType
       ID: 966
       Name: '*net.netFD'
@@ -1868,12 +1868,12 @@ Types:
       GoKind: 22
       Pointee: 967 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 336
+      ID: 346
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 904672
       GoKind: 22
-      Pointee: 337 UnresolvedPointeeType net.notFoundError
+      Pointee: 347 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 1023
       Name: '*net.onlyValuesCtx'
@@ -1882,12 +1882,12 @@ Types:
       GoKind: 22
       Pointee: 1024 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 338
+      ID: 348
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 905344
       GoKind: 22
-      Pointee: 339 StructureType net.result·2
+      Pointee: 349 StructureType net.result·2
     - __kind: PointerType
       ID: 956
       Name: '*net.tcpConnWithoutReadFrom'
@@ -1903,33 +1903,33 @@ Types:
       GoKind: 22
       Pointee: 955 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 622
+      ID: 632
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1191840
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net.temporaryError
+      Pointee: 633 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 669
+      ID: 679
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1418688
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType net.timeoutError
+      Pointee: 680 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 344
+      ID: 354
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 907936
       GoKind: 22
-      Pointee: 345 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 355 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 549
+      ID: 559
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1031936
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 560 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 118
       Name: '*net/http.Request'
@@ -1987,26 +1987,26 @@ Types:
       GoKind: 22
       Pointee: 919 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 346
+      ID: 356
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 908128
       GoKind: 22
-      Pointee: 260 BaseType net/http.http2ConnectionError
+      Pointee: 270 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 347
+      ID: 357
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 348 StructureType net/http.http2GoAwayError
+      Pointee: 358 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 671
+      ID: 681
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1419488
       GoKind: 22
-      Pointee: 672 StructureType net/http.http2StreamError
+      Pointee: 682 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 914
       Name: '*net/http.http2clientStream'
@@ -2015,31 +2015,31 @@ Types:
       GoKind: 22
       Pointee: 915 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 353
+      ID: 363
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 354 StructureType net/http.http2connError
+      Pointee: 364 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 350
+      ID: 360
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 264 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 274 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 266
+      ID: 276
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 275 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 351
+      ID: 361
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 908800
       GoKind: 22
-      Pointee: 352 StructureType net/http.http2goAwayFlowError
+      Pointee: 362 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
       ID: 916
       Name: '*net/http.http2gzipReader'
@@ -2048,36 +2048,36 @@ Types:
       GoKind: 22
       Pointee: 917 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 356
+      ID: 366
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 909472
       GoKind: 22
-      Pointee: 270 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 280 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 272
+      ID: 282
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 281 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 355
+      ID: 365
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 267 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 277 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 269
+      ID: 279
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 278 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 626
+      ID: 636
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1195424
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 637 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 878
       Name: '*net/http.http2missingBody'
@@ -2093,24 +2093,24 @@ Types:
       GoKind: 22
       Pointee: 887 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 555
+      ID: 565
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1034112
       GoKind: 22
-      Pointee: 556 StructureType net/http.http2noCachedConnError
+      Pointee: 566 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 349
+      ID: 359
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 261 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 271 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 263
+      ID: 273
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 272 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
       ID: 884
       Name: '*net/http.http2requestBody'
@@ -2154,12 +2154,12 @@ Types:
       GoKind: 22
       Pointee: 903 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 551
+      ID: 561
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1033856
       GoKind: 22
-      Pointee: 552 StructureType net/http.nothingWrittenError
+      Pointee: 562 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 870
       Name: '*net/http.pattern'
@@ -2182,12 +2182,12 @@ Types:
       GoKind: 22
       Pointee: 911 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 357
+      ID: 367
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 909664
       GoKind: 22
-      Pointee: 358 StructureType net/http.requestBodyReadError
+      Pointee: 368 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 791
       Name: '*net/http.response'
@@ -2203,33 +2203,33 @@ Types:
       GoKind: 22
       Pointee: 1019 StructureType net/http.segment
     - __kind: PointerType
-      ID: 342
+      ID: 352
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 907840
       GoKind: 22
-      Pointee: 343 StructureType net/http.statusError
+      Pointee: 353 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 673
+      ID: 683
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1420928
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 684 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 624
+      ID: 634
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1195296
       GoKind: 22
-      Pointee: 625 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 635 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 553
+      ID: 563
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1033984
       GoKind: 22
-      Pointee: 554 StructureType net/http.transportReadFromServerError
+      Pointee: 564 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 939
       Name: '*net/http.unencryptedNetConnInTLSConn'
@@ -2238,12 +2238,12 @@ Types:
       GoKind: 22
       Pointee: 940 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 340
+      ID: 350
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 907072
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 351 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 896
       Name: '*net/http/httputil.failureToReadBody'
@@ -2252,69 +2252,69 @@ Types:
       GoKind: 22
       Pointee: 897 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 375
+      ID: 385
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915136
       GoKind: 22
-      Pointee: 376 StructureType net/netip.parseAddrError
+      Pointee: 386 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 373
+      ID: 383
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915040
       GoKind: 22
-      Pointee: 374 StructureType net/netip.parsePrefixError
+      Pointee: 384 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 391
+      ID: 401
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 392 UnresolvedPointeeType net/textproto.Error
+      Pointee: 402 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 390
+      ID: 400
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 288 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 298 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 290
+      ID: 300
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 299 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 678
+      ID: 688
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1425888
       GoKind: 22
-      Pointee: 679 UnresolvedPointeeType net/url.Error
+      Pointee: 689 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 388
+      ID: 398
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 917440
       GoKind: 22
-      Pointee: 282 GoStringHeaderType net/url.EscapeError
+      Pointee: 292 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 284
+      ID: 294
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 283 GoStringDataType net/url.EscapeError.str
+      Pointee: 293 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 389
+      ID: 399
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 285 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 295 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 287
+      ID: 297
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 286 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 296 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
       ID: 859
       Name: '*net/url.URL'
@@ -2340,10 +2340,10 @@ Types:
       ByteSize: 8
       Pointee: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 252
+      ID: 262
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 990
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -2355,25 +2355,25 @@ Types:
       ByteSize: 8
       Pointee: 854 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 234
+      ID: 240
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 235 StructureType noalg.map.group[string]float64
+      Pointee: 241 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 719
+      ID: 729
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 226
+      ID: 232
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 227 StructureType noalg.map.group[string]interface {}
+      Pointee: 233 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 218
+      ID: 224
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 219 StructureType noalg.map.group[string]string
+      Pointee: 225 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 972
       Name: '*os.File'
@@ -2382,12 +2382,12 @@ Types:
       GoKind: 22
       Pointee: 973 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 557
+      ID: 567
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1036288
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType os.LinkError
+      Pointee: 568 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
       ID: 162
       Name: '*os.Signal'
@@ -2396,12 +2396,12 @@ Types:
       GoKind: 22
       Pointee: 163 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 628
+      ID: 638
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1195808
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType os.SyscallError
+      Pointee: 639 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
       ID: 970
       Name: '*os.fileWithoutReadFrom'
@@ -2417,26 +2417,26 @@ Types:
       GoKind: 22
       Pointee: 969 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 590
+      ID: 600
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1058048
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType os/exec.Error
+      Pointee: 601 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 715
+      ID: 725
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2110272
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 726 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 592
+      ID: 602
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1058176
       GoKind: 22
-      Pointee: 593 StructureType os/exec.wrappedError
+      Pointee: 603 StructureType os/exec.wrappedError
     - __kind: PointerType
       ID: 136
       Name: '*os/signal.signalCtx'
@@ -2445,64 +2445,64 @@ Types:
       GoKind: 22
       Pointee: 137 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 359
+      ID: 369
       Name: '*os/signal.signalError'
       ByteSize: 8
       GoRuntimeType: 910432
       GoKind: 22
-      Pointee: 273 GoStringHeaderType os/signal.signalError
+      Pointee: 283 GoStringHeaderType os/signal.signalError
     - __kind: PointerType
-      ID: 275
+      ID: 285
       Name: '*os/signal.signalError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType os/signal.signalError.str
+      Pointee: 284 GoStringDataType os/signal.signalError.str
     - __kind: PointerType
-      ID: 498
+      ID: 508
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 945376
       GoKind: 22
-      Pointee: 316 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 326 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 318
+      ID: 328
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 327 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 497
+      ID: 507
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 945280
       GoKind: 22
-      Pointee: 315 BaseType os/user.UnknownUserIdError
+      Pointee: 325 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 369
+      ID: 379
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 913024
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType reflect.ValueError
+      Pointee: 380 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 450
+      ID: 460
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 933280
       GoKind: 22
-      Pointee: 451 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 461 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 565
+      ID: 575
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1042176
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 576 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 569
+      ID: 579
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1042816
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 580 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -2518,12 +2518,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 567
+      ID: 577
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1042304
       GoKind: 22
-      Pointee: 568 StructureType runtime.boundsError
+      Pointee: 578 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -2539,24 +2539,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 630
+      ID: 640
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1204128
       GoKind: 22
-      Pointee: 631 StructureType runtime.errorAddressString
+      Pointee: 641 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 563
+      ID: 573
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1040512
       GoKind: 22
-      Pointee: 534 GoStringHeaderType runtime.errorString
+      Pointee: 544 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 536
+      ID: 546
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 535 GoStringDataType runtime.errorString.str
+      Pointee: 545 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -2579,17 +2579,17 @@ Types:
       GoKind: 22
       Pointee: 201 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 564
+      ID: 574
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1040640
       GoKind: 22
-      Pointee: 537 GoStringHeaderType runtime.plainError
+      Pointee: 547 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 539
+      ID: 549
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 538 GoStringDataType runtime.plainError.str
+      Pointee: 548 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -2605,12 +2605,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 371
+      ID: 381
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 914752
       GoKind: 22
-      Pointee: 372 StructureType runtime.synctestDeadlockError
+      Pointee: 382 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -2633,12 +2633,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 561
+      ID: 571
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1040128
       GoKind: 22
-      Pointee: 562 UnresolvedPointeeType strconv.NumError
+      Pointee: 572 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -2764,12 +2764,12 @@ Types:
       GoKind: 22
       Pointee: 899 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 675
+      ID: 685
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1424768
       GoKind: 22
-      Pointee: 664 BaseType syscall.Errno
+      Pointee: 674 BaseType syscall.Errno
     - __kind: PointerType
       ID: 748
       Name: '*syscall.Signal'
@@ -2788,10 +2788,10 @@ Types:
       ByteSize: 8
       Pointee: 824 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 246
+      ID: 252
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 250 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 260 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 987
       Name: '*table<string,[]*mime/multipart.FileHeader>'
@@ -2806,29 +2806,29 @@ Types:
       ID: 183
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 232 StructureType table<string,float64>
+      Pointee: 238 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 691
+      ID: 701
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 717 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 727 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 178
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 224 StructureType table<string,interface {}>
+      Pointee: 230 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 173
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 216 StructureType table<string,string>
+      Pointee: 222 StructureType table<string,string>
     - __kind: PointerType
-      ID: 610
+      ID: 620
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1095424
       GoKind: 22
-      Pointee: 611 StructureType text/template.ExecError
+      Pointee: 621 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 157
       Name: '*time.Location'
@@ -2837,12 +2837,12 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType time.Location
     - __kind: PointerType
-      ID: 363
+      ID: 373
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 910720
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType time.ParseError
+      Pointee: 374 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
       ID: 154
       Name: '*time.Timer'
@@ -2851,38 +2851,38 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType time.Timer
     - __kind: PointerType
-      ID: 360
+      ID: 370
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 910528
       GoKind: 22
-      Pointee: 276 GoStringHeaderType time.fileSizeError
+      Pointee: 286 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 278
+      ID: 288
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType time.fileSizeError.str
+      Pointee: 287 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 361
+      ID: 371
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 910624
       GoKind: 22
-      Pointee: 362 UnresolvedPointeeType time.parseDurationError
+      Pointee: 372 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 733
+      ID: 215
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399936
       GoKind: 22
-      Pointee: 734 StructureType time.zone
+      Pointee: 216 StructureType time.zone
     - __kind: PointerType
-      ID: 736
+      ID: 218
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 400000
       GoKind: 22
-      Pointee: 737 StructureType time.zoneTrans
+      Pointee: 219 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -2926,47 +2926,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 378
+      ID: 388
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 389 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 395
+      ID: 405
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 396 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 406 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 397
+      ID: 407
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 919360
       GoKind: 22
-      Pointee: 295 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 305 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 574
+      ID: 584
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1048192
       GoKind: 22
-      Pointee: 575 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 585 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 576
+      ID: 586
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1048320
       GoKind: 22
-      Pointee: 541 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 551 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
       ID: 867
       Name: <-chan struct {}
       GoRuntimeType: 603744
       GoKind: 18
     - __kind: GoChannelType
-      ID: 731
+      ID: 741
       Name: <-chan time.Time
       GoRuntimeType: 609440
       GoKind: 18
@@ -3144,7 +3144,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 699
+      ID: 709
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 707872
@@ -3192,7 +3192,7 @@ Types:
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 685 PointerType *crypto/x509.Certificate
+      Element: 695 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 742
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
@@ -3275,11 +3275,11 @@ Types:
       ByteSize: 8
       Element: 807 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 268
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 246 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 252 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 997
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
@@ -3293,25 +3293,25 @@ Types:
       ByteSize: 8
       Element: 846 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 244
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 183 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 723
+      ID: 733
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 701 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 236
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 178 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 228
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -3363,7 +3363,7 @@ Types:
       ByteSize: 24
       Element: 41 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 704
+      ID: 714
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 502016
@@ -3378,9 +3378,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 727 GoSliceDataType []float64.array
+      Data: 737 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 727
+      ID: 737
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -3401,9 +3401,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 240 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 246 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 246
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
@@ -3424,9 +3424,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 248 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 254 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 254
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
@@ -3467,11 +3467,11 @@ Types:
       ByteSize: 24
       Element: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 269
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 998
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
@@ -3485,29 +3485,29 @@ Types:
       ByteSize: 328
       Element: 854 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 245
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 235 StructureType noalg.map.group[string]float64
+      Element: 241 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 724
+      ID: 734
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 237
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 227 StructureType noalg.map.group[string]interface {}
+      Element: 233 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 229
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 219 StructureType noalg.map.group[string]string
+      Element: 225 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 161
       Name: '[]os.Signal'
@@ -3524,9 +3524,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 214 GoSliceDataType []os.Signal.array
+      Data: 220 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 220
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3536,7 +3536,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 703
+      ID: 713
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 502272
@@ -3551,15 +3551,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 725 GoSliceDataType []string.array
+      Data: 735 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 725
+      ID: 735
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 732
+      ID: 214
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 495264
@@ -3567,22 +3567,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 733 PointerType *time.zone
+          Type: 215 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 738 GoSliceDataType []time.zone.array
+      Data: 256 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 738
+      ID: 256
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 734 StructureType time.zone
+      Element: 216 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 735
+      ID: 217
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 495328
@@ -3590,20 +3590,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 736 PointerType *time.zoneTrans
+          Type: 218 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 740 GoSliceDataType []time.zoneTrans.array
+      Data: 258 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 740
+      ID: 258
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 737 StructureType time.zoneTrans
+      Element: 219 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 41
       Name: '[]uint8'
@@ -3651,7 +3651,7 @@ Types:
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 519
+      ID: 529
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 954976
@@ -3666,9 +3666,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 520 GoSliceDataType archive/tar.headerError.array
+      Data: 530 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 530
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
@@ -3726,13 +3726,13 @@ Types:
       GoRuntimeType: 590816
       GoKind: 15
     - __kind: BaseType
-      ID: 291
+      ID: 301
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 842176
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 292
+      ID: 302
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 842272
@@ -3740,13 +3740,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 294 PointerType *compress/flate.InternalError.str
+          Type: 304 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 293 GoStringDataType compress/flate.InternalError.str
+      Data: 303 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 293
+      ID: 303
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -3854,7 +3854,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 616
+      ID: 626
       Name: context.deadlineExceededError
       GoRuntimeType: 1468448
       GoKind: 25
@@ -3898,7 +3898,7 @@ Types:
           Type: 154 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 156 StructureType time.Time
+          Type: 156 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
@@ -3944,43 +3944,43 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 310
+      ID: 320
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844384
       GoKind: 2
     - __kind: BaseType
-      ID: 311
+      ID: 321
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844480
       GoKind: 2
     - __kind: BaseType
-      ID: 312
+      ID: 322
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844576
       GoKind: 2
     - __kind: StructureType
-      ID: 597
+      ID: 607
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1293152
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 313
+      ID: 323
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844672
       GoKind: 2
     - __kind: BaseType
-      ID: 280
+      ID: 290
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 841696
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 583
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -4052,11 +4052,11 @@ Types:
       GoRuntimeType: 841408
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 394
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 381
+      ID: 391
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1739872
@@ -4067,10 +4067,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 699 ArrayType [5]uint8
+          Type: 709 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 700 GoInterfaceType net.Conn
+          Type: 710 GoInterfaceType net.Conn
     - __kind: BaseType
       ID: 1010
       Name: crypto/tls.SignatureScheme
@@ -4078,25 +4078,25 @@ Types:
       GoRuntimeType: 841504
       GoKind: 9
     - __kind: BaseType
-      ID: 540
+      ID: 550
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 996096
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 396
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 687
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 696
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 439
+      ID: 449
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1741984
@@ -4104,21 +4104,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 695 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 709 BaseType crypto/x509.InvalidReason
+          Type: 719 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 433
+      ID: 443
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1122592
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 435
+      ID: 445
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1608256
@@ -4126,24 +4126,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 695 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 309
+      ID: 319
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 844096
       GoKind: 2
     - __kind: BaseType
-      ID: 709
+      ID: 719
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 593760
       GoKind: 2
     - __kind: StructureType
-      ID: 589
+      ID: 599
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1568064
@@ -4153,13 +4153,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 441
+      ID: 451
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1122848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 437
+      ID: 447
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1741792
@@ -4167,15 +4167,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 695 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 695 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 481
+      ID: 491
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1438848
@@ -4185,7 +4185,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 485
+      ID: 495
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1439008
@@ -4195,47 +4195,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 483
+      ID: 493
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 281
+      ID: 291
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 841792
       GoKind: 6
     - __kind: BaseType
-      ID: 305
+      ID: 315
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 843808
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 419
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 595
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 401
+      ID: 411
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 407
+      ID: 417
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 405
+      ID: 415
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 413
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 411
+      ID: 421
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1429568
@@ -4245,7 +4245,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 522
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4262,11 +4262,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 366
+      ID: 376
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 570
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4282,11 +4282,11 @@ Types:
       GoRuntimeType: 591008
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 554
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 546
+      ID: 556
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4320,7 +4320,7 @@ Types:
       GoRuntimeType: 1011936
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 422
+      ID: 432
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
@@ -4330,7 +4330,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 414
+      ID: 424
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1741024
@@ -4338,7 +4338,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 701 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 711 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4346,25 +4346,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 416
+      ID: 426
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 716
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 420
+      ID: 430
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1121568
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 718
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 299
+      ID: 309
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 843232
@@ -4372,18 +4372,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 301 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 311 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 300 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 310 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 300
+      ID: 310
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 701
+      ID: 711
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2234976
@@ -4391,13 +4391,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 702 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 712 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4406,7 +4406,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 704 GoSliceHeaderType []float64
+          Type: 714 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4415,13 +4415,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 705 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 715 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 707 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 717 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4432,13 +4432,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 702
+      ID: 712
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 592544
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 296
+      ID: 306
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 843136
@@ -4446,18 +4446,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 298 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 308 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 297 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 297
+      ID: 307
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 302
+      ID: 312
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 843328
@@ -4465,36 +4465,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 304 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 314 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 303 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 313 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 303
+      ID: 313
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 490
+      ID: 500
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1125280
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 314
+      ID: 324
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 845824
       GoKind: 2
     - __kind: StructureType
-      ID: 488
+      ID: 498
       Name: github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
       GoRuntimeType: 1125152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 455
+      ID: 465
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1609376
@@ -4507,7 +4507,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 459
+      ID: 469
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1744096
@@ -4523,7 +4523,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 457
+      ID: 467
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1437408
@@ -4533,7 +4533,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 453
+      ID: 463
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1437088
@@ -4543,14 +4543,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 687
+      ID: 697
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1512928
       GoKind: 21
-      HeaderType: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 699 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 710
+      ID: 720
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1059072
@@ -4565,15 +4565,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 739 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 729
+      ID: 739
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 467
+      ID: 477
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1609696
@@ -4581,12 +4581,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 697 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 697 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 461
+      ID: 471
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1437568
@@ -4596,7 +4596,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 465
+      ID: 475
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1744288
@@ -4607,12 +4607,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 463
+      ID: 473
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1609536
@@ -4625,7 +4625,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 469
+      ID: 479
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1437728
@@ -4633,9 +4633,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 156 StructureType time.Time
+          Type: 156 GoTimeType time.Time
     - __kind: StructureType
-      ID: 475
+      ID: 485
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1610016
@@ -4648,7 +4648,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 477
+      ID: 487
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1438048
@@ -4658,7 +4658,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 473
+      ID: 483
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1609856
@@ -4671,7 +4671,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 471
+      ID: 481
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1437888
@@ -4681,7 +4681,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 479
+      ID: 489
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1610176
@@ -4716,7 +4716,7 @@ Types:
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 500
+      ID: 510
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1443968
@@ -4730,7 +4730,7 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 502
+      ID: 512
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1444128
@@ -4738,7 +4738,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 500 StructureType github.com/cihub/seelog.baseError
+          Type: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 794
       Name: github.com/cihub/seelog.customReceiverDispatcher
@@ -4761,7 +4761,7 @@ Types:
           Offset: 8
           Type: 803 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 506
+      ID: 516
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1444448
@@ -4769,7 +4769,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 500 StructureType github.com/cihub/seelog.baseError
+          Type: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
       ID: 798
       Name: github.com/cihub/seelog.splitDispatcher
@@ -4785,7 +4785,7 @@ Types:
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 504
+      ID: 514
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1444288
@@ -4793,9 +4793,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 500 StructureType github.com/cihub/seelog.baseError
+          Type: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 508
+      ID: 518
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1444608
@@ -4803,7 +4803,7 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 500 StructureType github.com/cihub/seelog.baseError
+          Type: 510 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
       ID: 929
       Name: github.com/cihub/seelog/archive.Reader
@@ -4832,30 +4832,30 @@ Types:
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 613
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 615
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 605
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 425
+      ID: 435
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1430848
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 609
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1863456
@@ -4871,11 +4871,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 649
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 579
+      ID: 589
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1713280
@@ -4888,7 +4888,7 @@ Types:
           Offset: 1
           Type: 21 BaseType int8
     - __kind: StructureType
-      ID: 651
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1863904
@@ -4904,13 +4904,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 542
+      ID: 552
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 997248
       GoKind: 8
     - __kind: StructureType
-      ID: 643
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1863232
@@ -4926,13 +4926,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 713
+      ID: 723
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 842752
       GoKind: 8
     - __kind: StructureType
-      ID: 641
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1863008
@@ -4940,15 +4940,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 723 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 723 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 649
+      ID: 659
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1777632
@@ -4961,7 +4961,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 647
+      ID: 657
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1863680
@@ -4977,7 +4977,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 655
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1645600
@@ -4987,19 +4987,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 593
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1289440
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 581
+      ID: 591
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1289312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 653
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1777824
@@ -5012,7 +5012,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 329
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 847840
@@ -5020,22 +5020,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 331 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 320 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 330
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 704
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 609
+      ID: 619
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1453728
@@ -5045,19 +5045,19 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 322
+      ID: 332
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 848416
       GoKind: 10
     - __kind: BaseType
-      ID: 692
+      ID: 702
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1008960
       GoKind: 10
     - __kind: StructureType
-      ID: 663
+      ID: 673
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1895264
@@ -5068,12 +5068,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 692 BaseType golang.org/x/net/http2.ErrCode
+          Type: 702 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 526
+      ID: 536
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1616896
@@ -5081,12 +5081,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 692 BaseType golang.org/x/net/http2.ErrCode
+          Type: 702 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 326
+      ID: 336
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 848608
@@ -5094,18 +5094,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 328 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 338 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 327 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 327
+      ID: 337
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 332
+      ID: 342
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 848800
@@ -5113,18 +5113,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 334 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 344 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 333 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 333
+      ID: 343
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 329
+      ID: 339
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 848704
@@ -5132,18 +5132,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 331 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 341 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 330 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 330
+      ID: 340
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 323
+      ID: 333
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 848512
@@ -5151,18 +5151,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 325 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 335 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 324 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 324
+      ID: 334
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 530
+      ID: 540
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1455008
@@ -5172,13 +5172,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 335
+      ID: 345
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 848896
       GoKind: 2
     - __kind: StructureType
-      ID: 510
+      ID: 520
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1449408
@@ -5188,11 +5188,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 671
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 681
+      ID: 691
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1923424
@@ -5208,7 +5208,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 516
+      ID: 526
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1615936
@@ -5225,7 +5225,7 @@ Types:
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 607
+      ID: 617
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1575744
@@ -5239,25 +5239,25 @@ Types:
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 492
+      ID: 502
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 611
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 669
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 667
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1521408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 399
+      ID: 409
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -5503,16 +5503,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 242 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 248 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 247 GoMapType map[string]interface {}
+          Type: 253 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
       ID: 751
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 257
+      ID: 267
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1930464
@@ -5611,11 +5611,11 @@ Types:
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 449
+      ID: 459
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 494
+      ID: 504
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1441248
@@ -5625,7 +5625,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 496
+      ID: 506
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1441408
@@ -5635,7 +5635,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 524
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
@@ -5667,19 +5667,19 @@ Types:
       GroupType: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       GroupSliceType: 832 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 251
+      ID: 261
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 252 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 262 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
       ID: 989
       Name: groupReference<string,[]*mime/multipart.FileHeader>
@@ -5709,63 +5709,63 @@ Types:
       GroupType: 854 StructureType noalg.map.group[string][]string
       GroupSliceType: 858 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 233
+      ID: 239
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 234 PointerType *noalg.map.group[string]float64
+          Type: 240 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 235 StructureType noalg.map.group[string]float64
-      GroupSliceType: 239 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 241 StructureType noalg.map.group[string]float64
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 718
+      ID: 728
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 719 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 729 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 724 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 734 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 225
+      ID: 231
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 226 PointerType *noalg.map.group[string]interface {}
+          Type: 232 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 227 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 233 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 217
+      ID: 223
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 218 PointerType *noalg.map.group[string]string
+          Type: 224 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 219 StructureType noalg.map.group[string]string
-      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 225 StructureType noalg.map.group[string]string
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 533
+      ID: 543
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5812,17 +5812,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 714
+      ID: 724
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 593184
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 693
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 430
+      ID: 440
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5848,11 +5848,11 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 428
+      ID: 438
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 647
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -5860,13 +5860,13 @@ Types:
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 635
+      ID: 645
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1486848
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 368
+      ID: 378
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5938,7 +5938,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 316
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 844000
@@ -5946,18 +5946,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 318 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 317 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 317
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 587
+      ID: 597
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1567104
@@ -5965,9 +5965,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 682 PointerType *internal/abi.Type
+          Type: 692 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 279
+      ID: 289
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 841216
@@ -6053,7 +6053,7 @@ Types:
           Offset: 0
           Type: 920 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 643
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
@@ -6127,7 +6127,7 @@ Types:
       TablePtrSliceType: 831 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
       GroupType: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 244
+      ID: 250
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6140,7 +6140,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 245 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 251 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6159,8 +6159,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 268 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 985
       Name: map<string,[]*mime/multipart.FileHeader>
@@ -6264,10 +6264,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 238 GoSliceDataType []*table<string,float64>.array
-      GroupType: 235 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,float64>.array
+      GroupType: 241 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 689
+      ID: 699
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6280,7 +6280,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 690 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 700 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6299,8 +6299,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 723 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 733 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 176
       Name: map<string,interface {}>
@@ -6334,8 +6334,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 230 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 227 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 233 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 171
       Name: map<string,string>
@@ -6369,8 +6369,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 222 GoSliceDataType []*table<string,string>.array
-      GroupType: 219 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 228 GoSliceDataType []*table<string,string>.array
+      GroupType: 225 StructureType noalg.map.group[string]string
     - __kind: GoMapType
       ID: 143
       Name: map[context.canceler]struct {}
@@ -6386,12 +6386,12 @@ Types:
       GoKind: 21
       HeaderType: 805 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 242
+      ID: 248
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1141376
       GoKind: 21
-      HeaderType: 244 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 250 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 983
       Name: map[string][]*mime/multipart.FileHeader
@@ -6414,7 +6414,7 @@ Types:
       GoKind: 21
       HeaderType: 181 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 247
+      ID: 253
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1134624
@@ -6428,7 +6428,7 @@ Types:
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 447
+      ID: 457
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1434048
@@ -6472,11 +6472,11 @@ Types:
           Offset: 8
           Type: 930 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 629
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 700
+      ID: 710
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1605536
@@ -6489,7 +6489,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 678
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6497,11 +6497,11 @@ Types:
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 676
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 631
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -6517,7 +6517,7 @@ Types:
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 612
+      ID: 622
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1116192
@@ -6525,18 +6525,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 614 PointerType *net.UnknownNetworkError.str
+          Type: 624 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 613 GoStringDataType net.UnknownNetworkError.str
+      Data: 623 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 613
+      ID: 623
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 548
+      ID: 558
       Name: net.canceledError
       GoRuntimeType: 1286752
       GoKind: 25
@@ -6546,7 +6546,7 @@ Types:
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 712
+      ID: 722
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2122208
@@ -6554,7 +6554,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 700 GoInterfaceType net.Conn
+          Type: 710 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -6581,7 +6581,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 337
+      ID: 347
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
@@ -6598,7 +6598,7 @@ Types:
           Offset: 16
           Type: 123 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 339
+      ID: 349
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1734880
@@ -6606,7 +6606,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 695 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6640,11 +6640,11 @@ Types:
           Offset: 0
           Type: 960 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 633
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 680
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6694,11 +6694,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 345
+      ID: 355
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 560
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -6750,7 +6750,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6795,7 +6795,7 @@ Types:
           Type: 870 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
           Type: 169 GoMapType map[string]string
@@ -6832,7 +6832,7 @@ Types:
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6905,19 +6905,19 @@ Types:
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 260
+      ID: 270
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 839488
       GoKind: 10
     - __kind: BaseType
-      ID: 684
+      ID: 694
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 993312
       GoKind: 10
     - __kind: StructureType
-      ID: 348
+      ID: 358
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1736608
@@ -6928,12 +6928,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 694 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 672
+      ID: 682
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1912160
@@ -6944,7 +6944,7 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 694 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
@@ -6953,7 +6953,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 354
+      ID: 364
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1606016
@@ -6961,12 +6961,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 694 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 264
+      ID: 274
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839680
@@ -6974,18 +6974,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 266 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 276 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 275 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 265
+      ID: 275
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 352
+      ID: 362
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1117472
       GoKind: 25
@@ -6995,7 +6995,7 @@ Types:
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 280
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 839872
@@ -7003,18 +7003,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *net/http.http2headerFieldNameError.str
+          Type: 282 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 271 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 281 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 281
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 277
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 839776
@@ -7022,18 +7022,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *net/http.http2headerFieldValueError.str
+          Type: 279 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 278 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 278
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 637
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
@@ -7049,13 +7049,13 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 556
+      ID: 566
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1287648
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 271
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839584
@@ -7063,13 +7063,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 273 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 262 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 272 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 272
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7112,7 +7112,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 552
+      ID: 562
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1558944
@@ -7152,7 +7152,7 @@ Types:
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 358
+      ID: 368
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1421728
@@ -7227,7 +7227,7 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
           Type: 149 StructureType sync/atomic.Bool
@@ -7266,7 +7266,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 343
+      ID: 353
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1605856
@@ -7279,17 +7279,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 684
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 625
+      ID: 635
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1472928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 554
+      ID: 564
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1559104
@@ -7307,12 +7307,12 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 700 GoInterfaceType net.Conn
+          Type: 710 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 700 GoInterfaceType net.Conn
+          Type: 710 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 351
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -7322,7 +7322,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 376
+      ID: 386
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1739488
@@ -7338,7 +7338,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 374
+      ID: 384
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1607136
@@ -7351,11 +7351,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 392
+      ID: 402
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 298
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 842080
@@ -7363,22 +7363,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *net/textproto.ProtocolError.str
+          Type: 300 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType net/textproto.ProtocolError.str
+      Data: 299 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 299
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 679
+      ID: 689
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 282
+      ID: 292
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 841888
@@ -7386,18 +7386,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 284 PointerType *net/url.EscapeError.str
+          Type: 294 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 283 GoStringDataType net/url.EscapeError.str
+      Data: 293 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 283
+      ID: 293
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 285
+      ID: 295
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 841984
@@ -7405,13 +7405,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 287 PointerType *net/url.InvalidHostError.str
+          Type: 297 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 286 GoStringDataType net/url.InvalidHostError.str
+      Data: 296 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 286
+      ID: 296
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -7485,14 +7485,14 @@ Types:
       HasCount: true
       Element: 829 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 254
+      ID: 264
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 710944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 255 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 265 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
       ID: 992
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
@@ -7512,41 +7512,41 @@ Types:
       HasCount: true
       Element: 856 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 236
+      ID: 242
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 710848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 237 StructureType noalg.struct { key string; elem float64 }
+      Element: 243 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 721
+      ID: 731
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 767136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 722 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 732 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 228
+      ID: 234
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 687328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 229 StructureType noalg.struct { key string; elem interface {} }
+      Element: 235 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 220
+      ID: 226
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 700768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 221 StructureType noalg.struct { key string; elem string }
+      Element: 227 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
       ID: 207
       Name: noalg.map.group[context.canceler]struct {}
@@ -7574,7 +7574,7 @@ Types:
           Offset: 8
           Type: 828 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 253
+      ID: 263
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1316320
@@ -7585,7 +7585,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 254 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 264 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
       ID: 991
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
@@ -7613,7 +7613,7 @@ Types:
           Offset: 8
           Type: 855 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 235
+      ID: 241
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1316064
@@ -7624,9 +7624,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 236 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 242 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 720
+      ID: 730
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1357536
@@ -7637,9 +7637,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 721 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 731 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 227
+      ID: 233
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1297760
@@ -7650,9 +7650,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 228 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 234 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 219
+      ID: 225
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1302880
@@ -7663,7 +7663,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 220 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 226 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
       ID: 209
       Name: noalg.struct { key context.canceler; elem struct {} }
@@ -7691,7 +7691,7 @@ Types:
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 255
+      ID: 265
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1316192
@@ -7702,7 +7702,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 256 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 266 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
       ID: 993
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
@@ -7728,9 +7728,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 703 GoSliceHeaderType []string
+          Type: 713 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 237
+      ID: 243
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1315936
@@ -7743,7 +7743,7 @@ Types:
           Offset: 16
           Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 722
+      ID: 732
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1357408
@@ -7754,9 +7754,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 229
+      ID: 235
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1297632
@@ -7769,7 +7769,7 @@ Types:
           Offset: 16
           Type: 142 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 221
+      ID: 227
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1302752
@@ -7786,7 +7786,7 @@ Types:
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 568
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -7803,7 +7803,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 639
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
@@ -7845,15 +7845,15 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 601
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 726
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 593
+      ID: 603
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1713472
@@ -7887,7 +7887,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 283
       Name: os/signal.signalError
       ByteSize: 16
       GoRuntimeType: 839968
@@ -7895,18 +7895,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *os/signal.signalError.str
+          Type: 285 PointerType *os/signal.signalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType os/signal.signalError.str
+      Data: 284 GoStringDataType os/signal.signalError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 284
       Name: os/signal.signalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 326
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 846592
@@ -7914,36 +7914,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *os/user.UnknownGroupIdError.str
+          Type: 328 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 327 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 327
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 315
+      ID: 325
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 846496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 380
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 451
+      ID: 461
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 576
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 580
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7955,7 +7955,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 568
+      ID: 578
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1902208
@@ -7972,7 +7972,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 714 BaseType internal/abi.BoundsErrorCode
+          Type: 724 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -7988,7 +7988,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 631
+      ID: 641
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1771680
@@ -8001,7 +8001,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 534
+      ID: 544
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 994560
@@ -8009,13 +8009,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 536 PointerType *runtime.errorString.str
+          Type: 546 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 535 GoStringDataType runtime.errorString.str
+      Data: 545 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 535
+      ID: 545
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8700,7 +8700,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 537
+      ID: 547
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 994656
@@ -8708,13 +8708,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 539 PointerType *runtime.plainError.str
+          Type: 549 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 538 GoStringDataType runtime.plainError.str
+      Data: 548 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 538
+      ID: 548
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8755,7 +8755,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 372
+      ID: 382
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1606816
@@ -8827,7 +8827,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 562
+      ID: 572
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -9214,7 +9214,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 664
+      ID: 674
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1288416
@@ -9274,7 +9274,7 @@ Types:
           Offset: 16
           Type: 825 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 250
+      ID: 260
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9296,7 +9296,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 251 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 261 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
       ID: 988
       Name: table<string,[]*mime/multipart.FileHeader>
@@ -9346,7 +9346,7 @@ Types:
           Offset: 16
           Type: 852 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 232
+      ID: 238
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9368,9 +9368,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 233 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 239 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 717
+      ID: 727
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9392,9 +9392,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 718 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 728 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 224
+      ID: 230
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9416,9 +9416,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 225 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 231 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 216
+      ID: 222
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9440,9 +9440,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 217 GoSwissMapGroupsType groupReference<string,string>
+          Type: 223 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 611
+      ID: 621
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1717696
@@ -9472,10 +9472,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 732 GoSliceHeaderType []time.zone
+          Type: 214 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 735 GoSliceHeaderType []time.zoneTrans
+          Type: 217 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9487,12 +9487,12 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 733 PointerType *time.zone
+          Type: 215 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 374
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
+    - __kind: GoTimeType
       ID: 156
       Name: time.Time
       ByteSize: 24
@@ -9508,6 +9508,14 @@ Types:
         - Name: loc
           Offset: 16
           Type: 157 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
       ID: 155
       Name: time.Timer
@@ -9517,12 +9525,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 731 GoChannelType <-chan time.Time
+          Type: 741 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 286
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 840064
@@ -9530,22 +9538,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *time.fileSizeError.str
+          Type: 288 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType time.fileSizeError.str
+      Data: 287 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 287
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 362
+      ID: 372
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 734
+      ID: 216
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1628320
@@ -9561,7 +9569,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 737
+      ID: 219
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1768416
@@ -9622,7 +9630,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 26
     - __kind: StructureType
-      ID: 695
+      ID: 705
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2079008
@@ -9633,10 +9641,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 696 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 706 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 697 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9651,18 +9659,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 698 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 708 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 698
+      ID: 708
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995712
       GoKind: 9
     - __kind: StructureType
-      ID: 696
+      ID: 706
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1933280
@@ -9687,17 +9695,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 389
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 697
+      ID: 707
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 591968
       GoKind: 8
     - __kind: StructureType
-      ID: 396
+      ID: 406
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1427648
@@ -9707,13 +9715,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 295
+      ID: 305
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 842368
       GoKind: 2
     - __kind: StructureType
-      ID: 575
+      ID: 585
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1712896
@@ -9726,7 +9734,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 541
+      ID: 551
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 996576

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,11 +12,11 @@ Probes:
         - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1508 EventRootType Probe[main.stackC]
+              Type: 1509 EventRootType Probe[main.stackC]
               InjectionPoints: [{PC: "0xd0fb2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1509 EventRootType Probe[main.stackC]Return
+              Type: 1510 EventRootType Probe[main.stackC]Return
               InjectionPoints: [{PC: "0xd0fb65", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -32,11 +32,11 @@ Probes:
         - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 1347 EventRootType Probe[main.testAny]
+              Type: 1348 EventRootType Probe[main.testAny]
               InjectionPoints: [{PC: "0xd09aaa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1348 EventRootType Probe[main.testAny]Return
+              Type: 1349 EventRootType Probe[main.testAny]Return
               InjectionPoints: [{PC: "0xd09ae5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -58,11 +58,11 @@ Probes:
         - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 1350 EventRootType Probe[main.testAnyPtr]
+              Type: 1351 EventRootType Probe[main.testAnyPtr]
               InjectionPoints: [{PC: "0xd09b4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1351 EventRootType Probe[main.testAnyPtr]Return
+              Type: 1352 EventRootType Probe[main.testAnyPtr]Return
               InjectionPoints: [{PC: "0xd09b7d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -83,11 +83,11 @@ Probes:
         - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]
+              Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]
               InjectionPoints: [{PC: "0xd0e12e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]Return
+              Type: 1481 EventRootType Probe[main.testArrayArgAndReturn]Return
               InjectionPoints: [{PC: "0xd0e1e2", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -109,7 +109,7 @@ Probes:
         - subprogram: {subprogram: 19}
           events:
             - Kind: Entry
-              Type: 1294 EventRootType Probe[main.testArrayEmptyStructs]
+              Type: 1295 EventRootType Probe[main.testArrayEmptyStructs]
               InjectionPoints: [{PC: "0xd04b60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -131,7 +131,7 @@ Probes:
         - subprogram: {subprogram: 15}
           events:
             - Kind: Entry
-              Type: 1290 EventRootType Probe[main.testArrayOfArrays]
+              Type: 1291 EventRootType Probe[main.testArrayOfArrays]
               InjectionPoints: [{PC: "0xd04ae0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -153,7 +153,7 @@ Probes:
         - subprogram: {subprogram: 17}
           events:
             - Kind: Entry
-              Type: 1292 EventRootType Probe[main.testArrayOfArraysOfArrays]
+              Type: 1293 EventRootType Probe[main.testArrayOfArraysOfArrays]
               InjectionPoints: [{PC: "0xd04b20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -175,7 +175,7 @@ Probes:
         - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 1359 EventRootType Probe[main.testArrayOfMaps]
+              Type: 1360 EventRootType Probe[main.testArrayOfMaps]
               InjectionPoints: [{PC: "0xd0a3c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -197,7 +197,7 @@ Probes:
         - subprogram: {subprogram: 16}
           events:
             - Kind: Entry
-              Type: 1291 EventRootType Probe[main.testArrayOfStrings]
+              Type: 1292 EventRootType Probe[main.testArrayOfStrings]
               InjectionPoints: [{PC: "0xd04b00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -218,7 +218,7 @@ Probes:
         - subprogram: {subprogram: 18}
           events:
             - Kind: Entry
-              Type: 1293 EventRootType Probe[main.testArrayOfStructs]
+              Type: 1294 EventRootType Probe[main.testArrayOfStructs]
               InjectionPoints: [{PC: "0xd04b40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -240,11 +240,11 @@ Probes:
         - subprogram: {subprogram: 90}
           events:
             - Kind: Entry
-              Type: 1381 EventRootType Probe[main.testAtomicAdd]
+              Type: 1382 EventRootType Probe[main.testAtomicAdd]
               InjectionPoints: [{PC: "0xd0c0e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1382 EventRootType Probe[main.testAtomicAdd]Return
+              Type: 1383 EventRootType Probe[main.testAtomicAdd]Return
               InjectionPoints: [{PC: "0xd0c0f2", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -266,11 +266,11 @@ Probes:
         - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 1312 EventRootType Probe[main.testBigStruct]
+              Type: 1313 EventRootType Probe[main.testBigStruct]
               InjectionPoints: [{PC: "0xd05260", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1313 EventRootType Probe[main.testBigStruct]Return
+              Type: 1314 EventRootType Probe[main.testBigStruct]Return
               InjectionPoints: [{PC: "0xd0527e", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -292,7 +292,7 @@ Probes:
         - subprogram: {subprogram: 4}
           events:
             - Kind: Entry
-              Type: 1279 EventRootType Probe[main.testBoolArray]
+              Type: 1280 EventRootType Probe[main.testBoolArray]
               InjectionPoints: [{PC: "0xd04980", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -314,7 +314,7 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 1276 EventRootType Probe[main.testByteArray]
+              Type: 1277 EventRootType Probe[main.testByteArray]
               InjectionPoints: [{PC: "0xd04920", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -341,11 +341,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1527 EventRootType Probe[main.testStruct]
+              Type: 1528 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0xd0ff60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1528 EventRootType Probe[main.testStruct]Return
+              Type: 1529 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0xd0ff82", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1588 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1592 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xd092ce"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1589 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1593 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xd092ce"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 6 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 189, index: 0, name: x}
+                      Variable: {subprogram: 192, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -437,10 +437,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1590 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1594 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xd092ce"
                   Frameless: false
@@ -477,7 +477,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1378 EventRootType Probe[main.testCombinedString]
+              Type: 1379 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0xd0bd40", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
@@ -496,7 +496,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1379 EventRootType Probe[main.testCombinedString]
+              Type: 1380 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0xd0bd40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -522,7 +522,7 @@ Probes:
         - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testTenStrings]
+              Type: 1536 EventRootType Probe[main.testTenStrings]
               InjectionPoints: [{PC: "0xd10080", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
@@ -560,7 +560,7 @@ Probes:
         - subprogram: {subprogram: 91}
           events:
             - Kind: Entry
-              Type: 1383 EventRootType Probe[main.testChannel]
+              Type: 1384 EventRootType Probe[main.testChannel]
               InjectionPoints: [{PC: "0xd0c100", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -590,7 +590,7 @@ Probes:
         - subprogram: {subprogram: 87}
           events:
             - Kind: Entry
-              Type: 1377 EventRootType Probe[main.testCombinedByte]
+              Type: 1378 EventRootType Probe[main.testCombinedByte]
               InjectionPoints: [{PC: "0xd0bd00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -619,11 +619,11 @@ Probes:
         - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1444 EventRootType Probe[main.testConflictingReturn]
+              Type: 1445 EventRootType Probe[main.testConflictingReturn]
               InjectionPoints: [{PC: "0xd0d38e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1445 EventRootType Probe[main.testConflictingReturn]Return
+              Type: 1446 EventRootType Probe[main.testConflictingReturn]Return
               InjectionPoints: [{PC: "0xd0d454", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -645,7 +645,7 @@ Probes:
         - subprogram: {subprogram: 99}
           events:
             - Kind: Entry
-              Type: 1391 EventRootType Probe[main.testCycle]
+              Type: 1392 EventRootType Probe[main.testCycle]
               InjectionPoints: [{PC: "0xd0c4e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -667,7 +667,7 @@ Probes:
         - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 1319 EventRootType Probe[main.testDeepMap1]
+              Type: 1320 EventRootType Probe[main.testDeepMap1]
               InjectionPoints: [{PC: "0xd05760", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -689,7 +689,7 @@ Probes:
         - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 1320 EventRootType Probe[main.testDeepMap7]
+              Type: 1321 EventRootType Probe[main.testDeepMap7]
               InjectionPoints: [{PC: "0xd05780", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -711,7 +711,7 @@ Probes:
         - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 1315 EventRootType Probe[main.testDeepPtr1]
+              Type: 1316 EventRootType Probe[main.testDeepPtr1]
               InjectionPoints: [{PC: "0xd05440", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -733,7 +733,7 @@ Probes:
         - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 1316 EventRootType Probe[main.testDeepPtr7]
+              Type: 1317 EventRootType Probe[main.testDeepPtr7]
               InjectionPoints: [{PC: "0xd05460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -755,7 +755,7 @@ Probes:
         - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 1317 EventRootType Probe[main.testDeepSlice1]
+              Type: 1318 EventRootType Probe[main.testDeepSlice1]
               InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -777,7 +777,7 @@ Probes:
         - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 1318 EventRootType Probe[main.testDeepSlice7]
+              Type: 1319 EventRootType Probe[main.testDeepSlice7]
               InjectionPoints: [{PC: "0xd05600", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -799,7 +799,7 @@ Probes:
         - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1496 EventRootType Probe[main.testEmptySlice]
+              Type: 1497 EventRootType Probe[main.testEmptySlice]
               InjectionPoints: [{PC: "0xd0f220", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -826,7 +826,7 @@ Probes:
         - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1499 EventRootType Probe[main.testEmptySliceOfStructs]
+              Type: 1500 EventRootType Probe[main.testEmptySliceOfStructs]
               InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -854,7 +854,7 @@ Probes:
         - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testEmptyString]
+              Type: 1523 EventRootType Probe[main.testEmptyString]
               InjectionPoints: [{PC: "0xd0fc60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -876,7 +876,7 @@ Probes:
         - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1536 EventRootType Probe[main.testEmptyStruct]
+              Type: 1537 EventRootType Probe[main.testEmptyStruct]
               InjectionPoints: [{PC: "0xd100e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -897,7 +897,7 @@ Probes:
         - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testEmptyStructPointer]
+              Type: 1538 EventRootType Probe[main.testEmptyStructPointer]
               InjectionPoints: [{PC: "0xd10100", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -919,7 +919,7 @@ Probes:
         - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 1349 EventRootType Probe[main.testError]
+              Type: 1350 EventRootType Probe[main.testError]
               InjectionPoints: [{PC: "0xd09b20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -953,7 +953,7 @@ Probes:
         - subprogram: {subprogram: 38}
           events:
             - Kind: Line
-              Type: 1314 EventRootType Probe[main.testErrorAtLine]Line
+              Type: 1315 EventRootType Probe[main.testErrorAtLine]Line
               InjectionPoints: [{PC: "0xd052fb", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -981,11 +981,11 @@ Probes:
         - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 1331 EventRootType Probe[main.testEsotericHeap]
+              Type: 1332 EventRootType Probe[main.testEsotericHeap]
               InjectionPoints: [{PC: "0xd07daa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1332 EventRootType Probe[main.testEsotericHeap]Return
+              Type: 1333 EventRootType Probe[main.testEsotericHeap]Return
               InjectionPoints: [{PC: "0xd07dec", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1007,11 +1007,11 @@ Probes:
         - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 1329 EventRootType Probe[main.testEsotericStack]
+              Type: 1330 EventRootType Probe[main.testEsotericStack]
               InjectionPoints: [{PC: "0xd07c8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1330 EventRootType Probe[main.testEsotericStack]Return
+              Type: 1331 EventRootType Probe[main.testEsotericStack]Return
               InjectionPoints: [{PC: "0xd07d1b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1033,11 +1033,11 @@ Probes:
         - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 1341 EventRootType Probe[main.testFrameless]
+              Type: 1342 EventRootType Probe[main.testFrameless]
               InjectionPoints: [{PC: "0xd09780", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1342 EventRootType Probe[main.testFrameless]Return
+              Type: 1343 EventRootType Probe[main.testFrameless]Return
               InjectionPoints: [{PC: "0xd09785", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -1059,11 +1059,11 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 1343 EventRootType Probe[main.testFramelessArray]
+              Type: 1344 EventRootType Probe[main.testFramelessArray]
               InjectionPoints: [{PC: "0xd097a4", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1344 EventRootType Probe[main.testFramelessArray]Return
+              Type: 1345 EventRootType Probe[main.testFramelessArray]Return
               InjectionPoints: [{PC: "0xd097dd", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1088,7 +1088,7 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Line
-              Type: 1345 EventRootType Probe[main.testFramelessArray]Line
+              Type: 1346 EventRootType Probe[main.testFramelessArray]Line
               InjectionPoints: [{PC: "0xd097a8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1107,15 +1107,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1574 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xd12d00", Frameless: true}]
+              Type: 1578 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0xd12e80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1575 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd12d07", Frameless: true}]
+              Type: 1579 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd12e87", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,15 +1125,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1576 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xd12d24", Frameless: false}]
+              Type: 1580 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0xd12ea4", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1577 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xd12d71", Frameless: false}]
+              Type: 1581 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0xd12ef1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,15 +1152,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1570 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xd12c6a", Frameless: false}]
+              Type: 1574 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0xd12dea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1571 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xd12c79", Frameless: false}]
+              Type: 1575 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0xd12df9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,15 +1170,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1572 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xd12caa", Frameless: false}]
+              Type: 1576 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0xd12e2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1573 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xd12cc2", Frameless: false}]
+              Type: 1577 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0xd12e42", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,18 +1197,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1578 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xd12d80", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0xd12f00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1579 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1583 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xd12da0"
+                - PC: "0xd12f20"
                   Frameless: true
-                - PC: "0xd12da3"
+                - PC: "0xd12f23"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,18 +1219,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xd12dca", Frameless: false}]
+              Type: 1584 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0xd12f4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1581 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1585 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xd12e2b"
+                - PC: "0xd12fab"
                   Frameless: false
-                - PC: "0xd12e33"
+                - PC: "0xd12fb3"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,11 +1253,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Line
-              Type: 1582 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xd12d85", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0xd12f05", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,11 +1265,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1583 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xd12ddf", Frameless: false}]
+              Type: 1587 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0xd12f5f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,15 +1286,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xd12920", Frameless: true}]
+              Type: 1562 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0xd12aa0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1559 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xd12930", Frameless: true}]
+              Type: 1563 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0xd12ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,15 +1304,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xd129c0", Frameless: true}]
+              Type: 1564 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0xd12b40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1561 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xd129c8", Frameless: true}]
+              Type: 1565 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0xd12b48", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,15 +1332,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 169}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1546 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xd124ae", Frameless: false}]
+              Type: 1550 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0xd1262e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1547 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd12594", Frameless: false}]
+              Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xd12714", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1350,14 +1350,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1548 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1552 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0xd03aee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1549 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1553 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0xd03bdc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1378,15 +1378,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1550 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd125ea", Frameless: false}]
+              Type: 1554 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xd1276a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd125f9", Frameless: false}]
+              Type: 1555 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd12779", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,15 +1405,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xd12e80", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0xd13000", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1585 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xd12e86", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0xd13006", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,15 +1423,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xd12f0a", Frameless: false}]
+              Type: 1590 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0xd1308a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1587 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xd12f2d", Frameless: false}]
+              Type: 1591 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0xd130ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,15 +1450,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
+        - subprogram: {subprogram: 170}
           events:
             - Kind: Entry
-              Type: 1542 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xd12400", Frameless: true}]
+              Type: 1546 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0xd12580", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1543 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd12403", Frameless: true}]
+              Type: 1547 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xd12583", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,15 +1468,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 168}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1544 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xd12420", Frameless: true}]
+              Type: 1548 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0xd125a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1545 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1242b", Frameless: true}]
+              Type: 1549 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd125ab", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,15 +1495,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xd12a80", Frameless: true}]
+              Type: 1566 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0xd12c00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1563 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xd12a87", Frameless: true}]
+              Type: 1567 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0xd12c07", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,15 +1513,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xd12b2a", Frameless: false}]
+              Type: 1568 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0xd12caa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1565 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xd12b56", Frameless: false}]
+              Type: 1569 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0xd12cd6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,15 +1540,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1552 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xd128c0", Frameless: true}]
+              Type: 1556 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xd12a40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1553 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd128c3", Frameless: true}]
+              Type: 1557 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xd12a43", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,15 +1558,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1554 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xd128e0", Frameless: true}]
+              Type: 1558 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0xd12a60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1555 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xd128e3", Frameless: true}]
+              Type: 1559 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0xd12a63", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,15 +1576,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xd12900", Frameless: true}]
+              Type: 1560 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0xd12a80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xd12903", Frameless: true}]
+              Type: 1561 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0xd12a83", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,15 +1603,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xd12c20", Frameless: true}]
+              Type: 1570 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0xd12da0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1567 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xd12c27", Frameless: true}]
+              Type: 1571 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0xd12da7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,15 +1621,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd12c40", Frameless: true}]
+              Type: 1572 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xd12dc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1569 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd12c4e", Frameless: true}]
+              Type: 1573 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd12dce", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,15 +1648,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1538 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xd123c0", Frameless: true}]
+              Type: 1542 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0xd12540", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1539 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd123c3", Frameless: true}]
+              Type: 1543 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xd12543", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,15 +1666,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1540 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xd123e0", Frameless: true}]
+              Type: 1544 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0xd12560", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1541 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd123eb", Frameless: true}]
+              Type: 1545 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd1256b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1696,11 +1696,11 @@ Probes:
         - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 1333 EventRootType Probe[main.testInlinedBA]
+              Type: 1334 EventRootType Probe[main.testInlinedBA]
               InjectionPoints: [{PC: "0xd0946a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1334 EventRootType Probe[main.testInlinedBA]Return
+              Type: 1335 EventRootType Probe[main.testInlinedBA]Return
               InjectionPoints: [{PC: "0xd094ce", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1727,11 +1727,11 @@ Probes:
         - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 1335 EventRootType Probe[main.testInlinedBB]
+              Type: 1336 EventRootType Probe[main.testInlinedBB]
               InjectionPoints: [{PC: "0xd0950e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1336 EventRootType Probe[main.testInlinedBB]Return
+              Type: 1337 EventRootType Probe[main.testInlinedBB]Return
               InjectionPoints: [{PC: "0xd0959e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1758,11 +1758,11 @@ Probes:
         - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 1337 EventRootType Probe[main.testInlinedBBA]
+              Type: 1338 EventRootType Probe[main.testInlinedBBA]
               InjectionPoints: [{PC: "0xd095ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1338 EventRootType Probe[main.testInlinedBBA]Return
+              Type: 1339 EventRootType Probe[main.testInlinedBBA]Return
               InjectionPoints: [{PC: "0xd0962b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1781,10 +1781,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testInlinedBBB]
+              Type: 1598 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0xd09566", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1802,11 +1802,11 @@ Probes:
         - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 1339 EventRootType Probe[main.testInlinedBC]
+              Type: 1340 EventRootType Probe[main.testInlinedBC]
               InjectionPoints: [{PC: "0xd0966e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1340 EventRootType Probe[main.testInlinedBC]Return
+              Type: 1341 EventRootType Probe[main.testInlinedBC]Return
               InjectionPoints: [{PC: "0xd0975e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1821,10 +1821,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testInlinedBCA]
+              Type: 1599 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0xd09673", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1842,10 +1842,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Line
-              Type: 1596 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1600 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0xd09673", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1860,10 +1860,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testInlinedBCB]
+              Type: 1601 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0xd09726", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1881,10 +1881,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Line
-              Type: 1598 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1602 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0xd09726", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1899,10 +1899,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 196}
+        - subprogram: {subprogram: 199}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1608 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0xd035f2"
                   Frameless: true
@@ -1922,10 +1922,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testInlinedPrint]
+              Type: 1595 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0xd092ca"
                   Frameless: false
@@ -1939,7 +1939,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1592 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1596 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0xd0930a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1961,10 +1961,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1593 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1597 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xd092ce"
                   Frameless: false
@@ -1993,10 +1993,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testInlinedSq]
+              Type: 1603 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0xd09781", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2018,10 +2018,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Line
-              Type: 1600 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1604 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0xd09781", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2041,10 +2041,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 194}
+        - subprogram: {subprogram: 197}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1605 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0xd097c5"
                   Frameless: false
@@ -2070,7 +2070,7 @@ Probes:
         - subprogram: {subprogram: 7}
           events:
             - Kind: Entry
-              Type: 1282 EventRootType Probe[main.testInt16Array]
+              Type: 1283 EventRootType Probe[main.testInt16Array]
               InjectionPoints: [{PC: "0xd049e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2092,7 +2092,7 @@ Probes:
         - subprogram: {subprogram: 8}
           events:
             - Kind: Entry
-              Type: 1283 EventRootType Probe[main.testInt32Array]
+              Type: 1284 EventRootType Probe[main.testInt32Array]
               InjectionPoints: [{PC: "0xd04a00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2114,7 +2114,7 @@ Probes:
         - subprogram: {subprogram: 9}
           events:
             - Kind: Entry
-              Type: 1284 EventRootType Probe[main.testInt64Array]
+              Type: 1285 EventRootType Probe[main.testInt64Array]
               InjectionPoints: [{PC: "0xd04a20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2136,7 +2136,7 @@ Probes:
         - subprogram: {subprogram: 6}
           events:
             - Kind: Entry
-              Type: 1281 EventRootType Probe[main.testInt8Array]
+              Type: 1282 EventRootType Probe[main.testInt8Array]
               InjectionPoints: [{PC: "0xd049c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2158,7 +2158,7 @@ Probes:
         - subprogram: {subprogram: 5}
           events:
             - Kind: Entry
-              Type: 1280 EventRootType Probe[main.testIntArray]
+              Type: 1281 EventRootType Probe[main.testIntArray]
               InjectionPoints: [{PC: "0xd049a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2180,7 +2180,7 @@ Probes:
         - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 1346 EventRootType Probe[main.testInterface]
+              Type: 1347 EventRootType Probe[main.testInterface]
               InjectionPoints: [{PC: "0xd09a80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2201,11 +2201,11 @@ Probes:
         - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]
+              Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]
               InjectionPoints: [{PC: "0xd0dfae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]Return
+              Type: 1479 EventRootType Probe[main.testLargeArgAndReturn]Return
               InjectionPoints: [{PC: "0xd0e0f3", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2227,7 +2227,7 @@ Probes:
         - subprogram: {subprogram: 93}
           events:
             - Kind: Entry
-              Type: 1385 EventRootType Probe[main.testLinkedList]
+              Type: 1386 EventRootType Probe[main.testLinkedList]
               InjectionPoints: [{PC: "0xd0c300", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2252,7 +2252,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1323 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1324 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xd057fa", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2274,7 +2274,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1324 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1325 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xd058ad", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2296,7 +2296,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1325 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1326 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xd05974", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2339,11 +2339,11 @@ Probes:
         - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]
+              Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]
               InjectionPoints: [{PC: "0xd0e453", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              Type: 1485 EventRootType Probe[main.testManyArgsArrayReturn]Return
               InjectionPoints: [{PC: "0xd0e662", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2406,7 +2406,7 @@ Probes:
         - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 1327 EventRootType Probe[main.testManyPointers]
+              Type: 1328 EventRootType Probe[main.testManyPointers]
               InjectionPoints: [{PC: "0xd05fe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2430,7 +2430,7 @@ Probes:
         - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 1328 EventRootType Probe[main.testManyStrings]
+              Type: 1329 EventRootType Probe[main.testManyStrings]
               InjectionPoints: [{PC: "0xd079c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2452,7 +2452,7 @@ Probes:
         - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 1357 EventRootType Probe[main.testMapArrayToArray]
+              Type: 1358 EventRootType Probe[main.testMapArrayToArray]
               InjectionPoints: [{PC: "0xd0a380", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2474,7 +2474,7 @@ Probes:
         - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 1364 EventRootType Probe[main.testMapEmbeddedMaps]
+              Type: 1365 EventRootType Probe[main.testMapEmbeddedMaps]
               InjectionPoints: [{PC: "0xd0a440", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2496,7 +2496,7 @@ Probes:
         - subprogram: {subprogram: 84}
           events:
             - Kind: Entry
-              Type: 1374 EventRootType Probe[main.testMapEmptyKey]
+              Type: 1375 EventRootType Probe[main.testMapEmptyKey]
               InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2518,7 +2518,7 @@ Probes:
         - subprogram: {subprogram: 86}
           events:
             - Kind: Entry
-              Type: 1376 EventRootType Probe[main.testMapEmptyKeyAndValue]
+              Type: 1377 EventRootType Probe[main.testMapEmptyKeyAndValue]
               InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2540,7 +2540,7 @@ Probes:
         - subprogram: {subprogram: 85}
           events:
             - Kind: Entry
-              Type: 1375 EventRootType Probe[main.testMapEmptyValue]
+              Type: 1376 EventRootType Probe[main.testMapEmptyValue]
               InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2562,7 +2562,7 @@ Probes:
         - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 1361 EventRootType Probe[main.testMapIntToInt]
+              Type: 1362 EventRootType Probe[main.testMapIntToInt]
               InjectionPoints: [{PC: "0xd0a400", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2584,7 +2584,7 @@ Probes:
         - subprogram: {subprogram: 83}
           events:
             - Kind: Entry
-              Type: 1373 EventRootType Probe[main.testMapLargeKeyLargeValue]
+              Type: 1374 EventRootType Probe[main.testMapLargeKeyLargeValue]
               InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2606,7 +2606,7 @@ Probes:
         - subprogram: {subprogram: 82}
           events:
             - Kind: Entry
-              Type: 1372 EventRootType Probe[main.testMapLargeKeySmallValue]
+              Type: 1373 EventRootType Probe[main.testMapLargeKeySmallValue]
               InjectionPoints: [{PC: "0xd0a540", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2630,7 +2630,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1362 EventRootType Probe[main.testMapMassive]
+              Type: 1363 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0xd0a420", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2654,7 +2654,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1363 EventRootType Probe[main.testMapMassive]
+              Type: 1364 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0xd0a420", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2676,7 +2676,7 @@ Probes:
         - subprogram: {subprogram: 81}
           events:
             - Kind: Entry
-              Type: 1371 EventRootType Probe[main.testMapSmallKeyLargeValue]
+              Type: 1372 EventRootType Probe[main.testMapSmallKeyLargeValue]
               InjectionPoints: [{PC: "0xd0a520", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2698,7 +2698,7 @@ Probes:
         - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 1370 EventRootType Probe[main.testMapSmallKeySmallValue]
+              Type: 1371 EventRootType Probe[main.testMapSmallKeySmallValue]
               InjectionPoints: [{PC: "0xd0a500", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2720,7 +2720,7 @@ Probes:
         - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 1355 EventRootType Probe[main.testMapStringToInt]
+              Type: 1356 EventRootType Probe[main.testMapStringToInt]
               InjectionPoints: [{PC: "0xd0a340", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2742,7 +2742,7 @@ Probes:
         - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 1356 EventRootType Probe[main.testMapStringToSlice]
+              Type: 1357 EventRootType Probe[main.testMapStringToSlice]
               InjectionPoints: [{PC: "0xd0a360", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2764,7 +2764,7 @@ Probes:
         - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 1354 EventRootType Probe[main.testMapStringToStruct]
+              Type: 1355 EventRootType Probe[main.testMapStringToStruct]
               InjectionPoints: [{PC: "0xd0a320", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2786,7 +2786,7 @@ Probes:
         - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 1365 EventRootType Probe[main.testMapWithLinkedList]
+              Type: 1366 EventRootType Probe[main.testMapWithLinkedList]
               InjectionPoints: [{PC: "0xd0a460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2808,7 +2808,7 @@ Probes:
         - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 1368 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+              Type: 1369 EventRootType Probe[main.testMapWithSmallKeyAndValue]
               InjectionPoints: [{PC: "0xd0a4c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2830,7 +2830,7 @@ Probes:
         - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 1369 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+              Type: 1370 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
               InjectionPoints: [{PC: "0xd0a4e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2852,7 +2852,7 @@ Probes:
         - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 1366 EventRootType Probe[main.testMapWithSmallValue]
+              Type: 1367 EventRootType Probe[main.testMapWithSmallValue]
               InjectionPoints: [{PC: "0xd0a480", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2876,7 +2876,7 @@ Probes:
         - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 1367 EventRootType Probe[main.testMapWithSmallValueMassive]
+              Type: 1368 EventRootType Probe[main.testMapWithSmallValueMassive]
               InjectionPoints: [{PC: "0xd0a4a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2898,7 +2898,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1519 EventRootType Probe[main.testMassiveString]
+              Type: 1520 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0xd0fc20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2921,7 +2921,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1520 EventRootType Probe[main.testMassiveString]
+              Type: 1521 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0xd0fc20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2968,11 +2968,11 @@ Probes:
         - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]
+              Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]
               InjectionPoints: [{PC: "0xd0e6f3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              Type: 1487 EventRootType Probe[main.testMixedArgsStackReturn]Return
               InjectionPoints: [{PC: "0xd0e92b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3038,11 +3038,11 @@ Probes:
         - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]
+              Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]
               InjectionPoints: [{PC: "0xd0ea6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]Return
+              Type: 1491 EventRootType Probe[main.testMultipleArrayArgs]Return
               InjectionPoints: [{PC: "0xd0eb36", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3073,11 +3073,11 @@ Probes:
         - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]
+              Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]
               InjectionPoints: [{PC: "0xd0e20e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]Return
+              Type: 1483 EventRootType Probe[main.testMultipleLargeArgs]Return
               InjectionPoints: [{PC: "0xd0e42a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3103,11 +3103,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1422 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d26f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3143,7 +3143,7 @@ Probes:
         - subprogram: {subprogram: 89}
           events:
             - Kind: Entry
-              Type: 1380 EventRootType Probe[main.testMultipleSimpleParams]
+              Type: 1381 EventRootType Probe[main.testMultipleSimpleParams]
               InjectionPoints: [{PC: "0xd0bec0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3184,11 +3184,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1416 EventRootType Probe[main.testNamedReturn]
+              Type: 1417 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xd0d12a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1417 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1418 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d195", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3212,11 +3212,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1418 EventRootType Probe[main.testNamedReturn]
+              Type: 1419 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xd0d12a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1419 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1420 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d195", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
@@ -3235,11 +3235,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d26f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
@@ -3259,11 +3259,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1427 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1427 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1428 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d26f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3296,11 +3296,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1420 EventRootType Probe[main.testNamedReturn]
+              Type: 1421 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xd0d12a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1421 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1422 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d195", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3328,7 +3328,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testNestedPointer]
+              Type: 1532 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xd10060", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3353,7 +3353,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testNestedPointer]
+              Type: 1533 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xd10060", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3384,7 +3384,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testNestedPointer]
+              Type: 1534 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xd10060", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3409,7 +3409,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testNestedPointer]
+              Type: 1535 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xd10060", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3436,7 +3436,7 @@ Probes:
         - subprogram: {subprogram: 98}
           events:
             - Kind: Entry
-              Type: 1390 EventRootType Probe[main.testNilPointer]
+              Type: 1391 EventRootType Probe[main.testNilPointer]
               InjectionPoints: [{PC: "0xd0c4a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3463,7 +3463,7 @@ Probes:
         - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1503 EventRootType Probe[main.testNilSlice]
+              Type: 1504 EventRootType Probe[main.testNilSlice]
               InjectionPoints: [{PC: "0xd0f300", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3490,7 +3490,7 @@ Probes:
         - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1500 EventRootType Probe[main.testNilSliceOfStructs]
+              Type: 1501 EventRootType Probe[main.testNilSliceOfStructs]
               InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3525,7 +3525,7 @@ Probes:
         - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1502 EventRootType Probe[main.testNilSliceWithOtherParams]
+              Type: 1503 EventRootType Probe[main.testNilSliceWithOtherParams]
               InjectionPoints: [{PC: "0xd0f2e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3557,7 +3557,7 @@ Probes:
         - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testOneStringInStructPointer]
+              Type: 1519 EventRootType Probe[main.testOneStringInStructPointer]
               InjectionPoints: [{PC: "0xd0fc00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3579,7 +3579,7 @@ Probes:
         - subprogram: {subprogram: 94}
           events:
             - Kind: Entry
-              Type: 1386 EventRootType Probe[main.testPointerLoop]
+              Type: 1387 EventRootType Probe[main.testPointerLoop]
               InjectionPoints: [{PC: "0xd0c320", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3601,7 +3601,7 @@ Probes:
         - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 1360 EventRootType Probe[main.testPointerToMap]
+              Type: 1361 EventRootType Probe[main.testPointerToMap]
               InjectionPoints: [{PC: "0xd0a3e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3623,7 +3623,7 @@ Probes:
         - subprogram: {subprogram: 92}
           events:
             - Kind: Entry
-              Type: 1384 EventRootType Probe[main.testPointerToSimpleStruct]
+              Type: 1385 EventRootType Probe[main.testPointerToSimpleStruct]
               InjectionPoints: [{PC: "0xd0c2e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3647,11 +3647,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1392 EventRootType Probe[main.testReturnsInt]
+              Type: 1393 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xd0c9ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1393 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1394 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xd0ca3b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
@@ -3671,11 +3671,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1436 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1437 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xd0d2ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1437 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1438 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d34e", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3720,11 +3720,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1402 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1403 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xd0cb0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1403 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1404 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xd0cbc4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3766,11 +3766,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1394 EventRootType Probe[main.testReturnsInt]
+              Type: 1395 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xd0c9ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1395 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1396 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xd0ca3b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3815,11 +3815,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1404 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1405 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xd0cb0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1405 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1406 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xd0cbc4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3863,11 +3863,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1438 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1439 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xd0d2ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1439 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1440 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d34e", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
@@ -3884,11 +3884,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1440 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1441 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xd0d2ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1441 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1442 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d34e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3910,11 +3910,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1396 EventRootType Probe[main.testReturnsInt]
+              Type: 1397 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xd0c9ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1397 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1398 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xd0ca3b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3937,11 +3937,11 @@ Probes:
         - subprogram: {subprogram: 105}
           events:
             - Kind: Entry
-              Type: 1412 EventRootType Probe[main.testReturnsAny]
+              Type: 1413 EventRootType Probe[main.testReturnsAny]
               InjectionPoints: [{PC: "0xd0cdae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1413 EventRootType Probe[main.testReturnsAny]Return
+              Type: 1414 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
                 - PC: "0xd0ce64"
                   Frameless: false
@@ -3976,11 +3976,11 @@ Probes:
         - subprogram: {subprogram: 104}
           events:
             - Kind: Entry
-              Type: 1410 EventRootType Probe[main.testReturnsAnyAndError]
+              Type: 1411 EventRootType Probe[main.testReturnsAnyAndError]
               InjectionPoints: [{PC: "0xd0cc4e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1411 EventRootType Probe[main.testReturnsAnyAndError]Return
+              Type: 1412 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
                 - PC: "0xd0ccb8"
                   Frameless: false
@@ -4014,11 +4014,11 @@ Probes:
         - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1455 EventRootType Probe[main.testReturnsArray]
+              Type: 1456 EventRootType Probe[main.testReturnsArray]
               InjectionPoints: [{PC: "0xd0da4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1456 EventRootType Probe[main.testReturnsArray]Return
+              Type: 1457 EventRootType Probe[main.testReturnsArray]Return
               InjectionPoints: [{PC: "0xd0daad", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4035,11 +4035,11 @@ Probes:
         - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1457 EventRootType Probe[main.testReturnsArrayOne]
+              Type: 1458 EventRootType Probe[main.testReturnsArrayOne]
               InjectionPoints: [{PC: "0xd0daca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1458 EventRootType Probe[main.testReturnsArrayOne]Return
+              Type: 1459 EventRootType Probe[main.testReturnsArrayOne]Return
               InjectionPoints: [{PC: "0xd0db0b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4056,11 +4056,11 @@ Probes:
         - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1459 EventRootType Probe[main.testReturnsArrayZero]
+              Type: 1460 EventRootType Probe[main.testReturnsArrayZero]
               InjectionPoints: [{PC: "0xd0db2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1460 EventRootType Probe[main.testReturnsArrayZero]Return
+              Type: 1461 EventRootType Probe[main.testReturnsArrayZero]Return
               InjectionPoints: [{PC: "0xd0db66", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4077,11 +4077,11 @@ Probes:
         - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]
+              Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]
               InjectionPoints: [{PC: "0xd0dc0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              Type: 1465 EventRootType Probe[main.testReturnsBacktrackInt]Return
               InjectionPoints: [{PC: "0xd0dc8a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4098,11 +4098,11 @@ Probes:
         - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]
               InjectionPoints: [{PC: "0xd0df4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              Type: 1477 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
               InjectionPoints: [{PC: "0xd0df90", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4119,11 +4119,11 @@ Probes:
         - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1451 EventRootType Probe[main.testReturnsComplex]
+              Type: 1452 EventRootType Probe[main.testReturnsComplex]
               InjectionPoints: [{PC: "0xd0d90a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1452 EventRootType Probe[main.testReturnsComplex]Return
+              Type: 1453 EventRootType Probe[main.testReturnsComplex]Return
               InjectionPoints: [{PC: "0xd0d966", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4141,11 +4141,11 @@ Probes:
         - subprogram: {subprogram: 103}
           events:
             - Kind: Entry
-              Type: 1408 EventRootType Probe[main.testReturnsError]
+              Type: 1409 EventRootType Probe[main.testReturnsError]
               InjectionPoints: [{PC: "0xd0cbea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1409 EventRootType Probe[main.testReturnsError]Return
+              Type: 1410 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
                 - PC: "0xd0cc1a"
                   Frameless: false
@@ -4170,11 +4170,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1398 EventRootType Probe[main.testReturnsInt]
+              Type: 1399 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xd0c9ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1399 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1400 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xd0ca3b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4195,11 +4195,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1406 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1407 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xd0cb0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1407 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1408 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xd0cbc4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4220,11 +4220,11 @@ Probes:
         - subprogram: {subprogram: 101}
           events:
             - Kind: Entry
-              Type: 1400 EventRootType Probe[main.testReturnsIntPointer]
+              Type: 1401 EventRootType Probe[main.testReturnsIntPointer]
               InjectionPoints: [{PC: "0xd0ca6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1401 EventRootType Probe[main.testReturnsIntPointer]Return
+              Type: 1402 EventRootType Probe[main.testReturnsIntPointer]Return
               InjectionPoints: [{PC: "0xd0cadb", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4246,11 +4246,11 @@ Probes:
         - subprogram: {subprogram: 106}
           events:
             - Kind: Entry
-              Type: 1414 EventRootType Probe[main.testReturnsInterface]
+              Type: 1415 EventRootType Probe[main.testReturnsInterface]
               InjectionPoints: [{PC: "0xd0cfae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1415 EventRootType Probe[main.testReturnsInterface]Return
+              Type: 1416 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
                 - PC: "0xd0d091"
                   Frameless: false
@@ -4275,11 +4275,11 @@ Probes:
         - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]
+              Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]
               InjectionPoints: [{PC: "0xd0d98e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]Return
+              Type: 1455 EventRootType Probe[main.testReturnsLargeStruct]Return
               InjectionPoints: [{PC: "0xd0da13", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4296,11 +4296,11 @@ Probes:
         - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1449 EventRootType Probe[main.testReturnsManyFloats]
+              Type: 1450 EventRootType Probe[main.testReturnsManyFloats]
               InjectionPoints: [{PC: "0xd0d80e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1450 EventRootType Probe[main.testReturnsManyFloats]Return
+              Type: 1451 EventRootType Probe[main.testReturnsManyFloats]Return
               InjectionPoints: [{PC: "0xd0d8e5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4317,11 +4317,11 @@ Probes:
         - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1467 EventRootType Probe[main.testReturnsMixed]
+              Type: 1468 EventRootType Probe[main.testReturnsMixed]
               InjectionPoints: [{PC: "0xd0dd6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1468 EventRootType Probe[main.testReturnsMixed]Return
+              Type: 1469 EventRootType Probe[main.testReturnsMixed]Return
               InjectionPoints: [{PC: "0xd0ddcc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4338,11 +4338,11 @@ Probes:
         - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]
+              Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]
               InjectionPoints: [{PC: "0xd0db8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]Return
+              Type: 1463 EventRootType Probe[main.testReturnsMixedStruct]Return
               InjectionPoints: [{PC: "0xd0dbd8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4359,11 +4359,11 @@ Probes:
         - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]
+              Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]
               InjectionPoints: [{PC: "0xd0deca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              Type: 1475 EventRootType Probe[main.testReturnsMultipleFloats]Return
               InjectionPoints: [{PC: "0xd0df16", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4383,7 +4383,7 @@ Probes:
         - subprogram: {subprogram: 111}
           events:
             - Kind: Line
-              Type: 1446 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              Type: 1447 EventRootType Probe[main.testReturnsNamedDeferLine]Line
               InjectionPoints: [{PC: "0xd0d58f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4404,11 +4404,11 @@ Probes:
         - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]
+              Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]
               InjectionPoints: [{PC: "0xd0de6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              Type: 1473 EventRootType Probe[main.testReturnsOnlyFloat]Return
               InjectionPoints: [{PC: "0xd0deae", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4425,11 +4425,11 @@ Probes:
         - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1447 EventRootType Probe[main.testReturnsPrimitives]
+              Type: 1448 EventRootType Probe[main.testReturnsPrimitives]
               InjectionPoints: [{PC: "0xd0d78a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1448 EventRootType Probe[main.testReturnsPrimitives]Return
+              Type: 1449 EventRootType Probe[main.testReturnsPrimitives]Return
               InjectionPoints: [{PC: "0xd0d7f1", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4446,11 +4446,11 @@ Probes:
         - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]
+              Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]
               InjectionPoints: [{PC: "0xd0ddea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]Return
+              Type: 1471 EventRootType Probe[main.testReturnsStructWithArray]Return
               InjectionPoints: [{PC: "0xd0de4d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4467,11 +4467,11 @@ Probes:
         - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1465 EventRootType Probe[main.testReturnsWideStruct]
+              Type: 1466 EventRootType Probe[main.testReturnsWideStruct]
               InjectionPoints: [{PC: "0xd0dcae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1466 EventRootType Probe[main.testReturnsWideStruct]Return
+              Type: 1467 EventRootType Probe[main.testReturnsWideStruct]Return
               InjectionPoints: [{PC: "0xd0dd34", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4489,7 +4489,7 @@ Probes:
         - subprogram: {subprogram: 2}
           events:
             - Kind: Entry
-              Type: 1277 EventRootType Probe[main.testRuneArray]
+              Type: 1278 EventRootType Probe[main.testRuneArray]
               InjectionPoints: [{PC: "0xd04940", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4524,11 +4524,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1428 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1429 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1429 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d26f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4574,7 +4574,7 @@ Probes:
         - subprogram: {subprogram: 23}
           events:
             - Kind: Entry
-              Type: 1298 EventRootType Probe[main.testSingleBool]
+              Type: 1299 EventRootType Probe[main.testSingleBool]
               InjectionPoints: [{PC: "0xd04f60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4596,7 +4596,7 @@ Probes:
         - subprogram: {subprogram: 21}
           events:
             - Kind: Entry
-              Type: 1296 EventRootType Probe[main.testSingleByte]
+              Type: 1297 EventRootType Probe[main.testSingleByte]
               InjectionPoints: [{PC: "0xd04f20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4618,7 +4618,7 @@ Probes:
         - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 1309 EventRootType Probe[main.testSingleFloat32]
+              Type: 1310 EventRootType Probe[main.testSingleFloat32]
               InjectionPoints: [{PC: "0xd050c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4636,7 +4636,7 @@ Probes:
         - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 1310 EventRootType Probe[main.testSingleFloat64]
+              Type: 1311 EventRootType Probe[main.testSingleFloat64]
               InjectionPoints: [{PC: "0xd050e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4654,7 +4654,7 @@ Probes:
         - subprogram: {subprogram: 24}
           events:
             - Kind: Entry
-              Type: 1299 EventRootType Probe[main.testSingleInt]
+              Type: 1300 EventRootType Probe[main.testSingleInt]
               InjectionPoints: [{PC: "0xd04f80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4676,7 +4676,7 @@ Probes:
         - subprogram: {subprogram: 26}
           events:
             - Kind: Entry
-              Type: 1301 EventRootType Probe[main.testSingleInt16]
+              Type: 1302 EventRootType Probe[main.testSingleInt16]
               InjectionPoints: [{PC: "0xd04fc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4699,7 +4699,7 @@ Probes:
         - subprogram: {subprogram: 27}
           events:
             - Kind: Entry
-              Type: 1302 EventRootType Probe[main.testSingleInt32]
+              Type: 1303 EventRootType Probe[main.testSingleInt32]
               InjectionPoints: [{PC: "0xd04fe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4721,7 +4721,7 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Entry
-              Type: 1303 EventRootType Probe[main.testSingleInt64]
+              Type: 1304 EventRootType Probe[main.testSingleInt64]
               InjectionPoints: [{PC: "0xd05000", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4750,7 +4750,7 @@ Probes:
         - subprogram: {subprogram: 25}
           events:
             - Kind: Entry
-              Type: 1300 EventRootType Probe[main.testSingleInt8]
+              Type: 1301 EventRootType Probe[main.testSingleInt8]
               InjectionPoints: [{PC: "0xd04fa0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4781,7 +4781,7 @@ Probes:
         - subprogram: {subprogram: 22}
           events:
             - Kind: Entry
-              Type: 1297 EventRootType Probe[main.testSingleRune]
+              Type: 1298 EventRootType Probe[main.testSingleRune]
               InjectionPoints: [{PC: "0xd04f40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4803,7 +4803,7 @@ Probes:
         - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1510 EventRootType Probe[main.testSingleString]
+              Type: 1511 EventRootType Probe[main.testSingleString]
               InjectionPoints: [{PC: "0xd0fb80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4825,7 +4825,7 @@ Probes:
         - subprogram: {subprogram: 29}
           events:
             - Kind: Entry
-              Type: 1304 EventRootType Probe[main.testSingleUint]
+              Type: 1305 EventRootType Probe[main.testSingleUint]
               InjectionPoints: [{PC: "0xd05020", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4847,7 +4847,7 @@ Probes:
         - subprogram: {subprogram: 31}
           events:
             - Kind: Entry
-              Type: 1306 EventRootType Probe[main.testSingleUint16]
+              Type: 1307 EventRootType Probe[main.testSingleUint16]
               InjectionPoints: [{PC: "0xd05060", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4869,7 +4869,7 @@ Probes:
         - subprogram: {subprogram: 32}
           events:
             - Kind: Entry
-              Type: 1307 EventRootType Probe[main.testSingleUint32]
+              Type: 1308 EventRootType Probe[main.testSingleUint32]
               InjectionPoints: [{PC: "0xd05080", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4891,7 +4891,7 @@ Probes:
         - subprogram: {subprogram: 33}
           events:
             - Kind: Entry
-              Type: 1308 EventRootType Probe[main.testSingleUint64]
+              Type: 1309 EventRootType Probe[main.testSingleUint64]
               InjectionPoints: [{PC: "0xd050a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4913,7 +4913,7 @@ Probes:
         - subprogram: {subprogram: 30}
           events:
             - Kind: Entry
-              Type: 1305 EventRootType Probe[main.testSingleUint8]
+              Type: 1306 EventRootType Probe[main.testSingleUint8]
               InjectionPoints: [{PC: "0xd05040", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4935,7 +4935,7 @@ Probes:
         - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1506 EventRootType Probe[main.testSliceEmptyStructs]
+              Type: 1507 EventRootType Probe[main.testSliceEmptyStructs]
               InjectionPoints: [{PC: "0xd0f340", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4957,7 +4957,7 @@ Probes:
         - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1497 EventRootType Probe[main.testSliceOfSlices]
+              Type: 1498 EventRootType Probe[main.testSliceOfSlices]
               InjectionPoints: [{PC: "0xd0f240", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4979,7 +4979,7 @@ Probes:
         - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 1358 EventRootType Probe[main.testSmallMap]
+              Type: 1359 EventRootType Probe[main.testSmallMap]
               InjectionPoints: [{PC: "0xd0a3a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5000,11 +5000,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1442 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1443 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xd0d2ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1443 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1444 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d34e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5025,11 +5025,11 @@ Probes:
         - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1487 EventRootType Probe[main.testStackArgRegReturns]
+              Type: 1488 EventRootType Probe[main.testStackArgRegReturns]
               InjectionPoints: [{PC: "0xd0e9ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1488 EventRootType Probe[main.testStackArgRegReturns]Return
+              Type: 1489 EventRootType Probe[main.testStackArgRegReturns]Return
               InjectionPoints: [{PC: "0xd0ea3c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5051,7 +5051,7 @@ Probes:
         - subprogram: {subprogram: 3}
           events:
             - Kind: Entry
-              Type: 1278 EventRootType Probe[main.testStringArray]
+              Type: 1279 EventRootType Probe[main.testStringArray]
               InjectionPoints: [{PC: "0xd04960", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5073,7 +5073,7 @@ Probes:
         - subprogram: {subprogram: 97}
           events:
             - Kind: Entry
-              Type: 1389 EventRootType Probe[main.testStringPointer]
+              Type: 1390 EventRootType Probe[main.testStringPointer]
               InjectionPoints: [{PC: "0xd0c460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5095,7 +5095,7 @@ Probes:
         - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1501 EventRootType Probe[main.testStringSlice]
+              Type: 1502 EventRootType Probe[main.testStringSlice]
               InjectionPoints: [{PC: "0xd0f2c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5117,7 +5117,7 @@ Probes:
         - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 1321 EventRootType Probe[main.testStringType1]
+              Type: 1322 EventRootType Probe[main.testStringType1]
               InjectionPoints: [{PC: "0xd057a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5139,7 +5139,7 @@ Probes:
         - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 1322 EventRootType Probe[main.testStringType2]
+              Type: 1323 EventRootType Probe[main.testStringType2]
               InjectionPoints: [{PC: "0xd057c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5161,11 +5161,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1529 EventRootType Probe[main.testStruct]
+              Type: 1530 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0xd0ff60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1530 EventRootType Probe[main.testStruct]Return
+              Type: 1531 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0xd0ff82", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5192,7 +5192,7 @@ Probes:
         - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1498 EventRootType Probe[main.testStructSlice]
+              Type: 1499 EventRootType Probe[main.testStructSlice]
               InjectionPoints: [{PC: "0xd0f260", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5219,7 +5219,7 @@ Probes:
         - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 1352 EventRootType Probe[main.testStructWithAny]
+              Type: 1353 EventRootType Probe[main.testStructWithAny]
               InjectionPoints: [{PC: "0xd09ba0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5240,11 +5240,11 @@ Probes:
         - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1491 EventRootType Probe[main.testStructWithArrayArg]
+              Type: 1492 EventRootType Probe[main.testStructWithArrayArg]
               InjectionPoints: [{PC: "0xd0eb6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1492 EventRootType Probe[main.testStructWithArrayArg]Return
+              Type: 1493 EventRootType Probe[main.testStructWithArrayArg]Return
               InjectionPoints: [{PC: "0xd0ec1a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5266,11 +5266,11 @@ Probes:
         - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]
+              Type: 1526 EventRootType Probe[main.testStructWithCyclicMaps]
               InjectionPoints: [{PC: "0xd0fe20", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1526 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              Type: 1527 EventRootType Probe[main.testStructWithCyclicMaps]Return
               InjectionPoints: [{PC: "0xd0fe3e", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5291,7 +5291,7 @@ Probes:
         - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testStructWithCyclicSlices]
+              Type: 1525 EventRootType Probe[main.testStructWithCyclicSlices]
               InjectionPoints: [{PC: "0xd0fe00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5318,7 +5318,7 @@ Probes:
         - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 1353 EventRootType Probe[main.testStructWithMap]
+              Type: 1354 EventRootType Probe[main.testStructWithMap]
               InjectionPoints: [{PC: "0xd0a300", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5351,7 +5351,7 @@ Probes:
         - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1507 EventRootType Probe[main.testSubslices]
+              Type: 1508 EventRootType Probe[main.testSubslices]
               InjectionPoints: [{PC: "0xd0f360", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5391,7 +5391,7 @@ Probes:
         - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1523 EventRootType Probe[main.testSubstrings]
+              Type: 1524 EventRootType Probe[main.testSubstrings]
               InjectionPoints: [{PC: "0xd0fc80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5423,7 +5423,7 @@ Probes:
         - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 1326 EventRootType Probe[main.testTakeContext]
+              Type: 1327 EventRootType Probe[main.testTakeContext]
               InjectionPoints: [{PC: "0xd05e60", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
@@ -5439,11 +5439,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1431 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1431 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d26f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5464,11 +5464,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d26f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5491,11 +5491,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xd0d1ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xd0d26f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5527,7 +5527,7 @@ Probes:
         - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1511 EventRootType Probe[main.testThreeStrings]
+              Type: 1512 EventRootType Probe[main.testThreeStrings]
               InjectionPoints: [{PC: "0xd0fba0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5559,11 +5559,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0xd0fbc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0xd0fbde", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5593,11 +5593,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1515 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0xd0fbc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1515 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1516 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0xd0fbde", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5629,7 +5629,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1517 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0xd0fbe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5659,7 +5659,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1517 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1518 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0xd0fbe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5679,6 +5679,72 @@ Probes:
                   DSL: a.c
                   EventKind: Entry
                   EventExpressionIndex: 2
+    - id: testTimeFixedZone
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeFixedZone}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 166}
+          events:
+            - Kind: Entry
+              Type: 1540 EventRootType Probe[main.testTimeFixedZone]
+              InjectionPoints: [{PC: "0xd11480", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeMonotonic
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeMonotonic}
+      tags: ['foo:bar']
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 167}
+          events:
+            - Kind: Entry
+              Type: 1541 EventRootType Probe[main.testTimeMonotonic]
+              InjectionPoints: [{PC: "0xd114a0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{c}'
+            Segments:
+                - JSON: {Ref: c}
+                  DSL: c
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeUTC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeUTC}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 165}
+          events:
+            - Kind: Entry
+              Type: 1539 EventRootType Probe[main.testTimeUTC]
+              InjectionPoints: [{PC: "0xd11460", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -5691,7 +5757,7 @@ Probes:
         - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 1311 EventRootType Probe[main.testTypeAlias]
+              Type: 1312 EventRootType Probe[main.testTypeAlias]
               InjectionPoints: [{PC: "0xd05100", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5713,7 +5779,7 @@ Probes:
         - subprogram: {subprogram: 12}
           events:
             - Kind: Entry
-              Type: 1287 EventRootType Probe[main.testUint16Array]
+              Type: 1288 EventRootType Probe[main.testUint16Array]
               InjectionPoints: [{PC: "0xd04a80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5735,7 +5801,7 @@ Probes:
         - subprogram: {subprogram: 13}
           events:
             - Kind: Entry
-              Type: 1288 EventRootType Probe[main.testUint32Array]
+              Type: 1289 EventRootType Probe[main.testUint32Array]
               InjectionPoints: [{PC: "0xd04aa0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5757,7 +5823,7 @@ Probes:
         - subprogram: {subprogram: 14}
           events:
             - Kind: Entry
-              Type: 1289 EventRootType Probe[main.testUint64Array]
+              Type: 1290 EventRootType Probe[main.testUint64Array]
               InjectionPoints: [{PC: "0xd04ac0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5779,7 +5845,7 @@ Probes:
         - subprogram: {subprogram: 11}
           events:
             - Kind: Entry
-              Type: 1286 EventRootType Probe[main.testUint8Array]
+              Type: 1287 EventRootType Probe[main.testUint8Array]
               InjectionPoints: [{PC: "0xd04a60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5801,7 +5867,7 @@ Probes:
         - subprogram: {subprogram: 10}
           events:
             - Kind: Entry
-              Type: 1285 EventRootType Probe[main.testUintArray]
+              Type: 1286 EventRootType Probe[main.testUintArray]
               InjectionPoints: [{PC: "0xd04a40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5823,7 +5889,7 @@ Probes:
         - subprogram: {subprogram: 96}
           events:
             - Kind: Entry
-              Type: 1388 EventRootType Probe[main.testUintPointer]
+              Type: 1389 EventRootType Probe[main.testUintPointer]
               InjectionPoints: [{PC: "0xd0c380", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5845,7 +5911,7 @@ Probes:
         - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1495 EventRootType Probe[main.testUintSlice]
+              Type: 1496 EventRootType Probe[main.testUintSlice]
               InjectionPoints: [{PC: "0xd0f200", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5867,7 +5933,7 @@ Probes:
         - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1521 EventRootType Probe[main.testUnitializedString]
+              Type: 1522 EventRootType Probe[main.testUnitializedString]
               InjectionPoints: [{PC: "0xd0fc40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5889,7 +5955,7 @@ Probes:
         - subprogram: {subprogram: 95}
           events:
             - Kind: Entry
-              Type: 1387 EventRootType Probe[main.testUnsafePointer]
+              Type: 1388 EventRootType Probe[main.testUnsafePointer]
               InjectionPoints: [{PC: "0xd0c340", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5911,7 +5977,7 @@ Probes:
         - subprogram: {subprogram: 20}
           events:
             - Kind: Entry
-              Type: 1295 EventRootType Probe[main.testVeryLargeArray]
+              Type: 1296 EventRootType Probe[main.testVeryLargeArray]
               InjectionPoints: [{PC: "0xd04ba0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5933,7 +5999,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0xd0f320", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5955,7 +6021,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1506 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0xd0f320", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5974,18 +6040,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 195}
+        - subprogram: {subprogram: 198}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1606 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0xd099aa"
                   Frameless: false
-                - PC: "0xd13023"
+                - PC: "0xd131a3"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1603 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1607 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0xd099f0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -6007,11 +6073,11 @@ Probes:
         - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]
               InjectionPoints: [{PC: "0xd0ec4e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              Type: 1495 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
               InjectionPoints: [{PC: "0xd0eccc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -9919,130 +9985,187 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 165
-      Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xd123c0..0xd123c4]
+      Name: main.testTimeUTC
+      OutOfLinePCRanges: [0xd11460..0xd11461]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 323 BaseType go.shape.int
+        - Name: x
+          Type: 323 GoTimeType time.Time
           Locations:
-            - Range: 0xd123c0..0xd123c4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd11460..0xd11461
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0xd123c0..0xd123c3
-              Pieces: []
-            - Range: 0xd123c3..0xd123c4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+          DictIndex: -1
+      DictRegister: null
     - ID: 166
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xd123e0..0xd123ec]
+      Name: main.testTimeFixedZone
+      OutOfLinePCRanges: [0xd11480..0xd11481]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 325 GoStringHeaderType go.shape.string
+        - Name: x
+          Type: 323 GoTimeType time.Time
           Locations:
-            - Range: 0xd123e0..0xd123eb
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd123eb..0xd123ec
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xd123e0..0xd123eb
-              Pieces: []
-            - Range: 0xd123eb..0xd123ec
+            - Range: 0xd11480..0xd11481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 167
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xd12400..0xd12404]
+      Name: main.testTimeMonotonic
+      OutOfLinePCRanges: [0xd114a0..0xd114a1]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+        - Name: c
+          Type: 326 StructureType main.timeCapture
           Locations:
-            - Range: 0xd12400..0xd12404
+            - Range: 0xd114a0..0xd114a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 168
+      Name: main.wrapBox[go.shape.int]
+      OutOfLinePCRanges: [0xd12540..0xd12544]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 327 BaseType go.shape.int
+          Locations:
+            - Range: 0xd12540..0xd12544
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 323 BaseType go.shape.int
+          Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd12400..0xd12403
+            - Range: 0xd12540..0xd12543
               Pieces: []
-            - Range: 0xd12403..0xd12404
+            - Range: 0xd12543..0xd12544
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 168
-      Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xd12420..0xd1242c]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xd12420..0xd1242b
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd1242b..0xd1242c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 325 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0xd12420..0xd1242b
-              Pieces: []
-            - Range: 0xd1242b..0xd1242c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0xd12560..0xd1256c]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 329 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xd12560..0xd1256b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xd1256b..0xd1256c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xd12560..0xd1256b
+              Pieces: []
+            - Range: 0xd1256b..0xd1256c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0xd12580..0xd12584]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0xd12580..0xd12584
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 327 BaseType go.shape.int
+          Locations:
+            - Range: 0xd12580..0xd12583
+              Pieces: []
+            - Range: 0xd12583..0xd12584
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 171
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0xd125a0..0xd125ac]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xd125a0..0xd125ab
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xd125ab..0xd125ac
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 329 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xd125a0..0xd125ab
+              Pieces: []
+            - Range: 0xd125ab..0xd125ac
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xd124a0..0xd125d6]
+      OutOfLinePCRanges: [0xd12620..0xd12756]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 327 GoSliceHeaderType []go.shape.int
+          Type: 331 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd124a0..0xd124d3
+            - Range: 0xd12620..0xd12653
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10050,7 +10173,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd124d3..0xd124db
+            - Range: 0xd12653..0xd1265b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10058,7 +10181,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xd124db..0xd125d6
+            - Range: 0xd1265b..0xd12756
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10069,20 +10192,20 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 329 GoSubroutineType func(go.shape.int) bool
+          Type: 333 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xd124a0..0xd124db
+            - Range: 0xd12620..0xd1265b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd124db..0xd125d6
+            - Range: 0xd1265b..0xd12756
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 327 GoSliceHeaderType []go.shape.int
+          Type: 331 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd124a0..0xd12594
+            - Range: 0xd12620..0xd12714
               Pieces: []
-            - Range: 0xd12594..0xd12595
+            - Range: 0xd12714..0xd12715
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10090,14 +10213,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd12595..0xd125d6
+            - Range: 0xd12715..0xd12756
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 327 GoSliceHeaderType []go.shape.int
+          Type: 331 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd124db..0xd124f9
+            - Range: 0xd1265b..0xd12679
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10105,7 +10228,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd124f9..0xd12501
+            - Range: 0xd12679..0xd12681
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10113,7 +10236,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd12501..0xd12509
+            - Range: 0xd12681..0xd12689
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10121,7 +10244,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd12509..0xd12509
+            - Range: 0xd12689..0xd12689
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10129,7 +10252,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd12509..0xd12533
+            - Range: 0xd12689..0xd126b3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10137,7 +10260,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd12533..0xd1258b
+            - Range: 0xd126b3..0xd1270b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10145,7 +10268,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd1258b..0xd125d6
+            - Range: 0xd1270b..0xd12756
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10156,207 +10279,207 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0xd12526..0xd12533
+            - Range: 0xd126a6..0xd126b3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd12533..0xd1258b
+            - Range: 0xd126b3..0xd1270b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 170
+    - ID: 173
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd125e0..0xd12624]
+      OutOfLinePCRanges: [0xd12760..0xd127a4]
       InlinePCRanges: []
       Variables:
         - Name: box
-          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd125e0..0xd125f9
+            - Range: 0xd12760..0xd12779
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
-          Type: 330 GoSubroutineType func(go.shape.int) go.shape.string
+          Type: 334 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xd125e0..0xd125f9
+            - Range: 0xd12760..0xd12779
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd125e0..0xd125f9
+            - Range: 0xd12760..0xd12779
               Pieces: []
-            - Range: 0xd125f9..0xd125fa
+            - Range: 0xd12779..0xd1277a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd125fa..0xd12624
+            - Range: 0xd1277a..0xd127a4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xd128c0..0xd128c4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 328 PointerType *go.shape.int
-          Locations:
-            - Range: 0xd128c0..0xd128c4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 328 PointerType *go.shape.int
-          Locations:
-            - Range: 0xd128c0..0xd128c3
-              Pieces: []
-            - Range: 0xd128c3..0xd128c4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xd128e0..0xd128e4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 331 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0xd128e0..0xd128e4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0xd128e0..0xd128e3
-              Pieces: []
-            - Range: 0xd128e3..0xd128e4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 173
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xd12900..0xd12904]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 333 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0xd12900..0xd12904
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 333 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0xd12900..0xd12903
-              Pieces: []
-            - Range: 0xd12903..0xd12904
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 174
-      Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xd12920..0xd12931]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0xd12a40..0xd12a44]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 335 StructureType main.largeGenericType[go.shape.string]
+        - Name: p
+          Type: 332 PointerType *go.shape.int
           Locations:
-            - Range: 0xd12920..0xd12931
-              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+            - Range: 0xd12a40..0xd12a44
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 332 PointerType *go.shape.int
           Locations:
-            - Range: 0xd12920..0xd12930
+            - Range: 0xd12a40..0xd12a43
               Pieces: []
-            - Range: 0xd12930..0xd12931
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd12a43..0xd12a44
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
-      Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xd129c0..0xd129c9]
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0xd12a60..0xd12a64]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 337 StructureType main.largeGenericType[go.shape.int]
+        - Name: p
+          Type: 335 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xd129c0..0xd129c9
-              Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
+            - Range: 0xd12a60..0xd12a64
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 323 BaseType go.shape.int
+          Type: 335 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xd129c0..0xd129c8
+            - Range: 0xd12a60..0xd12a63
               Pieces: []
-            - Range: 0xd129c8..0xd129c9
+            - Range: 0xd12a63..0xd12a64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 176
-      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xd12a80..0xd12a88]
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0xd12a80..0xd12a84]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 337 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xd12a80..0xd12a84
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 337 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xd12a80..0xd12a83
+              Pieces: []
+            - Range: 0xd12a83..0xd12a84
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 177
+      Name: main.largeGenericType[go.shape.string].LargeGet
+      OutOfLinePCRanges: [0xd12aa0..0xd12ab1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 338 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Type: 339 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xd12a80..0xd12a88
+            - Range: 0xd12aa0..0xd12ab1
+              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 329 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xd12aa0..0xd12ab0
+              Pieces: []
+            - Range: 0xd12ab0..0xd12ab1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 178
+      Name: main.largeGenericType[go.shape.int].LargeGet
+      OutOfLinePCRanges: [0xd12b40..0xd12b49]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 341 StructureType main.largeGenericType[go.shape.int]
+          Locations:
+            - Range: 0xd12b40..0xd12b49
+              Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 327 BaseType go.shape.int
+          Locations:
+            - Range: 0xd12b40..0xd12b48
+              Pieces: []
+            - Range: 0xd12b48..0xd12b49
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 179
+      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
+      OutOfLinePCRanges: [0xd12c00..0xd12c08]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 342 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Locations:
+            - Range: 0xd12c00..0xd12c08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0xd12a80..0xd12a88
+            - Range: 0xd12c00..0xd12c08
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 340 BaseType go.shape.bool
+          Type: 344 BaseType go.shape.bool
           Locations:
-            - Range: 0xd12a80..0xd12a88
+            - Range: 0xd12c00..0xd12c08
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 177
+    - ID: 180
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xd12b20..0xd12b91]
+      OutOfLinePCRanges: [0xd12ca0..0xd12d11]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 341 PointerType *main.Pair[go.shape.string,go.shape.int]
+          Type: 345 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xd12b20..0xd12b91
+            - Range: 0xd12ca0..0xd12d11
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12b20..0xd12b91
+            - Range: 0xd12ca0..0xd12d11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10365,22 +10488,22 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0xd12b20..0xd12b91
+            - Range: 0xd12ca0..0xd12d11
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 178
+    - ID: 181
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xd12c20..0xd12c28]
+      OutOfLinePCRanges: [0xd12da0..0xd12da8]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12c20..0xd12c28
+            - Range: 0xd12da0..0xd12da8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10389,27 +10512,27 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 340 BaseType go.shape.bool
+          Type: 344 BaseType go.shape.bool
           Locations:
-            - Range: 0xd12c20..0xd12c28
+            - Range: 0xd12da0..0xd12da8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 340 BaseType go.shape.bool
+          Type: 344 BaseType go.shape.bool
           Locations:
-            - Range: 0xd12c20..0xd12c27
+            - Range: 0xd12da0..0xd12da7
               Pieces: []
-            - Range: 0xd12c27..0xd12c28
+            - Range: 0xd12da7..0xd12da8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12c20..0xd12c27
+            - Range: 0xd12da0..0xd12da7
               Pieces: []
-            - Range: 0xd12c27..0xd12c28
+            - Range: 0xd12da7..0xd12da8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10418,28 +10541,28 @@ Subprograms:
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 179
+    - ID: 182
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd12c40..0xd12c4f]
+      OutOfLinePCRanges: [0xd12dc0..0xd12dcf]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0xd12c40..0xd12c4e
+            - Range: 0xd12dc0..0xd12dce
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12c40..0xd12c4b
+            - Range: 0xd12dc0..0xd12dcb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd12c4b..0xd12c4f
+            - Range: 0xd12dcb..0xd12dcf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10448,11 +10571,11 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12c40..0xd12c4e
+            - Range: 0xd12dc0..0xd12dce
               Pieces: []
-            - Range: 0xd12c4e..0xd12c4f
+            - Range: 0xd12dce..0xd12dcf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10461,58 +10584,58 @@ Subprograms:
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0xd12c40..0xd12c4e
+            - Range: 0xd12dc0..0xd12dce
               Pieces: []
-            - Range: 0xd12c4e..0xd12c4f
+            - Range: 0xd12dce..0xd12dcf
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 180
+    - ID: 183
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xd12c60..0xd12c9a]
+      OutOfLinePCRanges: [0xd12de0..0xd12e1a]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 343 StructureType go.shape.struct { main.i int }
+          Type: 347 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xd12c60..0xd12c79
+            - Range: 0xd12de0..0xd12df9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd12c60..0xd12c79
+            - Range: 0xd12de0..0xd12df9
               Pieces: []
-            - Range: 0xd12c79..0xd12c7a
+            - Range: 0xd12df9..0xd12dfa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd12c7a..0xd12c9a
+            - Range: 0xd12dfa..0xd12e1a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 184
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xd12ca0..0xd12ced]
+      OutOfLinePCRanges: [0xd12e20..0xd12e6d]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 344 StructureType go.shape.struct { main.s string }
+          Type: 348 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xd12ca0..0xd12cbf
+            - Range: 0xd12e20..0xd12e3f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd12cbf..0xd12cc2
+            - Range: 0xd12e3f..0xd12e42
               Pieces:
                 - Size: 8
                   Op: null
@@ -10523,37 +10646,37 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd12ca0..0xd12cc2
+            - Range: 0xd12e20..0xd12e42
               Pieces: []
-            - Range: 0xd12cc2..0xd12cc3
+            - Range: 0xd12e42..0xd12e43
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd12cc3..0xd12ced
+            - Range: 0xd12e43..0xd12e6d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 182
+    - ID: 185
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xd12d00..0xd12d08]
+      OutOfLinePCRanges: [0xd12e80..0xd12e88]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 345 PointerType *go.shape.string
+          Type: 349 PointerType *go.shape.string
           Locations:
-            - Range: 0xd12d00..0xd12d07
+            - Range: 0xd12e80..0xd12e87
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12d00..0xd12d07
+            - Range: 0xd12e80..0xd12e87
               Pieces: []
-            - Range: 0xd12d07..0xd12d08
+            - Range: 0xd12e87..0xd12e88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10562,24 +10685,24 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 183
+    - ID: 186
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xd12d20..0xd12d77]
+      OutOfLinePCRanges: [0xd12ea0..0xd12ef7]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 346 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 350 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd12d20..0xd12d5d
+            - Range: 0xd12ea0..0xd12edd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 347 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 351 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd12d20..0xd12d71
+            - Range: 0xd12ea0..0xd12ef1
               Pieces: []
-            - Range: 0xd12d71..0xd12d72
+            - Range: 0xd12ef1..0xd12ef2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10593,20 +10716,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd12d72..0xd12d77
+            - Range: 0xd12ef2..0xd12ef7
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 184
+    - ID: 187
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xd12d80..0xd12da4]
+      OutOfLinePCRanges: [0xd12f00..0xd12f24]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 327 GoSliceHeaderType []go.shape.int
+          Type: 331 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd12d80..0xd12da4
+            - Range: 0xd12f00..0xd12f24
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10617,35 +10740,35 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0xd12d80..0xd12da4
+            - Range: 0xd12f00..0xd12f24
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd12d80..0xd12da0
+            - Range: 0xd12f00..0xd12f20
               Pieces: []
-            - Range: 0xd12da0..0xd12da1
+            - Range: 0xd12f20..0xd12f21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd12da1..0xd12da3
+            - Range: 0xd12f21..0xd12f23
               Pieces: []
-            - Range: 0xd12da3..0xd12da4
+            - Range: 0xd12f23..0xd12f24
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 185
+    - ID: 188
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xd12dc0..0xd12e7f]
+      OutOfLinePCRanges: [0xd12f40..0xd12fff]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 348 GoSliceHeaderType []go.shape.string
+          Type: 352 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xd12dc0..0xd12ddd
+            - Range: 0xd12f40..0xd12f5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10653,7 +10776,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd12ddd..0xd12ddf
+            - Range: 0xd12f5d..0xd12f5f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10664,15 +10787,15 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12dc0..0xd12e0c
+            - Range: 0xd12f40..0xd12f8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd12e0c..0xd12e7f
+            - Range: 0xd12f8c..0xd12fff
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10683,28 +10806,28 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd12dc0..0xd12e2b
+            - Range: 0xd12f40..0xd12fab
               Pieces: []
-            - Range: 0xd12e2b..0xd12e2c
+            - Range: 0xd12fab..0xd12fac
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd12e2c..0xd12e33
+            - Range: 0xd12fac..0xd12fb3
               Pieces: []
-            - Range: 0xd12e33..0xd12e34
+            - Range: 0xd12fb3..0xd12fb4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd12e34..0xd12e7f
+            - Range: 0xd12fb4..0xd12fff
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12def..0xd12e01
+            - Range: 0xd12f6f..0xd12f81
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xd12e01..0xd12e0c
+            - Range: 0xd12f81..0xd12f8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10713,56 +10836,56 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 186
+    - ID: 189
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xd12e80..0xd12e87]
+      OutOfLinePCRanges: [0xd13000..0xd13007]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 349 StructureType main.typeWithGenerics[go.shape.int]
+          Type: 353 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xd12e80..0xd12e86
+            - Range: 0xd13000..0xd13006
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0xd12e80..0xd12e87
+            - Range: 0xd13000..0xd13007
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd12e80..0xd12e86
+            - Range: 0xd13000..0xd13006
               Pieces: []
-            - Range: 0xd12e86..0xd12e87
+            - Range: 0xd13006..0xd13007
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
-    - ID: 187
+    - ID: 190
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xd12f00..0xd12f6c]
+      OutOfLinePCRanges: [0xd13080..0xd130ec]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 350 StructureType main.typeWithGenerics[go.shape.string]
+          Type: 354 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xd12f00..0xd12f20
+            - Range: 0xd13080..0xd130a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd12f20..0xd12f28
+            - Range: 0xd130a0..0xd130a8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd12f28..0xd12f2d
+            - Range: 0xd130a8..0xd130ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10771,9 +10894,9 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd12f00..0xd12f2d
+            - Range: 0xd13080..0xd130ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10784,22 +10907,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd12f00..0xd12f2d
+            - Range: 0xd13080..0xd130ad
               Pieces: []
-            - Range: 0xd12f2d..0xd12f2e
+            - Range: 0xd130ad..0xd130ae
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd12f2e..0xd12f6c
+            - Range: 0xd130ae..0xd130ec
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 188
+    - ID: 191
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0xd03ae0..0xd03c25]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 351 GoSliceHeaderType []go.shape.float64
+          Type: 355 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xd03ae0..0xd03b13
               Pieces:
@@ -10828,7 +10951,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 354 GoSubroutineType func(go.shape.float64) bool
+          Type: 358 GoSubroutineType func(go.shape.float64) bool
           Locations:
             - Range: 0xd03ae0..0xd03b1b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
@@ -10837,7 +10960,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 351 GoSliceHeaderType []go.shape.float64
+          Type: 355 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xd03ae0..0xd03bdc
               Pieces: []
@@ -10854,7 +10977,7 @@ Subprograms:
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 351 GoSliceHeaderType []go.shape.float64
+          Type: 355 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xd03b1b..0xd03b39
               Pieces:
@@ -10915,7 +11038,7 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 353 BaseType go.shape.float64
+          Type: 357 BaseType go.shape.float64
           Locations:
             - Range: 0xd03b6b..0xd03b79
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
@@ -10924,7 +11047,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 189
+    - ID: 192
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd092c0..0xd09322]
       InlinePCRanges:
@@ -10955,7 +11078,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 193
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10963,7 +11086,7 @@ Subprograms:
           RootRanges: [0xd09500..0xd095c5]
       Variables: []
       DictRegister: null
-    - ID: 191
+    - ID: 194
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10971,7 +11094,7 @@ Subprograms:
           RootRanges: [0xd09660..0xd0976e]
       Variables: []
       DictRegister: null
-    - ID: 192
+    - ID: 195
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10979,7 +11102,7 @@ Subprograms:
           RootRanges: [0xd09660..0xd0976e]
       Variables: []
       DictRegister: null
-    - ID: 193
+    - ID: 196
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10994,7 +11117,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 194
+    - ID: 197
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11013,15 +11136,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 195
+    - ID: 198
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xd099a0..0xd09a11]
       InlinePCRanges:
-        - Ranges: [0xd13023..0xd13065]
-          RootRanges: [0xd13000..0xd13096]
+        - Ranges: [0xd131a3..0xd131e5]
+          RootRanges: [0xd13180..0xd13216]
       Variables:
         - Name: b
-          Type: 355 StructureType main.firstBehavior
+          Type: 359 StructureType main.firstBehavior
           Locations:
             - Range: 0xd099a0..0xd099c8
               Pieces:
@@ -11053,7 +11176,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 196
+    - ID: 199
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11065,31 +11188,31 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1201
+      ID: 1202
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 382 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 134
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 135 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1206
+      ID: 1207
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1207 PointerType *main.deepSlice3
+      Pointee: 1208 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1235
+      ID: 1236
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1236 PointerType *main.deepSlice8
+      Pointee: 1237 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1241
+      ID: 1242
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1242 PointerType *main.deepSlice9
+      Pointee: 1243 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 150
       Name: '**main.stringType2'
@@ -11097,7 +11220,7 @@ Types:
       GoKind: 22
       Pointee: 151 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1186
+      ID: 1197
       Name: '**main.t'
       ByteSize: 8
       Pointee: 250 PointerType *main.t
@@ -11109,145 +11232,145 @@ Types:
       GoKind: 22
       Pointee: 90 PointerType *string
     - __kind: PointerType
-      ID: 1204
+      ID: 1205
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1203 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1204 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 423
+      ID: 424
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 422 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 423 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1210
+      ID: 1211
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1209 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1210 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1239
+      ID: 1240
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1238 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1239 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1245
+      ID: 1246
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1244 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1245 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 420
+      ID: 421
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 419 GoSliceDataType []*string.array
+      Pointee: 420 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 489
+      ID: 490
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 488 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 285
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 282 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 487
+      ID: 488
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 486 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 283
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 280 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 485
+      ID: 486
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 484 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 281
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 278 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 483
+      ID: 484
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 482 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 279
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 276 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 481
+      ID: 482
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 480 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 469
+      ID: 470
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 468 GoSliceDataType [][]uint.array
+      Pointee: 469 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 473
+      ID: 474
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 472 GoSliceDataType []bool.array
+      Pointee: 473 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 980
+      ID: 991
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 979 GoSliceDataType []float64.array
+      Pointee: 990 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 520
+      ID: 527
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 519 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 526 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 528
+      ID: 535
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 527 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 534 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 509
+      ID: 516
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 508 GoSliceDataType []go.shape.float64.array
+      Pointee: 515 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 505
+      ID: 512
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 504 GoSliceDataType []go.shape.int.array
+      Pointee: 511 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 507
+      ID: 514
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 506 GoSliceDataType []go.shape.string.array
+      Pointee: 513 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
-      ID: 1248
+      ID: 1249
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1247 GoSliceDataType []interface {}.array
+      Pointee: 1248 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 277
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 274 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 479
+      ID: 480
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 478 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 479 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 530
+      ID: 537
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 529 GoSliceDataType []main.structWithMap.array
+      Pointee: 536 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 471
+      ID: 472
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 470 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 471 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11256,111 +11379,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 431
+      ID: 432
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 430 GoSliceDataType []string.array
+      Pointee: 431 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 477
+      ID: 478
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 476 GoSliceDataType []struct {}.array
+      Pointee: 477 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 1197
+      ID: 539
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 1196 GoSliceDataType []time.zone.array
+      Pointee: 538 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 1199
+      ID: 541
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 1198 GoSliceDataType []time.zoneTrans.array
+      Pointee: 540 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 261
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 259 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 467
+      ID: 468
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 466 GoSliceDataType []uint.array
+      Pointee: 467 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 475
+      ID: 476
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 474 GoSliceDataType []uint16.array
+      Pointee: 475 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 416
+      ID: 417
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 415 GoSliceDataType []uint8.array
+      Pointee: 416 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 418
+      ID: 419
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 417 GoSliceDataType []uintptr.array
+      Pointee: 418 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1105
+      ID: 1116
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1858080
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1117 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 760
+      ID: 771
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 861792
       GoKind: 22
-      Pointee: 761 GoSliceHeaderType archive/tar.headerError
+      Pointee: 772 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 763
+      ID: 774
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 762 GoSliceDataType archive/tar.headerError.array
+      Pointee: 773 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1045
+      ID: 1056
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1259264
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1057 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 993
+      ID: 1004
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 861984
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1005 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 995
+      ID: 1006
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 862080
       GoKind: 22
-      Pointee: 996 StructureType archive/zip.dirWriter
+      Pointee: 1007 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1092
+      ID: 1103
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1782368
       GoKind: 22
-      Pointee: 1093 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1104 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1021
+      ID: 1032
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1021248
       GoKind: 22
-      Pointee: 1022 StructureType archive/zip.nopCloser
+      Pointee: 1033 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1023
+      ID: 1034
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1021504
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1035 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -11389,40 +11512,40 @@ Types:
       ByteSize: 8
       Pointee: 204 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 373
+      ID: 377
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 374 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 378 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
       ID: 142
       Name: '*bucket<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 143 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1214
+      ID: 1215
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1215 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1252
+      ID: 1253
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1253 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1254 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1261
+      ID: 1262
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1262 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1263 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 171
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 172 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 1270
+      ID: 1271
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 1271 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1272 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 238
       Name: '*bucket<int,struct {}>'
@@ -11434,10 +11557,10 @@ Types:
       ByteSize: 8
       Pointee: 209 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 524
+      ID: 531
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 525 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 198
       Name: '*bucket<string,[]main.structWithMap>'
@@ -11449,35 +11572,35 @@ Types:
       ByteSize: 8
       Pointee: 187 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 400
+      ID: 401
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 401 GoHMapBucketType bucket<string,float64>
+      Pointee: 402 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 949
+      ID: 960
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 950 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 181
       Name: '*bucket<string,int>'
       ByteSize: 8
       Pointee: 182 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 395
+      ID: 396
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 396 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 397 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
       ID: 176
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 177 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 390
+      ID: 391
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 391 GoHMapBucketType bucket<string,string>
+      Pointee: 392 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 233
       Name: '*bucket<struct {},int>'
@@ -11529,449 +11652,449 @@ Types:
       ByteSize: 8
       Pointee: 214 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 1069
+      ID: 1080
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2039264
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType bufio.Reader
+      Pointee: 1081 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1096
+      ID: 1107
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1824576
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType bufio.Writer
+      Pointee: 1108 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1141
+      ID: 1152
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2132224
       GoKind: 22
-      Pointee: 1142 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1153 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 671
+      ID: 682
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 844320
       GoKind: 22
-      Pointee: 568 BaseType compress/flate.CorruptInputError
+      Pointee: 579 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 672
+      ID: 683
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 844416
       GoKind: 22
-      Pointee: 569 GoStringHeaderType compress/flate.InternalError
+      Pointee: 580 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 571
+      ID: 582
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType compress/flate.InternalError.str
+      Pointee: 581 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1043
+      ID: 1054
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1249504
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1055 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 989
+      ID: 1000
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 844512
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1001 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1065
+      ID: 1076
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1609376
       GoKind: 22
-      Pointee: 1066 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1077 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1228
+      ID: 1229
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1370016
       GoKind: 22
-      Pointee: 366 StructureType context.backgroundCtx
+      Pointee: 370 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 356
+      ID: 360
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1606880
       GoKind: 22
-      Pointee: 357 StructureType context.cancelCtx
+      Pointee: 361 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 872
+      ID: 883
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1109984
       GoKind: 22
-      Pointee: 873 StructureType context.deadlineExceededError
+      Pointee: 884 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1223
+      ID: 1224
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1238304
       GoKind: 22
-      Pointee: 367 StructureType context.emptyCtx
+      Pointee: 371 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 358
+      ID: 362
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1238464
       GoKind: 22
-      Pointee: 359 StructureType context.stopCtx
+      Pointee: 363 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 360
+      ID: 364
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1607072
       GoKind: 22
-      Pointee: 361 StructureType context.timerCtx
+      Pointee: 365 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1229
+      ID: 1230
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1370176
       GoKind: 22
-      Pointee: 381 StructureType context.todoCtx
+      Pointee: 382 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 362
+      ID: 366
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1369696
       GoKind: 22
-      Pointee: 363 StructureType context.valueCtx
+      Pointee: 367 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 364
+      ID: 368
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1369856
       GoKind: 22
-      Pointee: 365 StructureType context.withoutCancelCtx
+      Pointee: 369 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 753
+      ID: 764
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 856704
       GoKind: 22
-      Pointee: 582 BaseType crypto/aes.KeySizeError
+      Pointee: 593 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 754
+      ID: 765
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 856896
       GoKind: 22
-      Pointee: 583 BaseType crypto/des.KeySizeError
+      Pointee: 594 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 1055
+      ID: 1066
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1380896
       GoKind: 22
-      Pointee: 1056 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 1067 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 1080
+      ID: 1091
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1687776
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1092 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 755
+      ID: 766
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 857184
       GoKind: 22
-      Pointee: 584 BaseType crypto/rc4.KeySizeError
+      Pointee: 595 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1088
+      ID: 1099
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1779552
       GoKind: 22
-      Pointee: 1089 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1100 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1082
+      ID: 1093
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1688448
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 1094 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 1084
+      ID: 1095
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1688896
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 1096 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 677
+      ID: 688
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 845952
       GoKind: 22
-      Pointee: 572 BaseType crypto/tls.AlertError
+      Pointee: 583 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 844
+      ID: 855
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1008832
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 856 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1167
+      ID: 1178
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2241344
       GoKind: 22
-      Pointee: 1168 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1179 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 675
+      ID: 686
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 687 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 673
+      ID: 684
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 22
-      Pointee: 674 StructureType crypto/tls.RecordHeaderError
+      Pointee: 685 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 843
+      ID: 854
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1007168
       GoKind: 22
-      Pointee: 800 BaseType crypto/tls.alert
+      Pointee: 811 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1053
+      ID: 1064
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1378016
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1065 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1060
+      ID: 1071
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1458176
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1072 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 939
+      ID: 950
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1249824
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 951 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 951
+      ID: 962
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1915232
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 963 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 747
+      ID: 758
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 855552
       GoKind: 22
-      Pointee: 748 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 759 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 741
+      ID: 752
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 855072
       GoKind: 22
-      Pointee: 742 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 753 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 743
+      ID: 754
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 855168
       GoKind: 22
-      Pointee: 744 StructureType crypto/x509.HostnameError
+      Pointee: 755 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 740
+      ID: 751
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 854976
       GoKind: 22
-      Pointee: 581 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 592 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 849
+      ID: 860
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1014720
       GoKind: 22
-      Pointee: 850 StructureType crypto/x509.SystemRootsError
+      Pointee: 861 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 749
+      ID: 760
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 855648
       GoKind: 22
-      Pointee: 750 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 761 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 745
+      ID: 756
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 855456
       GoKind: 22
-      Pointee: 746 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 757 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 764
+      ID: 775
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 862272
       GoKind: 22
-      Pointee: 765 StructureType encoding/asn1.StructuralError
+      Pointee: 776 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 768
+      ID: 779
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 862464
       GoKind: 22
-      Pointee: 769 StructureType encoding/asn1.SyntaxError
+      Pointee: 780 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 766
+      ID: 777
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 862368
       GoKind: 22
-      Pointee: 767 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 778 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 665
+      ID: 676
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 842016
       GoKind: 22
-      Pointee: 566 BaseType encoding/base64.CorruptInputError
+      Pointee: 577 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1011
+      ID: 1022
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1003328
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1023 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 668
+      ID: 679
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 842880
       GoKind: 22
-      Pointee: 567 BaseType encoding/hex.InvalidByteError
+      Pointee: 578 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 636
+      ID: 647
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 648 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 835
+      ID: 846
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 998976
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 847 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 628
+      ID: 639
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 836352
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 640 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 634
+      ID: 645
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 646 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 632
+      ID: 643
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 836544
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 644 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 630
+      ID: 641
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 836448
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 642 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1147
+      ID: 1158
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2157792
       GoKind: 22
-      Pointee: 1148 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1159 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 638
+      ID: 649
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 639 StructureType encoding/json.jsonError
+      Pointee: 650 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1019
+      ID: 1030
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1017792
       GoKind: 22
-      Pointee: 1020 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1031 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 735
+      ID: 746
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 854016
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 747 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 733
+      ID: 744
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 853920
       GoKind: 22
-      Pointee: 734 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 745 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 737
+      ID: 748
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 854112
       GoKind: 22
-      Pointee: 578 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 589 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 580
+      ID: 591
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 579 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 590 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 738
+      ID: 749
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 854208
       GoKind: 22
-      Pointee: 739 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 750 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1125
+      ID: 1136
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2027744
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1137 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -11980,19 +12103,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 606
+      ID: 617
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 827712
       GoKind: 22
-      Pointee: 607 UnresolvedPointeeType errors.errorString
+      Pointee: 618 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 802
+      ID: 813
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 984512
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType errors.joinError
+      Pointee: 814 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -12008,906 +12131,906 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 1135
+      ID: 1146
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2123520
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType fmt.pp
+      Pointee: 1147 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 804
+      ID: 815
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 984640
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType fmt.wrapError
+      Pointee: 816 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 806
+      ID: 817
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 984768
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 818 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 666
+      ID: 677
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 842400
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 678 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 647
+      ID: 658
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 839520
       GoKind: 22
-      Pointee: 648 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 659 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 649
+      ID: 660
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 839616
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 661 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 963
+      ID: 974
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 839328
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 975 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 653
+      ID: 664
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 839904
       GoKind: 22
-      Pointee: 654 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 665 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 965
+      ID: 976
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 839424
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 977 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 651
+      ID: 662
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 839712
       GoKind: 22
-      Pointee: 560 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 571 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 562
+      ID: 573
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 561 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 646
+      ID: 657
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 839232
       GoKind: 22
-      Pointee: 557 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 568 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 559
+      ID: 570
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 652
+      ID: 663
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 839808
       GoKind: 22
-      Pointee: 563 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 574 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 565
+      ID: 576
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1033
+      ID: 1044
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1128288
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1045 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1113
+      ID: 1124
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1929920
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1125 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 758
+      ID: 769
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 860736
       GoKind: 22
-      Pointee: 759 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 770 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 382
+      ID: 383
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2142464
       GoKind: 22
-      Pointee: 383 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 384 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 408
+      ID: 409
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1879840
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 403
+      ID: 404
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1110240
       GoKind: 22
-      Pointee: 404 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 405 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 406
+      ID: 407
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1110368
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 408 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1221
+      ID: 1222
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1111008
       GoKind: 22
-      Pointee: 1222 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1223 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 532
+      ID: 543
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1111136
       GoKind: 22
-      Pointee: 533 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 544 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 410
+      ID: 411
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2089344
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 907
+      ID: 918
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1131616
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 919 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1143
+      ID: 1154
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2133760
       GoKind: 22
-      Pointee: 1144 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1155 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1224
+      ID: 1225
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1243744
       GoKind: 22
-      Pointee: 1225 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 1226 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 684
+      ID: 695
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 696 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 691
+      ID: 702
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 850560
       GoKind: 22
-      Pointee: 692 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 703 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 686
+      ID: 697
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 850272
       GoKind: 22
-      Pointee: 577 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 588 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 689
+      ID: 700
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 850464
       GoKind: 22
-      Pointee: 690 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 701 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 687
+      ID: 698
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 850368
       GoKind: 22
-      Pointee: 688 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 699 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 707
+      ID: 718
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 852480
       GoKind: 22
-      Pointee: 708 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 719 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 711
+      ID: 722
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 852672
       GoKind: 22
-      Pointee: 712 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 723 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 709
+      ID: 720
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 852576
       GoKind: 22
-      Pointee: 710 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 721 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 705
+      ID: 716
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 852384
       GoKind: 22
-      Pointee: 706 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 717 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 982
+      ID: 993
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 981 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 992 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 719
+      ID: 730
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 853056
       GoKind: 22
-      Pointee: 720 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 731 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 713
+      ID: 724
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 852768
       GoKind: 22
-      Pointee: 714 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 725 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 717
+      ID: 728
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 852960
       GoKind: 22
-      Pointee: 718 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 729 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 715
+      ID: 726
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 852864
       GoKind: 22
-      Pointee: 716 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 727 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 721
+      ID: 732
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 853152
       GoKind: 22
-      Pointee: 722 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 733 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 727
+      ID: 738
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 853440
       GoKind: 22
-      Pointee: 728 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 739 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 729
+      ID: 740
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 853536
       GoKind: 22
-      Pointee: 730 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 741 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 725
+      ID: 736
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 853344
       GoKind: 22
-      Pointee: 726 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 737 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 723
+      ID: 734
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 853248
       GoKind: 22
-      Pointee: 724 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 735 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 731
+      ID: 742
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 732 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 743 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 655
+      ID: 666
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 656 StructureType github.com/cihub/seelog.baseError
+      Pointee: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1072
+      ID: 1083
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1684864
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1084 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 657
+      ID: 668
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 658 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 669 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1051
+      ID: 1062
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1376416
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1063 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1007
+      ID: 1018
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1002304
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1019 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1041
+      ID: 1052
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1247424
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1053 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 661
+      ID: 672
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 841344
       GoKind: 22
-      Pointee: 662 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 673 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1103
+      ID: 1114
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1847712
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1115 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1118
+      ID: 1129
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2002400
       GoKind: 22
-      Pointee: 1115 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1126 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1117
+      ID: 1128
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2002016
       GoKind: 22
-      Pointee: 1116 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1127 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1009
+      ID: 1020
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1002432
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1021 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 659
+      ID: 670
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 841248
       GoKind: 22
-      Pointee: 660 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 671 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 663
+      ID: 674
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 841440
       GoKind: 22
-      Pointee: 664 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 675 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1076
+      ID: 1087
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1686432
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1088 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1109
+      ID: 1120
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1884160
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1121 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1111
+      ID: 1122
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1914912
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1123 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 941
+      ID: 952
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1261664
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 953 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 857
+      ID: 868
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1029184
       GoKind: 22
-      Pointee: 858 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 869 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 855
+      ID: 866
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1029056
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 867 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 859
+      ID: 870
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1033152
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 871 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 861
+      ID: 872
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1033280
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 873 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1062
+      ID: 1073
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1486208
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1074 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 851
+      ID: 862
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1015488
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 863 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 669
+      ID: 680
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 843072
       GoKind: 22
-      Pointee: 670 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 681 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1159
+      ID: 1170
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2220448
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1171 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 915
+      ID: 926
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1140576
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 927 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 884
+      ID: 895
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1118816
       GoKind: 22
-      Pointee: 885 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 896 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 878
+      ID: 889
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1118432
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 890 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 821
+      ID: 832
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 993088
       GoKind: 22
-      Pointee: 822 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 833 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 890
+      ID: 901
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1119200
       GoKind: 22
-      Pointee: 891 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 902 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 820
+      ID: 831
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 992960
       GoKind: 22
-      Pointee: 799 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 810 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 882
+      ID: 893
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1118688
       GoKind: 22
-      Pointee: 883 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 894 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 880
+      ID: 891
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1118560
       GoKind: 22
-      Pointee: 881 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 892 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 888
+      ID: 899
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1119072
       GoKind: 22
-      Pointee: 889 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 900 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 886
+      ID: 897
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1118944
       GoKind: 22
-      Pointee: 887 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 898 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1163
+      ID: 1174
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2231488
       GoKind: 22
-      Pointee: 1164 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1175 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 894
+      ID: 905
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1119584
       GoKind: 22
-      Pointee: 895 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 906 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 825
+      ID: 836
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 993344
       GoKind: 22
-      Pointee: 826 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 837 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 823
+      ID: 834
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 993216
       GoKind: 22
-      Pointee: 824 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 835 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 892
+      ID: 903
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1119456
       GoKind: 22
-      Pointee: 893 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 904 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 780
+      ID: 791
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 874368
       GoKind: 22
-      Pointee: 589 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 600 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 591
+      ID: 602
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 590 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 601 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 352
+      ID: 356
       Name: '*go.shape.float64'
       ByteSize: 8
       GoRuntimeType: 450304
       GoKind: 22
-      Pointee: 353 BaseType go.shape.float64
+      Pointee: 357 BaseType go.shape.float64
     - __kind: PointerType
-      ID: 328
+      ID: 332
       Name: '*go.shape.int'
       ByteSize: 8
       GoRuntimeType: 449920
       GoKind: 22
-      Pointee: 323 BaseType go.shape.int
+      Pointee: 327 BaseType go.shape.int
     - __kind: PointerType
-      ID: 345
+      ID: 349
       Name: '*go.shape.string'
       ByteSize: 8
       GoRuntimeType: 449984
       GoKind: 22
-      Pointee: 325 GoStringHeaderType go.shape.string
+      Pointee: 329 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 503
+      ID: 510
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 502 GoStringDataType go.shape.string.str
+      Pointee: 509 GoStringDataType go.shape.string.str
     - __kind: PointerType
-      ID: 331
+      ID: 335
       Name: '*go.shape.struct { Name string }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 332 StructureType go.shape.struct { Name string }
+      Pointee: 336 StructureType go.shape.struct { Name string }
     - __kind: PointerType
-      ID: 333
+      ID: 337
       Name: '*go.shape.struct { X int; Y int }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 334 StructureType go.shape.struct { X int; Y int }
+      Pointee: 338 StructureType go.shape.struct { X int; Y int }
     - __kind: PointerType
-      ID: 346
+      ID: 350
       Name: '*go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 347 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+      Pointee: 351 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 954
+      ID: 965
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1484672
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 966 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 865
+      ID: 876
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1048128
       GoKind: 22
-      Pointee: 866 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 877 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1039
+      ID: 1050
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1179616
       GoKind: 22
-      Pointee: 1040 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1051 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1123
+      ID: 1134
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2017376
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1135 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1025
+      ID: 1036
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1050432
       GoKind: 22
-      Pointee: 1026 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1037 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 781
+      ID: 792
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 875616
       GoKind: 22
-      Pointee: 592 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 603 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 923
+      ID: 934
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1181280
       GoKind: 22
-      Pointee: 924 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 935 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 784
+      ID: 795
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 875904
       GoKind: 22
-      Pointee: 785 StructureType golang.org/x/net/http2.connError
+      Pointee: 796 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 783
+      ID: 794
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 875808
       GoKind: 22
-      Pointee: 596 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 607 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 598
+      ID: 609
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 597 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 608 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 787
+      ID: 798
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 876096
       GoKind: 22
-      Pointee: 602 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 613 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 604
+      ID: 615
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 603 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 614 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 786
+      ID: 797
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 876000
       GoKind: 22
-      Pointee: 599 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 610 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 601
+      ID: 612
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 600 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 611 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 782
+      ID: 793
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 875712
       GoKind: 22
-      Pointee: 593 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 604 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 595
+      ID: 606
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 594 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 605 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1121
+      ID: 1132
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2015456
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1133 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 788
+      ID: 799
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 876192
       GoKind: 22
-      Pointee: 789 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 800 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 790
+      ID: 801
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 876288
       GoKind: 22
-      Pointee: 605 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 616 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 776
+      ID: 787
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 869760
       GoKind: 22
-      Pointee: 777 StructureType google.golang.org/grpc.dropError
+      Pointee: 788 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 921
+      ID: 932
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1178208
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 933 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 943
+      ID: 954
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1269024
       GoKind: 22
-      Pointee: 944 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 955 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 778
+      ID: 789
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 872640
       GoKind: 22
-      Pointee: 779 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 790 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1086
+      ID: 1097
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1693376
       GoKind: 22
-      Pointee: 1087 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1098 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1037
+      ID: 1048
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1174752
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1049 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 863
+      ID: 874
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1042368
       GoKind: 22
-      Pointee: 864 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 875 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 997
+      ID: 1008
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 872736
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1009 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 756
+      ID: 767
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 858624
       GoKind: 22
-      Pointee: 757 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 768 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 853
+      ID: 864
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1019200
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 865 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 919
+      ID: 930
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1146464
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 931 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 917
+      ID: 928
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1146208
       GoKind: 22
-      Pointee: 918 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 929 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 770
+      ID: 781
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 863328
       GoKind: 22
-      Pointee: 771 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 782 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 772
+      ID: 783
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 863424
       GoKind: 22
-      Pointee: 773 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 784 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 699
+      ID: 710
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 850944
       GoKind: 22
-      Pointee: 700 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 711 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1074
+      ID: 1085
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1685536
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1086 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 226
       Name: '*hash<[4]int,[4]int>'
@@ -12929,40 +13052,40 @@ Types:
       ByteSize: 8
       Pointee: 202 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 371
+      ID: 375
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 372 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 376 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
       ID: 140
       Name: '*hash<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 141 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1212
+      ID: 1213
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1213 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1214 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1250
+      ID: 1251
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1251 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1252 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1259
+      ID: 1260
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1260 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1261 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 169
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 170 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 1268
+      ID: 1269
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 1269 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1270 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 236
       Name: '*hash<int,struct {}>'
@@ -12974,10 +13097,10 @@ Types:
       ByteSize: 8
       Pointee: 207 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 522
+      ID: 529
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 523 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 530 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 196
       Name: '*hash<string,[]main.structWithMap>'
@@ -12989,35 +13112,35 @@ Types:
       ByteSize: 8
       Pointee: 185 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 399 GoHMapHeaderType hash<string,float64>
+      Pointee: 400 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 947
+      ID: 958
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 948 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 959 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 179
       Name: '*hash<string,int>'
       ByteSize: 8
       Pointee: 180 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 393
+      ID: 394
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 394 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 395 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
       ID: 174
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 175 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 388
+      ID: 389
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 389 GoHMapHeaderType hash<string,string>
+      Pointee: 390 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 231
       Name: '*hash<struct {},int>'
@@ -13069,12 +13192,12 @@ Types:
       ByteSize: 8
       Pointee: 212 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 791
+      ID: 802
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 877056
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType html/template.Error
+      Pointee: 803 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 95
       Name: '*int'
@@ -13118,94 +13241,94 @@ Types:
       GoKind: 22
       Pointee: 159 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 751
+      ID: 762
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 856224
       GoKind: 22
-      Pointee: 752 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 763 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 987
+      ID: 998
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 843456
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 999 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 913
+      ID: 924
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1132768
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 925 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1165
+      ID: 1176
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2236160
       GoKind: 22
-      Pointee: 1166 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1177 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 911
+      ID: 922
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1132640
       GoKind: 22
-      Pointee: 912 StructureType internal/poll.errNetClosing
+      Pointee: 923 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 611
+      ID: 622
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 831840
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 623 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1029
+      ID: 1040
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1109728
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1041 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1027
+      ID: 1038
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1109344
       GoKind: 22
-      Pointee: 1028 StructureType io.discard
+      Pointee: 1039 StructureType io.discard
     - __kind: PointerType
-      ID: 1001
+      ID: 1012
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 985536
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType io.multiWriter
+      Pointee: 1013 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 909
+      ID: 920
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1132384
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType io/fs.PathError
+      Pointee: 921 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1078
+      ID: 1089
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1686656
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1090 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 338
+      ID: 342
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 339 StructureType main.Pair[go.shape.int,go.shape.bool]
+      Pointee: 343 StructureType main.Pair[go.shape.int,go.shape.bool]
     - __kind: PointerType
-      ID: 341
+      ID: 345
       Name: '*main.Pair[go.shape.string,go.shape.int]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 342 StructureType main.Pair[go.shape.string,go.shape.int]
+      Pointee: 346 StructureType main.Pair[go.shape.string,go.shape.int]
     - __kind: PointerType
       ID: 318
       Name: '*main.anotherStruct'
@@ -13213,19 +13336,19 @@ Types:
       GoKind: 22
       Pointee: 319 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 427
+      ID: 428
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 357952
       GoKind: 22
-      Pointee: 428 StructureType main.deepMap2
+      Pointee: 429 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1217
+      ID: 1218
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 357888
       GoKind: 22
-      Pointee: 1218 UnresolvedPointeeType main.deepMap3
+      Pointee: 1219 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 146
       Name: '*main.deepMap7'
@@ -13234,19 +13357,19 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1255
+      ID: 1256
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 357568
       GoKind: 22
-      Pointee: 1256 StructureType main.deepMap8
+      Pointee: 1257 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1264
+      ID: 1265
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 357504
       GoKind: 22
-      Pointee: 1265 StructureType main.deepMap9
+      Pointee: 1266 StructureType main.deepMap9
     - __kind: PointerType
       ID: 128
       Name: '*main.deepPtr2'
@@ -13255,12 +13378,12 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1169
+      ID: 1180
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 358464
       GoKind: 22
-      Pointee: 1170 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1181 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 130
       Name: '*main.deepPtr7'
@@ -13269,33 +13392,33 @@ Types:
       GoKind: 22
       Pointee: 131 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1230
+      ID: 1231
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 358144
       GoKind: 22
-      Pointee: 1231 StructureType main.deepPtr8
+      Pointee: 1232 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1232
+      ID: 1233
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 358080
       GoKind: 22
-      Pointee: 1233 StructureType main.deepPtr9
+      Pointee: 1234 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 135
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 359104
       GoKind: 22
-      Pointee: 421 StructureType main.deepSlice2
+      Pointee: 422 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1207
+      ID: 1208
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 359040
       GoKind: 22
-      Pointee: 1208 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1209 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 136
       Name: '*main.deepSlice7'
@@ -13304,19 +13427,19 @@ Types:
       GoKind: 22
       Pointee: 137 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1236
+      ID: 1237
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 358720
       GoKind: 22
-      Pointee: 1237 StructureType main.deepSlice8
+      Pointee: 1238 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1242
+      ID: 1243
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 358656
       GoKind: 22
-      Pointee: 1243 StructureType main.deepSlice9
+      Pointee: 1244 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 322
       Name: '*main.emptyStruct'
@@ -13331,14 +13454,14 @@ Types:
       GoKind: 22
       Pointee: 162 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1183
+      ID: 1194
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 827424
       GoKind: 22
-      Pointee: 355 StructureType main.firstBehavior
+      Pointee: 359 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1273
+      ID: 1274
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 359488
@@ -13364,19 +13487,19 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1184
+      ID: 1195
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 827520
       GoKind: 22
-      Pointee: 1185 StructureType main.secondBehavior
+      Pointee: 1196 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1175
+      ID: 1186
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 827616
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1187 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 148
       Name: '*main.stringType1'
@@ -13384,28 +13507,28 @@ Types:
       GoKind: 22
       Pointee: 149 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1172
+      ID: 1183
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1171 GoStringDataType main.stringType1.str
+      Pointee: 1182 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1173 GoStringHeaderType main.stringType2
+      Pointee: 1184 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1275
+      ID: 1276
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1274 GoStringDataType main.stringType2.str
+      Pointee: 1275 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 275
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 273 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 446
+      ID: 447
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 357440
@@ -13429,10 +13552,10 @@ Types:
       GoKind: 22
       Pointee: 251 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1188
+      ID: 1199
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1187 GoSliceDataType main.t.array
+      Pointee: 1198 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 270
       Name: '*main.threeStringStruct'
@@ -13446,561 +13569,561 @@ Types:
       GoKind: 22
       Pointee: 178 GoMapType map[string]int
     - __kind: PointerType
-      ID: 703
+      ID: 714
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 851808
       GoKind: 22
-      Pointee: 704 StructureType math/big.ErrNaN
+      Pointee: 715 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 991
+      ID: 1002
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 846432
       GoKind: 22
-      Pointee: 992 StructureType mime/multipart.writerOnly·1
+      Pointee: 1003 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 901
+      ID: 912
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1125856
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType net.AddrError
+      Pointee: 913 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 932
+      ID: 943
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1245664
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType net.DNSError
+      Pointee: 944 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1129
+      ID: 1140
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2095712
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType net.IPConn
+      Pointee: 1141 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 930
+      ID: 941
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1245344
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType net.OpError
+      Pointee: 942 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 903
+      ID: 914
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1125984
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType net.ParseError
+      Pointee: 915 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1139
+      ID: 1150
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2125568
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType net.TCPConn
+      Pointee: 1151 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1149
+      ID: 1160
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2170528
       GoKind: 22
-      Pointee: 1150 UnresolvedPointeeType net.UDPConn
+      Pointee: 1161 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1137
+      ID: 1148
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2125056
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType net.UnixConn
+      Pointee: 1149 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 900
+      ID: 911
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1125088
       GoKind: 22
-      Pointee: 869 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 880 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 871
+      ID: 882
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 870 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 881 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 837
+      ID: 848
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 999744
       GoKind: 22
-      Pointee: 838 StructureType net.canceledError
+      Pointee: 849 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1107
+      ID: 1118
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1881856
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType net.conn
+      Pointee: 1119 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 972
+      ID: 983
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1725184
       GoKind: 22
-      Pointee: 973 StructureType net.dialResult·1
+      Pointee: 984 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1151
+      ID: 1162
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2174784
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType net.netFD
+      Pointee: 1163 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 640
+      ID: 651
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 838080
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType net.notFoundError
+      Pointee: 652 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1226
+      ID: 1227
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1245504
       GoKind: 22
-      Pointee: 1227 StructureType net.onlyValuesCtx
+      Pointee: 1228 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 642
+      ID: 653
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 838752
       GoKind: 22
-      Pointee: 643 StructureType net.result·2
+      Pointee: 654 StructureType net.result·2
     - __kind: PointerType
-      ID: 1133
+      ID: 1144
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2110080
       GoKind: 22
-      Pointee: 1134 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1145 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1131
+      ID: 1142
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2109600
       GoKind: 22
-      Pointee: 1132 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1143 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 905
+      ID: 916
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1126624
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType net.temporaryError
+      Pointee: 917 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 934
+      ID: 945
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1245824
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType net.timeoutError
+      Pointee: 946 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 827
+      ID: 838
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 995776
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 839 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 983
+      ID: 994
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 833952
       GoKind: 22
-      Pointee: 984 StructureType net/http.bufioFlushWriter
+      Pointee: 995 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 617
+      ID: 628
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 834624
       GoKind: 22
-      Pointee: 538 BaseType net/http.http2ConnectionError
+      Pointee: 549 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 618
+      ID: 629
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 834720
       GoKind: 22
-      Pointee: 619 StructureType net/http.http2GoAwayError
+      Pointee: 630 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 926
+      ID: 937
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1241824
       GoKind: 22
-      Pointee: 927 StructureType net/http.http2StreamError
+      Pointee: 938 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 622
+      ID: 633
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 835200
       GoKind: 22
-      Pointee: 623 StructureType net/http.http2connError
+      Pointee: 634 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1047
+      ID: 1058
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1373696
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1059 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 621
+      ID: 632
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 835104
       GoKind: 22
-      Pointee: 542 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 553 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 544
+      ID: 555
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 543 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 625
+      ID: 636
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 835392
       GoKind: 22
-      Pointee: 548 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 559 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 550
+      ID: 561
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 549 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 560 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 624
+      ID: 635
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 835296
       GoKind: 22
-      Pointee: 545 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 556 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 547
+      ID: 558
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 546 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 557 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 898
+      ID: 909
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1121760
       GoKind: 22
-      Pointee: 899 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 910 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 833
+      ID: 844
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 996416
       GoKind: 22
-      Pointee: 834 StructureType net/http.http2noCachedConnError
+      Pointee: 845 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1098
+      ID: 1109
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1825600
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1110 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 620
+      ID: 631
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 835008
       GoKind: 22
-      Pointee: 539 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 550 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 541
+      ID: 552
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 540 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 551 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 985
+      ID: 996
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 835488
       GoKind: 22
-      Pointee: 986 StructureType net/http.http2stickyErrWriter
+      Pointee: 997 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 829
+      ID: 840
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 996032
       GoKind: 22
-      Pointee: 830 StructureType net/http.nothingWrittenError
+      Pointee: 841 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1049
+      ID: 1060
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2040512
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1061 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1005
+      ID: 1016
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 995904
       GoKind: 22
-      Pointee: 1006 StructureType net/http.persistConnWriter
+      Pointee: 1017 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1031
+      ID: 1042
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1120736
       GoKind: 22
-      Pointee: 1032 StructureType net/http.readWriteCloserBody
+      Pointee: 1043 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 626
+      ID: 637
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 835584
       GoKind: 22
-      Pointee: 627 StructureType net/http.requestBodyReadError
+      Pointee: 638 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 928
+      ID: 939
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1242944
       GoKind: 22
-      Pointee: 929 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 940 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 896
+      ID: 907
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1121632
       GoKind: 22
-      Pointee: 897 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 908 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 831
+      ID: 842
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 996160
       GoKind: 22
-      Pointee: 832 StructureType net/http.transportReadFromServerError
+      Pointee: 843 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 615
+      ID: 626
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 627 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1100
+      ID: 1111
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1827392
       GoKind: 22
-      Pointee: 1101 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1112 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1015
+      ID: 1026
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1009856
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1027 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 695
+      ID: 706
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 696 StructureType net/netip.parseAddrError
+      Pointee: 707 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 693
+      ID: 704
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 22
-      Pointee: 694 StructureType net/netip.parsePrefixError
+      Pointee: 705 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1057
+      ID: 1068
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1990176
       GoKind: 22
-      Pointee: 1058 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1069 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1017
+      ID: 1028
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1014976
       GoKind: 22
-      Pointee: 1018 StructureType net/smtp.dataCloser
+      Pointee: 1029 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 679
+      ID: 690
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 846624
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType net/textproto.Error
+      Pointee: 691 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 678
+      ID: 689
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 846528
       GoKind: 22
-      Pointee: 573 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 584 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 575
+      ID: 586
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 574 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 585 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1013
+      ID: 1024
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1009216
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1025 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 936
+      ID: 947
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1246144
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net/url.Error
+      Pointee: 948 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 644
+      ID: 655
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 838848
       GoKind: 22
-      Pointee: 551 GoStringHeaderType net/url.EscapeError
+      Pointee: 562 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 553
+      ID: 564
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 552 GoStringDataType net/url.EscapeError.str
+      Pointee: 563 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 645
+      ID: 656
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 838944
       GoKind: 22
-      Pointee: 554 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 565 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 556
+      ID: 567
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 555 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 566 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 1157
+      ID: 1168
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2212032
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType os.File
+      Pointee: 1169 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 810
+      ID: 821
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 989376
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType os.LinkError
+      Pointee: 822 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 874
+      ID: 885
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1114336
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType os.SyscallError
+      Pointee: 886 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1155
+      ID: 1166
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2209088
       GoKind: 22
-      Pointee: 1156 StructureType os.fileWithoutReadFrom
+      Pointee: 1167 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1153
+      ID: 1164
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2208352
       GoKind: 22
-      Pointee: 1154 StructureType os.fileWithoutWriteTo
+      Pointee: 1165 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 839
+      ID: 850
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1005888
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType os/exec.Error
+      Pointee: 851 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 975
+      ID: 986
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1961440
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 987 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1035
+      ID: 1046
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1133408
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1047 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 841
+      ID: 852
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1006016
       GoKind: 22
-      Pointee: 842 StructureType os/exec.wrappedError
+      Pointee: 853 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 775
+      ID: 786
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 867840
       GoKind: 22
-      Pointee: 586 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 597 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 588
+      ID: 599
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 587 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 598 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 774
+      ID: 785
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 867744
       GoKind: 22
-      Pointee: 585 BaseType os/user.UnknownUserIdError
+      Pointee: 596 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 613
+      ID: 624
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 832608
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType reflect.ValueError
+      Pointee: 625 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 701
+      ID: 712
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 851424
       GoKind: 22
-      Pointee: 702 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 713 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 813
+      ID: 824
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 990272
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 825 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 818
+      ID: 829
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 992192
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 830 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14016,12 +14139,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 815
+      ID: 826
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 990400
       GoKind: 22
-      Pointee: 816 StructureType runtime.boundsError
+      Pointee: 827 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -14037,24 +14160,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 876
+      ID: 887
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1116640
       GoKind: 22
-      Pointee: 877 StructureType runtime.errorAddressString
+      Pointee: 888 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 812
+      ID: 823
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 990016
       GoKind: 22
-      Pointee: 793 GoStringHeaderType runtime.errorString
+      Pointee: 804 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 795
+      ID: 806
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 794 GoStringDataType runtime.errorString.str
+      Pointee: 805 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -14077,17 +14200,17 @@ Types:
       GoKind: 22
       Pointee: 145 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 817
+      ID: 828
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 991936
       GoKind: 22
-      Pointee: 796 GoStringHeaderType runtime.plainError
+      Pointee: 807 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 798
+      ID: 809
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 797 GoStringDataType runtime.plainError.str
+      Pointee: 808 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14110,12 +14233,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 808
+      ID: 819
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 988224
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType strconv.NumError
+      Pointee: 820 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -14124,104 +14247,104 @@ Types:
       GoKind: 22
       Pointee: 13 GoStringHeaderType string
     - __kind: PointerType
-      ID: 414
+      ID: 415
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 413 GoStringDataType string.str
+      Pointee: 414 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1094
+      ID: 1105
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1824064
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType strings.Builder
+      Pointee: 1106 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1003
+      ID: 1014
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 988352
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1015 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 999
+      ID: 1010
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 1000 StructureType struct { io.Writer }
+      Pointee: 1011 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 268
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 120 StructureType struct {}
     - __kind: PointerType
-      ID: 938
+      ID: 949
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1248384
       GoKind: 22
-      Pointee: 925 BaseType syscall.Errno
+      Pointee: 936 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 1127
+      ID: 1138
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2028128
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1139 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 867
+      ID: 878
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1051968
       GoKind: 22
-      Pointee: 868 StructureType text/template.ExecError
+      Pointee: 879 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 379
+      ID: 324
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1433600
       GoKind: 22
-      Pointee: 380 StructureType time.Location
+      Pointee: 325 StructureType time.Location
     - __kind: PointerType
-      ID: 609
+      ID: 620
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 830112
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType time.ParseError
+      Pointee: 621 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 376
+      ID: 380
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 989760
       GoKind: 22
-      Pointee: 377 StructureType time.Timer
+      Pointee: 381 StructureType time.Timer
     - __kind: PointerType
-      ID: 608
+      ID: 619
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 830016
       GoKind: 22
-      Pointee: 535 GoStringHeaderType time.fileSizeError
+      Pointee: 546 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 537
+      ID: 548
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType time.fileSizeError.str
+      Pointee: 547 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 1191
+      ID: 504
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 364800
       GoKind: 22
-      Pointee: 1192 StructureType time.zone
+      Pointee: 505 StructureType time.zone
     - __kind: PointerType
-      ID: 1194
+      ID: 507
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 364864
       GoKind: 22
-      Pointee: 1195 StructureType time.zoneTrans
+      Pointee: 508 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -14265,56 +14388,56 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 1090
+      ID: 1101
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1780832
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 1102 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 697
+      ID: 708
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 709 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1119
+      ID: 1130
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2004704
       GoKind: 22
-      Pointee: 1120 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1131 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 681
+      ID: 692
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 22
-      Pointee: 682 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 693 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 683
+      ID: 694
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 22
-      Pointee: 576 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 587 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 846
+      ID: 857
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1009600
       GoKind: 22
-      Pointee: 847 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 858 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 848
+      ID: 859
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1009728
       GoKind: 22
-      Pointee: 801 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 812 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1189
+      ID: 1200
       Name: <-chan time.Time
       GoRuntimeType: 546784
       GoKind: 18
@@ -14327,7 +14450,7 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 1548
+      ID: 1552
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14343,10 +14466,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 351 GoSliceHeaderType []go.shape.float64
+            Type: 355 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14356,10 +14479,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 351 GoSliceHeaderType []go.shape.float64
+            Type: 355 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14369,17 +14492,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 354 GoSubroutineType func(go.shape.float64) bool
+            Type: 358 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 1, name: pred}
+                  Variable: {subprogram: 191, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1553
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14389,17 +14512,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 351 GoSliceHeaderType []go.shape.float64
+            Type: 355 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 2, name: ~r0}
+                  Variable: {subprogram: 191, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1546
+      ID: 1550
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14415,10 +14538,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14428,10 +14551,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14441,17 +14564,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 329 GoSubroutineType func(go.shape.int) bool
+            Type: 333 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: pred}
+                  Variable: {subprogram: 172, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1551
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14461,20 +14584,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 2, name: ~r0}
+                  Variable: {subprogram: 172, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1604
+      ID: 1608
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1550
+      ID: 1554
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14490,10 +14613,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14503,10 +14626,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14516,17 +14639,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 330 GoSubroutineType func(go.shape.int) go.shape.string
+            Type: 334 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: f}
+                  Variable: {subprogram: 173, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1555
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14536,17 +14659,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 2, name: ~r0}
+                  Variable: {subprogram: 173, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1562
+      ID: 1566
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14565,10 +14688,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14578,10 +14701,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 338 PointerType *main.Pair[go.shape.int,go.shape.bool]
+            Type: 342 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: x}
+                  Variable: {subprogram: 179, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14591,10 +14714,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14604,20 +14727,20 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 340 BaseType go.shape.bool
+            Type: 344 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 2, name: v}
+                  Variable: {subprogram: 179, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1563
+      ID: 1567
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1564
+      ID: 1568
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14636,10 +14759,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -14649,10 +14772,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 341 PointerType *main.Pair[go.shape.string,go.shape.int]
+            Type: 345 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: x}
+                  Variable: {subprogram: 180, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14662,10 +14785,10 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -14675,20 +14798,20 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 2, name: v}
+                  Variable: {subprogram: 180, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1565
+      ID: 1569
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1602
+      ID: 1606
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14697,17 +14820,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 355 StructureType main.firstBehavior
+            Type: 359 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 0, name: b}
+                  Variable: {subprogram: 198, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1607
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14719,14 +14842,14 @@ Types:
             Type: 13 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 1, name: ~r0}
+                  Variable: {subprogram: 198, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1582
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14742,10 +14865,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14755,10 +14878,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14768,17 +14891,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1586
       Name: Probe[main.genericContains[go.shape.int]]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -14794,10 +14917,10 @@ Types:
           Offset: 17
           Kind: local
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14807,17 +14930,17 @@ Types:
           Offset: 41
           Kind: local
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1583
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14829,14 +14952,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 187, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1584
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14852,10 +14975,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -14865,10 +14988,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 348 GoSliceHeaderType []go.shape.string
+            Type: 352 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: haystack}
+                  Variable: {subprogram: 188, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14878,17 +15001,17 @@ Types:
           Offset: 57
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1587
       Name: Probe[main.genericContains[go.shape.string]]Line
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14898,17 +15021,17 @@ Types:
           Offset: 9
           Kind: local
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1585
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14920,14 +15043,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 2, name: ~r0}
+                  Variable: {subprogram: 188, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1578
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14937,10 +15060,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 345 PointerType *go.shape.string
+            Type: 349 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14950,17 +15073,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 345 PointerType *go.shape.string
+            Type: 349 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1575
+      ID: 1579
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14970,17 +15093,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: ~r0}
+                  Variable: {subprogram: 185, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1580
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14990,10 +15113,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 346 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 350 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15003,17 +15126,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 346 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 350 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1577
+      ID: 1581
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15023,17 +15146,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 347 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 351 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: ~r0}
+                  Variable: {subprogram: 186, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1574
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15043,10 +15166,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 343 StructureType go.shape.struct { main.i int }
+            Type: 347 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15056,17 +15179,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 343 StructureType go.shape.struct { main.i int }
+            Type: 347 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1575
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15078,14 +15201,14 @@ Types:
             Type: 13 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: ~r0}
+                  Variable: {subprogram: 183, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1576
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15095,10 +15218,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 344 StructureType go.shape.struct { main.s string }
+            Type: 348 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15108,17 +15231,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 344 StructureType go.shape.struct { main.s string }
+            Type: 348 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1577
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15130,14 +15253,14 @@ Types:
             Type: 13 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: ~r0}
+                  Variable: {subprogram: 184, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1552
+      ID: 1556
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15147,10 +15270,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 328 PointerType *go.shape.int
+            Type: 332 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15160,17 +15283,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 328 PointerType *go.shape.int
+            Type: 332 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1553
+      ID: 1557
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15180,17 +15303,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 PointerType *go.shape.int
+            Type: 332 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 174, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1554
+      ID: 1558
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15200,10 +15323,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 331 PointerType *go.shape.struct { Name string }
+            Type: 335 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15213,17 +15336,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 331 PointerType *go.shape.struct { Name string }
+            Type: 335 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1555
+      ID: 1559
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15233,17 +15356,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 331 PointerType *go.shape.struct { Name string }
+            Type: 335 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: ~r0}
+                  Variable: {subprogram: 175, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1556
+      ID: 1560
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15253,10 +15376,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 333 PointerType *go.shape.struct { X int; Y int }
+            Type: 337 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15266,17 +15389,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 333 PointerType *go.shape.struct { X int; Y int }
+            Type: 337 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1557
+      ID: 1561
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15286,17 +15409,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 333 PointerType *go.shape.struct { X int; Y int }
+            Type: 337 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: ~r0}
+                  Variable: {subprogram: 176, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1572
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15312,10 +15435,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15325,10 +15448,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15338,17 +15461,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: b}
+                  Variable: {subprogram: 182, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1573
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15364,10 +15487,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15377,17 +15500,17 @@ Types:
           Offset: 33
           Kind: return
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 3, name: ~r1}
+                  Variable: {subprogram: 182, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1566
+      ID: 1570
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15403,10 +15526,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15416,10 +15539,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15429,17 +15552,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 340 BaseType go.shape.bool
+            Type: 344 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: b}
+                  Variable: {subprogram: 181, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1571
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15455,10 +15578,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 340 BaseType go.shape.bool
+            Type: 344 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
@@ -15468,17 +15591,17 @@ Types:
           Offset: 18
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 3, name: ~r1}
+                  Variable: {subprogram: 181, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1560
+      ID: 1564
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15488,10 +15611,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 337 StructureType main.largeGenericType[go.shape.int]
+            Type: 341 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
@@ -15501,17 +15624,17 @@ Types:
           Offset: 145
           Kind: argument
           Expression:
-            Type: 337 StructureType main.largeGenericType[go.shape.int]
+            Type: 341 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1561
+      ID: 1565
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15521,17 +15644,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: ~r0}
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1562
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15541,10 +15664,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 335 StructureType main.largeGenericType[go.shape.string]
+            Type: 339 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
@@ -15554,17 +15677,17 @@ Types:
           Offset: 153
           Kind: argument
           Expression:
-            Type: 335 StructureType main.largeGenericType[go.shape.string]
+            Type: 339 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1559
+      ID: 1563
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15574,17 +15697,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: ~r0}
+                  Variable: {subprogram: 177, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1546
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15594,10 +15717,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15607,17 +15730,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1543
+      ID: 1547
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15627,17 +15750,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1548
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15647,10 +15770,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15660,17 +15783,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1545
+      ID: 1549
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15680,20 +15803,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15712,7 +15835,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1350
+      ID: 1351
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15744,7 +15867,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1351
+      ID: 1352
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15763,7 +15886,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1347
+      ID: 1348
       Name: Probe[main.testAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -15795,7 +15918,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1348
+      ID: 1349
       Name: Probe[main.testAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15814,7 +15937,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1479
+      ID: 1480
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15846,7 +15969,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1480
+      ID: 1481
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15865,7 +15988,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1294
+      ID: 1295
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -15897,7 +16020,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1292
+      ID: 1293
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -15929,7 +16052,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1290
+      ID: 1291
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -15961,7 +16084,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1359
+      ID: 1360
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -15993,7 +16116,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1291
+      ID: 1292
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16025,7 +16148,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1293
+      ID: 1294
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16057,7 +16180,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16089,7 +16212,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -16108,7 +16231,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1312
+      ID: 1313
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16140,10 +16263,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1313
+      ID: 1314
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1279
+      ID: 1280
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16175,7 +16298,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1276
+      ID: 1277
       Name: Probe[main.testByteArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16207,7 +16330,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1383
+      ID: 1384
       Name: Probe[main.testChannel]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16239,7 +16362,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testCombinedByte]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16297,7 +16420,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1378
+      ID: 1379
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       ExprStatusArraySize: 1
@@ -16329,7 +16452,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1379
+      ID: 1380
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -16374,7 +16497,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.testConflictingReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16406,7 +16529,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.testConflictingReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16438,7 +16561,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1391
+      ID: 1392
       Name: Probe[main.testCycle]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16470,7 +16593,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1319
+      ID: 1320
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16502,7 +16625,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1320
+      ID: 1321
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16534,7 +16657,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1315
+      ID: 1316
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16566,7 +16689,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1316
+      ID: 1317
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16598,7 +16721,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1317
+      ID: 1318
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16630,7 +16753,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1318
+      ID: 1319
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16662,7 +16785,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16720,7 +16843,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16752,7 +16875,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16784,7 +16907,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16816,7 +16939,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16848,7 +16971,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1314
+      ID: 1315
       Name: Probe[main.testErrorAtLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16906,7 +17029,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1349
+      ID: 1350
       Name: Probe[main.testError]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16938,7 +17061,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1331
+      ID: 1332
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16970,10 +17093,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1332
+      ID: 1333
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1329
+      ID: 1330
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -17005,10 +17128,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1330
+      ID: 1331
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1343
+      ID: 1344
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17040,7 +17163,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1345
+      ID: 1346
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17072,7 +17195,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1344
+      ID: 1345
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17091,7 +17214,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1341
+      ID: 1342
       Name: Probe[main.testFrameless]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17123,7 +17246,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1342
+      ID: 1343
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17142,7 +17265,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1333
+      ID: 1334
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17174,10 +17297,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1334
+      ID: 1335
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1337
+      ID: 1338
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17209,13 +17332,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1338
+      ID: 1339
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1594
+      ID: 1598
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1335
+      ID: 1336
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17273,28 +17396,28 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1336
+      ID: 1337
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1595
+      ID: 1599
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1596
+      ID: 1600
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1597
+      ID: 1601
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1598
+      ID: 1602
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1339
+      ID: 1340
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1340
+      ID: 1341
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1591
+      ID: 1595
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17306,7 +17429,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17319,14 +17442,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
+      ID: 1592
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17338,14 +17461,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1589
+      ID: 1593
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17357,14 +17480,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1594
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17376,7 +17499,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17389,14 +17512,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1597
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17408,7 +17531,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17421,17 +17544,17 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1596
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1599
+      ID: 1603
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17443,7 +17566,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17456,14 +17579,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1604
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17475,7 +17598,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17488,14 +17611,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1605
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17507,7 +17630,7 @@ Types:
             Type: 163 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
@@ -17520,14 +17643,14 @@ Types:
             Type: 163 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1282
+      ID: 1283
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17559,7 +17682,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1283
+      ID: 1284
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17591,7 +17714,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1284
+      ID: 1285
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17623,7 +17746,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1281
+      ID: 1282
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -17655,7 +17778,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1280
+      ID: 1281
       Name: Probe[main.testIntArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17687,7 +17810,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1346
+      ID: 1347
       Name: Probe[main.testInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17719,7 +17842,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -17751,7 +17874,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1478
+      ID: 1479
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17770,7 +17893,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17802,40 +17925,8 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1323
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1324
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
     - __kind: EventRootType
       ID: 1325
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -17869,7 +17960,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1483
+      ID: 1326
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -18109,7 +18232,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18128,7 +18251,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1327
+      ID: 1328
       Name: Probe[main.testManyPointers]
       ByteSize: 1121
       ExprStatusArraySize: 1
@@ -18160,7 +18283,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1328
+      ID: 1329
       Name: Probe[main.testManyStrings]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -18192,7 +18315,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1357
+      ID: 1358
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18224,7 +18347,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18256,7 +18379,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18288,7 +18411,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18320,7 +18443,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18352,7 +18475,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18384,7 +18507,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18416,7 +18539,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18442,38 +18565,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1362
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 195 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 195 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18512,7 +18603,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1371
+      ID: 1364
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 195 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 195 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1372
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18544,7 +18667,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1370
+      ID: 1371
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18576,7 +18699,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1355
+      ID: 1356
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18608,7 +18731,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1356
+      ID: 1357
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18640,7 +18763,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1354
+      ID: 1355
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18672,7 +18795,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18704,7 +18827,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1369
+      ID: 1370
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18736,7 +18859,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18768,7 +18891,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18800,7 +18923,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18828,38 +18951,6 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1519
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 13 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 13 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -18896,7 +18987,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1485
+      ID: 1521
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 13 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 13 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -19136,7 +19259,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19155,7 +19278,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19213,7 +19336,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19245,7 +19368,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -19303,7 +19426,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19322,7 +19445,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19342,6 +19465,143 @@ Types:
           DictIndex: -1
         - Name: i
           Offset: 9
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1425
+      Name: Probe[main.testMultipleNamedReturn]
+    - __kind: EventRootType
+      ID: 1427
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1429
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1431
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
           Kind: argument
           Expression:
             Type: 11 BaseType int
@@ -19355,21 +19615,63 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1424
-      Name: Probe[main.testMultipleNamedReturn]
-    - __kind: EventRootType
-      ID: 1426
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
-          Kind: argument
+          Kind: return
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: return
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1426
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19377,57 +19679,57 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1428
-      Name: Probe[main.testMultipleNamedReturn]
+      Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result
           Offset: 17
-          Kind: template_segment
+          Kind: return
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 25
-          Kind: argument
+          Kind: return
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19435,185 +19737,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1430
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1432
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1423
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: return
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1425
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: capture_expression
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1427
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result
-          Offset: 17
-          Kind: return
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 25
-          Kind: return
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1429
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -19697,7 +19820,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1431
+      ID: 1432
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19729,7 +19852,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19761,7 +19884,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19806,7 +19929,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1380
+      ID: 1381
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 63
       ExprStatusArraySize: 3
@@ -19942,7 +20065,42 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1419
+      Name: Probe[main.testNamedReturn]
+    - __kind: EventRootType
+      ID: 1421
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19975,41 +20133,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1418
-      Name: Probe[main.testNamedReturn]
-    - __kind: EventRootType
-      ID: 1420
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: i
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1417
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20028,7 +20151,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20047,7 +20170,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20079,7 +20202,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20111,7 +20234,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20138,10 +20261,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20168,7 +20291,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20226,7 +20349,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -20284,7 +20407,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -20368,7 +20491,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1503
+      ID: 1504
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -20400,7 +20523,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20432,7 +20555,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1386
+      ID: 1387
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20464,7 +20587,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1360
+      ID: 1361
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20496,7 +20619,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20528,7 +20651,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1410
+      ID: 1411
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       ExprStatusArraySize: 1
@@ -20586,7 +20709,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1411
+      ID: 1412
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20618,7 +20741,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1412
+      ID: 1413
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20650,7 +20773,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20669,10 +20792,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20691,10 +20814,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -20713,10 +20836,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20735,10 +20858,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1463
+      ID: 1464
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -20861,10 +20984,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -20896,10 +21019,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1451
+      ID: 1452
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20931,7 +21054,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1408
+      ID: 1409
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -20963,7 +21086,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1409
+      ID: 1410
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20982,7 +21105,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21001,7 +21124,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21020,7 +21143,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1406
+      ID: 1407
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21052,7 +21175,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21097,7 +21220,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1405
+      ID: 1406
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21142,7 +21265,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21174,7 +21297,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21206,7 +21329,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21225,29 +21348,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1392
+      ID: 1393
       Name: Probe[main.testReturnsInt]
     - __kind: EventRootType
-      ID: 1394
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1396
+      ID: 1395
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21266,7 +21370,26 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1398
+      ID: 1397
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1399
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21298,7 +21421,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1393
+      ID: 1394
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21317,7 +21440,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1395
+      ID: 1396
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21349,7 +21472,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1397
+      ID: 1398
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21381,7 +21504,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1399
+      ID: 1400
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21400,7 +21523,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1414
+      ID: 1415
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21432,7 +21555,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21451,10 +21574,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21473,10 +21596,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1450
+      ID: 1451
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -21703,10 +21826,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1461
+      ID: 1462
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1462
+      ID: 1463
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21725,10 +21848,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -21799,10 +21922,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -21834,7 +21957,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.testReturnsNamedDeferLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21892,10 +22015,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21914,10 +22037,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -22027,10 +22150,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22049,10 +22172,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -22071,7 +22194,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1277
+      ID: 1278
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22103,7 +22226,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1298
+      ID: 1299
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22135,7 +22258,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1296
+      ID: 1297
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22167,13 +22290,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1309
+      ID: 1310
       Name: Probe[main.testSingleFloat32]
     - __kind: EventRootType
-      ID: 1310
+      ID: 1311
       Name: Probe[main.testSingleFloat64]
     - __kind: EventRootType
-      ID: 1301
+      ID: 1302
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22205,7 +22328,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1302
+      ID: 1303
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22237,7 +22360,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1303
+      ID: 1304
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22269,7 +22392,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1300
+      ID: 1301
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22327,7 +22450,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1299
+      ID: 1300
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22359,7 +22482,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1297
+      ID: 1298
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22391,7 +22514,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22423,7 +22546,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1306
+      ID: 1307
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22455,7 +22578,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1307
+      ID: 1308
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22487,7 +22610,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1308
+      ID: 1309
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22519,7 +22642,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1305
+      ID: 1306
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22551,7 +22674,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1304
+      ID: 1305
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22583,7 +22706,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22615,7 +22738,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22647,7 +22770,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1358
+      ID: 1359
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22679,7 +22802,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22698,10 +22821,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[main.testSomeNamedReturn]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22720,7 +22843,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1443
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22752,7 +22875,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22810,7 +22933,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22829,7 +22952,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22887,7 +23010,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22932,7 +23055,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -22964,7 +23087,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23009,7 +23132,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1278
+      ID: 1279
       Name: Probe[main.testStringArray]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23041,7 +23164,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1389
+      ID: 1390
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23073,7 +23196,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1501
+      ID: 1502
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23105,7 +23228,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1321
+      ID: 1322
       Name: Probe[main.testStringType1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23137,7 +23260,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1322
+      ID: 1323
       Name: Probe[main.testStringType2]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23169,7 +23292,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23227,7 +23350,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1352
+      ID: 1353
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23259,7 +23382,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23291,7 +23414,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23323,7 +23446,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -23355,10 +23478,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -23390,7 +23513,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1353
+      ID: 1354
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23422,7 +23545,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23441,7 +23564,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -23473,13 +23596,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -23563,7 +23686,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -23647,7 +23770,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1326
+      ID: 1327
       Name: Probe[main.testTakeContext]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23666,7 +23789,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -23685,7 +23808,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23717,7 +23840,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23774,7 +23897,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -23806,7 +23929,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23851,13 +23974,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -23941,7 +24064,103 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1311
+      ID: 1540
+      Name: Probe[main.testTimeFixedZone]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 323 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 323 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1541
+      Name: Probe[main.testTimeMonotonic]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 326 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: c
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 326 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1539
+      Name: Probe[main.testTimeUTC]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 323 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 323 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1312
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -23973,7 +24192,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1287
+      ID: 1288
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24005,7 +24224,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1288
+      ID: 1289
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24037,7 +24256,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1289
+      ID: 1290
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24069,7 +24288,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1286
+      ID: 1287
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24101,7 +24320,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1285
+      ID: 1286
       Name: Probe[main.testUintArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24133,7 +24352,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24165,7 +24384,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24197,7 +24416,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24229,7 +24448,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1387
+      ID: 1388
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24261,7 +24480,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1295
+      ID: 1296
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       ExprStatusArraySize: 1
@@ -24289,38 +24508,6 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1504
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 259 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 259 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -24357,7 +24544,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1493
+      ID: 1506
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 259 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 259 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1494
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24415,7 +24634,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24447,7 +24666,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1588
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -24463,10 +24682,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24476,10 +24695,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 349 StructureType main.typeWithGenerics[go.shape.int]
+            Type: 353 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 0, name: x}
+                  Variable: {subprogram: 189, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24489,17 +24708,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1589
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24511,14 +24730,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 2, name: ~r0}
+                  Variable: {subprogram: 189, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1590
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -24534,10 +24753,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24547,10 +24766,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 350 StructureType main.typeWithGenerics[go.shape.string]
+            Type: 354 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24560,17 +24779,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1591
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24582,14 +24801,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 2, name: ~r0}
+                  Variable: {subprogram: 190, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1538
+      ID: 1542
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -24599,10 +24818,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24612,17 +24831,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1539
+      ID: 1543
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24632,17 +24851,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1544
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -24652,10 +24871,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24665,17 +24884,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1541
+      ID: 1545
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -24685,10 +24904,10 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24718,7 +24937,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 336
+      ID: 340
       Name: '[16]uint8'
       ByteSize: 16
       GoRuntimeType: 622976
@@ -24930,7 +25149,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 456
+      ID: 457
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 625856
@@ -24939,7 +25158,7 @@ Types:
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 441
+      ID: 442
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 626144
@@ -24965,7 +25184,7 @@ Types:
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 967
+      ID: 978
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 627200
@@ -24974,7 +25193,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1174
+      ID: 1185
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25000,7 +25219,7 @@ Types:
       HasCount: true
       Element: 81 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 424
+      ID: 425
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 623072
@@ -25009,7 +25228,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 1200
+      ID: 1201
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 452224
@@ -25017,20 +25236,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1201 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1202 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1203 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1204 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1203
+      ID: 1204
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 382 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 133
       Name: '[]*main.deepSlice2'
@@ -25047,15 +25266,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 422 GoSliceDataType []*main.deepSlice2.array
+      Data: 423 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 422
+      ID: 423
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 135 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1205
+      ID: 1206
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 448704
@@ -25063,22 +25282,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1206 PointerType **main.deepSlice3
+          Type: 1207 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1209 GoSliceDataType []*main.deepSlice3.array
+      Data: 1210 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1209
+      ID: 1210
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1207 PointerType *main.deepSlice3
+      Element: 1208 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1234
+      ID: 1235
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 448384
@@ -25086,22 +25305,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1235 PointerType **main.deepSlice8
+          Type: 1236 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1238 GoSliceDataType []*main.deepSlice8.array
+      Data: 1239 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1238
+      ID: 1239
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1236 PointerType *main.deepSlice8
+      Element: 1237 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1240
+      ID: 1241
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 448320
@@ -25109,20 +25328,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1241 PointerType **main.deepSlice9
+          Type: 1242 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1244 GoSliceDataType []*main.deepSlice9.array
+      Data: 1245 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1244
+      ID: 1245
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1242 PointerType *main.deepSlice9
+      Element: 1243 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 124
       Name: '[]*string'
@@ -25139,9 +25358,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 419 GoSliceDataType []*string.array
+      Data: 420 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 419
+      ID: 420
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25161,9 +25380,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 488 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 489
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25183,9 +25402,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 486 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 487
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25205,9 +25424,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 484 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 484
+      ID: 485
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25227,9 +25446,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 482 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 483
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25249,9 +25468,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 480 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 481
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25271,9 +25490,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 468 GoSliceDataType [][]uint.array
+      Data: 469 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 468
+      ID: 469
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25294,207 +25513,207 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 472 GoSliceDataType []bool.array
+      Data: 473 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 473
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 461
       Name: '[]bucket<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 528
       Element: 229 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 460
       Name: '[]bucket<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 224 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 444
       Name: '[]bucket<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 656
       Element: 192 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 450
+      ID: 451
       Name: '[]bucket<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 152
       Element: 204 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 512
+      ID: 519
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 374 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 378 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 429
+      ID: 430
       Name: '[]bucket<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 143 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1219
+      ID: 1220
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1215 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1257
+      ID: 1258
       Name: '[]bucket<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1253 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1254 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1266
+      ID: 1267
       Name: '[]bucket<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1262 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1263 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 433
+      ID: 434
       Name: '[]bucket<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 172 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 1272
+      ID: 1273
       Name: '[]bucket<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 1271 GoHMapBucketType bucket<int,interface {}>
+      Element: 1272 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 465
       Name: '[]bucket<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 239 GoHMapBucketType bucket<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 452
+      ID: 453
       Name: '[]bucket<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
       Element: 209 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 534
+      ID: 545
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 525 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 447
+      ID: 448
       Name: '[]bucket<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 199 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 440
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 187 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 518
+      ID: 525
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 401 GoHMapBucketType bucket<string,float64>
+      Element: 402 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 978
+      ID: 989
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 950 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 438
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 182 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 516
+      ID: 523
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 396 GoHMapBucketType bucket<string,interface {}>
+      Element: 397 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 436
+      ID: 437
       Name: '[]bucket<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 177 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 521
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 391 GoHMapBucketType bucket<string,string>
+      Element: 392 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 462
+      ID: 463
       Name: '[]bucket<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 234 GoHMapBucketType bucket<struct {},int>
     - __kind: GoSliceDataType
-      ID: 491
+      ID: 492
       Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 400
       Element: 291 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 493
+      ID: 494
       Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 296 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 496
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 301 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 498
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 306 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 499
+      ID: 500
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 311 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 501
+      ID: 502
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 316 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 466
       Name: '[]bucket<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
       Element: 244 GoHMapBucketType bucket<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 457
+      ID: 458
       Name: '[]bucket<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 219 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 455
       Name: '[]bucket<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
       Element: 214 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 962
+      ID: 973
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 456704
@@ -25509,15 +25728,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 979 GoSliceDataType []float64.array
+      Data: 990 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 979
+      ID: 990
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 19 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 402
+      ID: 403
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 451776
@@ -25525,22 +25744,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 403 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 404 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 519 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 526 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 526
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 404 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 405 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 405
+      ID: 406
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 451968
@@ -25548,22 +25767,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 406 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 407 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 527 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 534 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 527
+      ID: 534
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 407 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 408 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 351
+      ID: 355
       Name: '[]go.shape.float64'
       ByteSize: 24
       GoRuntimeType: 454208
@@ -25571,44 +25790,44 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 352 PointerType *go.shape.float64
+          Type: 356 PointerType *go.shape.float64
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 508 GoSliceDataType []go.shape.float64.array
+      Data: 515 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 508
+      ID: 515
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 353 BaseType go.shape.float64
+      Element: 357 BaseType go.shape.float64
     - __kind: GoSliceHeaderType
-      ID: 327
+      ID: 331
       Name: '[]go.shape.int'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 328 PointerType *go.shape.int
+          Type: 332 PointerType *go.shape.int
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 504 GoSliceDataType []go.shape.int.array
+      Data: 511 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 504
+      ID: 511
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 323 BaseType go.shape.int
+      Element: 327 BaseType go.shape.int
     - __kind: GoSliceHeaderType
-      ID: 348
+      ID: 352
       Name: '[]go.shape.string'
       ByteSize: 24
       GoRuntimeType: 450112
@@ -25616,22 +25835,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 345 PointerType *go.shape.string
+          Type: 349 PointerType *go.shape.string
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 506 GoSliceDataType []go.shape.string.array
+      Data: 513 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 513
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 325 GoStringHeaderType go.shape.string
+      Element: 329 GoStringHeaderType go.shape.string
     - __kind: GoSliceHeaderType
-      ID: 1246
+      ID: 1247
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 457152
@@ -25646,63 +25865,63 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1247 GoSliceDataType []interface {}.array
+      Data: 1248 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1247
+      ID: 1248
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 159 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 458
+      ID: 459
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 456 ArrayType [4]int
+      Element: 457 ArrayType [4]int
     - __kind: ArrayType
-      ID: 440
+      ID: 441
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 441 ArrayType [4]string
+      Element: 442 ArrayType [4]string
     - __kind: ArrayType
-      ID: 448
+      ID: 449
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 510
+      ID: 517
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 511 GoInterfaceType context.canceler
+      Element: 518 GoInterfaceType context.canceler
     - __kind: ArrayType
-      ID: 425
+      ID: 426
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 434
+      ID: 435
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 461
+      ID: 462
       Name: '[]key<struct {}>'
       Count: 8
       HasCount: true
       Element: 120 StructureType struct {}
     - __kind: ArrayType
-      ID: 453
+      ID: 454
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -25723,15 +25942,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 478 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 479 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 479
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 273 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 445
+      ID: 446
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 449344
@@ -25739,16 +25958,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 446 PointerType *main.structWithMap
+          Type: 447 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 529 GoSliceDataType []main.structWithMap.array
+      Data: 536 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 536
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25768,9 +25987,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 470 GoSliceDataType []main.structWithNoStrings.array
+      Data: 471 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 471
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -25795,9 +26014,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 430 GoSliceDataType []string.array
+      Data: 431 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 430
+      ID: 431
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -25818,14 +26037,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 476 GoSliceDataType []struct {}.array
+      Data: 477 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 477
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 120 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 1190
+      ID: 503
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 455424
@@ -25833,22 +26052,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1191 PointerType *time.zone
+          Type: 504 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1196 GoSliceDataType []time.zone.array
+      Data: 538 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 1196
+      ID: 538
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 1192 StructureType time.zone
+      Element: 505 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 1193
+      ID: 506
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 455488
@@ -25856,20 +26075,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1194 PointerType *time.zoneTrans
+          Type: 507 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1198 GoSliceDataType []time.zoneTrans.array
+      Data: 540 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 1198
+      ID: 540
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 1195 StructureType time.zoneTrans
+      Element: 508 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 259
       Name: '[]uint'
@@ -25886,9 +26105,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 466 GoSliceDataType []uint.array
+      Data: 467 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 466
+      ID: 467
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25909,9 +26128,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 474 GoSliceDataType []uint16.array
+      Data: 475 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 474
+      ID: 475
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -25932,9 +26151,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 415 GoSliceDataType []uint8.array
+      Data: 416 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 415
+      ID: 416
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -25955,186 +26174,186 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 417 GoSliceDataType []uintptr.array
+      Data: 418 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 417
+      ID: 418
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 531
+      ID: 542
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 532 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 543 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 426
+      ID: 427
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 427 PointerType *main.deepMap2
+      Element: 428 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1216
+      ID: 1217
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1217 PointerType *main.deepMap3
+      Element: 1218 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 1254
+      ID: 1255
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1255 PointerType *main.deepMap8
+      Element: 1256 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 1263
+      ID: 1264
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1264 PointerType *main.deepMap9
+      Element: 1265 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 442
+      ID: 443
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 108 ArrayType [2]int
     - __kind: ArrayType
-      ID: 455
+      ID: 456
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 456 ArrayType [4]int
+      Element: 457 ArrayType [4]int
     - __kind: ArrayType
-      ID: 444
+      ID: 445
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 445 GoSliceHeaderType []main.structWithMap
+      Element: 446 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 438
+      ID: 439
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 156 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 517
+      ID: 524
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 977
+      ID: 988
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 969 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 432
+      ID: 433
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 515
+      ID: 522
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 159 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 435
+      ID: 436
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 118 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 449
+      ID: 450
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 248 StructureType main.node
     - __kind: ArrayType
-      ID: 490
+      ID: 491
       Name: '[]val<main.structWithCyclicMaps>'
       ByteSize: 384
       Count: 8
       HasCount: true
       Element: 286 StructureType main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 492
+      ID: 493
       Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 287 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 494
+      ID: 495
       Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 292 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 496
+      ID: 497
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 297 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 498
+      ID: 499
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 500
+      ID: 501
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 513
+      ID: 520
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 463
+      ID: 464
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
       Element: 120 StructureType struct {}
     - __kind: ArrayType
-      ID: 451
+      ID: 452
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1117
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 761
+      ID: 772
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 861888
@@ -26149,33 +26368,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 762 GoSliceDataType archive/tar.headerError.array
+      Data: 773 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 762
+      ID: 773
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1057
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 1005
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 996
+      ID: 1007
       Name: archive/zip.dirWriter
       GoRuntimeType: 1083968
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1093
+      ID: 1104
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1033
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1383616
@@ -26185,7 +26404,7 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1035
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26201,18 +26420,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 458 ArrayType []key<[4]int>
+          Type: 459 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 455 ArrayType []val<[4]int>
+          Type: 456 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 228 PointerType *bucket<[4]int,[4]int>
-      KeyType: 456 ArrayType [4]int
-      ValueType: 456 ArrayType [4]int
+      KeyType: 457 ArrayType [4]int
+      ValueType: 457 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 224
       Name: bucket<[4]int,uint8>
@@ -26220,17 +26439,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 458 ArrayType []key<[4]int>
+          Type: 459 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 451 ArrayType []val<uint8>
+          Type: 452 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 223 PointerType *bucket<[4]int,uint8>
-      KeyType: 456 ArrayType [4]int
+      KeyType: 457 ArrayType [4]int
       ValueType: 5 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 192
@@ -26239,17 +26458,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 440 ArrayType []key<[4]string>
+          Type: 441 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 442 ArrayType []val<[2]int>
+          Type: 443 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 191 PointerType *bucket<[4]string,[2]int>
-      KeyType: 441 ArrayType [4]string
+      KeyType: 442 ArrayType [4]string
       ValueType: 108 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 204
@@ -26258,36 +26477,36 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 448 ArrayType []key<bool>
+          Type: 449 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 449 ArrayType []val<main.node>
+          Type: 450 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 203 PointerType *bucket<bool,main.node>
       KeyType: 6 BaseType bool
       ValueType: 248 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 374
+      ID: 378
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 510 ArrayType []key<context.canceler>
+          Type: 517 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 463 ArrayType []val<struct {}>
+          Type: 464 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 373 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 511 GoInterfaceType context.canceler
+          Type: 377 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 518 GoInterfaceType context.canceler
       ValueType: 120 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 143
@@ -26296,75 +26515,75 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 426 ArrayType []val<*main.deepMap2>
+          Type: 427 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 142 PointerType *bucket<int,*main.deepMap2>
       KeyType: 11 BaseType int
-      ValueType: 427 PointerType *main.deepMap2
+      ValueType: 428 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1215
+      ID: 1216
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1216 ArrayType []val<*main.deepMap3>
+          Type: 1217 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1214 PointerType *bucket<int,*main.deepMap3>
+          Type: 1215 PointerType *bucket<int,*main.deepMap3>
       KeyType: 11 BaseType int
-      ValueType: 1217 PointerType *main.deepMap3
+      ValueType: 1218 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 1253
+      ID: 1254
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1254 ArrayType []val<*main.deepMap8>
+          Type: 1255 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 1252 PointerType *bucket<int,*main.deepMap8>
+          Type: 1253 PointerType *bucket<int,*main.deepMap8>
       KeyType: 11 BaseType int
-      ValueType: 1255 PointerType *main.deepMap8
+      ValueType: 1256 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 1262
+      ID: 1263
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1263 ArrayType []val<*main.deepMap9>
+          Type: 1264 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 1261 PointerType *bucket<int,*main.deepMap9>
+          Type: 1262 PointerType *bucket<int,*main.deepMap9>
       KeyType: 11 BaseType int
-      ValueType: 1264 PointerType *main.deepMap9
+      ValueType: 1265 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 172
       Name: bucket<int,int>
@@ -26372,35 +26591,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 432 ArrayType []val<int>
+          Type: 433 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 171 PointerType *bucket<int,int>
       KeyType: 11 BaseType int
       ValueType: 11 BaseType int
     - __kind: GoHMapBucketType
-      ID: 1271
+      ID: 1272
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 515 ArrayType []val<interface {}>
+          Type: 522 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 1270 PointerType *bucket<int,interface {}>
+          Type: 1271 PointerType *bucket<int,interface {}>
       KeyType: 11 BaseType int
       ValueType: 159 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -26410,13 +26629,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 463 ArrayType []val<struct {}>
+          Type: 464 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 238 PointerType *bucket<int,struct {}>
@@ -26429,37 +26648,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 451 ArrayType []val<uint8>
+          Type: 452 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 208 PointerType *bucket<int,uint8>
       KeyType: 11 BaseType int
       ValueType: 5 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 525
+      ID: 532
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 531 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 542 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 524 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 532 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 543 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 199
       Name: bucket<string,[]main.structWithMap>
@@ -26467,18 +26686,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 444 ArrayType []val<[]main.structWithMap>
+          Type: 445 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 198 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 445 GoSliceHeaderType []main.structWithMap
+      ValueType: 446 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 187
       Name: bucket<string,[]string>
@@ -26486,56 +26705,56 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 438 ArrayType []val<[]string>
+          Type: 439 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 186 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 156 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 401
+      ID: 402
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 517 ArrayType []val<float64>
+          Type: 524 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 400 PointerType *bucket<string,float64>
+          Type: 401 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 950
+      ID: 961
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 977 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 988 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 949 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 969 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 182
       Name: bucket<string,int>
@@ -26543,35 +26762,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 432 ArrayType []val<int>
+          Type: 433 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 181 PointerType *bucket<string,int>
       KeyType: 13 GoStringHeaderType string
       ValueType: 11 BaseType int
     - __kind: GoHMapBucketType
-      ID: 396
+      ID: 397
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 515 ArrayType []val<interface {}>
+          Type: 522 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 395 PointerType *bucket<string,interface {}>
+          Type: 396 PointerType *bucket<string,interface {}>
       KeyType: 13 GoStringHeaderType string
       ValueType: 159 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -26581,35 +26800,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 435 ArrayType []val<main.nestedStruct>
+          Type: 436 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 176 PointerType *bucket<string,main.nestedStruct>
       KeyType: 13 GoStringHeaderType string
       ValueType: 118 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 391
+      ID: 392
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 513 ArrayType []val<string>
+          Type: 520 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 390 PointerType *bucket<string,string>
+          Type: 391 PointerType *bucket<string,string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 13 GoStringHeaderType string
     - __kind: GoHMapBucketType
@@ -26619,13 +26838,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 432 ArrayType []val<int>
+          Type: 433 ArrayType []val<int>
         - Name: overflow
           Offset: 72
           Type: 233 PointerType *bucket<struct {},int>
@@ -26638,13 +26857,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 490 ArrayType []val<main.structWithCyclicMaps>
+          Type: 491 ArrayType []val<main.structWithCyclicMaps>
         - Name: overflow
           Offset: 392
           Type: 290 PointerType *bucket<struct {},main.structWithCyclicMaps>
@@ -26657,13 +26876,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 492 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+          Type: 493 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 295 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -26676,13 +26895,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 494 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 495 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 300 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -26695,13 +26914,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 496 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 497 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 305 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -26714,13 +26933,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 498 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 499 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 310 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -26733,13 +26952,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 500 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 501 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 315 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -26752,13 +26971,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 463 ArrayType []val<struct {}>
+          Type: 464 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 8
           Type: 243 PointerType *bucket<struct {},struct {}>
@@ -26771,18 +26990,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 453 ArrayType []key<uint8>
+          Type: 454 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 455 ArrayType []val<[4]int>
+          Type: 456 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 218 PointerType *bucket<uint8,[4]int>
       KeyType: 5 BaseType uint8
-      ValueType: 456 ArrayType [4]int
+      ValueType: 457 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 214
       Name: bucket<uint8,uint8>
@@ -26790,28 +27009,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 453 ArrayType []key<uint8>
+          Type: 454 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 451 ArrayType []val<uint8>
+          Type: 452 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 213 PointerType *bucket<uint8,uint8>
       KeyType: 5 BaseType uint8
       ValueType: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1081
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1108
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1142
+      ID: 1153
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -26837,13 +27056,13 @@ Types:
       GoRuntimeType: 534560
       GoKind: 15
     - __kind: BaseType
-      ID: 568
+      ID: 579
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 767712
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 580
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 767808
@@ -26851,26 +27070,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *compress/flate.InternalError.str
+          Type: 582 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 570 GoStringDataType compress/flate.InternalError.str
+      Data: 581 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 581
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1055
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 1001
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1066
+      ID: 1077
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -26887,19 +27106,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 370
       Name: context.backgroundCtx
       GoRuntimeType: 1681056
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 367 StructureType context.emptyCtx
+          Type: 371 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 357
+      ID: 361
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1837888
@@ -26910,13 +27129,13 @@ Types:
           Type: 152 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 368 StructureType sync.Mutex
+          Type: 372 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 369 StructureType sync/atomic.Value
+          Type: 373 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 370 GoMapType map[context.canceler]struct {}
+          Type: 374 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -26926,7 +27145,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 511
+      ID: 518
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1074624
@@ -26939,13 +27158,13 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 873
+      ID: 884
       Name: context.deadlineExceededError
       GoRuntimeType: 1288352
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 367
+      ID: 371
       Name: context.emptyCtx
       GoRuntimeType: 1412128
       GoKind: 25
@@ -26954,7 +27173,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 359
+      ID: 363
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1703616
@@ -26965,11 +27184,11 @@ Types:
           Type: 152 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 375 GoSubroutineType func() bool
+          Type: 379 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 361
+      ID: 365
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1429760
@@ -26977,29 +27196,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 357 StructureType context.cancelCtx
+          Type: 361 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 376 PointerType *time.Timer
+          Type: 380 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 378 StructureType time.Time
+          Type: 323 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 381
+      ID: 382
       Name: context.todoCtx
       GoRuntimeType: 1681280
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 367 StructureType context.emptyCtx
+          Type: 371 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 363
+      ID: 367
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1715104
@@ -27017,7 +27236,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 365
+      ID: 369
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1680832
@@ -27029,63 +27248,63 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 582
+      ID: 593
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770304
       GoKind: 2
     - __kind: BaseType
-      ID: 583
+      ID: 594
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770400
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1056
+      ID: 1067
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1092
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 584
+      ID: 595
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1089
+      ID: 1100
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1094
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1096
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 572
+      ID: 583
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 768288
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 856
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1168
+      ID: 1179
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 687
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 674
+      ID: 685
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1614176
@@ -27096,34 +27315,34 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 967 ArrayType [5]uint8
+          Type: 978 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 968 GoInterfaceType net.Conn
+          Type: 979 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 800
+      ID: 811
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 956096
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1065
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1072
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 951
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 963
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 748
+      ID: 759
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1617248
@@ -27131,21 +27350,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 951 PointerType *crypto/x509.Certificate
+          Type: 962 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 970 BaseType crypto/x509.InvalidReason
+          Type: 981 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 742
+      ID: 753
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1081280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 744
+      ID: 755
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1415968
@@ -27153,24 +27372,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 951 PointerType *crypto/x509.Certificate
+          Type: 962 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 581
+      ID: 592
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 769920
       GoKind: 2
     - __kind: BaseType
-      ID: 970
+      ID: 981
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 540064
       GoKind: 2
     - __kind: StructureType
-      ID: 850
+      ID: 861
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1379936
@@ -27180,13 +27399,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 750
+      ID: 761
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1081536
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 746
+      ID: 757
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1617056
@@ -27194,15 +27413,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 951 PointerType *crypto/x509.Certificate
+          Type: 962 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 951 PointerType *crypto/x509.Certificate
+          Type: 962 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 765
+      ID: 776
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1259904
@@ -27212,7 +27431,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 769
+      ID: 780
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1260064
@@ -27222,55 +27441,55 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 767
+      ID: 778
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 566
+      ID: 577
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 767328
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1023
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 567
+      ID: 578
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 767520
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 648
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 847
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 640
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 646
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 644
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 642
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1148
+      ID: 1159
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 639
+      ID: 650
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1244384
@@ -27280,19 +27499,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1020
+      ID: 1031
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 747
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 734
+      ID: 745
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 578
+      ID: 589
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 769824
@@ -27300,22 +27519,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 580 PointerType *encoding/xml.UnmarshalError.str
+          Type: 591 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 579 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 590 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 579
+      ID: 590
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 739
+      ID: 750
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1137
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27332,11 +27551,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 607
+      ID: 618
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 814
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27352,15 +27571,15 @@ Types:
       GoRuntimeType: 534752
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1147
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 816
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 818
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27370,7 +27589,7 @@ Types:
       GoRuntimeType: 447040
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 375
+      ID: 379
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 545632
@@ -27382,44 +27601,44 @@ Types:
       GoRuntimeType: 781920
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 354
+      ID: 358
       Name: func(go.shape.float64) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 329
+      ID: 333
       Name: func(go.shape.int) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 330
+      ID: 334
       Name: func(go.shape.int) go.shape.string
       ByteSize: 8
       GoKind: 19
     - __kind: StructureType
-      ID: 324
+      ID: 328
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
     - __kind: StructureType
-      ID: 326
+      ID: 330
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 678
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 648
+      ID: 659
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1612448
@@ -27427,7 +27646,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 960 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 971 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -27435,25 +27654,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 661
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 975
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 654
+      ID: 665
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1077440
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 977
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 560
+      ID: 571
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 766752
@@ -27461,18 +27680,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 562 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 573 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 561 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 561
+      ID: 572
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 960
+      ID: 971
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2083968
@@ -27480,7 +27699,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 961 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 972 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -27495,7 +27714,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 962 GoSliceHeaderType []float64
+          Type: 973 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -27504,10 +27723,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 963 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 974 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 965 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 976 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 156 GoSliceHeaderType []string
@@ -27521,13 +27740,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 961
+      ID: 972
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 536416
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 568
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 766656
@@ -27535,18 +27754,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 570 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 558 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 569
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 563
+      ID: 574
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 766848
@@ -27554,30 +27773,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 565 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 576 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 564
+      ID: 575
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1045
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1125
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 759
+      ID: 770
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 383
+      ID: 384
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2204128
@@ -27585,7 +27804,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 384 StructureType sync.RWMutex
+          Type: 385 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -27606,13 +27825,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 392 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 393 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 397 GoMapType map[string]float64
+          Type: 398 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 12 BaseType uint64
@@ -27627,10 +27846,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 402 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 403 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 405 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 406 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27642,7 +27861,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 408 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 13 GoStringHeaderType string
@@ -27665,7 +27884,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 409
+      ID: 410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2081280
@@ -27676,13 +27895,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 410 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 382 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 385 StructureType sync/atomic.Int32
+          Type: 386 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -27691,16 +27910,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 412 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 413 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 12 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 384 StructureType sync.RWMutex
+          Type: 385 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -27709,12 +27928,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 402 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 403 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 404
+      ID: 405
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1788224
@@ -27731,7 +27950,7 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -27739,20 +27958,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 392
+      ID: 393
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 987328
       GoKind: 21
-      HeaderType: 394 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 395 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 1202
+      ID: 1203
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 533536
       GoKind: 10
     - __kind: StructureType
-      ID: 407
+      ID: 408
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1632576
@@ -27766,16 +27985,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 521 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 528 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 526 GoMapType map[string]interface {}
+          Type: 533 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1222
+      ID: 1223
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 533
+      ID: 544
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1788480
@@ -27783,7 +28002,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1220 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1221 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -27798,15 +28017,15 @@ Types:
           Type: 19 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1221 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1220
+      ID: 1221
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 951392
       GoKind: 5
     - __kind: StructureType
-      ID: 411
+      ID: 412
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 1976128
@@ -27814,16 +28033,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 384 StructureType sync.RWMutex
+          Type: 385 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1200 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1201 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 11 BaseType int
@@ -27838,12 +28057,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1203 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 382 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 412
+      ID: 413
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 828672
@@ -27852,15 +28071,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 919
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1144
+      ID: 1155
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1225
+      ID: 1226
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1443968
@@ -27870,29 +28089,29 @@ Types:
           Offset: 0
           Type: 152 GoInterfaceType context.Context
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 696
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 692
+      ID: 703
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1080512
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 577
+      ID: 588
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 768960
       GoKind: 2
     - __kind: StructureType
-      ID: 690
+      ID: 701
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1080384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 688
+      ID: 699
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1414048
@@ -27905,7 +28124,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 708
+      ID: 719
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1414848
@@ -27918,7 +28137,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 712
+      ID: 723
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1616480
@@ -27934,7 +28153,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 710
+      ID: 721
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1254304
@@ -27944,7 +28163,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 706
+      ID: 717
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1253984
@@ -27954,14 +28173,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 946
+      ID: 957
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1140832
       GoKind: 21
-      HeaderType: 948 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 959 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 969
+      ID: 980
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1013312
@@ -27976,15 +28195,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 981 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 992 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 981
+      ID: 992
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 720
+      ID: 731
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1415168
@@ -27992,12 +28211,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 946 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 957 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 946 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 957 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 714
+      ID: 725
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1254464
@@ -28007,7 +28226,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 718
+      ID: 729
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1616672
@@ -28018,12 +28237,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 969 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 969 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 716
+      ID: 727
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1415008
@@ -28036,7 +28255,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 722
+      ID: 733
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1254624
@@ -28044,9 +28263,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 378 StructureType time.Time
+          Type: 323 GoTimeType time.Time
     - __kind: StructureType
-      ID: 728
+      ID: 739
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1415488
@@ -28059,7 +28278,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 730
+      ID: 741
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1254944
@@ -28069,7 +28288,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 726
+      ID: 737
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1415328
@@ -28082,7 +28301,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 724
+      ID: 735
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1254784
@@ -28092,7 +28311,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 732
+      ID: 743
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1415648
@@ -28105,7 +28324,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 656
+      ID: 667
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1246624
@@ -28115,11 +28334,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1084
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 658
+      ID: 669
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1246784
@@ -28127,21 +28346,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 656 StructureType github.com/cihub/seelog.baseError
+          Type: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1063
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1019
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1053
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 662
+      ID: 673
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1247104
@@ -28149,13 +28368,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 656 StructureType github.com/cihub/seelog.baseError
+          Type: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1115
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1115
+      ID: 1126
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1978240
@@ -28163,12 +28382,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1103 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1114 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 1116
+      ID: 1127
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2001632
@@ -28176,7 +28395,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1103 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1114 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -28184,11 +28403,11 @@ Types:
           Offset: 24
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1021
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 660
+      ID: 671
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1246944
@@ -28196,9 +28415,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 656 StructureType github.com/cihub/seelog.baseError
+          Type: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 664
+      ID: 675
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1247264
@@ -28206,64 +28425,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 656 StructureType github.com/cihub/seelog.baseError
+          Type: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1088
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1121
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1123
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 953
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 858
+      ID: 869
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 867
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 871
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 873
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1074
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 863
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 670
+      ID: 681
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1248224
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1171
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 927
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 896
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1720480
@@ -28279,11 +28498,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 890
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 822
+      ID: 833
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1518176
@@ -28296,7 +28515,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 891
+      ID: 902
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1720928
@@ -28312,13 +28531,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 799
+      ID: 810
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 953216
       GoKind: 8
     - __kind: StructureType
-      ID: 883
+      ID: 894
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1720256
@@ -28334,13 +28553,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 971
+      ID: 982
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 765024
       GoKind: 8
     - __kind: StructureType
-      ID: 881
+      ID: 892
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1720032
@@ -28348,15 +28567,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 971 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 982 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 971 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 982 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 889
+      ID: 900
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1638336
@@ -28369,7 +28588,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 887
+      ID: 898
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1720704
@@ -28385,11 +28604,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1164
+      ID: 1175
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 906
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1439744
@@ -28399,19 +28618,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 826
+      ID: 837
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1200672
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 824
+      ID: 835
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1200544
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 893
+      ID: 904
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1638528
@@ -28424,7 +28643,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 589
+      ID: 600
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 772320
@@ -28432,36 +28651,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 591 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 602 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 590 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 601 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 590
+      ID: 601
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 340
+      ID: 344
       Name: go.shape.bool
       ByteSize: 1
       GoRuntimeType: 546592
       GoKind: 1
     - __kind: BaseType
-      ID: 353
+      ID: 357
       Name: go.shape.float64
       ByteSize: 8
       GoRuntimeType: 546656
       GoKind: 14
     - __kind: BaseType
-      ID: 323
+      ID: 327
       Name: go.shape.int
       ByteSize: 8
       GoRuntimeType: 546464
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 329
       Name: go.shape.string
       ByteSize: 16
       GoRuntimeType: 546528
@@ -28469,18 +28688,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 503 PointerType *go.shape.string.str
+          Type: 510 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 502 GoStringDataType go.shape.string.str
+      Data: 509 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 502
+      ID: 509
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 332
+      ID: 336
       Name: go.shape.struct { Name string }
       ByteSize: 16
       GoKind: 25
@@ -28489,7 +28708,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 334
+      ID: 338
       Name: go.shape.struct { X int; Y int }
       ByteSize: 16
       GoKind: 25
@@ -28501,13 +28720,13 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 343
+      ID: 347
       Name: go.shape.struct { main.i int }
       ByteSize: 8
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 11 BaseType int}]
     - __kind: StructureType
-      ID: 344
+      ID: 348
       Name: go.shape.struct { main.s string }
       ByteSize: 16
       GoKind: 25
@@ -28516,7 +28735,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 347
+      ID: 351
       Name: go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
       ByteSize: 48
       GoKind: 25
@@ -28531,11 +28750,11 @@ Types:
           Offset: 32
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 966
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 877
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1271744
@@ -28545,7 +28764,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 1040
+      ID: 1051
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1495040
@@ -28553,13 +28772,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1064 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1075 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1135
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1064
+      ID: 1075
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1091392
@@ -28572,7 +28791,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1026
+      ID: 1037
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1388416
@@ -28582,19 +28801,19 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 592
+      ID: 603
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 772896
       GoKind: 10
     - __kind: BaseType
-      ID: 953
+      ID: 964
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 966752
       GoKind: 10
     - __kind: StructureType
-      ID: 924
+      ID: 935
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1759680
@@ -28605,12 +28824,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 953 BaseType golang.org/x/net/http2.ErrCode
+          Type: 964 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 785
+      ID: 796
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1422848
@@ -28618,12 +28837,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 953 BaseType golang.org/x/net/http2.ErrCode
+          Type: 964 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 596
+      ID: 607
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 773088
@@ -28631,18 +28850,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 598 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 609 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 597 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 608 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 597
+      ID: 608
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 602
+      ID: 613
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 773280
@@ -28650,18 +28869,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 604 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 615 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 603 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 614 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 603
+      ID: 614
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 599
+      ID: 610
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 773184
@@ -28669,18 +28888,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 601 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 612 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 600 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 611 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 600
+      ID: 611
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 593
+      ID: 604
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 772992
@@ -28688,22 +28907,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 595 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 606 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 594 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 605 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 594
+      ID: 605
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1133
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 789
+      ID: 800
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1272384
@@ -28713,13 +28932,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 605
+      ID: 616
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 773376
       GoKind: 2
     - __kind: StructureType
-      ID: 777
+      ID: 788
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1267424
@@ -28729,11 +28948,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 933
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 944
+      ID: 955
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1785440
@@ -28749,7 +28968,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 779
+      ID: 790
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1422368
@@ -28762,7 +28981,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1087
+      ID: 1098
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1838912
@@ -28770,16 +28989,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 968 GoInterfaceType net.Conn
+          Type: 979 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1102 GoInterfaceType io.Reader
+          Type: 1113 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1049
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 875
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1386016
@@ -28789,29 +29008,29 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1009
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 757
+      ID: 768
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 865
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 931
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 918
+      ID: 929
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1332832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 771
+      ID: 782
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1260704
@@ -28821,7 +29040,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 773
+      ID: 784
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1260864
@@ -28831,11 +29050,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 700
+      ID: 711
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1086
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -28871,7 +29090,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 229 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 460 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 461 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 222
       Name: hash<[4]int,uint8>
@@ -28905,7 +29124,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 224 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 459 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 460 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 190
       Name: hash<[4]string,[2]int>
@@ -28939,7 +29158,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 192 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 443 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 444 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 202
       Name: hash<bool,main.node>
@@ -28973,9 +29192,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 204 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 450 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 451 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 372
+      ID: 376
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -28996,18 +29215,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 373 PointerType *bucket<context.canceler,struct {}>
+          Type: 377 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 373 PointerType *bucket<context.canceler,struct {}>
+          Type: 377 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 374 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 512 GoSliceDataType []bucket<context.canceler,struct {}>.array
+      BucketType: 378 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 519 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 141
       Name: hash<int,*main.deepMap2>
@@ -29041,9 +29260,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 143 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 429 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 430 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1213
+      ID: 1214
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -29064,20 +29283,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1214 PointerType *bucket<int,*main.deepMap3>
+          Type: 1215 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1214 PointerType *bucket<int,*main.deepMap3>
+          Type: 1215 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1215 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1219 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1220 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 1251
+      ID: 1252
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -29098,20 +29317,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1252 PointerType *bucket<int,*main.deepMap8>
+          Type: 1253 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 1252 PointerType *bucket<int,*main.deepMap8>
+          Type: 1253 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1253 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 1257 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1254 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1258 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 1260
+      ID: 1261
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -29132,18 +29351,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1261 PointerType *bucket<int,*main.deepMap9>
+          Type: 1262 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 1261 PointerType *bucket<int,*main.deepMap9>
+          Type: 1262 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1262 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 1266 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1263 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1267 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 170
       Name: hash<int,int>
@@ -29177,9 +29396,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 172 GoHMapBucketType bucket<int,int>
-      BucketsType: 433 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 434 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 1269
+      ID: 1270
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -29200,18 +29419,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1270 PointerType *bucket<int,interface {}>
+          Type: 1271 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 1270 PointerType *bucket<int,interface {}>
+          Type: 1271 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1271 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 1272 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1272 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1273 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 237
       Name: hash<int,struct {}>
@@ -29245,7 +29464,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 239 GoHMapBucketType bucket<int,struct {}>
-      BucketsType: 464 GoSliceDataType []bucket<int,struct {}>.array
+      BucketsType: 465 GoSliceDataType []bucket<int,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 207
       Name: hash<int,uint8>
@@ -29279,9 +29498,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 209 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 452 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 453 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 523
+      ID: 530
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -29302,18 +29521,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 524 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 524 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 525 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 534 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 545 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
       ID: 197
       Name: hash<string,[]main.structWithMap>
@@ -29347,7 +29566,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 199 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 447 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 448 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 185
       Name: hash<string,[]string>
@@ -29381,9 +29600,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 187 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 439 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 440 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 399
+      ID: 400
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -29404,20 +29623,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 400 PointerType *bucket<string,float64>
+          Type: 401 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 400 PointerType *bucket<string,float64>
+          Type: 401 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 401 GoHMapBucketType bucket<string,float64>
-      BucketsType: 518 GoSliceDataType []bucket<string,float64>.array
+      BucketType: 402 GoHMapBucketType bucket<string,float64>
+      BucketsType: 525 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 948
+      ID: 959
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -29438,18 +29657,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 949 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 949 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 950 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 978 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 989 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 180
       Name: hash<string,int>
@@ -29483,9 +29702,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 182 GoHMapBucketType bucket<string,int>
-      BucketsType: 437 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 438 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 394
+      ID: 395
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -29506,18 +29725,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 395 PointerType *bucket<string,interface {}>
+          Type: 396 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 395 PointerType *bucket<string,interface {}>
+          Type: 396 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 396 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 516 GoSliceDataType []bucket<string,interface {}>.array
+      BucketType: 397 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 523 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 175
       Name: hash<string,main.nestedStruct>
@@ -29551,9 +29770,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 177 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 436 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 437 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 389
+      ID: 390
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -29574,18 +29793,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 390 PointerType *bucket<string,string>
+          Type: 391 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 390 PointerType *bucket<string,string>
+          Type: 391 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 391 GoHMapBucketType bucket<string,string>
-      BucketsType: 514 GoSliceDataType []bucket<string,string>.array
+      BucketType: 392 GoHMapBucketType bucket<string,string>
+      BucketsType: 521 GoSliceDataType []bucket<string,string>.array
     - __kind: GoHMapHeaderType
       ID: 232
       Name: hash<struct {},int>
@@ -29619,7 +29838,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 234 GoHMapBucketType bucket<struct {},int>
-      BucketsType: 462 GoSliceDataType []bucket<struct {},int>.array
+      BucketsType: 463 GoSliceDataType []bucket<struct {},int>.array
     - __kind: GoHMapHeaderType
       ID: 289
       Name: hash<struct {},main.structWithCyclicMaps>
@@ -29653,7 +29872,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 291 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
-      BucketsType: 491 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+      BucketsType: 492 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 294
       Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -29687,7 +29906,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 296 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 493 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 494 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 299
       Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -29721,7 +29940,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 301 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 495 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 496 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 304
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -29755,7 +29974,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 306 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 497 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 498 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 309
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -29789,7 +30008,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 311 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 499 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 500 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 314
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -29823,7 +30042,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 316 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 501 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 502 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 242
       Name: hash<struct {},struct {}>
@@ -29857,7 +30076,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 244 GoHMapBucketType bucket<struct {},struct {}>
-      BucketsType: 465 GoSliceDataType []bucket<struct {},struct {}>.array
+      BucketsType: 466 GoSliceDataType []bucket<struct {},struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 217
       Name: hash<uint8,[4]int>
@@ -29891,7 +30110,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 219 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 457 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 458 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 212
       Name: hash<uint8,uint8>
@@ -29925,9 +30144,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 214 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 454 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 455 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 803
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29974,7 +30193,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 752
+      ID: 763
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -30000,25 +30219,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 999
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 925
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1166
+      ID: 1177
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 912
+      ID: 923
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1313312
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 623
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -30099,11 +30318,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1041
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1071
+      ID: 1082
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1109472
@@ -30116,7 +30335,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1102
+      ID: 1113
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 985664
@@ -30129,7 +30348,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1059
+      ID: 1070
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1074112
@@ -30155,47 +30374,47 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1028
+      ID: 1039
       Name: io.discard
       GoRuntimeType: 1288032
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1013
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 921
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1090
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 339
+      ID: 343
       Name: main.Pair[go.shape.int,go.shape.bool]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
         - Name: Value
           Offset: 8
-          Type: 340 BaseType go.shape.bool
+          Type: 344 BaseType go.shape.bool
     - __kind: StructureType
-      ID: 342
+      ID: 346
       Name: main.Pair[go.shape.string,go.shape.int]
       ByteSize: 24
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
         - Name: Value
           Offset: 16
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
     - __kind: StructureType
       ID: 317
       Name: main.aStruct
@@ -30222,7 +30441,7 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1273 PointerType *main.nestedStruct
+          Type: 1274 PointerType *main.nestedStruct
     - __kind: GoInterfaceType
       ID: 164
       Name: main.behavior
@@ -30263,7 +30482,7 @@ Types:
           Offset: 0
           Type: 139 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 428
+      ID: 429
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1105632
@@ -30271,9 +30490,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1211 GoMapType map[int]*main.deepMap3
+          Type: 1212 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1218
+      ID: 1219
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30285,9 +30504,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1249 GoMapType map[int]*main.deepMap8
+          Type: 1250 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1256
+      ID: 1257
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1104864
@@ -30295,9 +30514,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1258 GoMapType map[int]*main.deepMap9
+          Type: 1259 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1265
+      ID: 1266
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1104736
@@ -30305,7 +30524,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1267 GoMapType map[int]interface {}
+          Type: 1268 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 127
       Name: main.deepPtr1
@@ -30325,9 +30544,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1169 PointerType *main.deepPtr3
+          Type: 1180 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1170
+      ID: 1181
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30339,9 +30558,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1230 PointerType *main.deepPtr8
+          Type: 1231 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1231
+      ID: 1232
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1106016
@@ -30349,9 +30568,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1232 PointerType *main.deepPtr9
+          Type: 1233 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1233
+      ID: 1234
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1105888
@@ -30371,7 +30590,7 @@ Types:
           Offset: 0
           Type: 133 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 421
+      ID: 422
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1107936
@@ -30379,9 +30598,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1205 GoSliceHeaderType []*main.deepSlice3
+          Type: 1206 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1208
+      ID: 1209
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -30393,9 +30612,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1234 GoSliceHeaderType []*main.deepSlice8
+          Type: 1235 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1237
+      ID: 1238
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1107168
@@ -30403,9 +30622,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1240 GoSliceHeaderType []*main.deepSlice9
+          Type: 1241 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1243
+      ID: 1244
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1107040
@@ -30413,7 +30632,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1246 GoSliceHeaderType []interface {}
+          Type: 1247 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 321
       Name: main.emptyStruct
@@ -30431,16 +30650,16 @@ Types:
           Type: 157 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 368 StructureType sync.Mutex
+          Type: 372 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1177 StructureType sync.Once
+          Type: 1188 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1179 StructureType sync.WaitGroup
+          Type: 1190 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 385 StructureType sync/atomic.Int32
+          Type: 386 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 157
       Name: main.esotericStack
@@ -30470,7 +30689,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 355
+      ID: 359
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1237824
@@ -30480,71 +30699,71 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 337
+      ID: 341
       Name: main.largeGenericType[go.shape.int]
       ByteSize: 136
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
     - __kind: StructureType
-      ID: 335
+      ID: 339
       Name: main.largeGenericType[go.shape.string]
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 252
       Name: main.largeStruct
@@ -30858,9 +31077,9 @@ Types:
           Type: 11 BaseType int
         - Name: data
           Offset: 8
-          Type: 1174 ArrayType [63]uint64
+          Type: 1185 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1185
+      ID: 1196
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1237984
@@ -30880,7 +31099,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1187
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30891,31 +31110,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1172 PointerType *main.stringType1.str
+          Type: 1183 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 1171 GoStringDataType main.stringType1.str
+      Data: 1182 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1171
+      ID: 1182
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1173
+      ID: 1184
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1275 PointerType *main.stringType2.str
+          Type: 1276 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 1274 GoStringDataType main.stringType2.str
+      Data: 1275 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1274
+      ID: 1275
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -31031,16 +31250,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1186 PointerType **main.t
+          Type: 1197 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1187 GoSliceDataType main.t.array
+      Data: 1198 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1187
+      ID: 1198
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -31096,29 +31315,38 @@ Types:
         - Name: c
           Offset: 32
           Type: 13 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 326
+      Name: main.timeCapture
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: monotonicNow
+          Offset: 0
+          Type: 323 GoTimeType time.Time
     - __kind: BaseType
       ID: 122
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 349
+      ID: 353
       Name: main.typeWithGenerics[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
     - __kind: StructureType
-      ID: 350
+      ID: 354
       Name: main.typeWithGenerics[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 257
       Name: main.wideStruct
@@ -31187,12 +31415,12 @@ Types:
       GoKind: 21
       HeaderType: 202 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 370
+      ID: 374
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 886560
       GoKind: 21
-      HeaderType: 372 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 376 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 139
       Name: map[int]*main.deepMap2
@@ -31201,26 +31429,26 @@ Types:
       GoKind: 21
       HeaderType: 141 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1211
+      ID: 1212
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 884064
       GoKind: 21
-      HeaderType: 1213 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1214 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1249
+      ID: 1250
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 883584
       GoKind: 21
-      HeaderType: 1251 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1252 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1258
+      ID: 1259
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 883488
       GoKind: 21
-      HeaderType: 1260 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1261 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 168
       Name: map[int]int
@@ -31229,12 +31457,12 @@ Types:
       GoKind: 21
       HeaderType: 170 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 1267
+      ID: 1268
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 883392
       GoKind: 21
-      HeaderType: 1269 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1270 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 235
       Name: map[int]struct {}
@@ -31250,12 +31478,12 @@ Types:
       GoKind: 21
       HeaderType: 207 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 521
+      ID: 528
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 886752
       GoKind: 21
-      HeaderType: 523 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 530 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 195
       Name: map[string][]main.structWithMap
@@ -31271,12 +31499,12 @@ Types:
       GoKind: 21
       HeaderType: 185 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 397
+      ID: 398
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 886656
       GoKind: 21
-      HeaderType: 399 GoHMapHeaderType hash<string,float64>
+      HeaderType: 400 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
       ID: 178
       Name: map[string]int
@@ -31285,12 +31513,12 @@ Types:
       GoKind: 21
       HeaderType: 180 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 526
+      ID: 533
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 882816
       GoKind: 21
-      HeaderType: 394 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 395 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
       ID: 173
       Name: map[string]main.nestedStruct
@@ -31299,12 +31527,12 @@ Types:
       GoKind: 21
       HeaderType: 175 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 387
+      ID: 388
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 885792
       GoKind: 21
-      HeaderType: 389 GoHMapHeaderType hash<string,string>
+      HeaderType: 390 GoHMapHeaderType hash<string,string>
     - __kind: GoMapType
       ID: 230
       Name: map[struct {}]int
@@ -31370,7 +31598,7 @@ Types:
       GoKind: 21
       HeaderType: 212 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 704
+      ID: 715
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1253664
@@ -31380,7 +31608,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 992
+      ID: 1003
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1250464
@@ -31390,11 +31618,11 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 913
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 968
+      ID: 979
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1412768
@@ -31407,35 +31635,35 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 944
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1141
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 942
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 915
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1151
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1150
+      ID: 1161
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1149
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 869
+      ID: 880
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1077056
@@ -31443,28 +31671,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 871 PointerType *net.UnknownNetworkError.str
+          Type: 882 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 870 GoStringDataType net.UnknownNetworkError.str
+      Data: 881 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 870
+      ID: 881
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 838
+      ID: 849
       Name: net.canceledError
       GoRuntimeType: 1201440
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1119
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 973
+      ID: 984
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1977536
@@ -31472,7 +31700,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 968 GoInterfaceType net.Conn
+          Type: 979 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -31483,27 +31711,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1163
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1146
+      ID: 1157
       Name: net.noReadFrom
       GoRuntimeType: 1077312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1145
+      ID: 1156
       Name: net.noWriteTo
       GoRuntimeType: 1077184
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 652
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1227
+      ID: 1228
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1643328
@@ -31516,7 +31744,7 @@ Types:
           Offset: 16
           Type: 152 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 643
+      ID: 654
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1612256
@@ -31524,7 +31752,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 956 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 967 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -31532,7 +31760,7 @@ Types:
           Offset: 96
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 1134
+      ID: 1145
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2153856
@@ -31540,12 +31768,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1146 StructureType net.noReadFrom
+          Type: 1157 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1139 PointerType *net.TCPConn
+          Type: 1150 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1132
+      ID: 1143
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2153312
@@ -31553,24 +31781,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1145 StructureType net.noWriteTo
+          Type: 1156 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1139 PointerType *net.TCPConn
+          Type: 1150 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 917
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 946
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 839
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 984
+      ID: 995
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1242144
@@ -31580,19 +31808,19 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 538
+      ID: 549
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 765504
       GoKind: 10
     - __kind: BaseType
-      ID: 945
+      ID: 956
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 953312
       GoKind: 10
     - __kind: StructureType
-      ID: 619
+      ID: 630
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1610720
@@ -31603,12 +31831,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 945 BaseType net/http.http2ErrCode
+          Type: 956 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 927
+      ID: 938
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1775712
@@ -31619,12 +31847,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 945 BaseType net/http.http2ErrCode
+          Type: 956 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 623
+      ID: 634
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1412448
@@ -31632,16 +31860,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 945 BaseType net/http.http2ErrCode
+          Type: 956 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1059
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 542
+      ID: 553
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 765696
@@ -31649,18 +31877,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 544 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 555 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 543 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 543
+      ID: 554
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 548
+      ID: 559
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 765888
@@ -31668,18 +31896,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 550 PointerType *net/http.http2headerFieldNameError.str
+          Type: 561 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 549 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 560 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 549
+      ID: 560
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 545
+      ID: 556
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 765792
@@ -31687,32 +31915,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 547 PointerType *net/http.http2headerFieldValueError.str
+          Type: 558 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 546 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 557 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 546
+      ID: 557
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 899
+      ID: 910
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 845
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1200928
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1110
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 539
+      ID: 550
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 765600
@@ -31720,18 +31948,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 541 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 552 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 540 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 551 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 540
+      ID: 551
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 986
+      ID: 997
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1611488
@@ -31739,22 +31967,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 968 GoInterfaceType net.Conn
+          Type: 979 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1067 BaseType time.Duration
+          Type: 1078 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 101 PointerType *error
     - __kind: ArrayType
-      ID: 1068
+      ID: 1079
       Name: net/http.incomparable
       GoRuntimeType: 833664
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 830
+      ID: 841
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1374336
@@ -31764,11 +31992,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1061
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1006
+      ID: 1017
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1374176
@@ -31776,9 +32004,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1049 PointerType *net/http.persistConn
+          Type: 1060 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1032
+      ID: 1043
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1682848
@@ -31786,15 +32014,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1068 ArrayType net/http.incomparable
+          Type: 1079 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1069 PointerType *bufio.Reader
+          Type: 1080 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1071 GoInterfaceType io.ReadWriteCloser
+          Type: 1082 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 627
+      ID: 638
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1243104
@@ -31804,17 +32032,17 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 929
+      ID: 940
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 897
+      ID: 908
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1300352
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 832
+      ID: 843
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1374496
@@ -31824,11 +32052,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 627
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1101
+      ID: 1112
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1913952
@@ -31836,13 +32064,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1096 PointerType *bufio.Writer
+          Type: 1107 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1027
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 696
+      ID: 707
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1616096
@@ -31858,7 +32086,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 694
+      ID: 705
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1414208
@@ -31871,11 +32099,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1058
+      ID: 1069
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1018
+      ID: 1029
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1416128
@@ -31883,16 +32111,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1057 PointerType *net/smtp.Client
+          Type: 1068 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1059 GoInterfaceType io.WriteCloser
+          Type: 1070 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 691
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 573
+      ID: 584
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 768384
@@ -31900,26 +32128,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 575 PointerType *net/textproto.ProtocolError.str
+          Type: 586 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 574 GoStringDataType net/textproto.ProtocolError.str
+      Data: 585 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 574
+      ID: 585
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1025
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 948
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 551
+      ID: 562
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 766368
@@ -31927,18 +32155,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 553 PointerType *net/url.EscapeError.str
+          Type: 564 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 552 GoStringDataType net/url.EscapeError.str
+      Data: 563 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 552
+      ID: 563
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 554
+      ID: 565
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 766464
@@ -31946,30 +32174,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 556 PointerType *net/url.InvalidHostError.str
+          Type: 567 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 555 GoStringDataType net/url.InvalidHostError.str
+      Data: 566 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 555
+      ID: 566
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1169
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 822
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 886
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1156
+      ID: 1167
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2222048
@@ -31977,12 +32205,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1162 StructureType os.noReadFrom
+          Type: 1173 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1157 PointerType *os.File
+          Type: 1168 PointerType *os.File
     - __kind: StructureType
-      ID: 1154
+      ID: 1165
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2221248
@@ -31990,36 +32218,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1161 StructureType os.noWriteTo
+          Type: 1172 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1157 PointerType *os.File
+          Type: 1168 PointerType *os.File
     - __kind: StructureType
-      ID: 1162
+      ID: 1173
       Name: os.noReadFrom
       GoRuntimeType: 1075392
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1161
+      ID: 1172
       Name: os.noWriteTo
       GoRuntimeType: 1075264
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 851
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 987
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1047
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 853
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1518752
@@ -32032,7 +32260,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 586
+      ID: 597
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 771552
@@ -32040,36 +32268,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 588 PointerType *os/user.UnknownGroupIdError.str
+          Type: 599 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 587 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 598 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 587
+      ID: 598
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 585
+      ID: 596
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 771456
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 625
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 702
+      ID: 713
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 825
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 830
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -32081,7 +32309,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 816
+      ID: 827
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1765280
@@ -32098,9 +32326,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 974 BaseType runtime.boundsErrorCode
+          Type: 985 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 974
+      ID: 985
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 534944
@@ -32120,7 +32348,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 877
+      ID: 888
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1636416
@@ -32133,7 +32361,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 793
+      ID: 804
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 952448
@@ -32141,13 +32369,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 795 PointerType *runtime.errorString.str
+          Type: 806 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 794 GoStringDataType runtime.errorString.str
+      Data: 805 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 794
+      ID: 805
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -32773,7 +33001,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 796
+      ID: 807
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 953024
@@ -32781,13 +33009,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 798 PointerType *runtime.plainError.str
+          Type: 809 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 797 GoStringDataType runtime.plainError.str
+      Data: 808 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 797
+      ID: 808
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -32869,7 +33097,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 820
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -32881,26 +33109,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 414 PointerType *string.str
+          Type: 415 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 413 GoStringDataType string.str
+      Data: 414 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 413
+      ID: 414
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1106
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1015
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1000
+      ID: 1011
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1279552
@@ -32916,7 +33144,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 368
+      ID: 372
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1291072
@@ -32929,7 +33157,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1177
+      ID: 1188
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1292192
@@ -32937,12 +33165,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1178 StructureType sync/atomic.Uint32
+          Type: 1189 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 368 StructureType sync.Mutex
+          Type: 372 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 384
+      ID: 385
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1717792
@@ -32950,7 +33178,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 368 StructureType sync.Mutex
+          Type: 372 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -32959,12 +33187,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 385 StructureType sync/atomic.Int32
+          Type: 386 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 385 StructureType sync/atomic.Int32
+          Type: 386 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1179
+      ID: 1190
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1432064
@@ -32972,21 +33200,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1180 StructureType sync.noCopy
+          Type: 1191 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1181 StructureType sync/atomic.Uint64
+          Type: 1192 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1180
+      ID: 1191
       Name: sync.noCopy
       GoRuntimeType: 952064
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 385
+      ID: 386
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1292512
@@ -32994,12 +33222,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 386 StructureType sync/atomic.noCopy
+          Type: 387 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 1178
+      ID: 1189
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1292672
@@ -33007,12 +33235,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 386 StructureType sync/atomic.noCopy
+          Type: 387 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1181
+      ID: 1192
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1432448
@@ -33020,15 +33248,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 386 StructureType sync/atomic.noCopy
+          Type: 387 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1182 StructureType sync/atomic.align64
+          Type: 1193 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 12 BaseType uint64
     - __kind: StructureType
-      ID: 369
+      ID: 373
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1113824
@@ -33038,29 +33266,29 @@ Types:
           Offset: 0
           Type: 159 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1182
+      ID: 1193
       Name: sync/atomic.align64
       GoRuntimeType: 952256
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 386
+      ID: 387
       Name: sync/atomic.noCopy
       GoRuntimeType: 952160
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 925
+      ID: 936
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1202208
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1139
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 868
+      ID: 879
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1523168
@@ -33073,13 +33301,13 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 1067
+      ID: 1078
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1790016
       GoKind: 6
     - __kind: StructureType
-      ID: 380
+      ID: 325
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1842240
@@ -33090,10 +33318,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 1190 GoSliceHeaderType []time.zone
+          Type: 503 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 1193 GoSliceHeaderType []time.zoneTrans
+          Type: 506 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -33105,13 +33333,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 1191 PointerType *time.zone
+          Type: 504 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 621
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 378
+    - __kind: GoTimeType
+      ID: 323
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2234272
@@ -33125,9 +33353,17 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 379 PointerType *time.Location
+          Type: 324 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 377
+      ID: 381
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1293312
@@ -33135,12 +33371,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1189 GoChannelType <-chan time.Time
+          Type: 1200 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 546
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 763968
@@ -33148,18 +33384,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *time.fileSizeError.str
+          Type: 548 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 536 GoStringDataType time.fileSizeError.str
+      Data: 547 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 547
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1192
+      ID: 505
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1433408
@@ -33175,7 +33411,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1195
+      ID: 508
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1635264
@@ -33236,11 +33472,11 @@ Types:
       GoRuntimeType: 534880
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1102
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 956
+      ID: 967
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1935680
@@ -33251,10 +33487,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 957 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 968 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 958 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 969 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -33269,18 +33505,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 959 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 970 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 959
+      ID: 970
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 957728
       GoKind: 9
     - __kind: StructureType
-      ID: 957
+      ID: 968
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1802048
@@ -33305,21 +33541,21 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 709
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 958
+      ID: 969
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 538528
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1120
+      ID: 1131
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 682
+      ID: 693
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1250784
@@ -33329,13 +33565,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 576
+      ID: 587
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 768480
       GoKind: 2
     - __kind: StructureType
-      ID: 847
+      ID: 858
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1518944
@@ -33348,12 +33584,12 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 801
+      ID: 812
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 956576
       GoKind: 5
-MaxTypeID: 1604
+MaxTypeID: 1608
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,11 +12,11 @@ Probes:
         - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1714 EventRootType Probe[main.stackC]
+              Type: 1715 EventRootType Probe[main.stackC]
               InjectionPoints: [{PC: "0xce0f2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1715 EventRootType Probe[main.stackC]Return
+              Type: 1716 EventRootType Probe[main.stackC]Return
               InjectionPoints: [{PC: "0xce0f65", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -32,11 +32,11 @@ Probes:
         - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testAny]
+              Type: 1554 EventRootType Probe[main.testAny]
               InjectionPoints: [{PC: "0xcdad8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1554 EventRootType Probe[main.testAny]Return
+              Type: 1555 EventRootType Probe[main.testAny]Return
               InjectionPoints: [{PC: "0xcdadc5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -58,11 +58,11 @@ Probes:
         - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.testAnyPtr]
+              Type: 1557 EventRootType Probe[main.testAnyPtr]
               InjectionPoints: [{PC: "0xcdae2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.testAnyPtr]Return
+              Type: 1558 EventRootType Probe[main.testAnyPtr]Return
               InjectionPoints: [{PC: "0xcdae5d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -83,11 +83,11 @@ Probes:
         - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1685 EventRootType Probe[main.testArrayArgAndReturn]
+              Type: 1686 EventRootType Probe[main.testArrayArgAndReturn]
               InjectionPoints: [{PC: "0xcdf52e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1686 EventRootType Probe[main.testArrayArgAndReturn]Return
+              Type: 1687 EventRootType Probe[main.testArrayArgAndReturn]Return
               InjectionPoints: [{PC: "0xcdf5e2", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -109,7 +109,7 @@ Probes:
         - subprogram: {subprogram: 19}
           events:
             - Kind: Entry
-              Type: 1500 EventRootType Probe[main.testArrayEmptyStructs]
+              Type: 1501 EventRootType Probe[main.testArrayEmptyStructs]
               InjectionPoints: [{PC: "0xcd5e40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -131,7 +131,7 @@ Probes:
         - subprogram: {subprogram: 15}
           events:
             - Kind: Entry
-              Type: 1496 EventRootType Probe[main.testArrayOfArrays]
+              Type: 1497 EventRootType Probe[main.testArrayOfArrays]
               InjectionPoints: [{PC: "0xcd5dc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -153,7 +153,7 @@ Probes:
         - subprogram: {subprogram: 17}
           events:
             - Kind: Entry
-              Type: 1498 EventRootType Probe[main.testArrayOfArraysOfArrays]
+              Type: 1499 EventRootType Probe[main.testArrayOfArraysOfArrays]
               InjectionPoints: [{PC: "0xcd5e00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -175,7 +175,7 @@ Probes:
         - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 1565 EventRootType Probe[main.testArrayOfMaps]
+              Type: 1566 EventRootType Probe[main.testArrayOfMaps]
               InjectionPoints: [{PC: "0xcdb6a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -197,7 +197,7 @@ Probes:
         - subprogram: {subprogram: 16}
           events:
             - Kind: Entry
-              Type: 1497 EventRootType Probe[main.testArrayOfStrings]
+              Type: 1498 EventRootType Probe[main.testArrayOfStrings]
               InjectionPoints: [{PC: "0xcd5de0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -218,7 +218,7 @@ Probes:
         - subprogram: {subprogram: 18}
           events:
             - Kind: Entry
-              Type: 1499 EventRootType Probe[main.testArrayOfStructs]
+              Type: 1500 EventRootType Probe[main.testArrayOfStructs]
               InjectionPoints: [{PC: "0xcd5e20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -240,11 +240,11 @@ Probes:
         - subprogram: {subprogram: 90}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testAtomicAdd]
+              Type: 1588 EventRootType Probe[main.testAtomicAdd]
               InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1588 EventRootType Probe[main.testAtomicAdd]Return
+              Type: 1589 EventRootType Probe[main.testAtomicAdd]Return
               InjectionPoints: [{PC: "0xcdd592", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -266,11 +266,11 @@ Probes:
         - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testBigStruct]
+              Type: 1519 EventRootType Probe[main.testBigStruct]
               InjectionPoints: [{PC: "0xcd6540", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1519 EventRootType Probe[main.testBigStruct]Return
+              Type: 1520 EventRootType Probe[main.testBigStruct]Return
               InjectionPoints: [{PC: "0xcd655e", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -292,7 +292,7 @@ Probes:
         - subprogram: {subprogram: 4}
           events:
             - Kind: Entry
-              Type: 1485 EventRootType Probe[main.testBoolArray]
+              Type: 1486 EventRootType Probe[main.testBoolArray]
               InjectionPoints: [{PC: "0xcd5c60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -314,7 +314,7 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 1482 EventRootType Probe[main.testByteArray]
+              Type: 1483 EventRootType Probe[main.testByteArray]
               InjectionPoints: [{PC: "0xcd5c00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -341,11 +341,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1733 EventRootType Probe[main.testStruct]
+              Type: 1734 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0xce1360", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1734 EventRootType Probe[main.testStruct]Return
+              Type: 1735 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0xce1382", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1794 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1798 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcda5ae"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1795 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1799 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcda5ae"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 6 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 189, index: 0, name: x}
+                      Variable: {subprogram: 192, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -437,10 +437,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1796 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1800 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcda5ae"
                   Frameless: false
@@ -477,7 +477,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testCombinedString]
+              Type: 1585 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0xcdd1e0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
@@ -496,7 +496,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testCombinedString]
+              Type: 1586 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0xcdd1e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -522,7 +522,7 @@ Probes:
         - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1741 EventRootType Probe[main.testTenStrings]
+              Type: 1742 EventRootType Probe[main.testTenStrings]
               InjectionPoints: [{PC: "0xce1480", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
@@ -560,7 +560,7 @@ Probes:
         - subprogram: {subprogram: 91}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testChannel]
+              Type: 1590 EventRootType Probe[main.testChannel]
               InjectionPoints: [{PC: "0xcdd5a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -590,7 +590,7 @@ Probes:
         - subprogram: {subprogram: 87}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testCombinedByte]
+              Type: 1584 EventRootType Probe[main.testCombinedByte]
               InjectionPoints: [{PC: "0xcdd1a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -619,11 +619,11 @@ Probes:
         - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1650 EventRootType Probe[main.testConflictingReturn]
+              Type: 1651 EventRootType Probe[main.testConflictingReturn]
               InjectionPoints: [{PC: "0xcde76e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1651 EventRootType Probe[main.testConflictingReturn]Return
+              Type: 1652 EventRootType Probe[main.testConflictingReturn]Return
               InjectionPoints: [{PC: "0xcde831", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -645,7 +645,7 @@ Probes:
         - subprogram: {subprogram: 99}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testCycle]
+              Type: 1598 EventRootType Probe[main.testCycle]
               InjectionPoints: [{PC: "0xcdd980", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -667,7 +667,7 @@ Probes:
         - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 1525 EventRootType Probe[main.testDeepMap1]
+              Type: 1526 EventRootType Probe[main.testDeepMap1]
               InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -689,7 +689,7 @@ Probes:
         - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 1526 EventRootType Probe[main.testDeepMap7]
+              Type: 1527 EventRootType Probe[main.testDeepMap7]
               InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -711,7 +711,7 @@ Probes:
         - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 1521 EventRootType Probe[main.testDeepPtr1]
+              Type: 1522 EventRootType Probe[main.testDeepPtr1]
               InjectionPoints: [{PC: "0xcd6720", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -733,7 +733,7 @@ Probes:
         - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testDeepPtr7]
+              Type: 1523 EventRootType Probe[main.testDeepPtr7]
               InjectionPoints: [{PC: "0xcd6740", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -755,7 +755,7 @@ Probes:
         - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 1523 EventRootType Probe[main.testDeepSlice1]
+              Type: 1524 EventRootType Probe[main.testDeepSlice1]
               InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -777,7 +777,7 @@ Probes:
         - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testDeepSlice7]
+              Type: 1525 EventRootType Probe[main.testDeepSlice7]
               InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -799,7 +799,7 @@ Probes:
         - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1702 EventRootType Probe[main.testEmptySlice]
+              Type: 1703 EventRootType Probe[main.testEmptySlice]
               InjectionPoints: [{PC: "0xce0620", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -826,7 +826,7 @@ Probes:
         - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1705 EventRootType Probe[main.testEmptySliceOfStructs]
+              Type: 1706 EventRootType Probe[main.testEmptySliceOfStructs]
               InjectionPoints: [{PC: "0xce0680", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -854,7 +854,7 @@ Probes:
         - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1728 EventRootType Probe[main.testEmptyString]
+              Type: 1729 EventRootType Probe[main.testEmptyString]
               InjectionPoints: [{PC: "0xce1060", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -876,7 +876,7 @@ Probes:
         - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1742 EventRootType Probe[main.testEmptyStruct]
+              Type: 1743 EventRootType Probe[main.testEmptyStruct]
               InjectionPoints: [{PC: "0xce14e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -897,7 +897,7 @@ Probes:
         - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1743 EventRootType Probe[main.testEmptyStructPointer]
+              Type: 1744 EventRootType Probe[main.testEmptyStructPointer]
               InjectionPoints: [{PC: "0xce1500", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -919,7 +919,7 @@ Probes:
         - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 1555 EventRootType Probe[main.testError]
+              Type: 1556 EventRootType Probe[main.testError]
               InjectionPoints: [{PC: "0xcdae00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -953,7 +953,7 @@ Probes:
         - subprogram: {subprogram: 38}
           events:
             - Kind: Line
-              Type: 1520 EventRootType Probe[main.testErrorAtLine]Line
+              Type: 1521 EventRootType Probe[main.testErrorAtLine]Line
               InjectionPoints: [{PC: "0xcd65db", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -981,11 +981,11 @@ Probes:
         - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testEsotericHeap]
+              Type: 1538 EventRootType Probe[main.testEsotericHeap]
               InjectionPoints: [{PC: "0xcd908a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1538 EventRootType Probe[main.testEsotericHeap]Return
+              Type: 1539 EventRootType Probe[main.testEsotericHeap]Return
               InjectionPoints: [{PC: "0xcd90cc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1007,11 +1007,11 @@ Probes:
         - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testEsotericStack]
+              Type: 1536 EventRootType Probe[main.testEsotericStack]
               InjectionPoints: [{PC: "0xcd8f6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1536 EventRootType Probe[main.testEsotericStack]Return
+              Type: 1537 EventRootType Probe[main.testEsotericStack]Return
               InjectionPoints: [{PC: "0xcd8ffb", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1033,11 +1033,11 @@ Probes:
         - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testFrameless]
+              Type: 1548 EventRootType Probe[main.testFrameless]
               InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1548 EventRootType Probe[main.testFrameless]Return
+              Type: 1549 EventRootType Probe[main.testFrameless]Return
               InjectionPoints: [{PC: "0xcdaa65", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -1059,11 +1059,11 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 1549 EventRootType Probe[main.testFramelessArray]
+              Type: 1550 EventRootType Probe[main.testFramelessArray]
               InjectionPoints: [{PC: "0xcdaa84", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1550 EventRootType Probe[main.testFramelessArray]Return
+              Type: 1551 EventRootType Probe[main.testFramelessArray]Return
               InjectionPoints: [{PC: "0xcdaabd", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1088,7 +1088,7 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Line
-              Type: 1551 EventRootType Probe[main.testFramelessArray]Line
+              Type: 1552 EventRootType Probe[main.testFramelessArray]Line
               InjectionPoints: [{PC: "0xcdaa88", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1107,15 +1107,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1780 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce4100", Frameless: true}]
+              Type: 1784 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0xce4280", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1781 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce4107", Frameless: true}]
+              Type: 1785 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce4287", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,15 +1125,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1782 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce4124", Frameless: false}]
+              Type: 1786 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0xce42a4", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1783 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce4171", Frameless: false}]
+              Type: 1787 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0xce42f1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,15 +1152,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1776 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce406a", Frameless: false}]
+              Type: 1780 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0xce41ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1777 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce4079", Frameless: false}]
+              Type: 1781 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0xce41f9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,15 +1170,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1778 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce40aa", Frameless: false}]
+              Type: 1782 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0xce422a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1779 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce40c2", Frameless: false}]
+              Type: 1783 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0xce4242", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,18 +1197,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1784 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce4180", Frameless: true}]
+              Type: 1788 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0xce4300", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1785 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1789 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce41a0"
+                - PC: "0xce4320"
                   Frameless: true
-                - PC: "0xce41a3"
+                - PC: "0xce4323"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,18 +1219,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1786 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce41ca", Frameless: false}]
+              Type: 1790 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0xce434a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1787 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1791 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce422b"
+                - PC: "0xce43ab"
                   Frameless: false
-                - PC: "0xce4233"
+                - PC: "0xce43b3"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,11 +1253,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Line
-              Type: 1788 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce4185", Frameless: true}]
+              Type: 1792 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0xce4305", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,11 +1265,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1789 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce41df", Frameless: false}]
+              Type: 1793 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0xce435f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,15 +1286,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1764 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce3d20", Frameless: true}]
+              Type: 1768 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0xce3ea0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1765 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce3d30", Frameless: true}]
+              Type: 1769 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0xce3eb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,15 +1304,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1766 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce3dc0", Frameless: true}]
+              Type: 1770 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0xce3f40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1767 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce3dc8", Frameless: true}]
+              Type: 1771 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0xce3f48", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,15 +1332,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 169}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1752 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce38ae", Frameless: false}]
+              Type: 1756 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0xce3a2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1753 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce3994", Frameless: false}]
+              Type: 1757 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce3b14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1350,14 +1350,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1754 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1758 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0xcd4dce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1755 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1759 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0xcd4ebc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1378,15 +1378,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1756 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce39ea", Frameless: false}]
+              Type: 1760 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xce3b6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1757 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce39f9", Frameless: false}]
+              Type: 1761 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce3b79", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,15 +1405,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1790 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce4280", Frameless: true}]
+              Type: 1794 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0xce4400", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1791 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce4286", Frameless: true}]
+              Type: 1795 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0xce4406", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,15 +1423,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1792 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce430a", Frameless: false}]
+              Type: 1796 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0xce448a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1793 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce432d", Frameless: false}]
+              Type: 1797 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0xce44ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,15 +1450,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
+        - subprogram: {subprogram: 170}
           events:
             - Kind: Entry
-              Type: 1748 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce3800", Frameless: true}]
+              Type: 1752 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0xce3980", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1749 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce3803", Frameless: true}]
+              Type: 1753 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce3983", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,15 +1468,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 168}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1750 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce3820", Frameless: true}]
+              Type: 1754 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0xce39a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1751 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce382b", Frameless: true}]
+              Type: 1755 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce39ab", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,15 +1495,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1768 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce3e80", Frameless: true}]
+              Type: 1772 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0xce4000", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1769 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce3e87", Frameless: true}]
+              Type: 1773 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0xce4007", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,15 +1513,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1770 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce3f2a", Frameless: false}]
+              Type: 1774 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0xce40aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1771 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce3f56", Frameless: false}]
+              Type: 1775 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0xce40d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,15 +1540,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1758 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce3cc0", Frameless: true}]
+              Type: 1762 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xce3e40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1759 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce3cc3", Frameless: true}]
+              Type: 1763 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce3e43", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,15 +1558,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1760 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce3ce0", Frameless: true}]
+              Type: 1764 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0xce3e60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1761 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce3ce3", Frameless: true}]
+              Type: 1765 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0xce3e63", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,15 +1576,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1762 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce3d00", Frameless: true}]
+              Type: 1766 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0xce3e80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1763 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce3d03", Frameless: true}]
+              Type: 1767 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0xce3e83", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,15 +1603,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1772 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce4020", Frameless: true}]
+              Type: 1776 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0xce41a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1773 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce4027", Frameless: true}]
+              Type: 1777 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0xce41a7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,15 +1621,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1774 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce4040", Frameless: true}]
+              Type: 1778 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xce41c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1775 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce404e", Frameless: true}]
+              Type: 1779 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce41ce", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,15 +1648,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1744 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce37c0", Frameless: true}]
+              Type: 1748 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0xce3940", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1745 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce37c3", Frameless: true}]
+              Type: 1749 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce3943", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,15 +1666,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1746 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce37e0", Frameless: true}]
+              Type: 1750 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0xce3960", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1747 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce37eb", Frameless: true}]
+              Type: 1751 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce396b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1696,11 +1696,11 @@ Probes:
         - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 1539 EventRootType Probe[main.testInlinedBA]
+              Type: 1540 EventRootType Probe[main.testInlinedBA]
               InjectionPoints: [{PC: "0xcda74a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1540 EventRootType Probe[main.testInlinedBA]Return
+              Type: 1541 EventRootType Probe[main.testInlinedBA]Return
               InjectionPoints: [{PC: "0xcda7ae", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1727,11 +1727,11 @@ Probes:
         - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 1541 EventRootType Probe[main.testInlinedBB]
+              Type: 1542 EventRootType Probe[main.testInlinedBB]
               InjectionPoints: [{PC: "0xcda7ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1542 EventRootType Probe[main.testInlinedBB]Return
+              Type: 1543 EventRootType Probe[main.testInlinedBB]Return
               InjectionPoints: [{PC: "0xcda87e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1758,11 +1758,11 @@ Probes:
         - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testInlinedBBA]
+              Type: 1544 EventRootType Probe[main.testInlinedBBA]
               InjectionPoints: [{PC: "0xcda8ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1544 EventRootType Probe[main.testInlinedBBA]Return
+              Type: 1545 EventRootType Probe[main.testInlinedBBA]Return
               InjectionPoints: [{PC: "0xcda90b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1781,10 +1781,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1800 EventRootType Probe[main.testInlinedBBB]
+              Type: 1804 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0xcda846", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1802,11 +1802,11 @@ Probes:
         - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testInlinedBC]
+              Type: 1546 EventRootType Probe[main.testInlinedBC]
               InjectionPoints: [{PC: "0xcda94e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1546 EventRootType Probe[main.testInlinedBC]Return
+              Type: 1547 EventRootType Probe[main.testInlinedBC]Return
               InjectionPoints: [{PC: "0xcdaa3e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1821,10 +1821,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Entry
-              Type: 1801 EventRootType Probe[main.testInlinedBCA]
+              Type: 1805 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0xcda953", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1842,10 +1842,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Line
-              Type: 1802 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1806 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0xcda953", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1860,10 +1860,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Entry
-              Type: 1803 EventRootType Probe[main.testInlinedBCB]
+              Type: 1807 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0xcdaa06", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1881,10 +1881,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Line
-              Type: 1804 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1808 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0xcdaa06", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1899,10 +1899,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 196}
+        - subprogram: {subprogram: 199}
           events:
             - Kind: Entry
-              Type: 1810 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1814 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0xcd48c1"
                   Frameless: true
@@ -1922,10 +1922,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1797 EventRootType Probe[main.testInlinedPrint]
+              Type: 1801 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0xcda5aa"
                   Frameless: false
@@ -1939,7 +1939,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1798 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1802 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0xcda5ea", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1961,10 +1961,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1799 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1803 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcda5ae"
                   Frameless: false
@@ -1993,10 +1993,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Entry
-              Type: 1805 EventRootType Probe[main.testInlinedSq]
+              Type: 1809 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0xcdaa61", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2018,10 +2018,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Line
-              Type: 1806 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1810 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0xcdaa61", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2041,10 +2041,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 194}
+        - subprogram: {subprogram: 197}
           events:
             - Kind: Entry
-              Type: 1807 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1811 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0xcdaaa5"
                   Frameless: false
@@ -2070,7 +2070,7 @@ Probes:
         - subprogram: {subprogram: 7}
           events:
             - Kind: Entry
-              Type: 1488 EventRootType Probe[main.testInt16Array]
+              Type: 1489 EventRootType Probe[main.testInt16Array]
               InjectionPoints: [{PC: "0xcd5cc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2092,7 +2092,7 @@ Probes:
         - subprogram: {subprogram: 8}
           events:
             - Kind: Entry
-              Type: 1489 EventRootType Probe[main.testInt32Array]
+              Type: 1490 EventRootType Probe[main.testInt32Array]
               InjectionPoints: [{PC: "0xcd5ce0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2114,7 +2114,7 @@ Probes:
         - subprogram: {subprogram: 9}
           events:
             - Kind: Entry
-              Type: 1490 EventRootType Probe[main.testInt64Array]
+              Type: 1491 EventRootType Probe[main.testInt64Array]
               InjectionPoints: [{PC: "0xcd5d00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2136,7 +2136,7 @@ Probes:
         - subprogram: {subprogram: 6}
           events:
             - Kind: Entry
-              Type: 1487 EventRootType Probe[main.testInt8Array]
+              Type: 1488 EventRootType Probe[main.testInt8Array]
               InjectionPoints: [{PC: "0xcd5ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2158,7 +2158,7 @@ Probes:
         - subprogram: {subprogram: 5}
           events:
             - Kind: Entry
-              Type: 1486 EventRootType Probe[main.testIntArray]
+              Type: 1487 EventRootType Probe[main.testIntArray]
               InjectionPoints: [{PC: "0xcd5c80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2180,7 +2180,7 @@ Probes:
         - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 1552 EventRootType Probe[main.testInterface]
+              Type: 1553 EventRootType Probe[main.testInterface]
               InjectionPoints: [{PC: "0xcdad60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2201,11 +2201,11 @@ Probes:
         - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1683 EventRootType Probe[main.testLargeArgAndReturn]
+              Type: 1684 EventRootType Probe[main.testLargeArgAndReturn]
               InjectionPoints: [{PC: "0xcdf38e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1684 EventRootType Probe[main.testLargeArgAndReturn]Return
+              Type: 1685 EventRootType Probe[main.testLargeArgAndReturn]Return
               InjectionPoints: [{PC: "0xcdf4f3", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2227,7 +2227,7 @@ Probes:
         - subprogram: {subprogram: 93}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testLinkedList]
+              Type: 1592 EventRootType Probe[main.testLinkedList]
               InjectionPoints: [{PC: "0xcdd7a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2252,7 +2252,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1529 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1530 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xcd6ada", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2274,7 +2274,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1530 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1531 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xcd6b8d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2296,7 +2296,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1531 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1532 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xcd6c54", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2339,11 +2339,11 @@ Probes:
         - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1689 EventRootType Probe[main.testManyArgsArrayReturn]
+              Type: 1690 EventRootType Probe[main.testManyArgsArrayReturn]
               InjectionPoints: [{PC: "0xcdf853", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1690 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              Type: 1691 EventRootType Probe[main.testManyArgsArrayReturn]Return
               InjectionPoints: [{PC: "0xcdfa62", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2406,7 +2406,7 @@ Probes:
         - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testManyPointers]
+              Type: 1534 EventRootType Probe[main.testManyPointers]
               InjectionPoints: [{PC: "0xcd72c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2430,7 +2430,7 @@ Probes:
         - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testManyStrings]
+              Type: 1535 EventRootType Probe[main.testManyStrings]
               InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2452,7 +2452,7 @@ Probes:
         - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 1563 EventRootType Probe[main.testMapArrayToArray]
+              Type: 1564 EventRootType Probe[main.testMapArrayToArray]
               InjectionPoints: [{PC: "0xcdb660", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2474,7 +2474,7 @@ Probes:
         - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 1570 EventRootType Probe[main.testMapEmbeddedMaps]
+              Type: 1571 EventRootType Probe[main.testMapEmbeddedMaps]
               InjectionPoints: [{PC: "0xcdb720", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2496,7 +2496,7 @@ Probes:
         - subprogram: {subprogram: 84}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testMapEmptyKey]
+              Type: 1581 EventRootType Probe[main.testMapEmptyKey]
               InjectionPoints: [{PC: "0xcdb860", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2518,7 +2518,7 @@ Probes:
         - subprogram: {subprogram: 86}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testMapEmptyKeyAndValue]
+              Type: 1583 EventRootType Probe[main.testMapEmptyKeyAndValue]
               InjectionPoints: [{PC: "0xcdb8a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2540,7 +2540,7 @@ Probes:
         - subprogram: {subprogram: 85}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testMapEmptyValue]
+              Type: 1582 EventRootType Probe[main.testMapEmptyValue]
               InjectionPoints: [{PC: "0xcdb880", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2562,7 +2562,7 @@ Probes:
         - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 1567 EventRootType Probe[main.testMapIntToInt]
+              Type: 1568 EventRootType Probe[main.testMapIntToInt]
               InjectionPoints: [{PC: "0xcdb6e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2584,7 +2584,7 @@ Probes:
         - subprogram: {subprogram: 83}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testMapLargeKeyLargeValue]
+              Type: 1580 EventRootType Probe[main.testMapLargeKeyLargeValue]
               InjectionPoints: [{PC: "0xcdb840", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2606,7 +2606,7 @@ Probes:
         - subprogram: {subprogram: 82}
           events:
             - Kind: Entry
-              Type: 1578 EventRootType Probe[main.testMapLargeKeySmallValue]
+              Type: 1579 EventRootType Probe[main.testMapLargeKeySmallValue]
               InjectionPoints: [{PC: "0xcdb820", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2630,7 +2630,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.testMapMassive]
+              Type: 1569 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0xcdb700", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2654,7 +2654,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1569 EventRootType Probe[main.testMapMassive]
+              Type: 1570 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0xcdb700", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2676,7 +2676,7 @@ Probes:
         - subprogram: {subprogram: 81}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testMapSmallKeyLargeValue]
+              Type: 1578 EventRootType Probe[main.testMapSmallKeyLargeValue]
               InjectionPoints: [{PC: "0xcdb800", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2698,7 +2698,7 @@ Probes:
         - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 1576 EventRootType Probe[main.testMapSmallKeySmallValue]
+              Type: 1577 EventRootType Probe[main.testMapSmallKeySmallValue]
               InjectionPoints: [{PC: "0xcdb7e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2720,7 +2720,7 @@ Probes:
         - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 1561 EventRootType Probe[main.testMapStringToInt]
+              Type: 1562 EventRootType Probe[main.testMapStringToInt]
               InjectionPoints: [{PC: "0xcdb620", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2742,7 +2742,7 @@ Probes:
         - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.testMapStringToSlice]
+              Type: 1563 EventRootType Probe[main.testMapStringToSlice]
               InjectionPoints: [{PC: "0xcdb640", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2764,7 +2764,7 @@ Probes:
         - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.testMapStringToStruct]
+              Type: 1561 EventRootType Probe[main.testMapStringToStruct]
               InjectionPoints: [{PC: "0xcdb600", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2786,7 +2786,7 @@ Probes:
         - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testMapWithLinkedList]
+              Type: 1572 EventRootType Probe[main.testMapWithLinkedList]
               InjectionPoints: [{PC: "0xcdb740", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2808,7 +2808,7 @@ Probes:
         - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 1574 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+              Type: 1575 EventRootType Probe[main.testMapWithSmallKeyAndValue]
               InjectionPoints: [{PC: "0xcdb7a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2830,7 +2830,7 @@ Probes:
         - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+              Type: 1576 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
               InjectionPoints: [{PC: "0xcdb7c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2852,7 +2852,7 @@ Probes:
         - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 1572 EventRootType Probe[main.testMapWithSmallValue]
+              Type: 1573 EventRootType Probe[main.testMapWithSmallValue]
               InjectionPoints: [{PC: "0xcdb760", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2876,7 +2876,7 @@ Probes:
         - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.testMapWithSmallValueMassive]
+              Type: 1574 EventRootType Probe[main.testMapWithSmallValueMassive]
               InjectionPoints: [{PC: "0xcdb780", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2898,7 +2898,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1725 EventRootType Probe[main.testMassiveString]
+              Type: 1726 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0xce1020", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2921,7 +2921,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1726 EventRootType Probe[main.testMassiveString]
+              Type: 1727 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0xce1020", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2968,11 +2968,11 @@ Probes:
         - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1691 EventRootType Probe[main.testMixedArgsStackReturn]
+              Type: 1692 EventRootType Probe[main.testMixedArgsStackReturn]
               InjectionPoints: [{PC: "0xcdfaf3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1692 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              Type: 1693 EventRootType Probe[main.testMixedArgsStackReturn]Return
               InjectionPoints: [{PC: "0xcdfd2b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3038,11 +3038,11 @@ Probes:
         - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1695 EventRootType Probe[main.testMultipleArrayArgs]
+              Type: 1696 EventRootType Probe[main.testMultipleArrayArgs]
               InjectionPoints: [{PC: "0xcdfe6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1696 EventRootType Probe[main.testMultipleArrayArgs]Return
+              Type: 1697 EventRootType Probe[main.testMultipleArrayArgs]Return
               InjectionPoints: [{PC: "0xcdff3e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3073,11 +3073,11 @@ Probes:
         - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1687 EventRootType Probe[main.testMultipleLargeArgs]
+              Type: 1688 EventRootType Probe[main.testMultipleLargeArgs]
               InjectionPoints: [{PC: "0xcdf60e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1688 EventRootType Probe[main.testMultipleLargeArgs]Return
+              Type: 1689 EventRootType Probe[main.testMultipleLargeArgs]Return
               InjectionPoints: [{PC: "0xcdf82a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3103,11 +3103,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1628 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1629 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcde5ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1629 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1630 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcde64f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3143,7 +3143,7 @@ Probes:
         - subprogram: {subprogram: 89}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testMultipleSimpleParams]
+              Type: 1587 EventRootType Probe[main.testMultipleSimpleParams]
               InjectionPoints: [{PC: "0xcdd360", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3184,11 +3184,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1622 EventRootType Probe[main.testNamedReturn]
+              Type: 1623 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xcde50a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1623 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1624 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xcde575", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3212,11 +3212,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1624 EventRootType Probe[main.testNamedReturn]
+              Type: 1625 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xcde50a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1625 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1626 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xcde575", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
@@ -3235,11 +3235,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1630 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1631 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcde5ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1631 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1632 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcde64f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
@@ -3259,11 +3259,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1632 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1633 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcde5ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1633 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1634 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcde64f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3296,11 +3296,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1626 EventRootType Probe[main.testNamedReturn]
+              Type: 1627 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xcde50a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1627 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1628 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xcde575", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3328,7 +3328,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1737 EventRootType Probe[main.testNestedPointer]
+              Type: 1738 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xce1460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3353,7 +3353,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1738 EventRootType Probe[main.testNestedPointer]
+              Type: 1739 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xce1460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3384,7 +3384,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1739 EventRootType Probe[main.testNestedPointer]
+              Type: 1740 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xce1460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3409,7 +3409,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1740 EventRootType Probe[main.testNestedPointer]
+              Type: 1741 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xce1460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3436,7 +3436,7 @@ Probes:
         - subprogram: {subprogram: 98}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testNilPointer]
+              Type: 1597 EventRootType Probe[main.testNilPointer]
               InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3463,7 +3463,7 @@ Probes:
         - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1709 EventRootType Probe[main.testNilSlice]
+              Type: 1710 EventRootType Probe[main.testNilSlice]
               InjectionPoints: [{PC: "0xce0700", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3490,7 +3490,7 @@ Probes:
         - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1706 EventRootType Probe[main.testNilSliceOfStructs]
+              Type: 1707 EventRootType Probe[main.testNilSliceOfStructs]
               InjectionPoints: [{PC: "0xce06a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3525,7 +3525,7 @@ Probes:
         - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1708 EventRootType Probe[main.testNilSliceWithOtherParams]
+              Type: 1709 EventRootType Probe[main.testNilSliceWithOtherParams]
               InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3557,7 +3557,7 @@ Probes:
         - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1724 EventRootType Probe[main.testOneStringInStructPointer]
+              Type: 1725 EventRootType Probe[main.testOneStringInStructPointer]
               InjectionPoints: [{PC: "0xce1000", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3579,7 +3579,7 @@ Probes:
         - subprogram: {subprogram: 94}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.testPointerLoop]
+              Type: 1593 EventRootType Probe[main.testPointerLoop]
               InjectionPoints: [{PC: "0xcdd7c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3601,7 +3601,7 @@ Probes:
         - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.testPointerToMap]
+              Type: 1567 EventRootType Probe[main.testPointerToMap]
               InjectionPoints: [{PC: "0xcdb6c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3623,7 +3623,7 @@ Probes:
         - subprogram: {subprogram: 92}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testPointerToSimpleStruct]
+              Type: 1591 EventRootType Probe[main.testPointerToSimpleStruct]
               InjectionPoints: [{PC: "0xcdd780", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3647,11 +3647,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testReturnsInt]
+              Type: 1599 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xcdddea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1599 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1600 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xcdde3b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
@@ -3671,11 +3671,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1642 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1643 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xcde68e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1643 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1644 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xcde72b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3720,11 +3720,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1609 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xcddf0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1609 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1610 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xcddfc4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3766,11 +3766,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testReturnsInt]
+              Type: 1601 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xcdddea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1601 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1602 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xcdde3b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3815,11 +3815,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1610 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1611 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xcddf0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1611 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1612 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xcddfc4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3863,11 +3863,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1644 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1645 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xcde68e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1645 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1646 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xcde72b", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
@@ -3884,11 +3884,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1646 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1647 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xcde68e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1647 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1648 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xcde72b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3910,11 +3910,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testReturnsInt]
+              Type: 1603 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xcdddea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1603 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1604 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xcdde3b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3937,11 +3937,11 @@ Probes:
         - subprogram: {subprogram: 105}
           events:
             - Kind: Entry
-              Type: 1618 EventRootType Probe[main.testReturnsAny]
+              Type: 1619 EventRootType Probe[main.testReturnsAny]
               InjectionPoints: [{PC: "0xcde1ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1619 EventRootType Probe[main.testReturnsAny]Return
+              Type: 1620 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
                 - PC: "0xcde264"
                   Frameless: false
@@ -3976,11 +3976,11 @@ Probes:
         - subprogram: {subprogram: 104}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testReturnsAnyAndError]
+              Type: 1617 EventRootType Probe[main.testReturnsAnyAndError]
               InjectionPoints: [{PC: "0xcde04e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1617 EventRootType Probe[main.testReturnsAnyAndError]Return
+              Type: 1618 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
                 - PC: "0xcde0a4"
                   Frameless: false
@@ -4014,11 +4014,11 @@ Probes:
         - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1661 EventRootType Probe[main.testReturnsArray]
+              Type: 1662 EventRootType Probe[main.testReturnsArray]
               InjectionPoints: [{PC: "0xcdee2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1662 EventRootType Probe[main.testReturnsArray]Return
+              Type: 1663 EventRootType Probe[main.testReturnsArray]Return
               InjectionPoints: [{PC: "0xcdee8d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4035,11 +4035,11 @@ Probes:
         - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1663 EventRootType Probe[main.testReturnsArrayOne]
+              Type: 1664 EventRootType Probe[main.testReturnsArrayOne]
               InjectionPoints: [{PC: "0xcdeeaa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1664 EventRootType Probe[main.testReturnsArrayOne]Return
+              Type: 1665 EventRootType Probe[main.testReturnsArrayOne]Return
               InjectionPoints: [{PC: "0xcdeeeb", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4056,11 +4056,11 @@ Probes:
         - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1665 EventRootType Probe[main.testReturnsArrayZero]
+              Type: 1666 EventRootType Probe[main.testReturnsArrayZero]
               InjectionPoints: [{PC: "0xcdef0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1666 EventRootType Probe[main.testReturnsArrayZero]Return
+              Type: 1667 EventRootType Probe[main.testReturnsArrayZero]Return
               InjectionPoints: [{PC: "0xcdef46", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4077,11 +4077,11 @@ Probes:
         - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1669 EventRootType Probe[main.testReturnsBacktrackInt]
+              Type: 1670 EventRootType Probe[main.testReturnsBacktrackInt]
               InjectionPoints: [{PC: "0xcdefee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1670 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              Type: 1671 EventRootType Probe[main.testReturnsBacktrackInt]Return
               InjectionPoints: [{PC: "0xcdf06a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4098,11 +4098,11 @@ Probes:
         - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1681 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              Type: 1682 EventRootType Probe[main.testReturnsBoolAndUintptr]
               InjectionPoints: [{PC: "0xcdf32a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1682 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              Type: 1683 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
               InjectionPoints: [{PC: "0xcdf370", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4119,11 +4119,11 @@ Probes:
         - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1657 EventRootType Probe[main.testReturnsComplex]
+              Type: 1658 EventRootType Probe[main.testReturnsComplex]
               InjectionPoints: [{PC: "0xcdecea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1658 EventRootType Probe[main.testReturnsComplex]Return
+              Type: 1659 EventRootType Probe[main.testReturnsComplex]Return
               InjectionPoints: [{PC: "0xcded46", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4141,11 +4141,11 @@ Probes:
         - subprogram: {subprogram: 103}
           events:
             - Kind: Entry
-              Type: 1614 EventRootType Probe[main.testReturnsError]
+              Type: 1615 EventRootType Probe[main.testReturnsError]
               InjectionPoints: [{PC: "0xcddfea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1615 EventRootType Probe[main.testReturnsError]Return
+              Type: 1616 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
                 - PC: "0xcde01a"
                   Frameless: false
@@ -4170,11 +4170,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testReturnsInt]
+              Type: 1605 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xcdddea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1605 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1606 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xcdde3b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4195,11 +4195,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1612 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1613 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xcddf0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1613 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1614 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xcddfc4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4220,11 +4220,11 @@ Probes:
         - subprogram: {subprogram: 101}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testReturnsIntPointer]
+              Type: 1607 EventRootType Probe[main.testReturnsIntPointer]
               InjectionPoints: [{PC: "0xcdde6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1607 EventRootType Probe[main.testReturnsIntPointer]Return
+              Type: 1608 EventRootType Probe[main.testReturnsIntPointer]Return
               InjectionPoints: [{PC: "0xcdded4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4246,11 +4246,11 @@ Probes:
         - subprogram: {subprogram: 106}
           events:
             - Kind: Entry
-              Type: 1620 EventRootType Probe[main.testReturnsInterface]
+              Type: 1621 EventRootType Probe[main.testReturnsInterface]
               InjectionPoints: [{PC: "0xcde3ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1621 EventRootType Probe[main.testReturnsInterface]Return
+              Type: 1622 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
                 - PC: "0xcde48f"
                   Frameless: false
@@ -4275,11 +4275,11 @@ Probes:
         - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.testReturnsLargeStruct]
+              Type: 1660 EventRootType Probe[main.testReturnsLargeStruct]
               InjectionPoints: [{PC: "0xcded6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1660 EventRootType Probe[main.testReturnsLargeStruct]Return
+              Type: 1661 EventRootType Probe[main.testReturnsLargeStruct]Return
               InjectionPoints: [{PC: "0xcdedf3", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4296,11 +4296,11 @@ Probes:
         - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1655 EventRootType Probe[main.testReturnsManyFloats]
+              Type: 1656 EventRootType Probe[main.testReturnsManyFloats]
               InjectionPoints: [{PC: "0xcdebee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1656 EventRootType Probe[main.testReturnsManyFloats]Return
+              Type: 1657 EventRootType Probe[main.testReturnsManyFloats]Return
               InjectionPoints: [{PC: "0xcdecc7", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4317,11 +4317,11 @@ Probes:
         - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1673 EventRootType Probe[main.testReturnsMixed]
+              Type: 1674 EventRootType Probe[main.testReturnsMixed]
               InjectionPoints: [{PC: "0xcdf14a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1674 EventRootType Probe[main.testReturnsMixed]Return
+              Type: 1675 EventRootType Probe[main.testReturnsMixed]Return
               InjectionPoints: [{PC: "0xcdf1ac", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4338,11 +4338,11 @@ Probes:
         - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1667 EventRootType Probe[main.testReturnsMixedStruct]
+              Type: 1668 EventRootType Probe[main.testReturnsMixedStruct]
               InjectionPoints: [{PC: "0xcdef6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1668 EventRootType Probe[main.testReturnsMixedStruct]Return
+              Type: 1669 EventRootType Probe[main.testReturnsMixedStruct]Return
               InjectionPoints: [{PC: "0xcdefb8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4359,11 +4359,11 @@ Probes:
         - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1679 EventRootType Probe[main.testReturnsMultipleFloats]
+              Type: 1680 EventRootType Probe[main.testReturnsMultipleFloats]
               InjectionPoints: [{PC: "0xcdf2aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1680 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              Type: 1681 EventRootType Probe[main.testReturnsMultipleFloats]Return
               InjectionPoints: [{PC: "0xcdf2f6", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4383,7 +4383,7 @@ Probes:
         - subprogram: {subprogram: 111}
           events:
             - Kind: Line
-              Type: 1652 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              Type: 1653 EventRootType Probe[main.testReturnsNamedDeferLine]Line
               InjectionPoints: [{PC: "0xcde96f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4404,11 +4404,11 @@ Probes:
         - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1677 EventRootType Probe[main.testReturnsOnlyFloat]
+              Type: 1678 EventRootType Probe[main.testReturnsOnlyFloat]
               InjectionPoints: [{PC: "0xcdf24a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1678 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              Type: 1679 EventRootType Probe[main.testReturnsOnlyFloat]Return
               InjectionPoints: [{PC: "0xcdf28e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4425,11 +4425,11 @@ Probes:
         - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1653 EventRootType Probe[main.testReturnsPrimitives]
+              Type: 1654 EventRootType Probe[main.testReturnsPrimitives]
               InjectionPoints: [{PC: "0xcdeb6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1654 EventRootType Probe[main.testReturnsPrimitives]Return
+              Type: 1655 EventRootType Probe[main.testReturnsPrimitives]Return
               InjectionPoints: [{PC: "0xcdebd1", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4446,11 +4446,11 @@ Probes:
         - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1675 EventRootType Probe[main.testReturnsStructWithArray]
+              Type: 1676 EventRootType Probe[main.testReturnsStructWithArray]
               InjectionPoints: [{PC: "0xcdf1ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1676 EventRootType Probe[main.testReturnsStructWithArray]Return
+              Type: 1677 EventRootType Probe[main.testReturnsStructWithArray]Return
               InjectionPoints: [{PC: "0xcdf22d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4467,11 +4467,11 @@ Probes:
         - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1671 EventRootType Probe[main.testReturnsWideStruct]
+              Type: 1672 EventRootType Probe[main.testReturnsWideStruct]
               InjectionPoints: [{PC: "0xcdf08e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1672 EventRootType Probe[main.testReturnsWideStruct]Return
+              Type: 1673 EventRootType Probe[main.testReturnsWideStruct]Return
               InjectionPoints: [{PC: "0xcdf114", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4489,7 +4489,7 @@ Probes:
         - subprogram: {subprogram: 2}
           events:
             - Kind: Entry
-              Type: 1483 EventRootType Probe[main.testRuneArray]
+              Type: 1484 EventRootType Probe[main.testRuneArray]
               InjectionPoints: [{PC: "0xcd5c20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4524,11 +4524,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1634 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1635 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcde5ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1635 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1636 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcde64f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4574,7 +4574,7 @@ Probes:
         - subprogram: {subprogram: 23}
           events:
             - Kind: Entry
-              Type: 1504 EventRootType Probe[main.testSingleBool]
+              Type: 1505 EventRootType Probe[main.testSingleBool]
               InjectionPoints: [{PC: "0xcd6240", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4596,7 +4596,7 @@ Probes:
         - subprogram: {subprogram: 21}
           events:
             - Kind: Entry
-              Type: 1502 EventRootType Probe[main.testSingleByte]
+              Type: 1503 EventRootType Probe[main.testSingleByte]
               InjectionPoints: [{PC: "0xcd6200", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4618,7 +4618,7 @@ Probes:
         - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 1515 EventRootType Probe[main.testSingleFloat32]
+              Type: 1516 EventRootType Probe[main.testSingleFloat32]
               InjectionPoints: [{PC: "0xcd63a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4636,7 +4636,7 @@ Probes:
         - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testSingleFloat64]
+              Type: 1517 EventRootType Probe[main.testSingleFloat64]
               InjectionPoints: [{PC: "0xcd63c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4654,7 +4654,7 @@ Probes:
         - subprogram: {subprogram: 24}
           events:
             - Kind: Entry
-              Type: 1505 EventRootType Probe[main.testSingleInt]
+              Type: 1506 EventRootType Probe[main.testSingleInt]
               InjectionPoints: [{PC: "0xcd6260", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4676,7 +4676,7 @@ Probes:
         - subprogram: {subprogram: 26}
           events:
             - Kind: Entry
-              Type: 1507 EventRootType Probe[main.testSingleInt16]
+              Type: 1508 EventRootType Probe[main.testSingleInt16]
               InjectionPoints: [{PC: "0xcd62a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4699,7 +4699,7 @@ Probes:
         - subprogram: {subprogram: 27}
           events:
             - Kind: Entry
-              Type: 1508 EventRootType Probe[main.testSingleInt32]
+              Type: 1509 EventRootType Probe[main.testSingleInt32]
               InjectionPoints: [{PC: "0xcd62c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4721,7 +4721,7 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Entry
-              Type: 1509 EventRootType Probe[main.testSingleInt64]
+              Type: 1510 EventRootType Probe[main.testSingleInt64]
               InjectionPoints: [{PC: "0xcd62e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4750,7 +4750,7 @@ Probes:
         - subprogram: {subprogram: 25}
           events:
             - Kind: Entry
-              Type: 1506 EventRootType Probe[main.testSingleInt8]
+              Type: 1507 EventRootType Probe[main.testSingleInt8]
               InjectionPoints: [{PC: "0xcd6280", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4781,7 +4781,7 @@ Probes:
         - subprogram: {subprogram: 22}
           events:
             - Kind: Entry
-              Type: 1503 EventRootType Probe[main.testSingleRune]
+              Type: 1504 EventRootType Probe[main.testSingleRune]
               InjectionPoints: [{PC: "0xcd6220", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4803,7 +4803,7 @@ Probes:
         - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1716 EventRootType Probe[main.testSingleString]
+              Type: 1717 EventRootType Probe[main.testSingleString]
               InjectionPoints: [{PC: "0xce0f80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4825,7 +4825,7 @@ Probes:
         - subprogram: {subprogram: 29}
           events:
             - Kind: Entry
-              Type: 1510 EventRootType Probe[main.testSingleUint]
+              Type: 1511 EventRootType Probe[main.testSingleUint]
               InjectionPoints: [{PC: "0xcd6300", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4847,7 +4847,7 @@ Probes:
         - subprogram: {subprogram: 31}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testSingleUint16]
+              Type: 1513 EventRootType Probe[main.testSingleUint16]
               InjectionPoints: [{PC: "0xcd6340", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4869,7 +4869,7 @@ Probes:
         - subprogram: {subprogram: 32}
           events:
             - Kind: Entry
-              Type: 1513 EventRootType Probe[main.testSingleUint32]
+              Type: 1514 EventRootType Probe[main.testSingleUint32]
               InjectionPoints: [{PC: "0xcd6360", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4891,7 +4891,7 @@ Probes:
         - subprogram: {subprogram: 33}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testSingleUint64]
+              Type: 1515 EventRootType Probe[main.testSingleUint64]
               InjectionPoints: [{PC: "0xcd6380", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4913,7 +4913,7 @@ Probes:
         - subprogram: {subprogram: 30}
           events:
             - Kind: Entry
-              Type: 1511 EventRootType Probe[main.testSingleUint8]
+              Type: 1512 EventRootType Probe[main.testSingleUint8]
               InjectionPoints: [{PC: "0xcd6320", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4935,7 +4935,7 @@ Probes:
         - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1712 EventRootType Probe[main.testSliceEmptyStructs]
+              Type: 1713 EventRootType Probe[main.testSliceEmptyStructs]
               InjectionPoints: [{PC: "0xce0740", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4957,7 +4957,7 @@ Probes:
         - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1703 EventRootType Probe[main.testSliceOfSlices]
+              Type: 1704 EventRootType Probe[main.testSliceOfSlices]
               InjectionPoints: [{PC: "0xce0640", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4979,7 +4979,7 @@ Probes:
         - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.testSmallMap]
+              Type: 1565 EventRootType Probe[main.testSmallMap]
               InjectionPoints: [{PC: "0xcdb680", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5000,11 +5000,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1648 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1649 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xcde68e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1649 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1650 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xcde72b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5025,11 +5025,11 @@ Probes:
         - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1693 EventRootType Probe[main.testStackArgRegReturns]
+              Type: 1694 EventRootType Probe[main.testStackArgRegReturns]
               InjectionPoints: [{PC: "0xcdfdca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1694 EventRootType Probe[main.testStackArgRegReturns]Return
+              Type: 1695 EventRootType Probe[main.testStackArgRegReturns]Return
               InjectionPoints: [{PC: "0xcdfe3c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5051,7 +5051,7 @@ Probes:
         - subprogram: {subprogram: 3}
           events:
             - Kind: Entry
-              Type: 1484 EventRootType Probe[main.testStringArray]
+              Type: 1485 EventRootType Probe[main.testStringArray]
               InjectionPoints: [{PC: "0xcd5c40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5073,7 +5073,7 @@ Probes:
         - subprogram: {subprogram: 97}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testStringPointer]
+              Type: 1596 EventRootType Probe[main.testStringPointer]
               InjectionPoints: [{PC: "0xcdd900", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5095,7 +5095,7 @@ Probes:
         - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1707 EventRootType Probe[main.testStringSlice]
+              Type: 1708 EventRootType Probe[main.testStringSlice]
               InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5117,7 +5117,7 @@ Probes:
         - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 1527 EventRootType Probe[main.testStringType1]
+              Type: 1528 EventRootType Probe[main.testStringType1]
               InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5139,7 +5139,7 @@ Probes:
         - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 1528 EventRootType Probe[main.testStringType2]
+              Type: 1529 EventRootType Probe[main.testStringType2]
               InjectionPoints: [{PC: "0xcd6aa0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5161,11 +5161,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1735 EventRootType Probe[main.testStruct]
+              Type: 1736 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0xce1360", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1736 EventRootType Probe[main.testStruct]Return
+              Type: 1737 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0xce1382", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5192,7 +5192,7 @@ Probes:
         - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1704 EventRootType Probe[main.testStructSlice]
+              Type: 1705 EventRootType Probe[main.testStructSlice]
               InjectionPoints: [{PC: "0xce0660", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5219,7 +5219,7 @@ Probes:
         - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.testStructWithAny]
+              Type: 1559 EventRootType Probe[main.testStructWithAny]
               InjectionPoints: [{PC: "0xcdae80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5240,11 +5240,11 @@ Probes:
         - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1697 EventRootType Probe[main.testStructWithArrayArg]
+              Type: 1698 EventRootType Probe[main.testStructWithArrayArg]
               InjectionPoints: [{PC: "0xcdff6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1698 EventRootType Probe[main.testStructWithArrayArg]Return
+              Type: 1699 EventRootType Probe[main.testStructWithArrayArg]Return
               InjectionPoints: [{PC: "0xce001a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5266,11 +5266,11 @@ Probes:
         - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1731 EventRootType Probe[main.testStructWithCyclicMaps]
+              Type: 1732 EventRootType Probe[main.testStructWithCyclicMaps]
               InjectionPoints: [{PC: "0xce1220", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1732 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              Type: 1733 EventRootType Probe[main.testStructWithCyclicMaps]Return
               InjectionPoints: [{PC: "0xce123e", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5291,7 +5291,7 @@ Probes:
         - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1730 EventRootType Probe[main.testStructWithCyclicSlices]
+              Type: 1731 EventRootType Probe[main.testStructWithCyclicSlices]
               InjectionPoints: [{PC: "0xce1200", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5318,7 +5318,7 @@ Probes:
         - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 1559 EventRootType Probe[main.testStructWithMap]
+              Type: 1560 EventRootType Probe[main.testStructWithMap]
               InjectionPoints: [{PC: "0xcdb5e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5351,7 +5351,7 @@ Probes:
         - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1713 EventRootType Probe[main.testSubslices]
+              Type: 1714 EventRootType Probe[main.testSubslices]
               InjectionPoints: [{PC: "0xce0760", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5391,7 +5391,7 @@ Probes:
         - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1729 EventRootType Probe[main.testSubstrings]
+              Type: 1730 EventRootType Probe[main.testSubstrings]
               InjectionPoints: [{PC: "0xce1080", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5423,7 +5423,7 @@ Probes:
         - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testTakeContext]
+              Type: 1533 EventRootType Probe[main.testTakeContext]
               InjectionPoints: [{PC: "0xcd7140", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
@@ -5439,11 +5439,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1636 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1637 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcde5ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1637 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1638 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcde64f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5464,11 +5464,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1638 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1639 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcde5ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1639 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1640 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcde64f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5491,11 +5491,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1640 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1641 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcde5ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1641 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1642 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcde64f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5527,7 +5527,7 @@ Probes:
         - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1717 EventRootType Probe[main.testThreeStrings]
+              Type: 1718 EventRootType Probe[main.testThreeStrings]
               InjectionPoints: [{PC: "0xce0fa0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5559,11 +5559,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1718 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1719 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0xce0fc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1719 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1720 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0xce0fde", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5593,11 +5593,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1720 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1721 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0xce0fc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1721 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1722 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0xce0fde", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5629,7 +5629,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1722 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1723 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0xce0fe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5659,7 +5659,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1723 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1724 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0xce0fe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5679,6 +5679,72 @@ Probes:
                   DSL: a.c
                   EventKind: Entry
                   EventExpressionIndex: 2
+    - id: testTimeFixedZone
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeFixedZone}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 166}
+          events:
+            - Kind: Entry
+              Type: 1746 EventRootType Probe[main.testTimeFixedZone]
+              InjectionPoints: [{PC: "0xce2880", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeMonotonic
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeMonotonic}
+      tags: ['foo:bar']
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 167}
+          events:
+            - Kind: Entry
+              Type: 1747 EventRootType Probe[main.testTimeMonotonic]
+              InjectionPoints: [{PC: "0xce28a0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{c}'
+            Segments:
+                - JSON: {Ref: c}
+                  DSL: c
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeUTC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeUTC}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 165}
+          events:
+            - Kind: Entry
+              Type: 1745 EventRootType Probe[main.testTimeUTC]
+              InjectionPoints: [{PC: "0xce2860", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -5691,7 +5757,7 @@ Probes:
         - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 1517 EventRootType Probe[main.testTypeAlias]
+              Type: 1518 EventRootType Probe[main.testTypeAlias]
               InjectionPoints: [{PC: "0xcd63e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5713,7 +5779,7 @@ Probes:
         - subprogram: {subprogram: 12}
           events:
             - Kind: Entry
-              Type: 1493 EventRootType Probe[main.testUint16Array]
+              Type: 1494 EventRootType Probe[main.testUint16Array]
               InjectionPoints: [{PC: "0xcd5d60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5735,7 +5801,7 @@ Probes:
         - subprogram: {subprogram: 13}
           events:
             - Kind: Entry
-              Type: 1494 EventRootType Probe[main.testUint32Array]
+              Type: 1495 EventRootType Probe[main.testUint32Array]
               InjectionPoints: [{PC: "0xcd5d80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5757,7 +5823,7 @@ Probes:
         - subprogram: {subprogram: 14}
           events:
             - Kind: Entry
-              Type: 1495 EventRootType Probe[main.testUint64Array]
+              Type: 1496 EventRootType Probe[main.testUint64Array]
               InjectionPoints: [{PC: "0xcd5da0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5779,7 +5845,7 @@ Probes:
         - subprogram: {subprogram: 11}
           events:
             - Kind: Entry
-              Type: 1492 EventRootType Probe[main.testUint8Array]
+              Type: 1493 EventRootType Probe[main.testUint8Array]
               InjectionPoints: [{PC: "0xcd5d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5801,7 +5867,7 @@ Probes:
         - subprogram: {subprogram: 10}
           events:
             - Kind: Entry
-              Type: 1491 EventRootType Probe[main.testUintArray]
+              Type: 1492 EventRootType Probe[main.testUintArray]
               InjectionPoints: [{PC: "0xcd5d20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5823,7 +5889,7 @@ Probes:
         - subprogram: {subprogram: 96}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testUintPointer]
+              Type: 1595 EventRootType Probe[main.testUintPointer]
               InjectionPoints: [{PC: "0xcdd820", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5845,7 +5911,7 @@ Probes:
         - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1701 EventRootType Probe[main.testUintSlice]
+              Type: 1702 EventRootType Probe[main.testUintSlice]
               InjectionPoints: [{PC: "0xce0600", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5867,7 +5933,7 @@ Probes:
         - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1727 EventRootType Probe[main.testUnitializedString]
+              Type: 1728 EventRootType Probe[main.testUnitializedString]
               InjectionPoints: [{PC: "0xce1040", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5889,7 +5955,7 @@ Probes:
         - subprogram: {subprogram: 95}
           events:
             - Kind: Entry
-              Type: 1593 EventRootType Probe[main.testUnsafePointer]
+              Type: 1594 EventRootType Probe[main.testUnsafePointer]
               InjectionPoints: [{PC: "0xcdd7e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5911,7 +5977,7 @@ Probes:
         - subprogram: {subprogram: 20}
           events:
             - Kind: Entry
-              Type: 1501 EventRootType Probe[main.testVeryLargeArray]
+              Type: 1502 EventRootType Probe[main.testVeryLargeArray]
               InjectionPoints: [{PC: "0xcd5e80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5933,7 +5999,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1710 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1711 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0xce0720", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5955,7 +6021,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1711 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1712 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0xce0720", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5974,18 +6040,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 195}
+        - subprogram: {subprogram: 198}
           events:
             - Kind: Entry
-              Type: 1808 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1812 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0xcdac8a"
                   Frameless: false
-                - PC: "0xce4423"
+                - PC: "0xce45a3"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1809 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1813 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0xcdacd0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -6007,11 +6073,11 @@ Probes:
         - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1699 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              Type: 1700 EventRootType Probe[main.testZeroSizeArgAndReturn]
               InjectionPoints: [{PC: "0xce004e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1700 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              Type: 1701 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
               InjectionPoints: [{PC: "0xce00cc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -9919,130 +9985,187 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 165
-      Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce37c0..0xce37c4]
+      Name: main.testTimeUTC
+      OutOfLinePCRanges: [0xce2860..0xce2861]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 326 BaseType go.shape.int
+        - Name: x
+          Type: 326 GoTimeType time.Time
           Locations:
-            - Range: 0xce37c0..0xce37c4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xce2860..0xce2861
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0xce37c0..0xce37c3
-              Pieces: []
-            - Range: 0xce37c3..0xce37c4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+          DictIndex: -1
+      DictRegister: null
     - ID: 166
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce37e0..0xce37ec]
+      Name: main.testTimeFixedZone
+      OutOfLinePCRanges: [0xce2880..0xce2881]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 328 GoStringHeaderType go.shape.string
+        - Name: x
+          Type: 326 GoTimeType time.Time
           Locations:
-            - Range: 0xce37e0..0xce37eb
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce37eb..0xce37ec
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xce37e0..0xce37eb
-              Pieces: []
-            - Range: 0xce37eb..0xce37ec
+            - Range: 0xce2880..0xce2881
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 167
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce3800..0xce3804]
+      Name: main.testTimeMonotonic
+      OutOfLinePCRanges: [0xce28a0..0xce28a1]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+        - Name: c
+          Type: 329 StructureType main.timeCapture
           Locations:
-            - Range: 0xce3800..0xce3804
+            - Range: 0xce28a0..0xce28a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 168
+      Name: main.wrapBox[go.shape.int]
+      OutOfLinePCRanges: [0xce3940..0xce3944]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 330 BaseType go.shape.int
+          Locations:
+            - Range: 0xce3940..0xce3944
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 326 BaseType go.shape.int
+          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce3800..0xce3803
+            - Range: 0xce3940..0xce3943
               Pieces: []
-            - Range: 0xce3803..0xce3804
+            - Range: 0xce3943..0xce3944
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 168
-      Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce3820..0xce382c]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xce3820..0xce382b
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce382b..0xce382c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0xce3820..0xce382b
-              Pieces: []
-            - Range: 0xce382b..0xce382c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0xce3960..0xce396c]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 332 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xce3960..0xce396b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xce396b..0xce396c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xce3960..0xce396b
+              Pieces: []
+            - Range: 0xce396b..0xce396c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0xce3980..0xce3984]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0xce3980..0xce3984
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 BaseType go.shape.int
+          Locations:
+            - Range: 0xce3980..0xce3983
+              Pieces: []
+            - Range: 0xce3983..0xce3984
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 171
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0xce39a0..0xce39ac]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xce39a0..0xce39ab
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xce39ab..0xce39ac
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xce39a0..0xce39ab
+              Pieces: []
+            - Range: 0xce39ab..0xce39ac
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce38a0..0xce39d6]
+      OutOfLinePCRanges: [0xce3a20..0xce3b56]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 330 GoSliceHeaderType []go.shape.int
+          Type: 334 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce38a0..0xce38d3
+            - Range: 0xce3a20..0xce3a53
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10050,7 +10173,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce38d3..0xce38db
+            - Range: 0xce3a53..0xce3a5b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10058,7 +10181,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce38db..0xce39d6
+            - Range: 0xce3a5b..0xce3b56
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10069,20 +10192,20 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 332 GoSubroutineType func(go.shape.int) bool
+          Type: 336 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce38a0..0xce38db
+            - Range: 0xce3a20..0xce3a5b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce38db..0xce39d6
+            - Range: 0xce3a5b..0xce3b56
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 330 GoSliceHeaderType []go.shape.int
+          Type: 334 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce38a0..0xce3994
+            - Range: 0xce3a20..0xce3b14
               Pieces: []
-            - Range: 0xce3994..0xce3995
+            - Range: 0xce3b14..0xce3b15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10090,14 +10213,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce3995..0xce39d6
+            - Range: 0xce3b15..0xce3b56
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 330 GoSliceHeaderType []go.shape.int
+          Type: 334 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce38db..0xce38f9
+            - Range: 0xce3a5b..0xce3a79
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10105,7 +10228,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce38f9..0xce3901
+            - Range: 0xce3a79..0xce3a81
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10113,7 +10236,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce3901..0xce3909
+            - Range: 0xce3a81..0xce3a89
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10121,7 +10244,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce3909..0xce3909
+            - Range: 0xce3a89..0xce3a89
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10129,7 +10252,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce3909..0xce3933
+            - Range: 0xce3a89..0xce3ab3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10137,7 +10260,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce3933..0xce398b
+            - Range: 0xce3ab3..0xce3b0b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10145,7 +10268,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce398b..0xce39d6
+            - Range: 0xce3b0b..0xce3b56
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10156,207 +10279,207 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0xce3926..0xce3933
+            - Range: 0xce3aa6..0xce3ab3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce3933..0xce398b
+            - Range: 0xce3ab3..0xce3b0b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 170
+    - ID: 173
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce39e0..0xce3a24]
+      OutOfLinePCRanges: [0xce3b60..0xce3ba4]
       InlinePCRanges: []
       Variables:
         - Name: box
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce39e0..0xce39f9
+            - Range: 0xce3b60..0xce3b79
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
-          Type: 333 GoSubroutineType func(go.shape.int) go.shape.string
+          Type: 337 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce39e0..0xce39f9
+            - Range: 0xce3b60..0xce3b79
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce39e0..0xce39f9
+            - Range: 0xce3b60..0xce3b79
               Pieces: []
-            - Range: 0xce39f9..0xce39fa
+            - Range: 0xce3b79..0xce3b7a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce39fa..0xce3a24
+            - Range: 0xce3b7a..0xce3ba4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce3cc0..0xce3cc4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 331 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce3cc0..0xce3cc4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce3cc0..0xce3cc3
-              Pieces: []
-            - Range: 0xce3cc3..0xce3cc4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce3ce0..0xce3ce4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 334 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0xce3ce0..0xce3ce4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 334 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0xce3ce0..0xce3ce3
-              Pieces: []
-            - Range: 0xce3ce3..0xce3ce4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 173
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce3d00..0xce3d04]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 336 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0xce3d00..0xce3d04
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0xce3d00..0xce3d03
-              Pieces: []
-            - Range: 0xce3d03..0xce3d04
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 174
-      Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce3d20..0xce3d31]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0xce3e40..0xce3e44]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 338 StructureType main.largeGenericType[go.shape.string]
+        - Name: p
+          Type: 335 PointerType *go.shape.int
           Locations:
-            - Range: 0xce3d20..0xce3d31
-              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+            - Range: 0xce3e40..0xce3e44
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 335 PointerType *go.shape.int
           Locations:
-            - Range: 0xce3d20..0xce3d30
+            - Range: 0xce3e40..0xce3e43
               Pieces: []
-            - Range: 0xce3d30..0xce3d31
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xce3e43..0xce3e44
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
-      Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce3dc0..0xce3dc9]
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0xce3e60..0xce3e64]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 340 StructureType main.largeGenericType[go.shape.int]
+        - Name: p
+          Type: 338 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce3dc0..0xce3dc9
-              Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
+            - Range: 0xce3e60..0xce3e64
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 326 BaseType go.shape.int
+          Type: 338 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce3dc0..0xce3dc8
+            - Range: 0xce3e60..0xce3e63
               Pieces: []
-            - Range: 0xce3dc8..0xce3dc9
+            - Range: 0xce3e63..0xce3e64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 176
-      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce3e80..0xce3e88]
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0xce3e80..0xce3e84]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 340 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xce3e80..0xce3e84
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 340 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xce3e80..0xce3e83
+              Pieces: []
+            - Range: 0xce3e83..0xce3e84
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 177
+      Name: main.largeGenericType[go.shape.string].LargeGet
+      OutOfLinePCRanges: [0xce3ea0..0xce3eb1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 341 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Type: 342 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce3e80..0xce3e88
+            - Range: 0xce3ea0..0xce3eb1
+              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xce3ea0..0xce3eb0
+              Pieces: []
+            - Range: 0xce3eb0..0xce3eb1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 178
+      Name: main.largeGenericType[go.shape.int].LargeGet
+      OutOfLinePCRanges: [0xce3f40..0xce3f49]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 344 StructureType main.largeGenericType[go.shape.int]
+          Locations:
+            - Range: 0xce3f40..0xce3f49
+              Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 BaseType go.shape.int
+          Locations:
+            - Range: 0xce3f40..0xce3f48
+              Pieces: []
+            - Range: 0xce3f48..0xce3f49
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 179
+      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
+      OutOfLinePCRanges: [0xce4000..0xce4008]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 345 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Locations:
+            - Range: 0xce4000..0xce4008
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0xce3e80..0xce3e88
+            - Range: 0xce4000..0xce4008
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 343 BaseType go.shape.bool
+          Type: 347 BaseType go.shape.bool
           Locations:
-            - Range: 0xce3e80..0xce3e88
+            - Range: 0xce4000..0xce4008
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 177
+    - ID: 180
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce3f20..0xce3f91]
+      OutOfLinePCRanges: [0xce40a0..0xce4111]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 344 PointerType *main.Pair[go.shape.string,go.shape.int]
+          Type: 348 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce3f20..0xce3f91
+            - Range: 0xce40a0..0xce4111
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce3f20..0xce3f91
+            - Range: 0xce40a0..0xce4111
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10365,22 +10488,22 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0xce3f20..0xce3f91
+            - Range: 0xce40a0..0xce4111
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 178
+    - ID: 181
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce4020..0xce4028]
+      OutOfLinePCRanges: [0xce41a0..0xce41a8]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4020..0xce4028
+            - Range: 0xce41a0..0xce41a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10389,27 +10512,27 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 343 BaseType go.shape.bool
+          Type: 347 BaseType go.shape.bool
           Locations:
-            - Range: 0xce4020..0xce4028
+            - Range: 0xce41a0..0xce41a8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 343 BaseType go.shape.bool
+          Type: 347 BaseType go.shape.bool
           Locations:
-            - Range: 0xce4020..0xce4027
+            - Range: 0xce41a0..0xce41a7
               Pieces: []
-            - Range: 0xce4027..0xce4028
+            - Range: 0xce41a7..0xce41a8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4020..0xce4027
+            - Range: 0xce41a0..0xce41a7
               Pieces: []
-            - Range: 0xce4027..0xce4028
+            - Range: 0xce41a7..0xce41a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10418,28 +10541,28 @@ Subprograms:
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 179
+    - ID: 182
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce4040..0xce404f]
+      OutOfLinePCRanges: [0xce41c0..0xce41cf]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0xce4040..0xce404e
+            - Range: 0xce41c0..0xce41ce
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4040..0xce404b
+            - Range: 0xce41c0..0xce41cb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce404b..0xce404f
+            - Range: 0xce41cb..0xce41cf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10448,11 +10571,11 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4040..0xce404e
+            - Range: 0xce41c0..0xce41ce
               Pieces: []
-            - Range: 0xce404e..0xce404f
+            - Range: 0xce41ce..0xce41cf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10461,58 +10584,58 @@ Subprograms:
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0xce4040..0xce404e
+            - Range: 0xce41c0..0xce41ce
               Pieces: []
-            - Range: 0xce404e..0xce404f
+            - Range: 0xce41ce..0xce41cf
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 180
+    - ID: 183
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce4060..0xce409a]
+      OutOfLinePCRanges: [0xce41e0..0xce421a]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 346 StructureType go.shape.struct { main.i int }
+          Type: 350 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce4060..0xce4079
+            - Range: 0xce41e0..0xce41f9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce4060..0xce4079
+            - Range: 0xce41e0..0xce41f9
               Pieces: []
-            - Range: 0xce4079..0xce407a
+            - Range: 0xce41f9..0xce41fa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce407a..0xce409a
+            - Range: 0xce41fa..0xce421a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 184
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce40a0..0xce40ed]
+      OutOfLinePCRanges: [0xce4220..0xce426d]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 347 StructureType go.shape.struct { main.s string }
+          Type: 351 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce40a0..0xce40bf
+            - Range: 0xce4220..0xce423f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce40bf..0xce40c2
+            - Range: 0xce423f..0xce4242
               Pieces:
                 - Size: 8
                   Op: null
@@ -10523,37 +10646,37 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce40a0..0xce40c2
+            - Range: 0xce4220..0xce4242
               Pieces: []
-            - Range: 0xce40c2..0xce40c3
+            - Range: 0xce4242..0xce4243
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce40c3..0xce40ed
+            - Range: 0xce4243..0xce426d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 182
+    - ID: 185
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce4100..0xce4108]
+      OutOfLinePCRanges: [0xce4280..0xce4288]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 348 PointerType *go.shape.string
+          Type: 352 PointerType *go.shape.string
           Locations:
-            - Range: 0xce4100..0xce4107
+            - Range: 0xce4280..0xce4287
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4100..0xce4107
+            - Range: 0xce4280..0xce4287
               Pieces: []
-            - Range: 0xce4107..0xce4108
+            - Range: 0xce4287..0xce4288
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10562,24 +10685,24 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 183
+    - ID: 186
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce4120..0xce4177]
+      OutOfLinePCRanges: [0xce42a0..0xce42f7]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 353 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce4120..0xce415d
+            - Range: 0xce42a0..0xce42dd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 354 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce4120..0xce4171
+            - Range: 0xce42a0..0xce42f1
               Pieces: []
-            - Range: 0xce4171..0xce4172
+            - Range: 0xce42f1..0xce42f2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10593,20 +10716,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce4172..0xce4177
+            - Range: 0xce42f2..0xce42f7
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 184
+    - ID: 187
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce4180..0xce41a4]
+      OutOfLinePCRanges: [0xce4300..0xce4324]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 330 GoSliceHeaderType []go.shape.int
+          Type: 334 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce4180..0xce41a4
+            - Range: 0xce4300..0xce4324
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10617,35 +10740,35 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0xce4180..0xce41a4
+            - Range: 0xce4300..0xce4324
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce4180..0xce41a0
+            - Range: 0xce4300..0xce4320
               Pieces: []
-            - Range: 0xce41a0..0xce41a1
+            - Range: 0xce4320..0xce4321
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce41a1..0xce41a3
+            - Range: 0xce4321..0xce4323
               Pieces: []
-            - Range: 0xce41a3..0xce41a4
+            - Range: 0xce4323..0xce4324
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 185
+    - ID: 188
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce41c0..0xce427f]
+      OutOfLinePCRanges: [0xce4340..0xce43ff]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 351 GoSliceHeaderType []go.shape.string
+          Type: 355 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce41c0..0xce41dd
+            - Range: 0xce4340..0xce435d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10653,7 +10776,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce41dd..0xce41df
+            - Range: 0xce435d..0xce435f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10664,15 +10787,15 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce41c0..0xce420c
+            - Range: 0xce4340..0xce438c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce420c..0xce427f
+            - Range: 0xce438c..0xce43ff
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10683,28 +10806,28 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce41c0..0xce422b
+            - Range: 0xce4340..0xce43ab
               Pieces: []
-            - Range: 0xce422b..0xce422c
+            - Range: 0xce43ab..0xce43ac
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce422c..0xce4233
+            - Range: 0xce43ac..0xce43b3
               Pieces: []
-            - Range: 0xce4233..0xce4234
+            - Range: 0xce43b3..0xce43b4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4234..0xce427f
+            - Range: 0xce43b4..0xce43ff
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce41ef..0xce4201
+            - Range: 0xce436f..0xce4381
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce4201..0xce420c
+            - Range: 0xce4381..0xce438c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10713,56 +10836,56 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 186
+    - ID: 189
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce4280..0xce4287]
+      OutOfLinePCRanges: [0xce4400..0xce4407]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 352 StructureType main.typeWithGenerics[go.shape.int]
+          Type: 356 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce4280..0xce4286
+            - Range: 0xce4400..0xce4406
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0xce4280..0xce4287
+            - Range: 0xce4400..0xce4407
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce4280..0xce4286
+            - Range: 0xce4400..0xce4406
               Pieces: []
-            - Range: 0xce4286..0xce4287
+            - Range: 0xce4406..0xce4407
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
-    - ID: 187
+    - ID: 190
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce4300..0xce436c]
+      OutOfLinePCRanges: [0xce4480..0xce44ec]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 353 StructureType main.typeWithGenerics[go.shape.string]
+          Type: 357 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce4300..0xce4320
+            - Range: 0xce4480..0xce44a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4320..0xce4328
+            - Range: 0xce44a0..0xce44a8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4328..0xce432d
+            - Range: 0xce44a8..0xce44ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10771,9 +10894,9 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4300..0xce432d
+            - Range: 0xce4480..0xce44ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10784,22 +10907,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce4300..0xce432d
+            - Range: 0xce4480..0xce44ad
               Pieces: []
-            - Range: 0xce432d..0xce432e
+            - Range: 0xce44ad..0xce44ae
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce432e..0xce436c
+            - Range: 0xce44ae..0xce44ec
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 188
+    - ID: 191
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0xcd4dc0..0xcd4f05]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 354 GoSliceHeaderType []go.shape.float64
+          Type: 358 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xcd4dc0..0xcd4df3
               Pieces:
@@ -10828,7 +10951,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 357 GoSubroutineType func(go.shape.float64) bool
+          Type: 361 GoSubroutineType func(go.shape.float64) bool
           Locations:
             - Range: 0xcd4dc0..0xcd4dfb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
@@ -10837,7 +10960,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 354 GoSliceHeaderType []go.shape.float64
+          Type: 358 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xcd4dc0..0xcd4ebc
               Pieces: []
@@ -10854,7 +10977,7 @@ Subprograms:
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 354 GoSliceHeaderType []go.shape.float64
+          Type: 358 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xcd4dfb..0xcd4e19
               Pieces:
@@ -10915,7 +11038,7 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 356 BaseType go.shape.float64
+          Type: 360 BaseType go.shape.float64
           Locations:
             - Range: 0xcd4e4b..0xcd4e59
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
@@ -10924,7 +11047,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 189
+    - ID: 192
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcda5a0..0xcda602]
       InlinePCRanges:
@@ -10955,7 +11078,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 193
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10963,7 +11086,7 @@ Subprograms:
           RootRanges: [0xcda7e0..0xcda8a5]
       Variables: []
       DictRegister: null
-    - ID: 191
+    - ID: 194
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10971,7 +11094,7 @@ Subprograms:
           RootRanges: [0xcda940..0xcdaa4e]
       Variables: []
       DictRegister: null
-    - ID: 192
+    - ID: 195
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10979,7 +11102,7 @@ Subprograms:
           RootRanges: [0xcda940..0xcdaa4e]
       Variables: []
       DictRegister: null
-    - ID: 193
+    - ID: 196
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10994,7 +11117,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 194
+    - ID: 197
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11013,15 +11136,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 195
+    - ID: 198
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcdac80..0xcdacf1]
       InlinePCRanges:
-        - Ranges: [0xce4423..0xce4465]
-          RootRanges: [0xce4400..0xce4496]
+        - Ranges: [0xce45a3..0xce45e5]
+          RootRanges: [0xce4580..0xce4616]
       Variables:
         - Name: b
-          Type: 358 StructureType main.firstBehavior
+          Type: 362 StructureType main.firstBehavior
           Locations:
             - Range: 0xcdac80..0xcdaca8
               Pieces:
@@ -11053,7 +11176,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 196
+    - ID: 199
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11065,31 +11188,31 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1382
+      ID: 1383
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 387 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 139
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 140 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1387
+      ID: 1388
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1388 PointerType *main.deepSlice3
+      Pointee: 1389 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1422
+      ID: 1423
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1423 PointerType *main.deepSlice8
+      Pointee: 1424 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1428
+      ID: 1429
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1429 PointerType *main.deepSlice9
+      Pointee: 1430 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 153
       Name: '**main.stringType2'
@@ -11097,7 +11220,7 @@ Types:
       GoKind: 22
       Pointee: 154 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1367
+      ID: 1378
       Name: '**main.t'
       ByteSize: 8
       Pointee: 253 PointerType *main.t
@@ -11129,40 +11252,40 @@ Types:
       ByteSize: 8
       Pointee: 207 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 378
+      ID: 382
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 379 PointerType *table<context.canceler,struct {}>
+      Pointee: 383 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 147
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 148 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1395
+      ID: 1396
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1396 PointerType *table<int,*main.deepMap3>
+      Pointee: 1397 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1439
+      ID: 1440
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1440 PointerType *table<int,*main.deepMap8>
+      Pointee: 1441 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1454
+      ID: 1455
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1455 PointerType *table<int,*main.deepMap9>
+      Pointee: 1456 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 174
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 175 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1469
+      ID: 1470
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1470 PointerType *table<int,interface {}>
+      Pointee: 1471 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 241
       Name: '**table<int,struct {}>'
@@ -11174,10 +11297,10 @@ Types:
       ByteSize: 8
       Pointee: 212 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 684 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 691 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 201
       Name: '**table<string,[]main.structWithMap>'
@@ -11189,35 +11312,35 @@ Types:
       ByteSize: 8
       Pointee: 190 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 405
+      ID: 406
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 406 PointerType *table<string,float64>
+      Pointee: 407 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1118
+      ID: 1129
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1119 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1130 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 184
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 185 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 400
+      ID: 401
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 401 PointerType *table<string,interface {}>
+      Pointee: 402 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 179
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 180 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 395
+      ID: 396
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 396 PointerType *table<string,string>
+      Pointee: 397 PointerType *table<string,string>
     - __kind: PointerType
       ID: 236
       Name: '**table<struct {},int>'
@@ -11269,145 +11392,145 @@ Types:
       ByteSize: 8
       Pointee: 217 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1385
+      ID: 1386
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1384 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1385 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 428
+      ID: 429
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 427 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 428 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1391
+      ID: 1392
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1390 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1391 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1426
+      ID: 1427
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1425 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1426 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1432
+      ID: 1433
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1431 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1432 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 425
+      ID: 426
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 424 GoSliceDataType []*string.array
+      Pointee: 425 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 588
+      ID: 589
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 587 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 588 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 586
+      ID: 587
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 585 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 586 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 584
+      ID: 585
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 583 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 584 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 582
+      ID: 583
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 581 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 582 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 282
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 580
+      ID: 581
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 579 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 580 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 568
+      ID: 569
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 567 GoSliceDataType [][]uint.array
+      Pointee: 568 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 572
+      ID: 573
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 571 GoSliceDataType []bool.array
+      Pointee: 572 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1155
+      ID: 1166
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1154 GoSliceDataType []float64.array
+      Pointee: 1165 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 678 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 685 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 686 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 644
+      ID: 651
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 643 GoSliceDataType []go.shape.float64.array
+      Pointee: 650 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 640
+      ID: 647
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 639 GoSliceDataType []go.shape.int.array
+      Pointee: 646 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 642
+      ID: 649
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 641 GoSliceDataType []go.shape.string.array
+      Pointee: 648 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
-      ID: 1435
+      ID: 1436
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1434 GoSliceDataType []interface {}.array
+      Pointee: 1435 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 280
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 277 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 578
+      ID: 579
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 577 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 578 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 688 GoSliceDataType []main.structWithMap.array
+      Pointee: 695 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 570
+      ID: 571
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 569 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 570 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11416,111 +11539,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 440
+      ID: 441
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 439 GoSliceDataType []string.array
+      Pointee: 440 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 576
+      ID: 577
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 575 GoSliceDataType []struct {}.array
+      Pointee: 576 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 1378
+      ID: 698
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 1377 GoSliceDataType []time.zone.array
+      Pointee: 697 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 1380
+      ID: 700
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 1379 GoSliceDataType []time.zoneTrans.array
+      Pointee: 699 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 264
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 262 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 566
+      ID: 567
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 565 GoSliceDataType []uint.array
+      Pointee: 566 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 574
+      ID: 575
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 573 GoSliceDataType []uint16.array
+      Pointee: 574 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 421
+      ID: 422
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 420 GoSliceDataType []uint8.array
+      Pointee: 421 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 423
+      ID: 424
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 422 GoSliceDataType []uintptr.array
+      Pointee: 423 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1285
+      ID: 1296
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1987904
       GoKind: 22
-      Pointee: 1286 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1297 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 929
+      ID: 940
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 931008
       GoKind: 22
-      Pointee: 930 GoSliceHeaderType archive/tar.headerError
+      Pointee: 941 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 932
+      ID: 943
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 931 GoSliceDataType archive/tar.headerError.array
+      Pointee: 942 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1220
+      ID: 1231
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1439136
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1232 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1168
+      ID: 1179
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 931200
       GoKind: 22
-      Pointee: 1169 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1180 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1170
+      ID: 1181
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 931296
       GoKind: 22
-      Pointee: 1171 StructureType archive/zip.dirWriter
+      Pointee: 1182 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1268
+      ID: 1279
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1907584
       GoKind: 22
-      Pointee: 1269 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1280 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1196
+      ID: 1207
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1058592
       GoKind: 22
-      Pointee: 1197 StructureType archive/zip.nopCloser
+      Pointee: 1208 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1198
+      ID: 1209
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1058848
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1210 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -11529,477 +11652,477 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1243
+      ID: 1254
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2176736
       GoKind: 22
-      Pointee: 1244 UnresolvedPointeeType bufio.Reader
+      Pointee: 1255 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1274
+      ID: 1285
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1952864
       GoKind: 22
-      Pointee: 1275 UnresolvedPointeeType bufio.Writer
+      Pointee: 1286 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1323
+      ID: 1334
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2274016
       GoKind: 22
-      Pointee: 1324 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1335 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 839
+      ID: 850
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 913440
       GoKind: 22
-      Pointee: 733 BaseType compress/flate.CorruptInputError
+      Pointee: 744 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 840
+      ID: 851
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 913536
       GoKind: 22
-      Pointee: 734 GoStringHeaderType compress/flate.InternalError
+      Pointee: 745 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 736
+      ID: 747
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 735 GoStringDataType compress/flate.InternalError.str
+      Pointee: 746 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1218
+      ID: 1229
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1428576
       GoKind: 22
-      Pointee: 1219 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1230 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1164
+      ID: 1175
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 913632
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1176 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1240
+      ID: 1251
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1729728
       GoKind: 22
-      Pointee: 1241 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1252 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1415
+      ID: 1416
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1554816
       GoKind: 22
-      Pointee: 369 StructureType context.backgroundCtx
+      Pointee: 373 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 359
+      ID: 363
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1727424
       GoKind: 22
-      Pointee: 360 StructureType context.cancelCtx
+      Pointee: 364 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1041
+      ID: 1052
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1193408
       GoKind: 22
-      Pointee: 1042 StructureType context.deadlineExceededError
+      Pointee: 1053 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1410
+      ID: 1411
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1417216
       GoKind: 22
-      Pointee: 370 StructureType context.emptyCtx
+      Pointee: 374 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 361
+      ID: 365
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1417376
       GoKind: 22
-      Pointee: 362 StructureType context.stopCtx
+      Pointee: 366 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 363
+      ID: 367
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1727616
       GoKind: 22
-      Pointee: 364 StructureType context.timerCtx
+      Pointee: 368 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1416
+      ID: 1417
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1554976
       GoKind: 22
-      Pointee: 386 StructureType context.todoCtx
+      Pointee: 387 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 365
+      ID: 369
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1554496
       GoKind: 22
-      Pointee: 366 StructureType context.valueCtx
+      Pointee: 370 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 367
+      ID: 371
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1554656
       GoKind: 22
-      Pointee: 368 StructureType context.withoutCancelCtx
+      Pointee: 372 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 921
+      ID: 932
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925632
       GoKind: 22
-      Pointee: 747 BaseType crypto/aes.KeySizeError
+      Pointee: 758 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 922
+      ID: 933
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925824
       GoKind: 22
-      Pointee: 748 BaseType crypto/des.KeySizeError
+      Pointee: 759 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 923
+      ID: 934
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 749 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 760 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1230
+      ID: 1241
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1570176
       GoKind: 22
-      Pointee: 1231 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1242 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1264
+      ID: 1275
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1866016
       GoKind: 22
-      Pointee: 1265 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1276 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1296
+      ID: 1307
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2124064
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1270
+      ID: 1281
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1908096
       GoKind: 22
-      Pointee: 1271 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1282 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1266
+      ID: 1277
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1866688
       GoKind: 22
-      Pointee: 1267 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1278 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1262
+      ID: 1273
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1858624
       GoKind: 22
-      Pointee: 1263 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1274 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 924
+      ID: 935
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926400
       GoKind: 22
-      Pointee: 750 BaseType crypto/rc4.KeySizeError
+      Pointee: 761 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1280
+      ID: 1291
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1957472
       GoKind: 22
-      Pointee: 1281 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1292 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1252
+      ID: 1263
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1812832
       GoKind: 22
-      Pointee: 1253 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1264 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 845
+      ID: 856
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 915168
       GoKind: 22
-      Pointee: 737 BaseType crypto/tls.AlertError
+      Pointee: 748 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1013
+      ID: 1024
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1046944
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1025 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1349
+      ID: 1360
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2385888
       GoKind: 22
-      Pointee: 1350 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1361 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 843
+      ID: 854
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 914976
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 855 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 841
+      ID: 852
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 914880
       GoKind: 22
-      Pointee: 842 StructureType crypto/tls.RecordHeaderError
+      Pointee: 853 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1012
+      ID: 1023
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1045280
       GoKind: 22
-      Pointee: 969 BaseType crypto/tls.alert
+      Pointee: 980 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1228
+      ID: 1239
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1563136
       GoKind: 22
-      Pointee: 1229 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1240 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1235
+      ID: 1246
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1646656
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1247 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1108
+      ID: 1119
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1428896
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1120 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1120
+      ID: 1131
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2045952
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1132 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 915
+      ID: 926
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 924576
       GoKind: 22
-      Pointee: 916 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 927 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 909
+      ID: 920
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 924096
       GoKind: 22
-      Pointee: 910 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 921 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 911
+      ID: 922
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 924192
       GoKind: 22
-      Pointee: 912 StructureType crypto/x509.HostnameError
+      Pointee: 923 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 908
+      ID: 919
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 746 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 757 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1018
+      ID: 1029
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1052704
       GoKind: 22
-      Pointee: 1019 StructureType crypto/x509.SystemRootsError
+      Pointee: 1030 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 917
+      ID: 928
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 924672
       GoKind: 22
-      Pointee: 918 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 929 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 913
+      ID: 924
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 914 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 925 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 933
+      ID: 944
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 931488
       GoKind: 22
-      Pointee: 934 StructureType encoding/asn1.StructuralError
+      Pointee: 945 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 937
+      ID: 948
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 938 StructureType encoding/asn1.SyntaxError
+      Pointee: 949 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 935
+      ID: 946
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 931584
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 947 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 831
+      ID: 842
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 910944
       GoKind: 22
-      Pointee: 731 BaseType encoding/base64.CorruptInputError
+      Pointee: 742 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1186
+      ID: 1197
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1041824
       GoKind: 22
-      Pointee: 1187 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1198 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 834
+      ID: 845
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 732 BaseType encoding/hex.InvalidByteError
+      Pointee: 743 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 802
+      ID: 813
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 905664
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 814 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1004
+      ID: 1015
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1038112
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1016 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 794
+      ID: 805
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 905280
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 806 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 800
+      ID: 811
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 905568
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 812 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 798
+      ID: 809
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 810 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 796
+      ID: 807
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 905376
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 808 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1329
+      ID: 1340
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2299040
       GoKind: 22
-      Pointee: 1330 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1341 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 804
+      ID: 815
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 906048
       GoKind: 22
-      Pointee: 805 StructureType encoding/json.jsonError
+      Pointee: 816 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1194
+      ID: 1205
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1055520
       GoKind: 22
-      Pointee: 1195 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1206 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 903
+      ID: 914
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923040
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 915 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 901
+      ID: 912
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 922944
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 913 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 905
+      ID: 916
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923136
       GoKind: 22
-      Pointee: 743 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 754 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 745
+      ID: 756
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 744 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 755 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 906
+      ID: 917
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923232
       GoKind: 22
-      Pointee: 907 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 918 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1307
+      ID: 1318
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2162496
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1319 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -12008,19 +12131,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 772
+      ID: 783
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896640
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType errors.errorString
+      Pointee: 784 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 971
+      ID: 982
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1023904
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType errors.joinError
+      Pointee: 983 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -12036,913 +12159,913 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 1317
+      ID: 1328
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2266336
       GoKind: 22
-      Pointee: 1318 UnresolvedPointeeType fmt.pp
+      Pointee: 1329 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 973
+      ID: 984
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1024032
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType fmt.wrapError
+      Pointee: 985 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 975
+      ID: 986
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1024160
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 987 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 832
+      ID: 843
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 844 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 813
+      ID: 824
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 908448
       GoKind: 22
-      Pointee: 814 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 825 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 815
+      ID: 826
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 908544
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 827 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1132
+      ID: 1143
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 1133 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1144 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 819
+      ID: 830
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 908832
       GoKind: 22
-      Pointee: 820 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 831 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1134
+      ID: 1145
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1146 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 817
+      ID: 828
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 725 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 736 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 727
+      ID: 738
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 726 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 737 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 812
+      ID: 823
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 722 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 733 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 724
+      ID: 735
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 723 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 818
+      ID: 829
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 728 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 739 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 730
+      ID: 741
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 729 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 740 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1208
+      ID: 1219
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1210944
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1220 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1293
+      ID: 1304
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2060640
       GoKind: 22
-      Pointee: 1294 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1305 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 927
+      ID: 938
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 929952
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 939 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 387
+      ID: 388
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2284256
       GoKind: 22
-      Pointee: 388 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 389 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 413
+      ID: 414
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2009952
       GoKind: 22
-      Pointee: 414 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 408
+      ID: 409
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1193664
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 411
+      ID: 412
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1193792
       GoKind: 22
-      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 413 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1408
+      ID: 1409
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1194432
       GoKind: 22
-      Pointee: 1409 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1410 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 696
+      ID: 707
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1194560
       GoKind: 22
-      Pointee: 697 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 708 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 415
+      ID: 416
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2228928
       GoKind: 22
-      Pointee: 416 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 417 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1076
+      ID: 1087
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1214528
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1088 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1325
+      ID: 1336
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2276064
       GoKind: 22
-      Pointee: 1326 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1337 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1411
+      ID: 1412
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1422816
       GoKind: 22
-      Pointee: 1412 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 1413 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 852
+      ID: 863
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 918528
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 864 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 859
+      ID: 870
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 919584
       GoKind: 22
-      Pointee: 860 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 871 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 854
+      ID: 865
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 919296
       GoKind: 22
-      Pointee: 742 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 753 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 857
+      ID: 868
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 919488
       GoKind: 22
-      Pointee: 858 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 869 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 855
+      ID: 866
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 919392
       GoKind: 22
-      Pointee: 856 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 867 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 875
+      ID: 886
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 921504
       GoKind: 22
-      Pointee: 876 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 887 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 879
+      ID: 890
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 921696
       GoKind: 22
-      Pointee: 880 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 891 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 877
+      ID: 888
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 921600
       GoKind: 22
-      Pointee: 878 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 889 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 873
+      ID: 884
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 921408
       GoKind: 22
-      Pointee: 874 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 885 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1157
+      ID: 1168
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1156 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1167 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 887
+      ID: 898
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 888 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 899 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 881
+      ID: 892
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 921792
       GoKind: 22
-      Pointee: 882 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 893 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 885
+      ID: 896
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 921984
       GoKind: 22
-      Pointee: 886 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 897 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 883
+      ID: 894
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 921888
       GoKind: 22
-      Pointee: 884 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 895 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 889
+      ID: 900
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 922176
       GoKind: 22
-      Pointee: 890 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 901 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 895
+      ID: 906
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 896 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 907 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 897
+      ID: 908
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 898 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 909 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 893
+      ID: 904
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 894 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 905 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 891
+      ID: 902
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 892 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 903 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 899
+      ID: 910
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 900 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 911 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 821
+      ID: 832
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 822 StructureType github.com/cihub/seelog.baseError
+      Pointee: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1246
+      ID: 1257
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1805216
       GoKind: 22
-      Pointee: 1247 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1258 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 823
+      ID: 834
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 824 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 835 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1226
+      ID: 1237
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1561376
       GoKind: 22
-      Pointee: 1227 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1238 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1182
+      ID: 1193
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1040800
       GoKind: 22
-      Pointee: 1183 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1194 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1216
+      ID: 1227
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1426496
       GoKind: 22
-      Pointee: 1217 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1228 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 827
+      ID: 838
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 910272
       GoKind: 22
-      Pointee: 828 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 839 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1283
+      ID: 1294
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1977248
       GoKind: 22
-      Pointee: 1284 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1295 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1300
+      ID: 1311
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2135648
       GoKind: 22
-      Pointee: 1295 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1306 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1299
+      ID: 1310
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2135264
       GoKind: 22
-      Pointee: 1298 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1309 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1184
+      ID: 1195
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1040928
       GoKind: 22
-      Pointee: 1185 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1196 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 825
+      ID: 836
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 826 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 837 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 829
+      ID: 840
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 910368
       GoKind: 22
-      Pointee: 830 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 841 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1248
+      ID: 1259
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1807008
       GoKind: 22
-      Pointee: 1249 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1260 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1289
+      ID: 1300
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2014560
       GoKind: 22
-      Pointee: 1290 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1301 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1291
+      ID: 1302
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2045632
       GoKind: 22
-      Pointee: 1292 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1303 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1110
+      ID: 1121
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1441536
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1122 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1026
+      ID: 1037
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1067040
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1038 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1024
+      ID: 1035
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1066912
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1036 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1028
+      ID: 1039
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1071008
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1040 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1030
+      ID: 1041
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1071136
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1042 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1237
+      ID: 1248
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1674112
       GoKind: 22
-      Pointee: 1238 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1249 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1020
+      ID: 1031
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1053344
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1032 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 835
+      ID: 846
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 912000
       GoKind: 22
-      Pointee: 836 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 847 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1341
+      ID: 1352
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2362112
       GoKind: 22
-      Pointee: 1342 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1353 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1084
+      ID: 1095
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1223744
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1096 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1053
+      ID: 1064
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1201856
       GoKind: 22
-      Pointee: 1054 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1065 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1047
+      ID: 1058
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1201472
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1059 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 990
+      ID: 1001
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1032352
       GoKind: 22
-      Pointee: 991 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1002 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1059
+      ID: 1070
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1202240
       GoKind: 22
-      Pointee: 1060 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1071 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 989
+      ID: 1000
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1032224
       GoKind: 22
-      Pointee: 968 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 979 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1051
+      ID: 1062
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1201728
       GoKind: 22
-      Pointee: 1052 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1063 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1049
+      ID: 1060
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1201600
       GoKind: 22
-      Pointee: 1050 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1061 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1057
+      ID: 1068
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1202112
       GoKind: 22
-      Pointee: 1058 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1069 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1055
+      ID: 1066
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1201984
       GoKind: 22
-      Pointee: 1056 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1067 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1345
+      ID: 1356
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2373920
       GoKind: 22
-      Pointee: 1346 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1357 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1063
+      ID: 1074
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1202624
       GoKind: 22
-      Pointee: 1064 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1075 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 994
+      ID: 1005
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1032608
       GoKind: 22
-      Pointee: 995 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1006 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 992
+      ID: 1003
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1032480
       GoKind: 22
-      Pointee: 993 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1004 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1061
+      ID: 1072
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1202496
       GoKind: 22
-      Pointee: 1062 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1073 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 949
+      ID: 960
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944448
       GoKind: 22
-      Pointee: 755 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 766 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 757
+      ID: 768
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 756 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 767 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 355
+      ID: 359
       Name: '*go.shape.float64'
       ByteSize: 8
       GoRuntimeType: 479360
       GoKind: 22
-      Pointee: 356 BaseType go.shape.float64
+      Pointee: 360 BaseType go.shape.float64
     - __kind: PointerType
-      ID: 331
+      ID: 335
       Name: '*go.shape.int'
       ByteSize: 8
       GoRuntimeType: 478912
       GoKind: 22
-      Pointee: 326 BaseType go.shape.int
+      Pointee: 330 BaseType go.shape.int
     - __kind: PointerType
-      ID: 348
+      ID: 352
       Name: '*go.shape.string'
       ByteSize: 8
       GoRuntimeType: 478976
       GoKind: 22
-      Pointee: 328 GoStringHeaderType go.shape.string
+      Pointee: 332 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 638
+      ID: 645
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 637 GoStringDataType go.shape.string.str
+      Pointee: 644 GoStringDataType go.shape.string.str
     - __kind: PointerType
-      ID: 334
+      ID: 338
       Name: '*go.shape.struct { Name string }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 335 StructureType go.shape.struct { Name string }
+      Pointee: 339 StructureType go.shape.struct { Name string }
     - __kind: PointerType
-      ID: 336
+      ID: 340
       Name: '*go.shape.struct { X int; Y int }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 337 StructureType go.shape.struct { X int; Y int }
+      Pointee: 341 StructureType go.shape.struct { X int; Y int }
     - __kind: PointerType
-      ID: 349
+      ID: 353
       Name: '*go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+      Pointee: 354 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1123
+      ID: 1134
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1672576
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1135 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1034
+      ID: 1045
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1085856
       GoKind: 22
-      Pointee: 1035 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1046 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1214
+      ID: 1225
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1263424
       GoKind: 22
-      Pointee: 1215 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1226 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1305
+      ID: 1316
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2150624
       GoKind: 22
-      Pointee: 1306 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1317 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1200
+      ID: 1211
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1088160
       GoKind: 22
-      Pointee: 1201 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1212 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 950
+      ID: 961
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 945696
       GoKind: 22
-      Pointee: 758 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 769 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1092
+      ID: 1103
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1265088
       GoKind: 22
-      Pointee: 1093 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1104 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 953
+      ID: 964
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 945984
       GoKind: 22
-      Pointee: 954 StructureType golang.org/x/net/http2.connError
+      Pointee: 965 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 952
+      ID: 963
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945888
       GoKind: 22
-      Pointee: 762 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 773 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 764
+      ID: 775
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 763 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 774 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 956
+      ID: 967
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 946176
       GoKind: 22
-      Pointee: 768 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 779 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 770
+      ID: 781
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 769 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 780 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 955
+      ID: 966
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 946080
       GoKind: 22
-      Pointee: 765 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 776 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 767
+      ID: 778
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 766 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 777 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 951
+      ID: 962
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945792
       GoKind: 22
-      Pointee: 759 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 770 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 761
+      ID: 772
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 760 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 771 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1303
+      ID: 1314
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2148704
       GoKind: 22
-      Pointee: 1304 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1315 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 957
+      ID: 968
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 946272
       GoKind: 22
-      Pointee: 958 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 969 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 959
+      ID: 970
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 946368
       GoKind: 22
-      Pointee: 771 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 782 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 945
+      ID: 956
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 939648
       GoKind: 22
-      Pointee: 946 StructureType google.golang.org/grpc.dropError
+      Pointee: 957 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1090
+      ID: 1101
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1262144
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1102 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1112
+      ID: 1123
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1448896
       GoKind: 22
-      Pointee: 1113 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1124 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 947
+      ID: 958
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942720
       GoKind: 22
-      Pointee: 948 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 959 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1254
+      ID: 1265
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1813280
       GoKind: 22
-      Pointee: 1255 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1266 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1212
+      ID: 1223
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1258688
       GoKind: 22
-      Pointee: 1213 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1224 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1032
+      ID: 1043
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1080096
       GoKind: 22
-      Pointee: 1033 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1044 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1172
+      ID: 1183
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 942816
       GoKind: 22
-      Pointee: 1173 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1184 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 925
+      ID: 936
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 927840
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 937 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1022
+      ID: 1033
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1056928
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1034 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1088
+      ID: 1099
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1230144
       GoKind: 22
-      Pointee: 1089 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1100 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1086
+      ID: 1097
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1229888
       GoKind: 22
-      Pointee: 1087 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1098 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 939
+      ID: 950
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932544
       GoKind: 22
-      Pointee: 940 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 951 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 941
+      ID: 952
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 932640
       GoKind: 22
-      Pointee: 942 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 953 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 867
+      ID: 878
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 919968
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 879 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1260
+      ID: 1271
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1853696
       GoKind: 22
-      Pointee: 1261 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1272 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 960
+      ID: 971
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 947136
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType html/template.Error
+      Pointee: 972 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -12986,101 +13109,101 @@ Types:
       GoKind: 22
       Pointee: 162 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 919
+      ID: 930
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 925248
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 931 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 837
+      ID: 848
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 913152
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 849 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1162
+      ID: 1173
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 912384
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1174 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1082
+      ID: 1093
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1215680
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1094 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1347
+      ID: 1358
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2379552
       GoKind: 22
-      Pointee: 1348 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1359 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1080
+      ID: 1091
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1215552
       GoKind: 22
-      Pointee: 1081 StructureType internal/poll.errNetClosing
+      Pointee: 1092 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 777
+      ID: 788
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900768
       GoKind: 22
-      Pointee: 778 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 789 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1204
+      ID: 1215
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1193152
       GoKind: 22
-      Pointee: 1205 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1216 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1202
+      ID: 1213
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1192768
       GoKind: 22
-      Pointee: 1203 StructureType io.discard
+      Pointee: 1214 StructureType io.discard
     - __kind: PointerType
-      ID: 1176
+      ID: 1187
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1024928
       GoKind: 22
-      Pointee: 1177 UnresolvedPointeeType io.multiWriter
+      Pointee: 1188 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1078
+      ID: 1089
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1215296
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1090 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1250
+      ID: 1261
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1807232
       GoKind: 22
-      Pointee: 1251 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1262 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 341
+      ID: 345
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 342 StructureType main.Pair[go.shape.int,go.shape.bool]
+      Pointee: 346 StructureType main.Pair[go.shape.int,go.shape.bool]
     - __kind: PointerType
-      ID: 344
+      ID: 348
       Name: '*main.Pair[go.shape.string,go.shape.int]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 345 StructureType main.Pair[go.shape.string,go.shape.int]
+      Pointee: 349 StructureType main.Pair[go.shape.string,go.shape.int]
     - __kind: PointerType
       ID: 321
       Name: '*main.anotherStruct'
@@ -13088,19 +13211,19 @@ Types:
       GoKind: 22
       Pointee: 322 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 435
+      ID: 436
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 385344
       GoKind: 22
-      Pointee: 436 StructureType main.deepMap2
+      Pointee: 437 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1403
+      ID: 1404
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385280
       GoKind: 22
-      Pointee: 1404 UnresolvedPointeeType main.deepMap3
+      Pointee: 1405 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
@@ -13109,19 +13232,19 @@ Types:
       GoKind: 22
       Pointee: 150 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1447
+      ID: 1448
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 384960
       GoKind: 22
-      Pointee: 1448 StructureType main.deepMap8
+      Pointee: 1449 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1462
+      ID: 1463
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 384896
       GoKind: 22
-      Pointee: 1463 StructureType main.deepMap9
+      Pointee: 1464 StructureType main.deepMap9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr2'
@@ -13130,12 +13253,12 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1351
+      ID: 1362
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 385856
       GoKind: 22
-      Pointee: 1352 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1363 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
@@ -13144,33 +13267,33 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1417
+      ID: 1418
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 385536
       GoKind: 22
-      Pointee: 1418 StructureType main.deepPtr8
+      Pointee: 1419 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1419
+      ID: 1420
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 385472
       GoKind: 22
-      Pointee: 1420 StructureType main.deepPtr9
+      Pointee: 1421 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 140
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 386496
       GoKind: 22
-      Pointee: 426 StructureType main.deepSlice2
+      Pointee: 427 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1388
+      ID: 1389
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 386432
       GoKind: 22
-      Pointee: 1389 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1390 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
@@ -13179,19 +13302,19 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1423
+      ID: 1424
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386112
       GoKind: 22
-      Pointee: 1424 StructureType main.deepSlice8
+      Pointee: 1425 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1429
+      ID: 1430
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 386048
       GoKind: 22
-      Pointee: 1430 StructureType main.deepSlice9
+      Pointee: 1431 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 325
       Name: '*main.emptyStruct'
@@ -13206,14 +13329,14 @@ Types:
       GoKind: 22
       Pointee: 165 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1364
+      ID: 1375
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 896352
       GoKind: 22
-      Pointee: 358 StructureType main.firstBehavior
+      Pointee: 362 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1479
+      ID: 1480
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 386880
@@ -13239,19 +13362,19 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1365
+      ID: 1376
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 896448
       GoKind: 22
-      Pointee: 1366 StructureType main.secondBehavior
+      Pointee: 1377 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1357
+      ID: 1368
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 896544
       GoKind: 22
-      Pointee: 1358 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1369 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType1'
@@ -13259,28 +13382,28 @@ Types:
       GoKind: 22
       Pointee: 152 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1354
+      ID: 1365
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1353 GoStringDataType main.stringType1.str
+      Pointee: 1364 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 154
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1355 GoStringHeaderType main.stringType2
+      Pointee: 1366 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1481
+      ID: 1482
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1480 GoStringDataType main.stringType2.str
+      Pointee: 1481 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 278
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 276 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 489
+      ID: 490
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 384832
@@ -13304,10 +13427,10 @@ Types:
       GoKind: 22
       Pointee: 254 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1369
+      ID: 1380
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1368 GoSliceDataType main.t.array
+      Pointee: 1379 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 273
       Name: '*main.threeStringStruct'
@@ -13335,40 +13458,40 @@ Types:
       ByteSize: 8
       Pointee: 205 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 376
+      ID: 380
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 377 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 381 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 145
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1393
+      ID: 1394
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1394 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1395 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1437
+      ID: 1438
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1438 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1439 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1452
+      ID: 1453
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1453 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1454 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 172
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 173 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1467
+      ID: 1468
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1468 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1469 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 239
       Name: '*map<int,struct {}>'
@@ -13380,10 +13503,10 @@ Types:
       ByteSize: 8
       Pointee: 210 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 681
+      ID: 688
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 682 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 689 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 199
       Name: '*map<string,[]main.structWithMap>'
@@ -13395,35 +13518,35 @@ Types:
       ByteSize: 8
       Pointee: 188 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 403
+      ID: 404
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 404 GoSwissMapHeaderType map<string,float64>
+      Pointee: 405 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1116
+      ID: 1127
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1117 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1128 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 182
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 183 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 399 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 400 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 177
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 178 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 393
+      ID: 394
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 394 GoSwissMapHeaderType map<string,string>
+      Pointee: 395 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 234
       Name: '*map<struct {},int>'
@@ -13481,728 +13604,728 @@ Types:
       GoKind: 22
       Pointee: 181 GoMapType map[string]int
     - __kind: PointerType
-      ID: 871
+      ID: 882
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920832
       GoKind: 22
-      Pointee: 872 StructureType math/big.ErrNaN
+      Pointee: 883 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1166
+      ID: 1177
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 915648
       GoKind: 22
-      Pointee: 1167 StructureType mime/multipart.writerOnly·1
+      Pointee: 1178 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1070
+      ID: 1081
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1208768
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType net.AddrError
+      Pointee: 1082 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1101
+      ID: 1112
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1424736
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType net.DNSError
+      Pointee: 1113 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1311
+      ID: 1322
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2236672
       GoKind: 22
-      Pointee: 1312 UnresolvedPointeeType net.IPConn
+      Pointee: 1323 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1099
+      ID: 1110
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1424416
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType net.OpError
+      Pointee: 1111 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1072
+      ID: 1083
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1208896
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType net.ParseError
+      Pointee: 1084 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1321
+      ID: 1332
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2267360
       GoKind: 22
-      Pointee: 1322 UnresolvedPointeeType net.TCPConn
+      Pointee: 1333 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1331
+      ID: 1342
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2312352
       GoKind: 22
-      Pointee: 1332 UnresolvedPointeeType net.UDPConn
+      Pointee: 1343 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1319
+      ID: 1330
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2266848
       GoKind: 22
-      Pointee: 1320 UnresolvedPointeeType net.UnixConn
+      Pointee: 1331 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1069
+      ID: 1080
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1208000
       GoKind: 22
-      Pointee: 1038 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1049 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1040
+      ID: 1051
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1039 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1050 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1006
+      ID: 1017
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1039008
       GoKind: 22
-      Pointee: 1007 StructureType net.canceledError
+      Pointee: 1018 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1287
+      ID: 1298
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2011680
       GoKind: 22
-      Pointee: 1288 UnresolvedPointeeType net.conn
+      Pointee: 1299 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1141
+      ID: 1152
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1848320
       GoKind: 22
-      Pointee: 1142 StructureType net.dialResult·1
+      Pointee: 1153 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1333
+      ID: 1344
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2316608
       GoKind: 22
-      Pointee: 1334 UnresolvedPointeeType net.netFD
+      Pointee: 1345 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 806
+      ID: 817
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType net.notFoundError
+      Pointee: 818 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1413
+      ID: 1414
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1424576
       GoKind: 22
-      Pointee: 1414 StructureType net.onlyValuesCtx
+      Pointee: 1415 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 808
+      ID: 819
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 907680
       GoKind: 22
-      Pointee: 809 StructureType net.result·2
+      Pointee: 820 StructureType net.result·2
     - __kind: PointerType
-      ID: 1315
+      ID: 1326
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2253376
       GoKind: 22
-      Pointee: 1316 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1327 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1313
+      ID: 1324
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2252896
       GoKind: 22
-      Pointee: 1314 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1325 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1074
+      ID: 1085
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1209536
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType net.temporaryError
+      Pointee: 1086 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1103
+      ID: 1114
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1424896
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType net.timeoutError
+      Pointee: 1115 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 996
+      ID: 1007
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1035040
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1008 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1158
+      ID: 1169
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 902784
       GoKind: 22
-      Pointee: 1159 StructureType net/http.bufioFlushWriter
+      Pointee: 1170 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 783
+      ID: 794
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 903456
       GoKind: 22
-      Pointee: 703 BaseType net/http.http2ConnectionError
+      Pointee: 714 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 784
+      ID: 795
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 903552
       GoKind: 22
-      Pointee: 785 StructureType net/http.http2GoAwayError
+      Pointee: 796 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1095
+      ID: 1106
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1420896
       GoKind: 22
-      Pointee: 1096 StructureType net/http.http2StreamError
+      Pointee: 1107 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 788
+      ID: 799
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 904128
       GoKind: 22
-      Pointee: 789 StructureType net/http.http2connError
+      Pointee: 800 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1222
+      ID: 1233
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1558496
       GoKind: 22
-      Pointee: 1223 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1234 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 787
+      ID: 798
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 22
-      Pointee: 707 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 718 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 709
+      ID: 720
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 708 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 719 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 791
+      ID: 802
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 904320
       GoKind: 22
-      Pointee: 713 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 724 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 715
+      ID: 726
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 714 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 725 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 790
+      ID: 801
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 904224
       GoKind: 22
-      Pointee: 710 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 721 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 712
+      ID: 723
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 711 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 722 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1067
+      ID: 1078
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1204672
       GoKind: 22
-      Pointee: 1068 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1079 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1002
+      ID: 1013
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1035680
       GoKind: 22
-      Pointee: 1003 StructureType net/http.http2noCachedConnError
+      Pointee: 1014 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1276
+      ID: 1287
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1953888
       GoKind: 22
-      Pointee: 1277 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1288 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 786
+      ID: 797
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 704 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 715 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 706
+      ID: 717
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 705 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 716 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1160
+      ID: 1171
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 904416
       GoKind: 22
-      Pointee: 1161 StructureType net/http.http2stickyErrWriter
+      Pointee: 1172 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 998
+      ID: 1009
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1035296
       GoKind: 22
-      Pointee: 999 StructureType net/http.nothingWrittenError
+      Pointee: 1010 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1224
+      ID: 1235
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2177984
       GoKind: 22
-      Pointee: 1225 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1236 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1180
+      ID: 1191
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1035168
       GoKind: 22
-      Pointee: 1181 StructureType net/http.persistConnWriter
+      Pointee: 1192 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1206
+      ID: 1217
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1203776
       GoKind: 22
-      Pointee: 1207 StructureType net/http.readWriteCloserBody
+      Pointee: 1218 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 792
+      ID: 803
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 793 StructureType net/http.requestBodyReadError
+      Pointee: 804 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1097
+      ID: 1108
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1422016
       GoKind: 22
-      Pointee: 1098 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1109 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1065
+      ID: 1076
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1204544
       GoKind: 22
-      Pointee: 1066 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1077 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1000
+      ID: 1011
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1035424
       GoKind: 22
-      Pointee: 1001 StructureType net/http.transportReadFromServerError
+      Pointee: 1012 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1258
+      ID: 1269
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1845184
       GoKind: 22
-      Pointee: 1259 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1270 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 781
+      ID: 792
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 793 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1278
+      ID: 1289
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1955680
       GoKind: 22
-      Pointee: 1279 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1290 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1190
+      ID: 1201
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1048096
       GoKind: 22
-      Pointee: 1191 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1202 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 863
+      ID: 874
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 864 StructureType net/netip.parseAddrError
+      Pointee: 875 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 861
+      ID: 872
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 919680
       GoKind: 22
-      Pointee: 862 StructureType net/netip.parsePrefixError
+      Pointee: 873 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1232
+      ID: 1243
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2122656
       GoKind: 22
-      Pointee: 1233 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1244 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1192
+      ID: 1203
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1052960
       GoKind: 22
-      Pointee: 1193 StructureType net/smtp.dataCloser
+      Pointee: 1204 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 847
+      ID: 858
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 915840
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType net/textproto.Error
+      Pointee: 859 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 846
+      ID: 857
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 915744
       GoKind: 22
-      Pointee: 738 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 749 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 740
+      ID: 751
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 739 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 750 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1188
+      ID: 1199
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1047328
       GoKind: 22
-      Pointee: 1189 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1200 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1105
+      ID: 1116
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1425216
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType net/url.Error
+      Pointee: 1117 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 810
+      ID: 821
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 907776
       GoKind: 22
-      Pointee: 716 GoStringHeaderType net/url.EscapeError
+      Pointee: 727 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 718
+      ID: 729
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 717 GoStringDataType net/url.EscapeError.str
+      Pointee: 728 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 811
+      ID: 822
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 907872
       GoKind: 22
-      Pointee: 719 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 730 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 721
+      ID: 732
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 720 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 731 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 535
+      ID: 536
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 536 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 537 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 527
+      ID: 528
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 528 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 529 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 475
+      ID: 476
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 476 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 477 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 494
+      ID: 495
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 495 StructureType noalg.map.group[bool]main.node
+      Pointee: 496 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 648 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 655 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 431
+      ID: 432
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 432 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 433 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1399
+      ID: 1400
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1400 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1401 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1443
+      ID: 1444
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1444 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1445 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1458
+      ID: 1459
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1459 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 443
+      ID: 444
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 444 StructureType noalg.map.group[int]int
+      Pointee: 445 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1473
+      ID: 1474
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1474 StructureType noalg.map.group[int]interface {}
+      Pointee: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 551
+      ID: 552
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 552 StructureType noalg.map.group[int]struct {}
+      Pointee: 553 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 502
+      ID: 503
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 503 StructureType noalg.map.group[int]uint8
+      Pointee: 504 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 692
+      ID: 703
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 693 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 484
+      ID: 485
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 485 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 486 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 467
+      ID: 468
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 468 StructureType noalg.map.group[string][]string
+      Pointee: 469 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 672
+      ID: 679
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 673 StructureType noalg.map.group[string]float64
+      Pointee: 680 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1148
+      ID: 1159
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1149 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 459
+      ID: 460
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 460 StructureType noalg.map.group[string]int
+      Pointee: 461 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 664
+      ID: 671
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 665 StructureType noalg.map.group[string]interface {}
+      Pointee: 672 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 451
+      ID: 452
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 452 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 453 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 657 StructureType noalg.map.group[string]string
+      Pointee: 664 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 543
+      ID: 544
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 544 StructureType noalg.map.group[struct {}]int
+      Pointee: 545 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 591
+      ID: 592
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 592 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 599
+      ID: 600
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 600 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 607
+      ID: 608
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 608 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 615
+      ID: 616
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 623
+      ID: 624
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 631
+      ID: 632
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 559
+      ID: 560
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 560 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 561 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 518
+      ID: 519
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 519 StructureType noalg.map.group[uint8][4]int
+      Pointee: 520 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 510
+      ID: 511
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 511 StructureType noalg.map.group[uint8]uint8
+      Pointee: 512 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1339
+      ID: 1350
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2355264
       GoKind: 22
-      Pointee: 1340 UnresolvedPointeeType os.File
+      Pointee: 1351 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 979
+      ID: 990
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1028640
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType os.LinkError
+      Pointee: 991 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1043
+      ID: 1054
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1197760
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType os.SyscallError
+      Pointee: 1055 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1337
+      ID: 1348
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2351584
       GoKind: 22
-      Pointee: 1338 StructureType os.fileWithoutReadFrom
+      Pointee: 1349 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1335
+      ID: 1346
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2350848
       GoKind: 22
-      Pointee: 1336 StructureType os.fileWithoutWriteTo
+      Pointee: 1347 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1008
+      ID: 1019
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1044000
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType os/exec.Error
+      Pointee: 1020 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1144
+      ID: 1155
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2091808
       GoKind: 22
-      Pointee: 1145 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1156 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1210
+      ID: 1221
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1216576
       GoKind: 22
-      Pointee: 1211 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1222 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1010
+      ID: 1021
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1044128
       GoKind: 22
-      Pointee: 1011 StructureType os/exec.wrappedError
+      Pointee: 1022 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 944
+      ID: 955
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 937728
       GoKind: 22
-      Pointee: 752 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 763 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 754
+      ID: 765
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 753 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 764 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 943
+      ID: 954
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 751 BaseType os/user.UnknownUserIdError
+      Pointee: 762 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 779
+      ID: 790
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 901440
       GoKind: 22
-      Pointee: 780 UnresolvedPointeeType reflect.ValueError
+      Pointee: 791 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 869
+      ID: 880
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 881 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 983
+      ID: 994
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1029664
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 995 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 987
+      ID: 998
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1031456
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 999 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14218,12 +14341,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 985
+      ID: 996
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1029792
       GoKind: 22
-      Pointee: 986 StructureType runtime.boundsError
+      Pointee: 997 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -14239,24 +14362,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1045
+      ID: 1056
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1200064
       GoKind: 22
-      Pointee: 1046 StructureType runtime.errorAddressString
+      Pointee: 1057 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 981
+      ID: 992
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1029280
       GoKind: 22
-      Pointee: 962 GoStringHeaderType runtime.errorString
+      Pointee: 973 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 964
+      ID: 975
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 963 GoStringDataType runtime.errorString.str
+      Pointee: 974 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -14272,17 +14395,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 982
+      ID: 993
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1029408
       GoKind: 22
-      Pointee: 965 GoStringHeaderType runtime.plainError
+      Pointee: 976 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 967
+      ID: 978
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 966 GoStringDataType runtime.plainError.str
+      Pointee: 977 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14312,12 +14435,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 977
+      ID: 988
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1027488
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType strconv.NumError
+      Pointee: 989 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -14326,264 +14449,264 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 419
+      ID: 420
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 418 GoStringDataType string.str
+      Pointee: 419 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1272
+      ID: 1283
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1952352
       GoKind: 22
-      Pointee: 1273 UnresolvedPointeeType strings.Builder
+      Pointee: 1284 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1178
+      ID: 1189
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1027616
       GoKind: 22
-      Pointee: 1179 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1190 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1174
+      ID: 1185
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 971488
       GoKind: 22
-      Pointee: 1175 StructureType struct { io.Writer }
+      Pointee: 1186 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 271
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
-      ID: 1107
+      ID: 1118
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1427456
       GoKind: 22
-      Pointee: 1094 BaseType syscall.Errno
+      Pointee: 1105 BaseType syscall.Errno
     - __kind: PointerType
       ID: 232
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 533 StructureType table<[4]int,[4]int>
+      Pointee: 534 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 227
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 525 StructureType table<[4]int,uint8>
+      Pointee: 526 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 195
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 473 StructureType table<[4]string,[2]int>
+      Pointee: 474 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 207
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 492 StructureType table<bool,main.node>
+      Pointee: 493 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 379
+      ID: 383
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 645 StructureType table<context.canceler,struct {}>
+      Pointee: 652 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 148
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 429 StructureType table<int,*main.deepMap2>
+      Pointee: 430 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1396
+      ID: 1397
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1397 StructureType table<int,*main.deepMap3>
+      Pointee: 1398 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1440
+      ID: 1441
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1441 StructureType table<int,*main.deepMap8>
+      Pointee: 1442 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1455
+      ID: 1456
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1456 StructureType table<int,*main.deepMap9>
+      Pointee: 1457 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 175
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 441 StructureType table<int,int>
+      Pointee: 442 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1470
+      ID: 1471
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1471 StructureType table<int,interface {}>
+      Pointee: 1472 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 242
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 549 StructureType table<int,struct {}>
+      Pointee: 550 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 212
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 500 StructureType table<int,uint8>
+      Pointee: 501 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 690 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 701 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 202
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 482 StructureType table<string,[]main.structWithMap>
+      Pointee: 483 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 190
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 465 StructureType table<string,[]string>
+      Pointee: 466 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 406
+      ID: 407
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 670 StructureType table<string,float64>
+      Pointee: 677 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1119
+      ID: 1130
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1146 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1157 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 185
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 457 StructureType table<string,int>
+      Pointee: 458 StructureType table<string,int>
     - __kind: PointerType
-      ID: 401
+      ID: 402
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 662 StructureType table<string,interface {}>
+      Pointee: 669 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 180
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 449 StructureType table<string,main.nestedStruct>
+      Pointee: 450 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 396
+      ID: 397
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 654 StructureType table<string,string>
+      Pointee: 661 StructureType table<string,string>
     - __kind: PointerType
       ID: 237
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 541 StructureType table<struct {},int>
+      Pointee: 542 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 294
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 589 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 590 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 299
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 597 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 598 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 304
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 605 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 606 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 309
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 613 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 614 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 314
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 621 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 622 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 319
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 629 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 630 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 247
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 557 StructureType table<struct {},struct {}>
+      Pointee: 558 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 222
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 516 StructureType table<uint8,[4]int>
+      Pointee: 517 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 217
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 508 StructureType table<uint8,uint8>
+      Pointee: 509 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1309
+      ID: 1320
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2162880
       GoKind: 22
-      Pointee: 1310 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1321 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1036
+      ID: 1047
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1089696
       GoKind: 22
-      Pointee: 1037 StructureType text/template.ExecError
+      Pointee: 1048 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 384
+      ID: 327
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1622080
       GoKind: 22
-      Pointee: 385 StructureType time.Location
+      Pointee: 328 StructureType time.Location
     - __kind: PointerType
-      ID: 775
+      ID: 786
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 899040
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType time.ParseError
+      Pointee: 787 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 381
+      ID: 385
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1029024
       GoKind: 22
-      Pointee: 382 StructureType time.Timer
+      Pointee: 386 StructureType time.Timer
     - __kind: PointerType
-      ID: 774
+      ID: 785
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 898944
       GoKind: 22
-      Pointee: 700 GoStringHeaderType time.fileSizeError
+      Pointee: 711 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 702
+      ID: 713
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 701 GoStringDataType time.fileSizeError.str
+      Pointee: 712 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 1372
+      ID: 639
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 392128
       GoKind: 22
-      Pointee: 1373 StructureType time.zone
+      Pointee: 640 StructureType time.zone
     - __kind: PointerType
-      ID: 1375
+      ID: 642
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 392192
       GoKind: 22
-      Pointee: 1376 StructureType time.zoneTrans
+      Pointee: 643 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -14627,49 +14750,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 865
+      ID: 876
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 919872
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 877 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1301
+      ID: 1312
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2138336
       GoKind: 22
-      Pointee: 1302 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1313 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 849
+      ID: 860
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 916032
       GoKind: 22
-      Pointee: 850 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 861 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 851
+      ID: 862
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 916128
       GoKind: 22
-      Pointee: 741 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 752 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1015
+      ID: 1026
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1047840
       GoKind: 22
-      Pointee: 1016 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1027 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1017
+      ID: 1028
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1047968
       GoKind: 22
-      Pointee: 970 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 981 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1370
+      ID: 1381
       Name: <-chan time.Time
       GoRuntimeType: 596576
       GoKind: 18
@@ -14682,7 +14805,7 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 1754
+      ID: 1758
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14698,10 +14821,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 354 GoSliceHeaderType []go.shape.float64
+            Type: 358 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14711,10 +14834,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 354 GoSliceHeaderType []go.shape.float64
+            Type: 358 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14724,17 +14847,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 357 GoSubroutineType func(go.shape.float64) bool
+            Type: 361 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 1, name: pred}
+                  Variable: {subprogram: 191, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1755
+      ID: 1759
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14744,17 +14867,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 354 GoSliceHeaderType []go.shape.float64
+            Type: 358 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 2, name: ~r0}
+                  Variable: {subprogram: 191, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1752
+      ID: 1756
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14770,10 +14893,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14783,10 +14906,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14796,17 +14919,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 332 GoSubroutineType func(go.shape.int) bool
+            Type: 336 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: pred}
+                  Variable: {subprogram: 172, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1753
+      ID: 1757
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14816,20 +14939,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 2, name: ~r0}
+                  Variable: {subprogram: 172, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1810
+      ID: 1814
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1756
+      ID: 1760
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14845,10 +14968,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14858,10 +14981,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14871,17 +14994,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 333 GoSubroutineType func(go.shape.int) go.shape.string
+            Type: 337 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: f}
+                  Variable: {subprogram: 173, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1757
+      ID: 1761
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14891,17 +15014,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 2, name: ~r0}
+                  Variable: {subprogram: 173, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1768
+      ID: 1772
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14920,10 +15043,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14933,10 +15056,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 341 PointerType *main.Pair[go.shape.int,go.shape.bool]
+            Type: 345 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: x}
+                  Variable: {subprogram: 179, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14946,10 +15069,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14959,20 +15082,20 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 343 BaseType go.shape.bool
+            Type: 347 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 2, name: v}
+                  Variable: {subprogram: 179, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1769
+      ID: 1773
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1770
+      ID: 1774
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14991,10 +15114,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15004,10 +15127,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 344 PointerType *main.Pair[go.shape.string,go.shape.int]
+            Type: 348 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: x}
+                  Variable: {subprogram: 180, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15017,10 +15140,10 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15030,20 +15153,20 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 2, name: v}
+                  Variable: {subprogram: 180, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1771
+      ID: 1775
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1808
+      ID: 1812
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15052,17 +15175,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 358 StructureType main.firstBehavior
+            Type: 362 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 0, name: b}
+                  Variable: {subprogram: 198, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1809
+      ID: 1813
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15074,14 +15197,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 1, name: ~r0}
+                  Variable: {subprogram: 198, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1784
+      ID: 1788
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15097,10 +15220,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15110,10 +15233,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15123,17 +15246,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1788
+      ID: 1792
       Name: Probe[main.genericContains[go.shape.int]]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15149,10 +15272,10 @@ Types:
           Offset: 17
           Kind: local
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15162,17 +15285,17 @@ Types:
           Offset: 41
           Kind: local
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1785
+      ID: 1789
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15184,14 +15307,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 187, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1786
+      ID: 1790
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15207,10 +15330,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15220,10 +15343,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 351 GoSliceHeaderType []go.shape.string
+            Type: 355 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: haystack}
+                  Variable: {subprogram: 188, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15233,17 +15356,17 @@ Types:
           Offset: 57
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1789
+      ID: 1793
       Name: Probe[main.genericContains[go.shape.string]]Line
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15253,17 +15376,17 @@ Types:
           Offset: 9
           Kind: local
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1787
+      ID: 1791
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15275,14 +15398,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 2, name: ~r0}
+                  Variable: {subprogram: 188, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1780
+      ID: 1784
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15292,10 +15415,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 348 PointerType *go.shape.string
+            Type: 352 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15305,17 +15428,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 348 PointerType *go.shape.string
+            Type: 352 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1781
+      ID: 1785
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15325,17 +15448,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: ~r0}
+                  Variable: {subprogram: 185, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1782
+      ID: 1786
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15345,10 +15468,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 353 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15358,17 +15481,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 353 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1783
+      ID: 1787
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15378,17 +15501,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 354 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: ~r0}
+                  Variable: {subprogram: 186, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1776
+      ID: 1780
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15398,10 +15521,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 346 StructureType go.shape.struct { main.i int }
+            Type: 350 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15411,17 +15534,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 346 StructureType go.shape.struct { main.i int }
+            Type: 350 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1777
+      ID: 1781
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15433,14 +15556,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: ~r0}
+                  Variable: {subprogram: 183, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1778
+      ID: 1782
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15450,10 +15573,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 347 StructureType go.shape.struct { main.s string }
+            Type: 351 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15463,17 +15586,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 347 StructureType go.shape.struct { main.s string }
+            Type: 351 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1779
+      ID: 1783
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15485,14 +15608,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: ~r0}
+                  Variable: {subprogram: 184, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1758
+      ID: 1762
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15502,10 +15625,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 331 PointerType *go.shape.int
+            Type: 335 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15515,17 +15638,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 331 PointerType *go.shape.int
+            Type: 335 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1759
+      ID: 1763
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15535,17 +15658,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 331 PointerType *go.shape.int
+            Type: 335 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 174, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1760
+      ID: 1764
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15555,10 +15678,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 334 PointerType *go.shape.struct { Name string }
+            Type: 338 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15568,17 +15691,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 334 PointerType *go.shape.struct { Name string }
+            Type: 338 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1761
+      ID: 1765
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15588,17 +15711,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 334 PointerType *go.shape.struct { Name string }
+            Type: 338 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: ~r0}
+                  Variable: {subprogram: 175, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1762
+      ID: 1766
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15608,10 +15731,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 336 PointerType *go.shape.struct { X int; Y int }
+            Type: 340 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15621,17 +15744,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 336 PointerType *go.shape.struct { X int; Y int }
+            Type: 340 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1763
+      ID: 1767
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15641,17 +15764,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 PointerType *go.shape.struct { X int; Y int }
+            Type: 340 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: ~r0}
+                  Variable: {subprogram: 176, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1774
+      ID: 1778
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15667,10 +15790,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15680,10 +15803,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15693,17 +15816,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: b}
+                  Variable: {subprogram: 182, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1775
+      ID: 1779
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15719,10 +15842,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15732,17 +15855,17 @@ Types:
           Offset: 33
           Kind: return
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 3, name: ~r1}
+                  Variable: {subprogram: 182, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1772
+      ID: 1776
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15758,10 +15881,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15771,10 +15894,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15784,17 +15907,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 343 BaseType go.shape.bool
+            Type: 347 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: b}
+                  Variable: {subprogram: 181, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1773
+      ID: 1777
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15810,10 +15933,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 343 BaseType go.shape.bool
+            Type: 347 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
@@ -15823,17 +15946,17 @@ Types:
           Offset: 18
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 3, name: ~r1}
+                  Variable: {subprogram: 181, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1766
+      ID: 1770
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15843,10 +15966,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 340 StructureType main.largeGenericType[go.shape.int]
+            Type: 344 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
@@ -15856,17 +15979,17 @@ Types:
           Offset: 145
           Kind: argument
           Expression:
-            Type: 340 StructureType main.largeGenericType[go.shape.int]
+            Type: 344 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1767
+      ID: 1771
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15876,17 +15999,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: ~r0}
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1764
+      ID: 1768
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15896,10 +16019,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 338 StructureType main.largeGenericType[go.shape.string]
+            Type: 342 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
@@ -15909,17 +16032,17 @@ Types:
           Offset: 153
           Kind: argument
           Expression:
-            Type: 338 StructureType main.largeGenericType[go.shape.string]
+            Type: 342 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1765
+      ID: 1769
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15929,17 +16052,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: ~r0}
+                  Variable: {subprogram: 177, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1748
+      ID: 1752
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15949,10 +16072,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15962,17 +16085,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1749
+      ID: 1753
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15982,17 +16105,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1750
+      ID: 1754
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16002,10 +16125,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16015,17 +16138,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1751
+      ID: 1755
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16035,20 +16158,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1714
+      ID: 1715
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1715
+      ID: 1716
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16067,7 +16190,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16099,7 +16222,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16118,7 +16241,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16150,7 +16273,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16169,7 +16292,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1685
+      ID: 1686
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16201,7 +16324,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1686
+      ID: 1687
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16220,7 +16343,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16252,7 +16375,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -16284,7 +16407,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16316,7 +16439,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16348,7 +16471,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16380,7 +16503,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16412,7 +16535,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16444,7 +16567,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
+      ID: 1589
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -16463,7 +16586,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16495,10 +16618,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16530,7 +16653,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testByteArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16562,7 +16685,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1589
+      ID: 1590
       Name: Probe[main.testChannel]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16594,7 +16717,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testCombinedByte]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16652,7 +16775,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       ExprStatusArraySize: 1
@@ -16684,7 +16807,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -16729,7 +16852,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1650
+      ID: 1651
       Name: Probe[main.testConflictingReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16761,7 +16884,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1651
+      ID: 1652
       Name: Probe[main.testConflictingReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16793,7 +16916,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testCycle]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16825,7 +16948,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16857,7 +16980,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16889,7 +17012,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16921,7 +17044,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16953,7 +17076,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16985,7 +17108,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17017,7 +17140,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1705
+      ID: 1706
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -17075,7 +17198,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1702
+      ID: 1703
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17107,7 +17230,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1728
+      ID: 1729
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17139,7 +17262,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1743
+      ID: 1744
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17171,7 +17294,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1742
+      ID: 1743
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -17203,7 +17326,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testErrorAtLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17261,7 +17384,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testError]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17293,7 +17416,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17325,10 +17448,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -17360,10 +17483,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17395,7 +17518,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17427,7 +17550,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17446,7 +17569,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testFrameless]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17478,7 +17601,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17497,7 +17620,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17529,10 +17652,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17564,13 +17687,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1800
+      ID: 1804
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17628,28 +17751,28 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1801
+      ID: 1805
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1802
+      ID: 1806
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1803
+      ID: 1807
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1804
+      ID: 1808
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1797
+      ID: 1801
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17661,7 +17784,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17674,14 +17797,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1794
+      ID: 1798
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17693,14 +17816,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1795
+      ID: 1799
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17712,14 +17835,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1796
+      ID: 1800
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17731,7 +17854,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17744,14 +17867,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1799
+      ID: 1803
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17763,7 +17886,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17776,17 +17899,17 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1798
+      ID: 1802
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1805
+      ID: 1809
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17798,7 +17921,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17811,14 +17934,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1806
+      ID: 1810
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17830,7 +17953,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17843,14 +17966,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1807
+      ID: 1811
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17862,7 +17985,7 @@ Types:
             Type: 166 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
@@ -17875,14 +17998,14 @@ Types:
             Type: 166 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17914,7 +18037,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17946,7 +18069,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17978,7 +18101,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -18010,7 +18133,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testIntArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18042,7 +18165,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18074,7 +18197,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -18106,7 +18229,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1684
+      ID: 1685
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18125,7 +18248,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18157,40 +18280,8 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1529
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1530
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -18224,7 +18315,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1689
+      ID: 1532
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1690
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -18464,7 +18587,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1690
+      ID: 1691
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18483,7 +18606,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testManyPointers]
       ByteSize: 1121
       ExprStatusArraySize: 1
@@ -18515,7 +18638,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testManyStrings]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -18547,7 +18670,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18579,7 +18702,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18611,7 +18734,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18643,7 +18766,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18675,7 +18798,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18707,7 +18830,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18739,7 +18862,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18771,7 +18894,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18797,38 +18920,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1568
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 198 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 198 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18867,7 +18958,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1570
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 198 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1578
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18899,7 +19022,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18931,7 +19054,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18963,7 +19086,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18995,7 +19118,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19027,7 +19150,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19059,7 +19182,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19091,7 +19214,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19123,7 +19246,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19155,7 +19278,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19183,38 +19306,6 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1725
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -19251,7 +19342,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1691
+      ID: 1727
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1692
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -19491,7 +19614,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1692
+      ID: 1693
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19510,7 +19633,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1695
+      ID: 1696
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19568,7 +19691,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1696
+      ID: 1697
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19600,7 +19723,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1687
+      ID: 1688
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -19658,7 +19781,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1688
+      ID: 1689
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19677,7 +19800,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19697,6 +19820,143 @@ Types:
           DictIndex: -1
         - Name: i
           Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1631
+      Name: Probe[main.testMultipleNamedReturn]
+    - __kind: EventRootType
+      ID: 1633
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1635
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1637
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1639
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1641
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -19710,21 +19970,63 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1630
-      Name: Probe[main.testMultipleNamedReturn]
-    - __kind: EventRootType
-      ID: 1632
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: return
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1632
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19732,57 +20034,57 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1634
-      Name: Probe[main.testMultipleNamedReturn]
+      Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result
           Offset: 17
-          Kind: template_segment
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 25
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19790,185 +20092,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1636
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1638
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1640
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1629
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1631
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1633
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result
-          Offset: 17
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 25
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1635
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20052,7 +20175,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20084,7 +20207,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20116,7 +20239,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20161,7 +20284,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 63
       ExprStatusArraySize: 3
@@ -20297,7 +20420,42 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1625
+      Name: Probe[main.testNamedReturn]
+    - __kind: EventRootType
+      ID: 1627
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20330,41 +20488,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1624
-      Name: Probe[main.testNamedReturn]
-    - __kind: EventRootType
-      ID: 1626
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: i
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1623
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20383,7 +20506,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20402,7 +20525,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20434,7 +20557,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1737
+      ID: 1738
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20466,7 +20589,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1738
+      ID: 1739
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20493,10 +20616,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1739
+      ID: 1740
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1740
+      ID: 1741
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20523,7 +20646,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20581,7 +20704,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1706
+      ID: 1707
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -20639,7 +20762,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1708
+      ID: 1709
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -20723,7 +20846,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1709
+      ID: 1710
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -20755,7 +20878,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1724
+      ID: 1725
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20787,7 +20910,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20819,7 +20942,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20851,7 +20974,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20883,7 +21006,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       ExprStatusArraySize: 1
@@ -20941,7 +21064,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20973,7 +21096,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21005,7 +21128,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21024,10 +21147,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21046,10 +21169,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -21068,10 +21191,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21090,10 +21213,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -21216,10 +21339,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -21251,10 +21374,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1657
+      ID: 1658
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21286,7 +21409,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -21318,7 +21441,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21337,7 +21460,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21356,7 +21479,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21375,7 +21498,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21407,7 +21530,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21452,7 +21575,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21497,7 +21620,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21529,7 +21652,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21561,7 +21684,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21580,29 +21703,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testReturnsInt]
     - __kind: EventRootType
-      ID: 1600
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1602
+      ID: 1601
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21621,7 +21725,26 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1604
+      ID: 1603
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1605
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21653,7 +21776,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21672,7 +21795,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21704,7 +21827,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21736,7 +21859,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21755,7 +21878,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21787,7 +21910,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1621
+      ID: 1622
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21806,10 +21929,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1659
+      ID: 1660
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21828,10 +21951,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1655
+      ID: 1656
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1656
+      ID: 1657
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -22058,10 +22181,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22080,10 +22203,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1673
+      ID: 1674
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1674
+      ID: 1675
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -22154,10 +22277,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -22189,7 +22312,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1652
+      ID: 1653
       Name: Probe[main.testReturnsNamedDeferLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22247,10 +22370,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22269,10 +22392,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1653
+      ID: 1654
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1654
+      ID: 1655
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -22382,10 +22505,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22404,10 +22527,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1672
+      ID: 1673
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -22426,7 +22549,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22458,7 +22581,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22490,7 +22613,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22522,13 +22645,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testSingleFloat32]
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testSingleFloat64]
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22560,7 +22683,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22592,7 +22715,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22624,7 +22747,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22682,7 +22805,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22714,7 +22837,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1503
+      ID: 1504
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22746,7 +22869,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1716
+      ID: 1717
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22778,7 +22901,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22810,7 +22933,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22842,7 +22965,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22874,7 +22997,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22906,7 +23029,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22938,7 +23061,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1712
+      ID: 1713
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22970,7 +23093,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1703
+      ID: 1704
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23002,7 +23125,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23034,7 +23157,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23053,10 +23176,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.testSomeNamedReturn]
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23075,7 +23198,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23107,7 +23230,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23165,7 +23288,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1645
+      ID: 1646
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23184,7 +23307,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23242,7 +23365,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23287,7 +23410,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1693
+      ID: 1694
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -23319,7 +23442,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1694
+      ID: 1695
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23364,7 +23487,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testStringArray]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23396,7 +23519,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23428,7 +23551,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1707
+      ID: 1708
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23460,7 +23583,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testStringType1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23492,7 +23615,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testStringType2]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23524,7 +23647,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1704
+      ID: 1705
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23582,7 +23705,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23614,7 +23737,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1697
+      ID: 1698
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23646,7 +23769,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1698
+      ID: 1699
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23678,7 +23801,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1731
+      ID: 1732
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -23710,10 +23833,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1732
+      ID: 1733
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1730
+      ID: 1731
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -23745,7 +23868,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23777,7 +23900,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1733
+      ID: 1734
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23796,7 +23919,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1735
+      ID: 1736
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -23828,13 +23951,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1734
+      ID: 1735
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1736
+      ID: 1737
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1713
+      ID: 1714
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -23918,7 +24041,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1729
+      ID: 1730
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24002,7 +24125,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testTakeContext]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24021,7 +24144,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1741
+      ID: 1742
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -24040,7 +24163,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1722
+      ID: 1723
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24072,7 +24195,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1723
+      ID: 1724
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24129,7 +24252,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1718
+      ID: 1719
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24161,7 +24284,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1720
+      ID: 1721
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24206,13 +24329,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1719
+      ID: 1720
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1721
+      ID: 1722
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1717
+      ID: 1718
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24296,7 +24419,103 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1517
+      ID: 1746
+      Name: Probe[main.testTimeFixedZone]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 326 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 326 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1747
+      Name: Probe[main.testTimeMonotonic]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 329 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: c
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 329 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1745
+      Name: Probe[main.testTimeUTC]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 326 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 326 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1518
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24328,7 +24547,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24360,7 +24579,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24392,7 +24611,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24424,7 +24643,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24456,7 +24675,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testUintArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24488,7 +24707,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24520,7 +24739,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1701
+      ID: 1702
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24552,7 +24771,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1727
+      ID: 1728
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24584,7 +24803,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24616,7 +24835,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1501
+      ID: 1502
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       ExprStatusArraySize: 1
@@ -24644,38 +24863,6 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1710
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 262 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 262 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -24712,7 +24899,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1699
+      ID: 1712
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 262 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 262 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1700
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24770,7 +24989,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1700
+      ID: 1701
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24802,7 +25021,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1790
+      ID: 1794
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -24818,10 +25037,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24831,10 +25050,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 352 StructureType main.typeWithGenerics[go.shape.int]
+            Type: 356 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 0, name: x}
+                  Variable: {subprogram: 189, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24844,17 +25063,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1791
+      ID: 1795
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24866,14 +25085,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 2, name: ~r0}
+                  Variable: {subprogram: 189, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1792
+      ID: 1796
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -24889,10 +25108,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24902,10 +25121,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 353 StructureType main.typeWithGenerics[go.shape.string]
+            Type: 357 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24915,17 +25134,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1793
+      ID: 1797
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24937,14 +25156,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 2, name: ~r0}
+                  Variable: {subprogram: 190, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1744
+      ID: 1748
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -24954,10 +25173,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24967,17 +25186,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1745
+      ID: 1749
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24987,17 +25206,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1746
+      ID: 1750
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25007,10 +25226,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25020,17 +25239,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1747
+      ID: 1751
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25040,10 +25259,10 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25080,7 +25299,7 @@ Types:
       HasCount: true
       Element: 92 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 339
+      ID: 343
       Name: '[16]uint8'
       ByteSize: 16
       GoRuntimeType: 680384
@@ -25301,7 +25520,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 522
+      ID: 523
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 683072
@@ -25310,7 +25529,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 479
+      ID: 480
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683360
@@ -25336,7 +25555,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1136
+      ID: 1147
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684896
@@ -25345,7 +25564,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1356
+      ID: 1367
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25371,7 +25590,7 @@ Types:
       HasCount: true
       Element: 85 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1381
+      ID: 1382
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 481408
@@ -25379,20 +25598,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1382 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1383 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1384 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1385 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1384
+      ID: 1385
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 387 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 138
       Name: '[]*main.deepSlice2'
@@ -25409,15 +25628,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 427 GoSliceDataType []*main.deepSlice2.array
+      Data: 428 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 427
+      ID: 428
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 140 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1386
+      ID: 1387
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477312
@@ -25425,22 +25644,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1387 PointerType **main.deepSlice3
+          Type: 1388 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1390 GoSliceDataType []*main.deepSlice3.array
+      Data: 1391 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1390
+      ID: 1391
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1388 PointerType *main.deepSlice3
+      Element: 1389 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1421
+      ID: 1422
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 476992
@@ -25448,22 +25667,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1422 PointerType **main.deepSlice8
+          Type: 1423 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1425 GoSliceDataType []*main.deepSlice8.array
+      Data: 1426 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1425
+      ID: 1426
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1423 PointerType *main.deepSlice8
+      Element: 1424 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1427
+      ID: 1428
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 476928
@@ -25471,20 +25690,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1428 PointerType **main.deepSlice9
+          Type: 1429 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1431 GoSliceDataType []*main.deepSlice9.array
+      Data: 1432 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1431
+      ID: 1432
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1429 PointerType *main.deepSlice9
+      Element: 1430 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 129
       Name: '[]*string'
@@ -25501,201 +25720,201 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 424 GoSliceDataType []*string.array
+      Data: 425 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 424
+      ID: 425
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 95 PointerType *string
     - __kind: GoSliceDataType
-      ID: 539
+      ID: 540
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 232 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 531
+      ID: 532
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 227 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 481
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 195 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 498
+      ID: 499
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 207 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 652
+      ID: 659
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 379 PointerType *table<context.canceler,struct {}>
+      Element: 383 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 438
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 148 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1405
+      ID: 1406
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1396 PointerType *table<int,*main.deepMap3>
+      Element: 1397 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1449
+      ID: 1450
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1440 PointerType *table<int,*main.deepMap8>
+      Element: 1441 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1464
+      ID: 1465
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1455 PointerType *table<int,*main.deepMap9>
+      Element: 1456 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 447
+      ID: 448
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 175 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1477
+      ID: 1478
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1470 PointerType *table<int,interface {}>
+      Element: 1471 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 555
+      ID: 556
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 242 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 507
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 212 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 698
+      ID: 709
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 684 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 691 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 490
+      ID: 491
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 202 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 472
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 190 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 676
+      ID: 683
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 406 PointerType *table<string,float64>
+      Element: 407 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1152
+      ID: 1163
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1119 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1130 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 464
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 185 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 668
+      ID: 675
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 401 PointerType *table<string,interface {}>
+      Element: 402 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 456
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 180 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 660
+      ID: 667
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 396 PointerType *table<string,string>
+      Element: 397 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 547
+      ID: 548
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 237 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 595
+      ID: 596
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 294 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 603
+      ID: 604
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 299 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 611
+      ID: 612
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 304 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 619
+      ID: 620
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 309 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 627
+      ID: 628
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 314 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 635
+      ID: 636
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 319 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 563
+      ID: 564
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 247 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 523
+      ID: 524
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 222 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 515
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -25715,9 +25934,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 587 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 588 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 587
+      ID: 588
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25737,9 +25956,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 585 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 586 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 585
+      ID: 586
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25759,9 +25978,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 583 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 584 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 583
+      ID: 584
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25781,9 +26000,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 581 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 582 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 581
+      ID: 582
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25803,9 +26022,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 579 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 580 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 579
+      ID: 580
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25825,9 +26044,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 567 GoSliceDataType [][]uint.array
+      Data: 568 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 567
+      ID: 568
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25848,15 +26067,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 571 GoSliceDataType []bool.array
+      Data: 572 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 571
+      ID: 572
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1131
+      ID: 1142
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -25871,15 +26090,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1154 GoSliceDataType []float64.array
+      Data: 1165 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1154
+      ID: 1165
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 20 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 407
+      ID: 408
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 480960
@@ -25887,22 +26106,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 408 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 678 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 685 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 678
+      ID: 685
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 409 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 410
+      ID: 411
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 481152
@@ -25910,22 +26129,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 412 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 686 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 686
+      ID: 693
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 413 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 354
+      ID: 358
       Name: '[]go.shape.float64'
       ByteSize: 24
       GoRuntimeType: 483520
@@ -25933,66 +26152,66 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 355 PointerType *go.shape.float64
+          Type: 359 PointerType *go.shape.float64
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 643 GoSliceDataType []go.shape.float64.array
+      Data: 650 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 643
+      ID: 650
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 356 BaseType go.shape.float64
+      Element: 360 BaseType go.shape.float64
     - __kind: GoSliceHeaderType
-      ID: 330
+      ID: 334
       Name: '[]go.shape.int'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 331 PointerType *go.shape.int
+          Type: 335 PointerType *go.shape.int
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 639 GoSliceDataType []go.shape.int.array
+      Data: 646 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 639
+      ID: 646
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 326 BaseType go.shape.int
+      Element: 330 BaseType go.shape.int
     - __kind: GoSliceHeaderType
-      ID: 351
+      ID: 355
       Name: '[]go.shape.string'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 348 PointerType *go.shape.string
+          Type: 352 PointerType *go.shape.string
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 641 GoSliceDataType []go.shape.string.array
+      Data: 648 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 641
+      ID: 648
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 328 GoStringHeaderType go.shape.string
+      Element: 332 GoStringHeaderType go.shape.string
     - __kind: GoSliceHeaderType
-      ID: 1433
+      ID: 1434
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487744
@@ -26007,9 +26226,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1434 GoSliceDataType []interface {}.array
+      Data: 1435 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1434
+      ID: 1435
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26029,15 +26248,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 577 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 578 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 577
+      ID: 578
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 276 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 488
+      ID: 489
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 477952
@@ -26045,16 +26264,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 489 PointerType *main.structWithMap
+          Type: 490 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 688 GoSliceDataType []main.structWithMap.array
+      Data: 695 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 688
+      ID: 695
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26074,205 +26293,205 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 569 GoSliceDataType []main.structWithNoStrings.array
+      Data: 570 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 569
+      ID: 570
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 267 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 541
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 536 StructureType noalg.map.group[[4]int][4]int
+      Element: 537 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 532
+      ID: 533
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 528 StructureType noalg.map.group[[4]int]uint8
+      Element: 529 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 481
+      ID: 482
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 476 StructureType noalg.map.group[[4]string][2]int
+      Element: 477 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 499
+      ID: 500
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 495 StructureType noalg.map.group[bool]main.node
+      Element: 496 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 653
+      ID: 660
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 648 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 655 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 439
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 432 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 433 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1406
+      ID: 1407
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1400 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1401 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1450
+      ID: 1451
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1444 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1445 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1465
+      ID: 1466
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1459 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 448
+      ID: 449
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 444 StructureType noalg.map.group[int]int
+      Element: 445 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1478
+      ID: 1479
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1474 StructureType noalg.map.group[int]interface {}
+      Element: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 556
+      ID: 557
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 552 StructureType noalg.map.group[int]struct {}
+      Element: 553 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 507
+      ID: 508
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 503 StructureType noalg.map.group[int]uint8
+      Element: 504 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 699
+      ID: 710
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 693 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 491
+      ID: 492
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 485 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 486 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 473
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 468 StructureType noalg.map.group[string][]string
+      Element: 469 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 677
+      ID: 684
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 673 StructureType noalg.map.group[string]float64
+      Element: 680 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1153
+      ID: 1164
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1149 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 465
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 460 StructureType noalg.map.group[string]int
+      Element: 461 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 669
+      ID: 676
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 665 StructureType noalg.map.group[string]interface {}
+      Element: 672 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 456
+      ID: 457
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 452 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 453 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 661
+      ID: 668
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 657 StructureType noalg.map.group[string]string
+      Element: 664 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 548
+      ID: 549
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 544 StructureType noalg.map.group[struct {}]int
+      Element: 545 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 596
+      ID: 597
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 592 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 604
+      ID: 605
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 600 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 612
+      ID: 613
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 608 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 620
+      ID: 621
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 628
+      ID: 629
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 636
+      ID: 637
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 564
+      ID: 565
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 560 StructureType noalg.map.group[struct {}]struct {}
+      Element: 561 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 524
+      ID: 525
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 519 StructureType noalg.map.group[uint8][4]int
+      Element: 520 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 515
+      ID: 516
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 511 StructureType noalg.map.group[uint8]uint8
+      Element: 512 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -26293,9 +26512,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 439 GoSliceDataType []string.array
+      Data: 440 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 440
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26315,14 +26534,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 575 GoSliceDataType []struct {}.array
+      Data: 576 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 575
+      ID: 576
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 125 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 1371
+      ID: 638
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -26330,22 +26549,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1372 PointerType *time.zone
+          Type: 639 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1377 GoSliceDataType []time.zone.array
+      Data: 697 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 1377
+      ID: 697
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 1373 StructureType time.zone
+      Element: 640 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 1374
+      ID: 641
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -26353,20 +26572,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1375 PointerType *time.zoneTrans
+          Type: 642 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1379 GoSliceDataType []time.zoneTrans.array
+      Data: 699 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 1379
+      ID: 699
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 1376 StructureType time.zoneTrans
+      Element: 643 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 262
       Name: '[]uint'
@@ -26383,9 +26602,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 565 GoSliceDataType []uint.array
+      Data: 566 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 565
+      ID: 566
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26406,9 +26625,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 573 GoSliceDataType []uint16.array
+      Data: 574 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 573
+      ID: 574
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26429,9 +26648,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 420 GoSliceDataType []uint8.array
+      Data: 421 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 420
+      ID: 421
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26452,19 +26671,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 422 GoSliceDataType []uintptr.array
+      Data: 423 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 422
+      ID: 423
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1286
+      ID: 1297
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 930
+      ID: 941
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 931104
@@ -26479,33 +26698,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 931 GoSliceDataType archive/tar.headerError.array
+      Data: 942 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 931
+      ID: 942
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1232
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1169
+      ID: 1180
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1171
+      ID: 1182
       Name: archive/zip.dirWriter
       GoRuntimeType: 1121728
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1269
+      ID: 1280
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1197
+      ID: 1208
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1569056
@@ -26515,7 +26734,7 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1210
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26525,15 +26744,15 @@ Types:
       GoRuntimeType: 584544
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1244
+      ID: 1255
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1275
+      ID: 1286
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1324
+      ID: 1335
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -26559,13 +26778,13 @@ Types:
       GoRuntimeType: 584288
       GoKind: 15
     - __kind: BaseType
-      ID: 733
+      ID: 744
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835232
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 734
+      ID: 745
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 835328
@@ -26573,26 +26792,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 736 PointerType *compress/flate.InternalError.str
+          Type: 747 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 735 GoStringDataType compress/flate.InternalError.str
+      Data: 746 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 735
+      ID: 746
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1219
+      ID: 1230
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1176
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1241
+      ID: 1252
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -26609,19 +26828,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 369
+      ID: 373
       Name: context.backgroundCtx
       GoRuntimeType: 1801408
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 370 StructureType context.emptyCtx
+          Type: 374 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 360
+      ID: 364
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1967712
@@ -26632,13 +26851,13 @@ Types:
           Type: 155 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 371 StructureType sync.Mutex
+          Type: 375 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 374 StructureType sync/atomic.Value
+          Type: 378 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 375 GoMapType map[context.canceler]struct {}
+          Type: 379 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 15 GoInterfaceType error
@@ -26648,7 +26867,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 651
+      ID: 658
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1112384
@@ -26661,13 +26880,13 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1042
+      ID: 1053
       Name: context.deadlineExceededError
       GoRuntimeType: 1468096
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 374
       Name: context.emptyCtx
       GoRuntimeType: 1599936
       GoKind: 25
@@ -26676,7 +26895,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 362
+      ID: 366
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1825632
@@ -26687,11 +26906,11 @@ Types:
           Type: 155 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 380 GoSubroutineType func() bool
+          Type: 384 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 364
+      ID: 368
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1618048
@@ -26699,29 +26918,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 360 StructureType context.cancelCtx
+          Type: 364 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 381 PointerType *time.Timer
+          Type: 385 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 383 StructureType time.Time
+          Type: 326 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 386
+      ID: 387
       Name: context.todoCtx
       GoRuntimeType: 1801632
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 370 StructureType context.emptyCtx
+          Type: 374 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 370
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1837568
@@ -26739,7 +26958,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 372
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1801184
@@ -26751,81 +26970,81 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 747
+      ID: 758
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837824
       GoKind: 2
     - __kind: BaseType
-      ID: 748
+      ID: 759
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837920
       GoKind: 2
     - __kind: BaseType
-      ID: 749
+      ID: 760
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838016
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1231
+      ID: 1242
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1265
+      ID: 1276
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1308
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1271
+      ID: 1282
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1267
+      ID: 1278
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1263
+      ID: 1274
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 750
+      ID: 761
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838112
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1281
+      ID: 1292
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1253
+      ID: 1264
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 737
+      ID: 748
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835808
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1025
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1350
+      ID: 1361
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 855
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 853
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1733952
@@ -26836,34 +27055,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1136 ArrayType [5]uint8
+          Type: 1147 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 969
+      ID: 980
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 994304
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1229
+      ID: 1240
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1247
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1120
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1132
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 927
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1736832
@@ -26871,21 +27090,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1120 PointerType *crypto/x509.Certificate
+          Type: 1131 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1139 BaseType crypto/x509.InvalidReason
+          Type: 1150 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 910
+      ID: 921
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1119296
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 912
+      ID: 923
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1603776
@@ -26893,24 +27112,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1120 PointerType *crypto/x509.Certificate
+          Type: 1131 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 746
+      ID: 757
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 837440
       GoKind: 2
     - __kind: BaseType
-      ID: 1139
+      ID: 1150
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 589728
       GoKind: 2
     - __kind: StructureType
-      ID: 1019
+      ID: 1030
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1565056
@@ -26920,13 +27139,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 918
+      ID: 929
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1119552
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 914
+      ID: 925
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1736640
@@ -26934,15 +27153,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1120 PointerType *crypto/x509.Certificate
+          Type: 1131 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1120 PointerType *crypto/x509.Certificate
+          Type: 1131 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 934
+      ID: 945
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1439776
@@ -26952,7 +27171,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 938
+      ID: 949
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1439936
@@ -26962,55 +27181,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 947
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 731
+      ID: 742
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834848
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1187
+      ID: 1198
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 732
+      ID: 743
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 835040
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 814
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1016
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 806
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 812
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 810
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 808
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1330
+      ID: 1341
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 805
+      ID: 816
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1423456
@@ -27020,19 +27239,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1195
+      ID: 1206
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 915
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 913
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 743
+      ID: 754
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 837344
@@ -27040,22 +27259,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 745 PointerType *encoding/xml.UnmarshalError.str
+          Type: 756 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 744 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 755 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 744
+      ID: 755
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 907
+      ID: 918
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1319
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27072,11 +27291,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 784
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 983
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27092,15 +27311,15 @@ Types:
       GoRuntimeType: 584480
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1318
+      ID: 1329
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 985
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 987
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27110,7 +27329,7 @@ Types:
       GoRuntimeType: 475456
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 380
+      ID: 384
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 595424
@@ -27122,44 +27341,44 @@ Types:
       GoRuntimeType: 849920
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 357
+      ID: 361
       Name: func(go.shape.float64) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 332
+      ID: 336
       Name: func(go.shape.int) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 333
+      ID: 337
       Name: func(go.shape.int) go.shape.string
       ByteSize: 8
       GoKind: 19
     - __kind: StructureType
-      ID: 327
+      ID: 331
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
     - __kind: StructureType
-      ID: 329
+      ID: 333
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 844
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 814
+      ID: 825
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1732800
@@ -27167,7 +27386,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1129 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1140 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27175,25 +27394,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 827
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1133
+      ID: 1144
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 820
+      ID: 831
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1115072
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1146
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 725
+      ID: 736
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 834272
@@ -27201,18 +27420,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 727 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 738 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 726 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 737 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 726
+      ID: 737
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1129
+      ID: 1140
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2222688
@@ -27220,7 +27439,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1130 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1141 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27235,7 +27454,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1131 GoSliceHeaderType []float64
+          Type: 1142 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -27244,10 +27463,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1132 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1143 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1134 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1145 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 159 GoSliceHeaderType []string
@@ -27261,13 +27480,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 1130
+      ID: 1141
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586144
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 722
+      ID: 733
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 834176
@@ -27275,18 +27494,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 724 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 723 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 723
+      ID: 734
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 728
+      ID: 739
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 834368
@@ -27294,30 +27513,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 730 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 741 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 729 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 740 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 729
+      ID: 740
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1220
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1294
+      ID: 1305
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 939
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 388
+      ID: 389
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2345920
@@ -27325,7 +27544,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 389 StructureType sync.RWMutex
+          Type: 390 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -27346,13 +27565,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 397 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 398 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 402 GoMapType map[string]float64
+          Type: 403 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -27367,10 +27586,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 407 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 408 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 411 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27382,7 +27601,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 413 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 414 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -27405,7 +27624,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 414
+      ID: 415
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2219552
@@ -27416,13 +27635,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 415 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 387 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 390 StructureType sync/atomic.Int32
+          Type: 391 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27431,16 +27650,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 417 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 418 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 389 StructureType sync.RWMutex
+          Type: 390 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -27449,12 +27668,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 407 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 408 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 409
+      ID: 410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1913952
@@ -27471,7 +27690,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27479,20 +27698,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 397
+      ID: 398
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1285120
       GoKind: 21
-      HeaderType: 399 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 400 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1383
+      ID: 1384
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 583264
       GoKind: 10
     - __kind: StructureType
-      ID: 412
+      ID: 413
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1751776
@@ -27506,16 +27725,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 680 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 687 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 685 GoMapType map[string]interface {}
+          Type: 692 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1409
+      ID: 1410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 697
+      ID: 708
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1914208
@@ -27523,7 +27742,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1407 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1408 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27538,15 +27757,15 @@ Types:
           Type: 20 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1408 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1407
+      ID: 1408
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 989312
       GoKind: 5
     - __kind: StructureType
-      ID: 416
+      ID: 417
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2108608
@@ -27554,16 +27773,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 389 StructureType sync.RWMutex
+          Type: 390 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1381 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1382 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -27578,12 +27797,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1383 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1384 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 387 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 417
+      ID: 418
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 897600
@@ -27592,15 +27811,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1088
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1326
+      ID: 1337
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1412
+      ID: 1413
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1631872
@@ -27610,29 +27829,29 @@ Types:
           Offset: 0
           Type: 155 GoInterfaceType context.Context
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 864
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 860
+      ID: 871
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1118528
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 742
+      ID: 753
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 836480
       GoKind: 2
     - __kind: StructureType
-      ID: 858
+      ID: 869
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1118400
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 856
+      ID: 867
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1601856
@@ -27645,7 +27864,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 876
+      ID: 887
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1602656
@@ -27658,7 +27877,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 880
+      ID: 891
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1736064
@@ -27674,7 +27893,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 878
+      ID: 889
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1433376
@@ -27684,7 +27903,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 874
+      ID: 885
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1433056
@@ -27694,14 +27913,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1115
+      ID: 1126
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1504096
       GoKind: 21
-      HeaderType: 1117 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1128 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1138
+      ID: 1149
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1051424
@@ -27716,15 +27935,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1156 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1167 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1156
+      ID: 1167
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 888
+      ID: 899
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1602976
@@ -27732,12 +27951,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1115 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1126 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1115 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1126 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 882
+      ID: 893
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1433536
@@ -27747,7 +27966,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 886
+      ID: 897
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1736256
@@ -27758,12 +27977,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1138 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1138 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 884
+      ID: 895
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1602816
@@ -27776,7 +27995,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 890
+      ID: 901
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1433696
@@ -27784,9 +28003,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 383 StructureType time.Time
+          Type: 326 GoTimeType time.Time
     - __kind: StructureType
-      ID: 896
+      ID: 907
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1603296
@@ -27799,7 +28018,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 898
+      ID: 909
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1434016
@@ -27809,7 +28028,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 894
+      ID: 905
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1603136
@@ -27822,7 +28041,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 892
+      ID: 903
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1433856
@@ -27832,7 +28051,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 911
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1603456
@@ -27845,7 +28064,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 822
+      ID: 833
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1425696
@@ -27855,11 +28074,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1247
+      ID: 1258
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 824
+      ID: 835
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1425856
@@ -27867,21 +28086,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 822 StructureType github.com/cihub/seelog.baseError
+          Type: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1227
+      ID: 1238
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1183
+      ID: 1194
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1217
+      ID: 1228
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 828
+      ID: 839
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1426176
@@ -27889,13 +28108,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 822 StructureType github.com/cihub/seelog.baseError
+          Type: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1284
+      ID: 1295
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1295
+      ID: 1306
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2111072
@@ -27903,12 +28122,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1283 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1294 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 1298
+      ID: 1309
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2134880
@@ -27916,7 +28135,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1283 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1294 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27924,11 +28143,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1185
+      ID: 1196
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 826
+      ID: 837
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1426016
@@ -27936,9 +28155,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 822 StructureType github.com/cihub/seelog.baseError
+          Type: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 830
+      ID: 841
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1426336
@@ -27946,64 +28165,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 822 StructureType github.com/cihub/seelog.baseError
+          Type: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1249
+      ID: 1260
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1290
+      ID: 1301
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1292
+      ID: 1303
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1122
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1038
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1036
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1040
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1042
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1238
+      ID: 1249
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1032
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 836
+      ID: 847
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1427296
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1342
+      ID: 1353
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1096
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1054
+      ID: 1065
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1843392
@@ -28019,11 +28238,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1059
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 991
+      ID: 1002
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1706848
@@ -28036,7 +28255,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 1060
+      ID: 1071
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1843840
@@ -28052,13 +28271,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 968
+      ID: 979
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 991136
       GoKind: 8
     - __kind: StructureType
-      ID: 1052
+      ID: 1063
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1843168
@@ -28074,13 +28293,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1140
+      ID: 1151
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 832544
       GoKind: 8
     - __kind: StructureType
-      ID: 1050
+      ID: 1061
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1842944
@@ -28088,15 +28307,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1140 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1151 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1140 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1151 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1058
+      ID: 1069
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1757344
@@ -28109,7 +28328,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1056
+      ID: 1067
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1843616
@@ -28125,11 +28344,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1346
+      ID: 1357
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1064
+      ID: 1075
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1627648
@@ -28139,19 +28358,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 995
+      ID: 1006
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1285632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 993
+      ID: 1004
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1285504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1062
+      ID: 1073
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1757536
@@ -28164,7 +28383,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 755
+      ID: 766
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839936
@@ -28172,36 +28391,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 757 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 768 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 756 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 767 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 756
+      ID: 767
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 343
+      ID: 347
       Name: go.shape.bool
       ByteSize: 1
       GoRuntimeType: 596384
       GoKind: 1
     - __kind: BaseType
-      ID: 356
+      ID: 360
       Name: go.shape.float64
       ByteSize: 8
       GoRuntimeType: 596448
       GoKind: 14
     - __kind: BaseType
-      ID: 326
+      ID: 330
       Name: go.shape.int
       ByteSize: 8
       GoRuntimeType: 596256
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 332
       Name: go.shape.string
       ByteSize: 16
       GoRuntimeType: 596320
@@ -28209,18 +28428,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 638 PointerType *go.shape.string.str
+          Type: 645 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 637 GoStringDataType go.shape.string.str
+      Data: 644 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 637
+      ID: 644
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 335
+      ID: 339
       Name: go.shape.struct { Name string }
       ByteSize: 16
       GoKind: 25
@@ -28229,7 +28448,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 337
+      ID: 341
       Name: go.shape.struct { X int; Y int }
       ByteSize: 16
       GoKind: 25
@@ -28241,13 +28460,13 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 346
+      ID: 350
       Name: go.shape.struct { main.i int }
       ByteSize: 8
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 347
+      ID: 351
       Name: go.shape.struct { main.s string }
       ByteSize: 16
       GoKind: 25
@@ -28256,7 +28475,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 350
+      ID: 354
       Name: go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
       ByteSize: 48
       GoKind: 25
@@ -28271,11 +28490,11 @@ Types:
           Offset: 32
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1135
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1035
+      ID: 1046
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1451616
@@ -28285,7 +28504,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1215
+      ID: 1226
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1682944
@@ -28293,13 +28512,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1239 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1250 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1306
+      ID: 1317
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1239
+      ID: 1250
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1129280
@@ -28312,7 +28531,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1201
+      ID: 1212
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1574016
@@ -28322,19 +28541,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 758
+      ID: 769
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 840512
       GoKind: 10
     - __kind: BaseType
-      ID: 1122
+      ID: 1133
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1004768
       GoKind: 10
     - __kind: StructureType
-      ID: 1093
+      ID: 1104
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1883264
@@ -28345,12 +28564,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1122 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1133 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 954
+      ID: 965
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1610496
@@ -28358,12 +28577,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1122 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1133 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 762
+      ID: 773
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840704
@@ -28371,18 +28590,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 764 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 775 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 763 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 774 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 763
+      ID: 774
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 768
+      ID: 779
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840896
@@ -28390,18 +28609,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 770 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 781 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 769 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 780 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 769
+      ID: 780
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 765
+      ID: 776
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840800
@@ -28409,18 +28628,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 767 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 778 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 766 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 777 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 766
+      ID: 777
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 759
+      ID: 770
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840608
@@ -28428,22 +28647,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 761 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 772 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 760 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 771 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 760
+      ID: 771
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1304
+      ID: 1315
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 958
+      ID: 969
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1452256
@@ -28453,13 +28672,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 771
+      ID: 782
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840992
       GoKind: 2
     - __kind: StructureType
-      ID: 946
+      ID: 957
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1447296
@@ -28469,11 +28688,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1102
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1113
+      ID: 1124
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1911168
@@ -28489,7 +28708,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 948
+      ID: 959
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1610016
@@ -28502,7 +28721,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1255
+      ID: 1266
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1968736
@@ -28510,16 +28729,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1282 GoInterfaceType io.Reader
+          Type: 1293 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1213
+      ID: 1224
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1033
+      ID: 1044
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1571616
@@ -28529,29 +28748,29 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1173
+      ID: 1184
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 937
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1034
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1089
+      ID: 1100
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1087
+      ID: 1098
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1514656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 940
+      ID: 951
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1440576
@@ -28561,7 +28780,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 942
+      ID: 953
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1440736
@@ -28571,463 +28790,463 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 879
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 534
+      ID: 535
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 535 PointerType *noalg.map.group[[4]int][4]int
+          Type: 536 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 536 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 540 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 537 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 541 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 526
+      ID: 527
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 527 PointerType *noalg.map.group[[4]int]uint8
+          Type: 528 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 528 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 532 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 529 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 533 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 474
+      ID: 475
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 475 PointerType *noalg.map.group[[4]string][2]int
+          Type: 476 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 476 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 481 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 477 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 482 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 493
+      ID: 494
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 494 PointerType *noalg.map.group[bool]main.node
+          Type: 495 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 495 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 499 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 496 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 500 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 646
+      ID: 653
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 647 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 654 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 648 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 653 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 655 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 660 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 430
+      ID: 431
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 431 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 432 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 432 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 438 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 433 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 439 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1398
+      ID: 1399
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1399 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1400 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1400 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1406 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1401 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1407 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1442
+      ID: 1443
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1443 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1444 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1444 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1450 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1445 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1451 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1457
+      ID: 1458
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1458 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1459 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1459 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1465 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1460 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1466 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 442
+      ID: 443
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 443 PointerType *noalg.map.group[int]int
+          Type: 444 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 444 StructureType noalg.map.group[int]int
-      GroupSliceType: 448 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 445 StructureType noalg.map.group[int]int
+      GroupSliceType: 449 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1472
+      ID: 1473
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1473 PointerType *noalg.map.group[int]interface {}
+          Type: 1474 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1474 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1478 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1475 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1479 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 550
+      ID: 551
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 551 PointerType *noalg.map.group[int]struct {}
+          Type: 552 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 552 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 556 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 553 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 557 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 501
+      ID: 502
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 502 PointerType *noalg.map.group[int]uint8
+          Type: 503 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 503 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 507 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 504 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 508 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 691
+      ID: 702
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 692 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 703 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 693 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 699 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 710 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 483
+      ID: 484
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 484 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 485 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 485 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 491 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 486 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 492 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 466
+      ID: 467
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 467 PointerType *noalg.map.group[string][]string
+          Type: 468 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 468 StructureType noalg.map.group[string][]string
-      GroupSliceType: 472 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 469 StructureType noalg.map.group[string][]string
+      GroupSliceType: 473 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 671
+      ID: 678
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 672 PointerType *noalg.map.group[string]float64
+          Type: 679 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 673 StructureType noalg.map.group[string]float64
-      GroupSliceType: 677 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 680 StructureType noalg.map.group[string]float64
+      GroupSliceType: 684 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1147
+      ID: 1158
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1148 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1159 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1149 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1153 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1164 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 458
+      ID: 459
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 459 PointerType *noalg.map.group[string]int
+          Type: 460 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 460 StructureType noalg.map.group[string]int
-      GroupSliceType: 464 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 461 StructureType noalg.map.group[string]int
+      GroupSliceType: 465 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 663
+      ID: 670
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 664 PointerType *noalg.map.group[string]interface {}
+          Type: 671 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 665 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 669 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 672 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 676 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 450
+      ID: 451
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 451 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 452 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 452 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 456 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 453 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 457 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 655
+      ID: 662
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 656 PointerType *noalg.map.group[string]string
+          Type: 663 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 657 StructureType noalg.map.group[string]string
-      GroupSliceType: 661 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 664 StructureType noalg.map.group[string]string
+      GroupSliceType: 668 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 542
+      ID: 543
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 543 PointerType *noalg.map.group[struct {}]int
+          Type: 544 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 544 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 548 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 545 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 549 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 590
+      ID: 591
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 591 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 592 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 592 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 596 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 597 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 598
+      ID: 599
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 599 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 600 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 600 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 604 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 605 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 606
+      ID: 607
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 607 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 608 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 608 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 612 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 613 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 614
+      ID: 615
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 615 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 616 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 620 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 621 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 622
+      ID: 623
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 623 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 624 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 628 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 629 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 630
+      ID: 631
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 631 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 632 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 636 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 637 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 558
+      ID: 559
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 559 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 560 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 560 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 564 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 561 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 565 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 517
+      ID: 518
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 518 PointerType *noalg.map.group[uint8][4]int
+          Type: 519 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 519 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 524 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 520 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 525 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 509
+      ID: 510
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 510 PointerType *noalg.map.group[uint8]uint8
+          Type: 511 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 511 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 515 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 512 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 516 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1261
+      ID: 1272
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 972
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29074,7 +29293,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 931
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29100,29 +29319,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 849
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1174
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1094
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1348
+      ID: 1359
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1081
+      ID: 1092
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1493536
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 778
+      ID: 789
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29203,7 +29422,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 373
+      ID: 377
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1490976
@@ -29216,11 +29435,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1205
+      ID: 1216
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1245
+      ID: 1256
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1192896
@@ -29233,7 +29452,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1282
+      ID: 1293
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1025056
@@ -29246,7 +29465,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1234
+      ID: 1245
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1111872
@@ -29272,47 +29491,47 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1203
+      ID: 1214
       Name: io.discard
       GoRuntimeType: 1467776
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1177
+      ID: 1188
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1090
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1251
+      ID: 1262
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 342
+      ID: 346
       Name: main.Pair[go.shape.int,go.shape.bool]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
         - Name: Value
           Offset: 8
-          Type: 343 BaseType go.shape.bool
+          Type: 347 BaseType go.shape.bool
     - __kind: StructureType
-      ID: 345
+      ID: 349
       Name: main.Pair[go.shape.string,go.shape.int]
       ByteSize: 24
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
         - Name: Value
           Offset: 16
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
     - __kind: StructureType
       ID: 320
       Name: main.aStruct
@@ -29339,7 +29558,7 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1479 PointerType *main.nestedStruct
+          Type: 1480 PointerType *main.nestedStruct
     - __kind: GoInterfaceType
       ID: 167
       Name: main.behavior
@@ -29380,7 +29599,7 @@ Types:
           Offset: 0
           Type: 144 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 436
+      ID: 437
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1189056
@@ -29388,9 +29607,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1392 GoMapType map[int]*main.deepMap3
+          Type: 1393 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1404
+      ID: 1405
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -29402,9 +29621,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1436 GoMapType map[int]*main.deepMap8
+          Type: 1437 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1448
+      ID: 1449
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1188288
@@ -29412,9 +29631,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1451 GoMapType map[int]*main.deepMap9
+          Type: 1452 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1463
+      ID: 1464
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1188160
@@ -29422,7 +29641,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1466 GoMapType map[int]interface {}
+          Type: 1467 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 132
       Name: main.deepPtr1
@@ -29442,9 +29661,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1351 PointerType *main.deepPtr3
+          Type: 1362 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1352
+      ID: 1363
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -29456,9 +29675,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1417 PointerType *main.deepPtr8
+          Type: 1418 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1418
+      ID: 1419
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1189440
@@ -29466,9 +29685,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1419 PointerType *main.deepPtr9
+          Type: 1420 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1420
+      ID: 1421
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1189312
@@ -29488,7 +29707,7 @@ Types:
           Offset: 0
           Type: 138 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 426
+      ID: 427
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1191360
@@ -29496,9 +29715,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1386 GoSliceHeaderType []*main.deepSlice3
+          Type: 1387 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1389
+      ID: 1390
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -29510,9 +29729,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1421 GoSliceHeaderType []*main.deepSlice8
+          Type: 1422 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1424
+      ID: 1425
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1190592
@@ -29520,9 +29739,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1427 GoSliceHeaderType []*main.deepSlice9
+          Type: 1428 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1430
+      ID: 1431
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1190464
@@ -29530,7 +29749,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1433 GoSliceHeaderType []interface {}
+          Type: 1434 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 324
       Name: main.emptyStruct
@@ -29548,16 +29767,16 @@ Types:
           Type: 160 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 371 StructureType sync.Mutex
+          Type: 375 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1359 StructureType sync.Once
+          Type: 1370 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1361 StructureType sync.WaitGroup
+          Type: 1372 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 390 StructureType sync/atomic.Int32
+          Type: 391 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 160
       Name: main.esotericStack
@@ -29587,7 +29806,7 @@ Types:
           Offset: 56
           Type: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 358
+      ID: 362
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1416736
@@ -29597,71 +29816,71 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 340
+      ID: 344
       Name: main.largeGenericType[go.shape.int]
       ByteSize: 136
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
     - __kind: StructureType
-      ID: 338
+      ID: 342
       Name: main.largeGenericType[go.shape.string]
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 255
       Name: main.largeStruct
@@ -29975,9 +30194,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1356 ArrayType [63]uint64
+          Type: 1367 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1366
+      ID: 1377
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1416896
@@ -29997,7 +30216,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1358
+      ID: 1369
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30008,31 +30227,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1354 PointerType *main.stringType1.str
+          Type: 1365 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1353 GoStringDataType main.stringType1.str
+      Data: 1364 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1353
+      ID: 1364
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1355
+      ID: 1366
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1481 PointerType *main.stringType2.str
+          Type: 1482 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1480 GoStringDataType main.stringType2.str
+      Data: 1481 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1480
+      ID: 1481
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -30148,16 +30367,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1367 PointerType **main.t
+          Type: 1378 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1368 GoSliceDataType main.t.array
+      Data: 1379 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1368
+      ID: 1379
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -30213,29 +30432,38 @@ Types:
         - Name: c
           Offset: 32
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 329
+      Name: main.timeCapture
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: monotonicNow
+          Offset: 0
+          Type: 326 GoTimeType time.Time
     - __kind: BaseType
       ID: 127
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 352
+      ID: 356
       Name: main.typeWithGenerics[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
     - __kind: StructureType
-      ID: 353
+      ID: 357
       Name: main.typeWithGenerics[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 260
       Name: main.wideStruct
@@ -30305,8 +30533,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 539 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 536 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 540 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 537 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 225
       Name: map<[4]int,uint8>
@@ -30337,8 +30565,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 531 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 528 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 532 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 529 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 193
       Name: map<[4]string,[2]int>
@@ -30369,8 +30597,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 480 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 476 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 481 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 477 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 205
       Name: map<bool,main.node>
@@ -30401,10 +30629,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 498 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 495 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 499 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 496 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 377
+      ID: 381
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -30417,7 +30645,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 378 PointerType **table<context.canceler,struct {}>
+          Type: 382 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30433,8 +30661,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 652 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 648 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 659 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 655 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 146
       Name: map<int,*main.deepMap2>
@@ -30465,10 +30693,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 437 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 432 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 438 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 433 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1394
+      ID: 1395
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -30481,7 +30709,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1395 PointerType **table<int,*main.deepMap3>
+          Type: 1396 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30497,10 +30725,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1405 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1400 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1406 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1401 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1438
+      ID: 1439
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -30513,7 +30741,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1439 PointerType **table<int,*main.deepMap8>
+          Type: 1440 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30529,10 +30757,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1449 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1444 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1450 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1445 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1453
+      ID: 1454
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -30545,7 +30773,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1454 PointerType **table<int,*main.deepMap9>
+          Type: 1455 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30561,8 +30789,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1464 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1459 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1465 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 173
       Name: map<int,int>
@@ -30593,10 +30821,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 447 GoSliceDataType []*table<int,int>.array
-      GroupType: 444 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 448 GoSliceDataType []*table<int,int>.array
+      GroupType: 445 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1468
+      ID: 1469
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -30609,7 +30837,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1469 PointerType **table<int,interface {}>
+          Type: 1470 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30625,8 +30853,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1477 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1474 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1478 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 240
       Name: map<int,struct {}>
@@ -30657,8 +30885,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 555 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 552 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 556 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 553 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 210
       Name: map<int,uint8>
@@ -30689,10 +30917,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 506 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 503 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 507 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 504 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 682
+      ID: 689
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -30705,7 +30933,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 683 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 690 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30721,8 +30949,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 698 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 693 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 709 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 200
       Name: map<string,[]main.structWithMap>
@@ -30753,8 +30981,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 490 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 485 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 491 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 486 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 188
       Name: map<string,[]string>
@@ -30785,10 +31013,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 471 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 468 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 472 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 469 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 404
+      ID: 405
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -30801,7 +31029,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 405 PointerType **table<string,float64>
+          Type: 406 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30817,10 +31045,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 676 GoSliceDataType []*table<string,float64>.array
-      GroupType: 673 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 683 GoSliceDataType []*table<string,float64>.array
+      GroupType: 680 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1117
+      ID: 1128
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -30833,7 +31061,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1118 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1129 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30849,8 +31077,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1152 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1149 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1163 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 183
       Name: map<string,int>
@@ -30881,10 +31109,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 463 GoSliceDataType []*table<string,int>.array
-      GroupType: 460 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 464 GoSliceDataType []*table<string,int>.array
+      GroupType: 461 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 399
+      ID: 400
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -30897,7 +31125,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 400 PointerType **table<string,interface {}>
+          Type: 401 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30913,8 +31141,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 668 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 665 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 675 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 672 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 178
       Name: map<string,main.nestedStruct>
@@ -30945,10 +31173,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 455 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 452 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 456 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 453 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 394
+      ID: 395
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -30961,7 +31189,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 395 PointerType **table<string,string>
+          Type: 396 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30977,8 +31205,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 660 GoSliceDataType []*table<string,string>.array
-      GroupType: 657 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 667 GoSliceDataType []*table<string,string>.array
+      GroupType: 664 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 235
       Name: map<struct {},int>
@@ -31009,8 +31237,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 547 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 544 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 548 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 545 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 292
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31041,8 +31269,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 595 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 592 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 596 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 297
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31073,8 +31301,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 603 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 600 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 604 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 302
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31105,8 +31333,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 611 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 608 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 612 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 307
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31137,8 +31365,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 619 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 620 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 312
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31169,8 +31397,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 627 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 628 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 317
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31201,8 +31429,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 635 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 636 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 245
       Name: map<struct {},struct {}>
@@ -31233,8 +31461,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 563 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 560 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 564 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 561 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 220
       Name: map<uint8,[4]int>
@@ -31265,8 +31493,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 523 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 519 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 524 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 520 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 215
       Name: map<uint8,uint8>
@@ -31297,8 +31525,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 514 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 511 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 515 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 512 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 228
       Name: map[[4]int][4]int
@@ -31328,12 +31556,12 @@ Types:
       GoKind: 21
       HeaderType: 205 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 375
+      ID: 379
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1133504
       GoKind: 21
-      HeaderType: 377 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 381 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 144
       Name: map[int]*main.deepMap2
@@ -31342,26 +31570,26 @@ Types:
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1392
+      ID: 1393
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1131072
       GoKind: 21
-      HeaderType: 1394 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1395 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1436
+      ID: 1437
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1130432
       GoKind: 21
-      HeaderType: 1438 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1439 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1451
+      ID: 1452
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1130304
       GoKind: 21
-      HeaderType: 1453 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1454 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 171
       Name: map[int]int
@@ -31370,12 +31598,12 @@ Types:
       GoKind: 21
       HeaderType: 173 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1466
+      ID: 1467
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1130176
       GoKind: 21
-      HeaderType: 1468 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1469 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 238
       Name: map[int]struct {}
@@ -31391,12 +31619,12 @@ Types:
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 680
+      ID: 687
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1133760
       GoKind: 21
-      HeaderType: 682 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 689 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 198
       Name: map[string][]main.structWithMap
@@ -31412,12 +31640,12 @@ Types:
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 402
+      ID: 403
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1133632
       GoKind: 21
-      HeaderType: 404 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 405 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 181
       Name: map[string]int
@@ -31426,12 +31654,12 @@ Types:
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 685
+      ID: 692
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1130048
       GoKind: 21
-      HeaderType: 399 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 400 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 176
       Name: map[string]main.nestedStruct
@@ -31440,12 +31668,12 @@ Types:
       GoKind: 21
       HeaderType: 178 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 392
+      ID: 393
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1133376
       GoKind: 21
-      HeaderType: 394 GoSwissMapHeaderType map<string,string>
+      HeaderType: 395 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 233
       Name: map[struct {}]int
@@ -31511,7 +31739,7 @@ Types:
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 872
+      ID: 883
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1432736
@@ -31521,7 +31749,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1167
+      ID: 1178
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1429536
@@ -31531,11 +31759,11 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1082
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1137
+      ID: 1148
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1600576
@@ -31548,35 +31776,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1113
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1312
+      ID: 1323
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1111
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1084
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1322
+      ID: 1333
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1332
+      ID: 1343
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1320
+      ID: 1331
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1038
+      ID: 1049
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1114688
@@ -31584,28 +31812,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1040 PointerType *net.UnknownNetworkError.str
+          Type: 1051 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1039 GoStringDataType net.UnknownNetworkError.str
+      Data: 1050 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1039
+      ID: 1050
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1007
+      ID: 1018
       Name: net.canceledError
       GoRuntimeType: 1286528
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1288
+      ID: 1299
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1142
+      ID: 1153
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2110368
@@ -31613,7 +31841,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -31624,27 +31852,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1334
+      ID: 1345
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1328
+      ID: 1339
       Name: net.noReadFrom
       GoRuntimeType: 1114944
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1327
+      ID: 1338
       Name: net.noWriteTo
       GoRuntimeType: 1114816
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 818
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1414
+      ID: 1415
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1762336
@@ -31657,7 +31885,7 @@ Types:
           Offset: 16
           Type: 155 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 809
+      ID: 820
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1732608
@@ -31665,7 +31893,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1125 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1136 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -31673,7 +31901,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1316
+      ID: 1327
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2295104
@@ -31681,12 +31909,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1328 StructureType net.noReadFrom
+          Type: 1339 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1321 PointerType *net.TCPConn
+          Type: 1332 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1314
+      ID: 1325
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2294560
@@ -31694,24 +31922,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1327 StructureType net.noWriteTo
+          Type: 1338 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1321 PointerType *net.TCPConn
+          Type: 1332 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1086
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1115
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 1008
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1159
+      ID: 1170
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1421216
@@ -31721,19 +31949,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 703
+      ID: 714
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 833024
       GoKind: 10
     - __kind: BaseType
-      ID: 1114
+      ID: 1125
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 991232
       GoKind: 10
     - __kind: StructureType
-      ID: 785
+      ID: 796
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1731264
@@ -31744,12 +31972,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1114 BaseType net/http.http2ErrCode
+          Type: 1125 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1096
+      ID: 1107
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1902464
@@ -31760,12 +31988,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1114 BaseType net/http.http2ErrCode
+          Type: 1125 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 789
+      ID: 800
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1600256
@@ -31773,16 +32001,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1114 BaseType net/http.http2ErrCode
+          Type: 1125 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1223
+      ID: 1234
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 707
+      ID: 718
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833216
@@ -31790,18 +32018,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 709 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 720 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 708 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 719 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 708
+      ID: 719
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 713
+      ID: 724
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833408
@@ -31809,18 +32037,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 715 PointerType *net/http.http2headerFieldNameError.str
+          Type: 726 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 714 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 725 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 714
+      ID: 725
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 710
+      ID: 721
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 833312
@@ -31828,32 +32056,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 712 PointerType *net/http.http2headerFieldValueError.str
+          Type: 723 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 711 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 722 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 711
+      ID: 722
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1068
+      ID: 1079
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1003
+      ID: 1014
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1285888
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1277
+      ID: 1288
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 704
+      ID: 715
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833120
@@ -31861,18 +32089,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 706 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 717 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 705 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 716 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 705
+      ID: 716
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1161
+      ID: 1172
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1826752
@@ -31880,18 +32108,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1256 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1267 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1257 BaseType time.Duration
+          Type: 1268 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1256
+      ID: 1267
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1420576
@@ -31904,14 +32132,14 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1242
+      ID: 1253
       Name: net/http.incomparable
       GoRuntimeType: 902496
       GoKind: 17
       HasCount: true
       Element: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 999
+      ID: 1010
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1559136
@@ -31921,11 +32149,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1225
+      ID: 1236
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1181
+      ID: 1192
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1558976
@@ -31933,9 +32161,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1224 PointerType *net/http.persistConn
+          Type: 1235 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1207
+      ID: 1218
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1803200
@@ -31943,15 +32171,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1242 ArrayType net/http.incomparable
+          Type: 1253 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1243 PointerType *bufio.Reader
+          Type: 1254 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1245 GoInterfaceType io.ReadWriteCloser
+          Type: 1256 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 793
+      ID: 804
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1422176
@@ -31961,17 +32189,17 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1098
+      ID: 1109
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1066
+      ID: 1077
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1480096
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1001
+      ID: 1012
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1559296
@@ -31981,7 +32209,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1259
+      ID: 1270
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2028640
@@ -31989,16 +32217,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 793
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1279
+      ID: 1290
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2044672
@@ -32006,13 +32234,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1274 PointerType *bufio.Writer
+          Type: 1285 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1191
+      ID: 1202
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 875
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1735680
@@ -32028,7 +32256,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 862
+      ID: 873
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1602016
@@ -32041,11 +32269,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1233
+      ID: 1244
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1193
+      ID: 1204
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1603936
@@ -32053,16 +32281,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1232 PointerType *net/smtp.Client
+          Type: 1243 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1234 GoInterfaceType io.WriteCloser
+          Type: 1245 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 859
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 738
+      ID: 749
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835904
@@ -32070,26 +32298,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 740 PointerType *net/textproto.ProtocolError.str
+          Type: 751 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 739 GoStringDataType net/textproto.ProtocolError.str
+      Data: 750 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 739
+      ID: 750
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1189
+      ID: 1200
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1117
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 716
+      ID: 727
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833888
@@ -32097,18 +32325,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 718 PointerType *net/url.EscapeError.str
+          Type: 729 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 717 GoStringDataType net/url.EscapeError.str
+      Data: 728 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 717
+      ID: 728
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 719
+      ID: 730
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833984
@@ -32116,299 +32344,299 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 721 PointerType *net/url.InvalidHostError.str
+          Type: 732 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 720 GoStringDataType net/url.InvalidHostError.str
+      Data: 731 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 720
+      ID: 731
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 537
+      ID: 538
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 683168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 538 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 539 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 529
+      ID: 530
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 530 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 531 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 477
+      ID: 478
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 478 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 479 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 496
+      ID: 497
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 497 StructureType noalg.struct { key bool; elem main.node }
+      Element: 498 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 649
+      ID: 656
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 689216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 650 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 657 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 433
+      ID: 434
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682400
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 434 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 435 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1401
+      ID: 1402
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1402 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1403 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1445
+      ID: 1446
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681824
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1446 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1447 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1460
+      ID: 1461
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1461 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1462 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 445
+      ID: 446
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680480
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 446 StructureType noalg.struct { key int; elem int }
+      Element: 447 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1475
+      ID: 1476
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681632
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1476 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1477 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 553
+      ID: 554
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 683744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 554 StructureType noalg.struct { key int; elem struct {} }
+      Element: 555 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 504
+      ID: 505
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 505 StructureType noalg.struct { key int; elem uint8 }
+      Element: 506 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 694
+      ID: 705
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 689856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 695 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 706 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 486
+      ID: 487
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 487 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 488 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 469
+      ID: 470
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 470 StructureType noalg.struct { key string; elem []string }
+      Element: 471 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 674
+      ID: 681
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 689760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 675 StructureType noalg.struct { key string; elem float64 }
+      Element: 682 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1150
+      ID: 1161
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 758848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1151 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1162 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 461
+      ID: 462
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 684128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 462 StructureType noalg.struct { key string; elem int }
+      Element: 463 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 666
+      ID: 673
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 681248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 667 StructureType noalg.struct { key string; elem interface {} }
+      Element: 674 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 453
+      ID: 454
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 684224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 454 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 455 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 658
+      ID: 665
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 687392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 659 StructureType noalg.struct { key string; elem string }
+      Element: 666 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 545
+      ID: 546
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 684320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 546 StructureType noalg.struct { key struct {}; elem int }
+      Element: 547 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 593
+      ID: 594
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 594 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 595 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 601
+      ID: 602
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 602 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 603 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 609
+      ID: 610
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 610 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 611 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 617
+      ID: 618
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 618 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 619 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 625
+      ID: 626
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 626 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 627 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 633
+      ID: 634
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 634 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 635 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 561
+      ID: 562
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 684416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 562 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 563 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 520
+      ID: 521
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 684512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 521 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 522 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 512
+      ID: 513
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 684608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 513 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 514 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 536
+      ID: 537
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1298176
@@ -32419,9 +32647,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 537 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 538 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 528
+      ID: 529
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1298432
@@ -32432,9 +32660,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 529 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 530 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 476
+      ID: 477
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1298688
@@ -32445,9 +32673,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 477 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 478 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 495
+      ID: 496
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1298944
@@ -32458,9 +32686,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 496 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 497 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 648
+      ID: 655
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1303040
@@ -32471,9 +32699,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 649 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 656 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 432
+      ID: 433
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1297920
@@ -32484,9 +32712,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 433 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 434 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1400
+      ID: 1401
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1297664
@@ -32497,9 +32725,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1401 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1402 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1444
+      ID: 1445
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1296384
@@ -32510,9 +32738,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1445 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1446 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1459
+      ID: 1460
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1296128
@@ -32523,9 +32751,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1460 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1461 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 444
+      ID: 445
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1294848
@@ -32536,9 +32764,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 445 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 446 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1474
+      ID: 1475
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1295872
@@ -32549,9 +32777,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1475 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1476 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 552
+      ID: 553
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1299200
@@ -32562,9 +32790,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 553 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 554 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 503
+      ID: 504
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1299456
@@ -32575,9 +32803,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 504 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 505 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 693
+      ID: 704
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1303936
@@ -32588,9 +32816,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 694 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 705 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 485
+      ID: 486
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1299712
@@ -32601,9 +32829,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 486 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 487 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 468
+      ID: 469
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1299968
@@ -32614,9 +32842,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 469 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 470 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 673
+      ID: 680
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1303680
@@ -32627,9 +32855,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 674 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 681 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1149
+      ID: 1160
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1361920
@@ -32640,9 +32868,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1150 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1161 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 460
+      ID: 461
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1300224
@@ -32653,9 +32881,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 461 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 462 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 665
+      ID: 672
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1295616
@@ -32666,9 +32894,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 666 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 673 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 452
+      ID: 453
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1300480
@@ -32679,9 +32907,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 453 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 454 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 657
+      ID: 664
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1302272
@@ -32692,9 +32920,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 658 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 665 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 544
+      ID: 545
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1300736
@@ -32705,9 +32933,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 545 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 546 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 592
+      ID: 593
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -32717,9 +32945,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 593 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 594 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 600
+      ID: 601
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32729,9 +32957,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 601 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 602 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 608
+      ID: 609
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32741,9 +32969,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 609 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 610 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 616
+      ID: 617
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32753,9 +32981,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 617 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 618 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 624
+      ID: 625
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32765,9 +32993,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 625 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 626 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 632
+      ID: 633
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32777,9 +33005,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 633 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 634 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 560
+      ID: 561
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1300992
@@ -32790,9 +33018,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 561 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 562 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 519
+      ID: 520
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1301248
@@ -32803,9 +33031,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 520 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 521 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 511
+      ID: 512
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1301504
@@ -32816,9 +33044,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 512 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 513 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 538
+      ID: 539
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1298048
@@ -32826,12 +33054,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 522 ArrayType [4]int
+          Type: 523 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 522 ArrayType [4]int
+          Type: 523 ArrayType [4]int
     - __kind: StructureType
-      ID: 530
+      ID: 531
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1298304
@@ -32839,12 +33067,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 522 ArrayType [4]int
+          Type: 523 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 478
+      ID: 479
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1298560
@@ -32852,12 +33080,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 479 ArrayType [4]string
+          Type: 480 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 113 ArrayType [2]int
     - __kind: StructureType
-      ID: 497
+      ID: 498
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1298816
@@ -32870,7 +33098,7 @@ Types:
           Offset: 8
           Type: 251 StructureType main.node
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1302912
@@ -32878,12 +33106,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 651 GoInterfaceType context.canceler
+          Type: 658 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 434
+      ID: 435
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1297792
@@ -32894,9 +33122,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 435 PointerType *main.deepMap2
+          Type: 436 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1402
+      ID: 1403
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1297536
@@ -32907,9 +33135,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1403 PointerType *main.deepMap3
+          Type: 1404 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1446
+      ID: 1447
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1296256
@@ -32920,9 +33148,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1447 PointerType *main.deepMap8
+          Type: 1448 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1461
+      ID: 1462
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1296000
@@ -32933,9 +33161,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1462 PointerType *main.deepMap9
+          Type: 1463 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 446
+      ID: 447
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1294720
@@ -32948,7 +33176,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 1476
+      ID: 1477
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1295744
@@ -32961,7 +33189,7 @@ Types:
           Offset: 8
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 554
+      ID: 555
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1299072
@@ -32974,7 +33202,7 @@ Types:
           Offset: 8
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 505
+      ID: 506
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1299328
@@ -32987,7 +33215,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 695
+      ID: 706
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1303808
@@ -32998,9 +33226,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 696 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 707 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 487
+      ID: 488
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1299584
@@ -33011,9 +33239,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 488 GoSliceHeaderType []main.structWithMap
+          Type: 489 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 470
+      ID: 471
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1299840
@@ -33026,7 +33254,7 @@ Types:
           Offset: 16
           Type: 159 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 675
+      ID: 682
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1303552
@@ -33039,7 +33267,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 1151
+      ID: 1162
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1361792
@@ -33050,9 +33278,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1138 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 462
+      ID: 463
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1300096
@@ -33065,7 +33293,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1295488
@@ -33078,7 +33306,7 @@ Types:
           Offset: 16
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 454
+      ID: 455
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1300352
@@ -33091,7 +33319,7 @@ Types:
           Offset: 16
           Type: 123 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 659
+      ID: 666
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1302144
@@ -33104,7 +33332,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 546
+      ID: 547
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1300608
@@ -33117,7 +33345,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 594
+      ID: 595
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33129,7 +33357,7 @@ Types:
           Offset: 0
           Type: 289 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 602
+      ID: 603
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33141,7 +33369,7 @@ Types:
           Offset: 0
           Type: 290 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 610
+      ID: 611
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33153,7 +33381,7 @@ Types:
           Offset: 0
           Type: 295 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 618
+      ID: 619
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33165,7 +33393,7 @@ Types:
           Offset: 0
           Type: 300 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 626
+      ID: 627
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33177,7 +33405,7 @@ Types:
           Offset: 0
           Type: 305 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 634
+      ID: 635
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33189,7 +33417,7 @@ Types:
           Offset: 0
           Type: 310 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 562
+      ID: 563
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1300864
       GoKind: 25
@@ -33201,7 +33429,7 @@ Types:
           Offset: 0
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 521
+      ID: 522
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1301120
@@ -33212,9 +33440,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 522 ArrayType [4]int
+          Type: 523 ArrayType [4]int
     - __kind: StructureType
-      ID: 513
+      ID: 514
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1301376
@@ -33227,19 +33455,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1340
+      ID: 1351
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 991
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1055
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1338
+      ID: 1349
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2363712
@@ -33247,12 +33475,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1344 StructureType os.noReadFrom
+          Type: 1355 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1339 PointerType *os.File
+          Type: 1350 PointerType *os.File
     - __kind: StructureType
-      ID: 1336
+      ID: 1347
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2362912
@@ -33260,36 +33488,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1343 StructureType os.noWriteTo
+          Type: 1354 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1339 PointerType *os.File
+          Type: 1350 PointerType *os.File
     - __kind: StructureType
-      ID: 1344
+      ID: 1355
       Name: os.noReadFrom
       GoRuntimeType: 1113152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1343
+      ID: 1354
       Name: os.noWriteTo
       GoRuntimeType: 1113024
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1020
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1145
+      ID: 1156
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1211
+      ID: 1222
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1011
+      ID: 1022
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1707424
@@ -33302,7 +33530,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 752
+      ID: 763
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 839168
@@ -33310,36 +33538,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 754 PointerType *os/user.UnknownGroupIdError.str
+          Type: 765 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 753 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 764 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 753
+      ID: 764
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 751
+      ID: 762
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 839072
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 780
+      ID: 791
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 881
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 995
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 999
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33351,7 +33579,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 986
+      ID: 997
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1890880
@@ -33368,9 +33596,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1143 BaseType runtime.boundsErrorCode
+          Type: 1154 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1143
+      ID: 1154
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 584672
@@ -33390,7 +33618,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1046
+      ID: 1057
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1755424
@@ -33403,7 +33631,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 962
+      ID: 973
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 990368
@@ -33411,13 +33639,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 964 PointerType *runtime.errorString.str
+          Type: 975 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 963 GoStringDataType runtime.errorString.str
+      Data: 974 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 963
+      ID: 974
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34073,7 +34301,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 965
+      ID: 976
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 990464
@@ -34081,13 +34309,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 967 PointerType *runtime.plainError.str
+          Type: 978 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 966 GoStringDataType runtime.plainError.str
+      Data: 977 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 966
+      ID: 977
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34173,7 +34401,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 989
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -34185,26 +34413,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 419 PointerType *string.str
+          Type: 420 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 418 GoStringDataType string.str
+      Data: 419 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 418
+      ID: 419
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1273
+      ID: 1284
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1179
+      ID: 1190
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1175
+      ID: 1186
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1459456
@@ -34220,7 +34448,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 371
+      ID: 375
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1470816
@@ -34228,12 +34456,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 372 StructureType sync.noCopy
+          Type: 376 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 373 StructureType internal/sync.Mutex
+          Type: 377 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1359
+      ID: 1370
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1620352
@@ -34241,15 +34469,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 372 StructureType sync.noCopy
+          Type: 376 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1360 StructureType sync/atomic.Uint32
+          Type: 1371 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 371 StructureType sync.Mutex
+          Type: 375 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 389
+      ID: 390
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1840256
@@ -34257,7 +34485,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 371 StructureType sync.Mutex
+          Type: 375 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -34266,12 +34494,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 390 StructureType sync/atomic.Int32
+          Type: 391 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 390 StructureType sync/atomic.Int32
+          Type: 391 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1361
+      ID: 1372
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1620544
@@ -34279,21 +34507,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 372 StructureType sync.noCopy
+          Type: 376 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1362 StructureType sync/atomic.Uint64
+          Type: 1373 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 372
+      ID: 376
       Name: sync.noCopy
       GoRuntimeType: 989984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 390
+      ID: 391
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1472096
@@ -34301,12 +34529,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 391 StructureType sync/atomic.noCopy
+          Type: 392 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1360
+      ID: 1371
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1472256
@@ -34314,12 +34542,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 391 StructureType sync/atomic.noCopy
+          Type: 392 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1362
+      ID: 1373
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1620928
@@ -34327,15 +34555,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 391 StructureType sync/atomic.noCopy
+          Type: 392 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1363 StructureType sync/atomic.align64
+          Type: 1374 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 374
+      ID: 378
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1197248
@@ -34345,25 +34573,25 @@ Types:
           Offset: 0
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1363
+      ID: 1374
       Name: sync/atomic.align64
       GoRuntimeType: 990176
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 391
+      ID: 392
       Name: sync/atomic.noCopy
       GoRuntimeType: 990080
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1094
+      ID: 1105
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1287936
       GoKind: 12
     - __kind: StructureType
-      ID: 533
+      ID: 534
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -34385,9 +34613,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 534 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 535 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 525
+      ID: 526
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34409,9 +34637,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 526 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 527 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 473
+      ID: 474
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -34433,9 +34661,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 474 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 475 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 492
+      ID: 493
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -34457,9 +34685,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 493 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 494 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 645
+      ID: 652
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -34481,9 +34709,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 646 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 653 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 429
+      ID: 430
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -34505,9 +34733,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 430 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 431 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1397
+      ID: 1398
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -34529,9 +34757,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1398 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1399 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1441
+      ID: 1442
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -34553,9 +34781,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1442 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1443 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1456
+      ID: 1457
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -34577,9 +34805,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1457 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1458 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 441
+      ID: 442
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -34601,9 +34829,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 442 GoSwissMapGroupsType groupReference<int,int>
+          Type: 443 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1471
+      ID: 1472
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -34625,9 +34853,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1472 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1473 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 549
+      ID: 550
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -34649,9 +34877,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 550 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 551 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 500
+      ID: 501
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34673,9 +34901,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 501 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 502 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 690
+      ID: 701
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -34697,9 +34925,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 691 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 702 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 482
+      ID: 483
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -34721,9 +34949,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 483 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 484 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 465
+      ID: 466
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -34745,9 +34973,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 466 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 467 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 670
+      ID: 677
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -34769,9 +34997,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 671 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 678 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1146
+      ID: 1157
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -34793,9 +35021,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1147 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1158 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 457
+      ID: 458
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -34817,9 +35045,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 458 GoSwissMapGroupsType groupReference<string,int>
+          Type: 459 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 662
+      ID: 669
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -34841,9 +35069,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 663 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 670 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 449
+      ID: 450
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -34865,9 +35093,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 450 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 451 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 654
+      ID: 661
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -34889,9 +35117,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 655 GoSwissMapGroupsType groupReference<string,string>
+          Type: 662 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 541
+      ID: 542
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -34913,9 +35141,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 542 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 543 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 589
+      ID: 590
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -34937,9 +35165,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 590 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 591 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 597
+      ID: 598
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -34961,9 +35189,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 598 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 599 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 605
+      ID: 606
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -34985,9 +35213,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 606 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 607 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 613
+      ID: 614
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35009,9 +35237,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 614 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 615 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 621
+      ID: 622
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35033,9 +35261,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 622 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 623 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 629
+      ID: 630
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35057,9 +35285,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 630 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 631 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 557
+      ID: 558
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35081,9 +35309,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 558 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 559 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 516
+      ID: 517
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35105,9 +35333,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 517 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 518 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 508
+      ID: 509
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35129,13 +35357,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 509 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 510 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1310
+      ID: 1321
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1037
+      ID: 1048
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1711840
@@ -35148,13 +35376,13 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 1257
+      ID: 1268
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1915744
       GoKind: 6
     - __kind: StructureType
-      ID: 385
+      ID: 328
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1972064
@@ -35165,10 +35393,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 1371 GoSliceHeaderType []time.zone
+          Type: 638 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 1374 GoSliceHeaderType []time.zoneTrans
+          Type: 641 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -35180,13 +35408,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 1372 PointerType *time.zone
+          Type: 639 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 787
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 383
+    - __kind: GoTimeType
+      ID: 326
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2378592
@@ -35200,9 +35428,17 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 384 PointerType *time.Location
+          Type: 327 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 382
+      ID: 386
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1472896
@@ -35210,12 +35446,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1370 GoChannelType <-chan time.Time
+          Type: 1381 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 700
+      ID: 711
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 831488
@@ -35223,18 +35459,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 702 PointerType *time.fileSizeError.str
+          Type: 713 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 701 GoStringDataType time.fileSizeError.str
+      Data: 712 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 701
+      ID: 712
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1373
+      ID: 640
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1621888
@@ -35250,7 +35486,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1376
+      ID: 643
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1754272
@@ -35311,7 +35547,7 @@ Types:
       GoRuntimeType: 584608
       GoKind: 26
     - __kind: StructureType
-      ID: 1125
+      ID: 1136
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2066080
@@ -35322,10 +35558,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1126 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1137 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1127 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1138 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -35340,18 +35576,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1128 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1139 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1128
+      ID: 1139
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995936
       GoKind: 9
     - __kind: StructureType
-      ID: 1126
+      ID: 1137
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1927776
@@ -35376,21 +35612,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 877
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1127
+      ID: 1138
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588256
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1302
+      ID: 1313
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 861
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1429856
@@ -35400,13 +35636,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 741
+      ID: 752
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836000
       GoKind: 2
     - __kind: StructureType
-      ID: 1016
+      ID: 1027
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1707616
@@ -35419,12 +35655,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 970
+      ID: 981
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 994784
       GoKind: 5
-MaxTypeID: 1810
+MaxTypeID: 1814
 Issues:
     - probe_definition:
         id: testReturnCondBadField
@@ -35456,10 +35692,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x18133a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x18143a0", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x190296b"
-    AeskeyschedAddr: "0x1903ac0"
+    UseAeshashAddr: "0x190396b"
+    AeskeyschedAddr: "0x1904ac0"
 CommonTypes:
     G: 24 StructureType runtime.g
     M: 31 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,11 +12,11 @@ Probes:
         - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1733 EventRootType Probe[main.stackC]
+              Type: 1734 EventRootType Probe[main.stackC]
               InjectionPoints: [{PC: "0xce580a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1734 EventRootType Probe[main.stackC]Return
+              Type: 1735 EventRootType Probe[main.stackC]Return
               InjectionPoints: [{PC: "0xce5845", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -32,11 +32,11 @@ Probes:
         - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 1572 EventRootType Probe[main.testAny]
+              Type: 1573 EventRootType Probe[main.testAny]
               InjectionPoints: [{PC: "0xcdf72a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1573 EventRootType Probe[main.testAny]Return
+              Type: 1574 EventRootType Probe[main.testAny]Return
               InjectionPoints: [{PC: "0xcdf765", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -58,11 +58,11 @@ Probes:
         - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testAnyPtr]
+              Type: 1576 EventRootType Probe[main.testAnyPtr]
               InjectionPoints: [{PC: "0xcdf7ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1576 EventRootType Probe[main.testAnyPtr]Return
+              Type: 1577 EventRootType Probe[main.testAnyPtr]Return
               InjectionPoints: [{PC: "0xcdf7fd", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -83,11 +83,11 @@ Probes:
         - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1704 EventRootType Probe[main.testArrayArgAndReturn]
+              Type: 1705 EventRootType Probe[main.testArrayArgAndReturn]
               InjectionPoints: [{PC: "0xce3e2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1705 EventRootType Probe[main.testArrayArgAndReturn]Return
+              Type: 1706 EventRootType Probe[main.testArrayArgAndReturn]Return
               InjectionPoints: [{PC: "0xce3ee2", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -109,7 +109,7 @@ Probes:
         - subprogram: {subprogram: 19}
           events:
             - Kind: Entry
-              Type: 1519 EventRootType Probe[main.testArrayEmptyStructs]
+              Type: 1520 EventRootType Probe[main.testArrayEmptyStructs]
               InjectionPoints: [{PC: "0xcda8a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -131,7 +131,7 @@ Probes:
         - subprogram: {subprogram: 15}
           events:
             - Kind: Entry
-              Type: 1515 EventRootType Probe[main.testArrayOfArrays]
+              Type: 1516 EventRootType Probe[main.testArrayOfArrays]
               InjectionPoints: [{PC: "0xcda820", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -153,7 +153,7 @@ Probes:
         - subprogram: {subprogram: 17}
           events:
             - Kind: Entry
-              Type: 1517 EventRootType Probe[main.testArrayOfArraysOfArrays]
+              Type: 1518 EventRootType Probe[main.testArrayOfArraysOfArrays]
               InjectionPoints: [{PC: "0xcda860", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -175,7 +175,7 @@ Probes:
         - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testArrayOfMaps]
+              Type: 1585 EventRootType Probe[main.testArrayOfMaps]
               InjectionPoints: [{PC: "0xcdffe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -197,7 +197,7 @@ Probes:
         - subprogram: {subprogram: 16}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testArrayOfStrings]
+              Type: 1517 EventRootType Probe[main.testArrayOfStrings]
               InjectionPoints: [{PC: "0xcda840", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -218,7 +218,7 @@ Probes:
         - subprogram: {subprogram: 18}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testArrayOfStructs]
+              Type: 1519 EventRootType Probe[main.testArrayOfStructs]
               InjectionPoints: [{PC: "0xcda880", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -240,11 +240,11 @@ Probes:
         - subprogram: {subprogram: 90}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testAtomicAdd]
+              Type: 1607 EventRootType Probe[main.testAtomicAdd]
               InjectionPoints: [{PC: "0xce1ec0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1607 EventRootType Probe[main.testAtomicAdd]Return
+              Type: 1608 EventRootType Probe[main.testAtomicAdd]Return
               InjectionPoints: [{PC: "0xce1ed2", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -266,11 +266,11 @@ Probes:
         - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testBigStruct]
+              Type: 1538 EventRootType Probe[main.testBigStruct]
               InjectionPoints: [{PC: "0xcdafa0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1538 EventRootType Probe[main.testBigStruct]Return
+              Type: 1539 EventRootType Probe[main.testBigStruct]Return
               InjectionPoints: [{PC: "0xcdafbe", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -292,7 +292,7 @@ Probes:
         - subprogram: {subprogram: 4}
           events:
             - Kind: Entry
-              Type: 1504 EventRootType Probe[main.testBoolArray]
+              Type: 1505 EventRootType Probe[main.testBoolArray]
               InjectionPoints: [{PC: "0xcda6c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -314,7 +314,7 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 1501 EventRootType Probe[main.testByteArray]
+              Type: 1502 EventRootType Probe[main.testByteArray]
               InjectionPoints: [{PC: "0xcda660", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -341,11 +341,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1752 EventRootType Probe[main.testStruct]
+              Type: 1753 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0xce5c40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1753 EventRootType Probe[main.testStruct]Return
+              Type: 1754 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0xce5c62", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1813 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1817 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcdef4e"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1814 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1818 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcdef4e"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 6 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 189, index: 0, name: x}
+                      Variable: {subprogram: 192, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -437,10 +437,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1815 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1819 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcdef4e"
                   Frameless: false
@@ -477,7 +477,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.testCombinedString]
+              Type: 1604 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0xce1b20", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
@@ -496,7 +496,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testCombinedString]
+              Type: 1605 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0xce1b20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -522,7 +522,7 @@ Probes:
         - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1760 EventRootType Probe[main.testTenStrings]
+              Type: 1761 EventRootType Probe[main.testTenStrings]
               InjectionPoints: [{PC: "0xce5d60", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
@@ -560,7 +560,7 @@ Probes:
         - subprogram: {subprogram: 91}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testChannel]
+              Type: 1609 EventRootType Probe[main.testChannel]
               InjectionPoints: [{PC: "0xce1ee0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -590,7 +590,7 @@ Probes:
         - subprogram: {subprogram: 87}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testCombinedByte]
+              Type: 1603 EventRootType Probe[main.testCombinedByte]
               InjectionPoints: [{PC: "0xce1ae0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -619,11 +619,11 @@ Probes:
         - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1669 EventRootType Probe[main.testConflictingReturn]
+              Type: 1670 EventRootType Probe[main.testConflictingReturn]
               InjectionPoints: [{PC: "0xce306e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1670 EventRootType Probe[main.testConflictingReturn]Return
+              Type: 1671 EventRootType Probe[main.testConflictingReturn]Return
               InjectionPoints: [{PC: "0xce3131", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -645,7 +645,7 @@ Probes:
         - subprogram: {subprogram: 99}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testCycle]
+              Type: 1617 EventRootType Probe[main.testCycle]
               InjectionPoints: [{PC: "0xce22a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -667,7 +667,7 @@ Probes:
         - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 1544 EventRootType Probe[main.testDeepMap1]
+              Type: 1545 EventRootType Probe[main.testDeepMap1]
               InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -689,7 +689,7 @@ Probes:
         - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testDeepMap7]
+              Type: 1546 EventRootType Probe[main.testDeepMap7]
               InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -711,7 +711,7 @@ Probes:
         - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 1540 EventRootType Probe[main.testDeepPtr1]
+              Type: 1541 EventRootType Probe[main.testDeepPtr1]
               InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -733,7 +733,7 @@ Probes:
         - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 1541 EventRootType Probe[main.testDeepPtr7]
+              Type: 1542 EventRootType Probe[main.testDeepPtr7]
               InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -755,7 +755,7 @@ Probes:
         - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 1542 EventRootType Probe[main.testDeepSlice1]
+              Type: 1543 EventRootType Probe[main.testDeepSlice1]
               InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -777,7 +777,7 @@ Probes:
         - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testDeepSlice7]
+              Type: 1544 EventRootType Probe[main.testDeepSlice7]
               InjectionPoints: [{PC: "0xcdb320", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -799,7 +799,7 @@ Probes:
         - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1721 EventRootType Probe[main.testEmptySlice]
+              Type: 1722 EventRootType Probe[main.testEmptySlice]
               InjectionPoints: [{PC: "0xce4f00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -826,7 +826,7 @@ Probes:
         - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1724 EventRootType Probe[main.testEmptySliceOfStructs]
+              Type: 1725 EventRootType Probe[main.testEmptySliceOfStructs]
               InjectionPoints: [{PC: "0xce4f60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -854,7 +854,7 @@ Probes:
         - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1747 EventRootType Probe[main.testEmptyString]
+              Type: 1748 EventRootType Probe[main.testEmptyString]
               InjectionPoints: [{PC: "0xce5940", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -876,7 +876,7 @@ Probes:
         - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1761 EventRootType Probe[main.testEmptyStruct]
+              Type: 1762 EventRootType Probe[main.testEmptyStruct]
               InjectionPoints: [{PC: "0xce5dc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -897,7 +897,7 @@ Probes:
         - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1762 EventRootType Probe[main.testEmptyStructPointer]
+              Type: 1763 EventRootType Probe[main.testEmptyStructPointer]
               InjectionPoints: [{PC: "0xce5de0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -919,7 +919,7 @@ Probes:
         - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 1574 EventRootType Probe[main.testError]
+              Type: 1575 EventRootType Probe[main.testError]
               InjectionPoints: [{PC: "0xcdf7a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -953,7 +953,7 @@ Probes:
         - subprogram: {subprogram: 38}
           events:
             - Kind: Line
-              Type: 1539 EventRootType Probe[main.testErrorAtLine]Line
+              Type: 1540 EventRootType Probe[main.testErrorAtLine]Line
               InjectionPoints: [{PC: "0xcdb03b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -981,11 +981,11 @@ Probes:
         - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.testEsotericHeap]
+              Type: 1557 EventRootType Probe[main.testEsotericHeap]
               InjectionPoints: [{PC: "0xcddb2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.testEsotericHeap]Return
+              Type: 1558 EventRootType Probe[main.testEsotericHeap]Return
               InjectionPoints: [{PC: "0xcddb6c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1007,11 +1007,11 @@ Probes:
         - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 1554 EventRootType Probe[main.testEsotericStack]
+              Type: 1555 EventRootType Probe[main.testEsotericStack]
               InjectionPoints: [{PC: "0xcdda0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1555 EventRootType Probe[main.testEsotericStack]Return
+              Type: 1556 EventRootType Probe[main.testEsotericStack]Return
               InjectionPoints: [{PC: "0xcdda9b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1033,11 +1033,11 @@ Probes:
         - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.testFrameless]
+              Type: 1567 EventRootType Probe[main.testFrameless]
               InjectionPoints: [{PC: "0xcdf400", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1567 EventRootType Probe[main.testFrameless]Return
+              Type: 1568 EventRootType Probe[main.testFrameless]Return
               InjectionPoints: [{PC: "0xcdf405", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -1059,11 +1059,11 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.testFramelessArray]
+              Type: 1569 EventRootType Probe[main.testFramelessArray]
               InjectionPoints: [{PC: "0xcdf424", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1569 EventRootType Probe[main.testFramelessArray]Return
+              Type: 1570 EventRootType Probe[main.testFramelessArray]Return
               InjectionPoints: [{PC: "0xcdf45d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1088,7 +1088,7 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Line
-              Type: 1570 EventRootType Probe[main.testFramelessArray]Line
+              Type: 1571 EventRootType Probe[main.testFramelessArray]Line
               InjectionPoints: [{PC: "0xcdf428", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1107,15 +1107,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1799 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce88e0", Frameless: true}]
+              Type: 1803 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0xce8a60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1800 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce88e7", Frameless: true}]
+              Type: 1804 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce8a67", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,15 +1125,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1801 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce8904", Frameless: false}]
+              Type: 1805 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0xce8a84", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1802 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce8951", Frameless: false}]
+              Type: 1806 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0xce8ad1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,15 +1152,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1795 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce884a", Frameless: false}]
+              Type: 1799 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0xce89ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1796 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce8859", Frameless: false}]
+              Type: 1800 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0xce89d9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,15 +1170,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1797 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce888a", Frameless: false}]
+              Type: 1801 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0xce8a0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1798 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce88a2", Frameless: false}]
+              Type: 1802 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0xce8a22", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,18 +1197,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1803 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce8960", Frameless: true}]
+              Type: 1807 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0xce8ae0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1804 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1808 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce8980"
+                - PC: "0xce8b00"
                   Frameless: true
-                - PC: "0xce8983"
+                - PC: "0xce8b03"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,18 +1219,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1805 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce89aa", Frameless: false}]
+              Type: 1809 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0xce8b2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1806 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1810 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce8a0b"
+                - PC: "0xce8b8b"
                   Frameless: false
-                - PC: "0xce8a13"
+                - PC: "0xce8b93"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,11 +1253,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Line
-              Type: 1807 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce8965", Frameless: true}]
+              Type: 1811 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0xce8ae5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,11 +1265,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1808 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce89bf", Frameless: false}]
+              Type: 1812 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0xce8b3f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,15 +1286,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1783 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce8500", Frameless: true}]
+              Type: 1787 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0xce8680", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1784 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce8510", Frameless: true}]
+              Type: 1788 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0xce8690", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,15 +1304,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1785 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce85a0", Frameless: true}]
+              Type: 1789 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0xce8720", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1786 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce85a8", Frameless: true}]
+              Type: 1790 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0xce8728", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,15 +1332,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 169}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1771 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce808e", Frameless: false}]
+              Type: 1775 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0xce820e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1772 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce8174", Frameless: false}]
+              Type: 1776 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce82f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1350,14 +1350,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1773 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1777 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1774 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1778 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0xcd98dc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1378,15 +1378,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1775 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce81ca", Frameless: false}]
+              Type: 1779 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xce834a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1776 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce81d9", Frameless: false}]
+              Type: 1780 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce8359", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,15 +1405,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1809 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce8a60", Frameless: true}]
+              Type: 1813 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0xce8be0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1810 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce8a66", Frameless: true}]
+              Type: 1814 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0xce8be6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,15 +1423,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1811 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce8aea", Frameless: false}]
+              Type: 1815 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0xce8c6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1812 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce8b0d", Frameless: false}]
+              Type: 1816 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0xce8c8d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,15 +1450,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
+        - subprogram: {subprogram: 170}
           events:
             - Kind: Entry
-              Type: 1767 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce7fe0", Frameless: true}]
+              Type: 1771 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0xce8160", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1768 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce7fe3", Frameless: true}]
+              Type: 1772 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce8163", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,15 +1468,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 168}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1769 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce8000", Frameless: true}]
+              Type: 1773 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0xce8180", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1770 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce800b", Frameless: true}]
+              Type: 1774 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce818b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,15 +1495,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1787 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce8660", Frameless: true}]
+              Type: 1791 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0xce87e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1788 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce8667", Frameless: true}]
+              Type: 1792 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0xce87e7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,15 +1513,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1789 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce870a", Frameless: false}]
+              Type: 1793 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0xce888a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1790 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce8733", Frameless: false}]
+              Type: 1794 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0xce88b3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,15 +1540,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1777 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce84a0", Frameless: true}]
+              Type: 1781 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xce8620", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1778 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce84a3", Frameless: true}]
+              Type: 1782 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce8623", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,15 +1558,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1779 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce84c0", Frameless: true}]
+              Type: 1783 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0xce8640", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1780 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce84c3", Frameless: true}]
+              Type: 1784 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0xce8643", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,15 +1576,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1781 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce84e0", Frameless: true}]
+              Type: 1785 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0xce8660", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1782 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce84e3", Frameless: true}]
+              Type: 1786 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0xce8663", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,15 +1603,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1791 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce8800", Frameless: true}]
+              Type: 1795 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0xce8980", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1792 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce8807", Frameless: true}]
+              Type: 1796 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0xce8987", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,15 +1621,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1793 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce8820", Frameless: true}]
+              Type: 1797 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xce89a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1794 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce882e", Frameless: true}]
+              Type: 1798 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce89ae", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,15 +1648,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1763 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce7fa0", Frameless: true}]
+              Type: 1767 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0xce8120", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1764 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce7fa3", Frameless: true}]
+              Type: 1768 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce8123", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,15 +1666,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1765 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce7fc0", Frameless: true}]
+              Type: 1769 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0xce8140", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1766 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce7fcb", Frameless: true}]
+              Type: 1770 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce814b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1696,11 +1696,11 @@ Probes:
         - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.testInlinedBA]
+              Type: 1559 EventRootType Probe[main.testInlinedBA]
               InjectionPoints: [{PC: "0xcdf0ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1559 EventRootType Probe[main.testInlinedBA]Return
+              Type: 1560 EventRootType Probe[main.testInlinedBA]Return
               InjectionPoints: [{PC: "0xcdf14e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1727,11 +1727,11 @@ Probes:
         - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.testInlinedBB]
+              Type: 1561 EventRootType Probe[main.testInlinedBB]
               InjectionPoints: [{PC: "0xcdf18e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1561 EventRootType Probe[main.testInlinedBB]Return
+              Type: 1562 EventRootType Probe[main.testInlinedBB]Return
               InjectionPoints: [{PC: "0xcdf21e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1758,11 +1758,11 @@ Probes:
         - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.testInlinedBBA]
+              Type: 1563 EventRootType Probe[main.testInlinedBBA]
               InjectionPoints: [{PC: "0xcdf26a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1563 EventRootType Probe[main.testInlinedBBA]Return
+              Type: 1564 EventRootType Probe[main.testInlinedBBA]Return
               InjectionPoints: [{PC: "0xcdf2ab", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1781,10 +1781,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1819 EventRootType Probe[main.testInlinedBBB]
+              Type: 1823 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0xcdf1e6", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1802,11 +1802,11 @@ Probes:
         - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.testInlinedBC]
+              Type: 1565 EventRootType Probe[main.testInlinedBC]
               InjectionPoints: [{PC: "0xcdf2ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1565 EventRootType Probe[main.testInlinedBC]Return
+              Type: 1566 EventRootType Probe[main.testInlinedBC]Return
               InjectionPoints: [{PC: "0xcdf3d3", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1821,10 +1821,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Entry
-              Type: 1820 EventRootType Probe[main.testInlinedBCA]
+              Type: 1824 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0xcdf2f3", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1842,10 +1842,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Line
-              Type: 1821 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1825 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0xcdf2f3", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1860,10 +1860,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Entry
-              Type: 1822 EventRootType Probe[main.testInlinedBCB]
+              Type: 1826 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0xcdf39b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1881,10 +1881,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Line
-              Type: 1823 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1827 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0xcdf39b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1899,10 +1899,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 196}
+        - subprogram: {subprogram: 199}
           events:
             - Kind: Entry
-              Type: 1829 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1833 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0xcd9301"
                   Frameless: true
@@ -1922,10 +1922,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1816 EventRootType Probe[main.testInlinedPrint]
+              Type: 1820 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0xcdef4a"
                   Frameless: false
@@ -1939,7 +1939,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1817 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1821 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0xcdef8a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1961,10 +1961,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1818 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1822 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcdef4e"
                   Frameless: false
@@ -1993,10 +1993,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Entry
-              Type: 1824 EventRootType Probe[main.testInlinedSq]
+              Type: 1828 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0xcdf401", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2018,10 +2018,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Line
-              Type: 1825 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1829 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0xcdf401", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2041,10 +2041,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 194}
+        - subprogram: {subprogram: 197}
           events:
             - Kind: Entry
-              Type: 1826 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1830 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0xcdf445"
                   Frameless: false
@@ -2070,7 +2070,7 @@ Probes:
         - subprogram: {subprogram: 7}
           events:
             - Kind: Entry
-              Type: 1507 EventRootType Probe[main.testInt16Array]
+              Type: 1508 EventRootType Probe[main.testInt16Array]
               InjectionPoints: [{PC: "0xcda720", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2092,7 +2092,7 @@ Probes:
         - subprogram: {subprogram: 8}
           events:
             - Kind: Entry
-              Type: 1508 EventRootType Probe[main.testInt32Array]
+              Type: 1509 EventRootType Probe[main.testInt32Array]
               InjectionPoints: [{PC: "0xcda740", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2114,7 +2114,7 @@ Probes:
         - subprogram: {subprogram: 9}
           events:
             - Kind: Entry
-              Type: 1509 EventRootType Probe[main.testInt64Array]
+              Type: 1510 EventRootType Probe[main.testInt64Array]
               InjectionPoints: [{PC: "0xcda760", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2136,7 +2136,7 @@ Probes:
         - subprogram: {subprogram: 6}
           events:
             - Kind: Entry
-              Type: 1506 EventRootType Probe[main.testInt8Array]
+              Type: 1507 EventRootType Probe[main.testInt8Array]
               InjectionPoints: [{PC: "0xcda700", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2158,7 +2158,7 @@ Probes:
         - subprogram: {subprogram: 5}
           events:
             - Kind: Entry
-              Type: 1505 EventRootType Probe[main.testIntArray]
+              Type: 1506 EventRootType Probe[main.testIntArray]
               InjectionPoints: [{PC: "0xcda6e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2180,7 +2180,7 @@ Probes:
         - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testInterface]
+              Type: 1572 EventRootType Probe[main.testInterface]
               InjectionPoints: [{PC: "0xcdf700", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2201,11 +2201,11 @@ Probes:
         - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1702 EventRootType Probe[main.testLargeArgAndReturn]
+              Type: 1703 EventRootType Probe[main.testLargeArgAndReturn]
               InjectionPoints: [{PC: "0xce3c8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1703 EventRootType Probe[main.testLargeArgAndReturn]Return
+              Type: 1704 EventRootType Probe[main.testLargeArgAndReturn]Return
               InjectionPoints: [{PC: "0xce3df3", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2227,7 +2227,7 @@ Probes:
         - subprogram: {subprogram: 93}
           events:
             - Kind: Entry
-              Type: 1610 EventRootType Probe[main.testLinkedList]
+              Type: 1611 EventRootType Probe[main.testLinkedList]
               InjectionPoints: [{PC: "0xce20c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2252,7 +2252,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1548 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1549 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xcdb51a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2274,7 +2274,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1549 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1550 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xcdb5cd", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2296,7 +2296,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1550 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1551 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xcdb694", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2339,11 +2339,11 @@ Probes:
         - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1708 EventRootType Probe[main.testManyArgsArrayReturn]
+              Type: 1709 EventRootType Probe[main.testManyArgsArrayReturn]
               InjectionPoints: [{PC: "0xce4153", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1709 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              Type: 1710 EventRootType Probe[main.testManyArgsArrayReturn]Return
               InjectionPoints: [{PC: "0xce4362", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2406,7 +2406,7 @@ Probes:
         - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 1552 EventRootType Probe[main.testManyPointers]
+              Type: 1553 EventRootType Probe[main.testManyPointers]
               InjectionPoints: [{PC: "0xcdbd00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2430,7 +2430,7 @@ Probes:
         - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testManyStrings]
+              Type: 1554 EventRootType Probe[main.testManyStrings]
               InjectionPoints: [{PC: "0xcdd6e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2452,7 +2452,7 @@ Probes:
         - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testMapArrayToArray]
+              Type: 1583 EventRootType Probe[main.testMapArrayToArray]
               InjectionPoints: [{PC: "0xcdffa0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2474,7 +2474,7 @@ Probes:
         - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testMapEmbeddedMaps]
+              Type: 1590 EventRootType Probe[main.testMapEmbeddedMaps]
               InjectionPoints: [{PC: "0xce0060", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2496,7 +2496,7 @@ Probes:
         - subprogram: {subprogram: 84}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testMapEmptyKey]
+              Type: 1600 EventRootType Probe[main.testMapEmptyKey]
               InjectionPoints: [{PC: "0xce01a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2518,7 +2518,7 @@ Probes:
         - subprogram: {subprogram: 86}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testMapEmptyKeyAndValue]
+              Type: 1602 EventRootType Probe[main.testMapEmptyKeyAndValue]
               InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2540,7 +2540,7 @@ Probes:
         - subprogram: {subprogram: 85}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testMapEmptyValue]
+              Type: 1601 EventRootType Probe[main.testMapEmptyValue]
               InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2562,7 +2562,7 @@ Probes:
         - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testMapIntToInt]
+              Type: 1587 EventRootType Probe[main.testMapIntToInt]
               InjectionPoints: [{PC: "0xce0020", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2584,7 +2584,7 @@ Probes:
         - subprogram: {subprogram: 83}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testMapLargeKeyLargeValue]
+              Type: 1599 EventRootType Probe[main.testMapLargeKeyLargeValue]
               InjectionPoints: [{PC: "0xce0180", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2606,7 +2606,7 @@ Probes:
         - subprogram: {subprogram: 82}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testMapLargeKeySmallValue]
+              Type: 1598 EventRootType Probe[main.testMapLargeKeySmallValue]
               InjectionPoints: [{PC: "0xce0160", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2630,7 +2630,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testMapMassive]
+              Type: 1588 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0xce0040", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2654,7 +2654,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testMapMassive]
+              Type: 1589 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0xce0040", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2676,7 +2676,7 @@ Probes:
         - subprogram: {subprogram: 81}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testMapSmallKeyLargeValue]
+              Type: 1597 EventRootType Probe[main.testMapSmallKeyLargeValue]
               InjectionPoints: [{PC: "0xce0140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2698,7 +2698,7 @@ Probes:
         - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testMapSmallKeySmallValue]
+              Type: 1596 EventRootType Probe[main.testMapSmallKeySmallValue]
               InjectionPoints: [{PC: "0xce0120", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2720,7 +2720,7 @@ Probes:
         - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testMapStringToInt]
+              Type: 1581 EventRootType Probe[main.testMapStringToInt]
               InjectionPoints: [{PC: "0xcdff60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2742,7 +2742,7 @@ Probes:
         - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testMapStringToSlice]
+              Type: 1582 EventRootType Probe[main.testMapStringToSlice]
               InjectionPoints: [{PC: "0xcdff80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2764,7 +2764,7 @@ Probes:
         - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testMapStringToStruct]
+              Type: 1580 EventRootType Probe[main.testMapStringToStruct]
               InjectionPoints: [{PC: "0xcdff40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2786,7 +2786,7 @@ Probes:
         - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testMapWithLinkedList]
+              Type: 1591 EventRootType Probe[main.testMapWithLinkedList]
               InjectionPoints: [{PC: "0xce0080", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2808,7 +2808,7 @@ Probes:
         - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 1593 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+              Type: 1594 EventRootType Probe[main.testMapWithSmallKeyAndValue]
               InjectionPoints: [{PC: "0xce00e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2830,7 +2830,7 @@ Probes:
         - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+              Type: 1595 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
               InjectionPoints: [{PC: "0xce0100", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2852,7 +2852,7 @@ Probes:
         - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testMapWithSmallValue]
+              Type: 1592 EventRootType Probe[main.testMapWithSmallValue]
               InjectionPoints: [{PC: "0xce00a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2876,7 +2876,7 @@ Probes:
         - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.testMapWithSmallValueMassive]
+              Type: 1593 EventRootType Probe[main.testMapWithSmallValueMassive]
               InjectionPoints: [{PC: "0xce00c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2898,7 +2898,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1744 EventRootType Probe[main.testMassiveString]
+              Type: 1745 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0xce5900", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2921,7 +2921,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1745 EventRootType Probe[main.testMassiveString]
+              Type: 1746 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0xce5900", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2968,11 +2968,11 @@ Probes:
         - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1710 EventRootType Probe[main.testMixedArgsStackReturn]
+              Type: 1711 EventRootType Probe[main.testMixedArgsStackReturn]
               InjectionPoints: [{PC: "0xce43f3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1711 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              Type: 1712 EventRootType Probe[main.testMixedArgsStackReturn]Return
               InjectionPoints: [{PC: "0xce462b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3038,11 +3038,11 @@ Probes:
         - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1714 EventRootType Probe[main.testMultipleArrayArgs]
+              Type: 1715 EventRootType Probe[main.testMultipleArrayArgs]
               InjectionPoints: [{PC: "0xce476e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1715 EventRootType Probe[main.testMultipleArrayArgs]Return
+              Type: 1716 EventRootType Probe[main.testMultipleArrayArgs]Return
               InjectionPoints: [{PC: "0xce483f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3073,11 +3073,11 @@ Probes:
         - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1706 EventRootType Probe[main.testMultipleLargeArgs]
+              Type: 1707 EventRootType Probe[main.testMultipleLargeArgs]
               InjectionPoints: [{PC: "0xce3f0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1707 EventRootType Probe[main.testMultipleLargeArgs]Return
+              Type: 1708 EventRootType Probe[main.testMultipleLargeArgs]Return
               InjectionPoints: [{PC: "0xce412a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3103,11 +3103,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1647 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1648 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xce2eae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1648 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1649 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xce2f4f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3143,7 +3143,7 @@ Probes:
         - subprogram: {subprogram: 89}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.testMultipleSimpleParams]
+              Type: 1606 EventRootType Probe[main.testMultipleSimpleParams]
               InjectionPoints: [{PC: "0xce1ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3184,11 +3184,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1641 EventRootType Probe[main.testNamedReturn]
+              Type: 1642 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xce2e0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1642 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1643 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xce2e75", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3212,11 +3212,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1643 EventRootType Probe[main.testNamedReturn]
+              Type: 1644 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xce2e0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1644 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1645 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xce2e75", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
@@ -3235,11 +3235,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1649 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1650 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xce2eae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1650 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1651 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xce2f4f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
@@ -3259,11 +3259,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1651 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1652 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xce2eae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1652 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1653 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xce2f4f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3296,11 +3296,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1645 EventRootType Probe[main.testNamedReturn]
+              Type: 1646 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xce2e0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1646 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1647 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xce2e75", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3328,7 +3328,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1756 EventRootType Probe[main.testNestedPointer]
+              Type: 1757 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xce5d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3353,7 +3353,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1757 EventRootType Probe[main.testNestedPointer]
+              Type: 1758 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xce5d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3384,7 +3384,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1758 EventRootType Probe[main.testNestedPointer]
+              Type: 1759 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xce5d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3409,7 +3409,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1759 EventRootType Probe[main.testNestedPointer]
+              Type: 1760 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xce5d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3436,7 +3436,7 @@ Probes:
         - subprogram: {subprogram: 98}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[main.testNilPointer]
+              Type: 1616 EventRootType Probe[main.testNilPointer]
               InjectionPoints: [{PC: "0xce2260", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3463,7 +3463,7 @@ Probes:
         - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1728 EventRootType Probe[main.testNilSlice]
+              Type: 1729 EventRootType Probe[main.testNilSlice]
               InjectionPoints: [{PC: "0xce4fe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3490,7 +3490,7 @@ Probes:
         - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1725 EventRootType Probe[main.testNilSliceOfStructs]
+              Type: 1726 EventRootType Probe[main.testNilSliceOfStructs]
               InjectionPoints: [{PC: "0xce4f80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3525,7 +3525,7 @@ Probes:
         - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1727 EventRootType Probe[main.testNilSliceWithOtherParams]
+              Type: 1728 EventRootType Probe[main.testNilSliceWithOtherParams]
               InjectionPoints: [{PC: "0xce4fc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3557,7 +3557,7 @@ Probes:
         - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1743 EventRootType Probe[main.testOneStringInStructPointer]
+              Type: 1744 EventRootType Probe[main.testOneStringInStructPointer]
               InjectionPoints: [{PC: "0xce58e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3579,7 +3579,7 @@ Probes:
         - subprogram: {subprogram: 94}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[main.testPointerLoop]
+              Type: 1612 EventRootType Probe[main.testPointerLoop]
               InjectionPoints: [{PC: "0xce20e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3601,7 +3601,7 @@ Probes:
         - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testPointerToMap]
+              Type: 1586 EventRootType Probe[main.testPointerToMap]
               InjectionPoints: [{PC: "0xce0000", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3623,7 +3623,7 @@ Probes:
         - subprogram: {subprogram: 92}
           events:
             - Kind: Entry
-              Type: 1609 EventRootType Probe[main.testPointerToSimpleStruct]
+              Type: 1610 EventRootType Probe[main.testPointerToSimpleStruct]
               InjectionPoints: [{PC: "0xce20a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3647,11 +3647,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1617 EventRootType Probe[main.testReturnsInt]
+              Type: 1618 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xce26ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1618 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1619 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xce273b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
@@ -3671,11 +3671,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1661 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1662 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xce2f8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1662 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1663 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xce302d", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3720,11 +3720,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1627 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1628 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xce280e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1628 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1629 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xce28c4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3766,11 +3766,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.testReturnsInt]
+              Type: 1620 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xce26ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1620 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1621 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xce273b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3815,11 +3815,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1629 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1630 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xce280e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1630 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1631 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xce28c4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3863,11 +3863,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1663 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1664 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xce2f8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1664 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1665 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xce302d", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
@@ -3884,11 +3884,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1665 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1666 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xce2f8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1666 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1667 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xce302d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3910,11 +3910,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.testReturnsInt]
+              Type: 1622 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xce26ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1622 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1623 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xce273b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3937,11 +3937,11 @@ Probes:
         - subprogram: {subprogram: 105}
           events:
             - Kind: Entry
-              Type: 1637 EventRootType Probe[main.testReturnsAny]
+              Type: 1638 EventRootType Probe[main.testReturnsAny]
               InjectionPoints: [{PC: "0xce2aae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1638 EventRootType Probe[main.testReturnsAny]Return
+              Type: 1639 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
                 - PC: "0xce2b55"
                   Frameless: false
@@ -3976,11 +3976,11 @@ Probes:
         - subprogram: {subprogram: 104}
           events:
             - Kind: Entry
-              Type: 1635 EventRootType Probe[main.testReturnsAnyAndError]
+              Type: 1636 EventRootType Probe[main.testReturnsAnyAndError]
               InjectionPoints: [{PC: "0xce294e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1636 EventRootType Probe[main.testReturnsAnyAndError]Return
+              Type: 1637 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
                 - PC: "0xce29a4"
                   Frameless: false
@@ -4014,11 +4014,11 @@ Probes:
         - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1680 EventRootType Probe[main.testReturnsArray]
+              Type: 1681 EventRootType Probe[main.testReturnsArray]
               InjectionPoints: [{PC: "0xce372a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1681 EventRootType Probe[main.testReturnsArray]Return
+              Type: 1682 EventRootType Probe[main.testReturnsArray]Return
               InjectionPoints: [{PC: "0xce378d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4035,11 +4035,11 @@ Probes:
         - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1682 EventRootType Probe[main.testReturnsArrayOne]
+              Type: 1683 EventRootType Probe[main.testReturnsArrayOne]
               InjectionPoints: [{PC: "0xce37aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1683 EventRootType Probe[main.testReturnsArrayOne]Return
+              Type: 1684 EventRootType Probe[main.testReturnsArrayOne]Return
               InjectionPoints: [{PC: "0xce37eb", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4056,11 +4056,11 @@ Probes:
         - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1684 EventRootType Probe[main.testReturnsArrayZero]
+              Type: 1685 EventRootType Probe[main.testReturnsArrayZero]
               InjectionPoints: [{PC: "0xce380a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1685 EventRootType Probe[main.testReturnsArrayZero]Return
+              Type: 1686 EventRootType Probe[main.testReturnsArrayZero]Return
               InjectionPoints: [{PC: "0xce3846", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4077,11 +4077,11 @@ Probes:
         - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1688 EventRootType Probe[main.testReturnsBacktrackInt]
+              Type: 1689 EventRootType Probe[main.testReturnsBacktrackInt]
               InjectionPoints: [{PC: "0xce38ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1689 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              Type: 1690 EventRootType Probe[main.testReturnsBacktrackInt]Return
               InjectionPoints: [{PC: "0xce396a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4098,11 +4098,11 @@ Probes:
         - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1700 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              Type: 1701 EventRootType Probe[main.testReturnsBoolAndUintptr]
               InjectionPoints: [{PC: "0xce3c2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1701 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              Type: 1702 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
               InjectionPoints: [{PC: "0xce3c70", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4119,11 +4119,11 @@ Probes:
         - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1676 EventRootType Probe[main.testReturnsComplex]
+              Type: 1677 EventRootType Probe[main.testReturnsComplex]
               InjectionPoints: [{PC: "0xce35ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1677 EventRootType Probe[main.testReturnsComplex]Return
+              Type: 1678 EventRootType Probe[main.testReturnsComplex]Return
               InjectionPoints: [{PC: "0xce3646", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4141,11 +4141,11 @@ Probes:
         - subprogram: {subprogram: 103}
           events:
             - Kind: Entry
-              Type: 1633 EventRootType Probe[main.testReturnsError]
+              Type: 1634 EventRootType Probe[main.testReturnsError]
               InjectionPoints: [{PC: "0xce28ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1634 EventRootType Probe[main.testReturnsError]Return
+              Type: 1635 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
                 - PC: "0xce291a"
                   Frameless: false
@@ -4170,11 +4170,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1623 EventRootType Probe[main.testReturnsInt]
+              Type: 1624 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xce26ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1624 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1625 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xce273b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4195,11 +4195,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1631 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1632 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xce280e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1632 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1633 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xce28c4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4220,11 +4220,11 @@ Probes:
         - subprogram: {subprogram: 101}
           events:
             - Kind: Entry
-              Type: 1625 EventRootType Probe[main.testReturnsIntPointer]
+              Type: 1626 EventRootType Probe[main.testReturnsIntPointer]
               InjectionPoints: [{PC: "0xce276a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1626 EventRootType Probe[main.testReturnsIntPointer]Return
+              Type: 1627 EventRootType Probe[main.testReturnsIntPointer]Return
               InjectionPoints: [{PC: "0xce27d4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4246,11 +4246,11 @@ Probes:
         - subprogram: {subprogram: 106}
           events:
             - Kind: Entry
-              Type: 1639 EventRootType Probe[main.testReturnsInterface]
+              Type: 1640 EventRootType Probe[main.testReturnsInterface]
               InjectionPoints: [{PC: "0xce2cae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1640 EventRootType Probe[main.testReturnsInterface]Return
+              Type: 1641 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
                 - PC: "0xce2d7f"
                   Frameless: false
@@ -4275,11 +4275,11 @@ Probes:
         - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1678 EventRootType Probe[main.testReturnsLargeStruct]
+              Type: 1679 EventRootType Probe[main.testReturnsLargeStruct]
               InjectionPoints: [{PC: "0xce366e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1679 EventRootType Probe[main.testReturnsLargeStruct]Return
+              Type: 1680 EventRootType Probe[main.testReturnsLargeStruct]Return
               InjectionPoints: [{PC: "0xce36f3", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4296,11 +4296,11 @@ Probes:
         - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1674 EventRootType Probe[main.testReturnsManyFloats]
+              Type: 1675 EventRootType Probe[main.testReturnsManyFloats]
               InjectionPoints: [{PC: "0xce34ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1675 EventRootType Probe[main.testReturnsManyFloats]Return
+              Type: 1676 EventRootType Probe[main.testReturnsManyFloats]Return
               InjectionPoints: [{PC: "0xce35c7", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4317,11 +4317,11 @@ Probes:
         - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1692 EventRootType Probe[main.testReturnsMixed]
+              Type: 1693 EventRootType Probe[main.testReturnsMixed]
               InjectionPoints: [{PC: "0xce3a4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1693 EventRootType Probe[main.testReturnsMixed]Return
+              Type: 1694 EventRootType Probe[main.testReturnsMixed]Return
               InjectionPoints: [{PC: "0xce3aac", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4338,11 +4338,11 @@ Probes:
         - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1686 EventRootType Probe[main.testReturnsMixedStruct]
+              Type: 1687 EventRootType Probe[main.testReturnsMixedStruct]
               InjectionPoints: [{PC: "0xce386a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1687 EventRootType Probe[main.testReturnsMixedStruct]Return
+              Type: 1688 EventRootType Probe[main.testReturnsMixedStruct]Return
               InjectionPoints: [{PC: "0xce38b8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4359,11 +4359,11 @@ Probes:
         - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1698 EventRootType Probe[main.testReturnsMultipleFloats]
+              Type: 1699 EventRootType Probe[main.testReturnsMultipleFloats]
               InjectionPoints: [{PC: "0xce3baa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1699 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              Type: 1700 EventRootType Probe[main.testReturnsMultipleFloats]Return
               InjectionPoints: [{PC: "0xce3bf6", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4383,7 +4383,7 @@ Probes:
         - subprogram: {subprogram: 111}
           events:
             - Kind: Line
-              Type: 1671 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              Type: 1672 EventRootType Probe[main.testReturnsNamedDeferLine]Line
               InjectionPoints: [{PC: "0xce326f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4404,11 +4404,11 @@ Probes:
         - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1696 EventRootType Probe[main.testReturnsOnlyFloat]
+              Type: 1697 EventRootType Probe[main.testReturnsOnlyFloat]
               InjectionPoints: [{PC: "0xce3b4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1697 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              Type: 1698 EventRootType Probe[main.testReturnsOnlyFloat]Return
               InjectionPoints: [{PC: "0xce3b8e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4425,11 +4425,11 @@ Probes:
         - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1672 EventRootType Probe[main.testReturnsPrimitives]
+              Type: 1673 EventRootType Probe[main.testReturnsPrimitives]
               InjectionPoints: [{PC: "0xce346a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1673 EventRootType Probe[main.testReturnsPrimitives]Return
+              Type: 1674 EventRootType Probe[main.testReturnsPrimitives]Return
               InjectionPoints: [{PC: "0xce34d1", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4446,11 +4446,11 @@ Probes:
         - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1694 EventRootType Probe[main.testReturnsStructWithArray]
+              Type: 1695 EventRootType Probe[main.testReturnsStructWithArray]
               InjectionPoints: [{PC: "0xce3aca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1695 EventRootType Probe[main.testReturnsStructWithArray]Return
+              Type: 1696 EventRootType Probe[main.testReturnsStructWithArray]Return
               InjectionPoints: [{PC: "0xce3b2d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4467,11 +4467,11 @@ Probes:
         - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1690 EventRootType Probe[main.testReturnsWideStruct]
+              Type: 1691 EventRootType Probe[main.testReturnsWideStruct]
               InjectionPoints: [{PC: "0xce398e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1691 EventRootType Probe[main.testReturnsWideStruct]Return
+              Type: 1692 EventRootType Probe[main.testReturnsWideStruct]Return
               InjectionPoints: [{PC: "0xce3a14", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4489,7 +4489,7 @@ Probes:
         - subprogram: {subprogram: 2}
           events:
             - Kind: Entry
-              Type: 1502 EventRootType Probe[main.testRuneArray]
+              Type: 1503 EventRootType Probe[main.testRuneArray]
               InjectionPoints: [{PC: "0xcda680", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4524,11 +4524,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1653 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1654 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xce2eae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1654 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1655 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xce2f4f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4574,7 +4574,7 @@ Probes:
         - subprogram: {subprogram: 23}
           events:
             - Kind: Entry
-              Type: 1523 EventRootType Probe[main.testSingleBool]
+              Type: 1524 EventRootType Probe[main.testSingleBool]
               InjectionPoints: [{PC: "0xcdaca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4596,7 +4596,7 @@ Probes:
         - subprogram: {subprogram: 21}
           events:
             - Kind: Entry
-              Type: 1521 EventRootType Probe[main.testSingleByte]
+              Type: 1522 EventRootType Probe[main.testSingleByte]
               InjectionPoints: [{PC: "0xcdac60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4618,7 +4618,7 @@ Probes:
         - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testSingleFloat32]
+              Type: 1535 EventRootType Probe[main.testSingleFloat32]
               InjectionPoints: [{PC: "0xcdae00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4636,7 +4636,7 @@ Probes:
         - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testSingleFloat64]
+              Type: 1536 EventRootType Probe[main.testSingleFloat64]
               InjectionPoints: [{PC: "0xcdae20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4654,7 +4654,7 @@ Probes:
         - subprogram: {subprogram: 24}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testSingleInt]
+              Type: 1525 EventRootType Probe[main.testSingleInt]
               InjectionPoints: [{PC: "0xcdacc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4676,7 +4676,7 @@ Probes:
         - subprogram: {subprogram: 26}
           events:
             - Kind: Entry
-              Type: 1526 EventRootType Probe[main.testSingleInt16]
+              Type: 1527 EventRootType Probe[main.testSingleInt16]
               InjectionPoints: [{PC: "0xcdad00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4699,7 +4699,7 @@ Probes:
         - subprogram: {subprogram: 27}
           events:
             - Kind: Entry
-              Type: 1527 EventRootType Probe[main.testSingleInt32]
+              Type: 1528 EventRootType Probe[main.testSingleInt32]
               InjectionPoints: [{PC: "0xcdad20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4721,7 +4721,7 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Entry
-              Type: 1528 EventRootType Probe[main.testSingleInt64]
+              Type: 1529 EventRootType Probe[main.testSingleInt64]
               InjectionPoints: [{PC: "0xcdad40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4750,7 +4750,7 @@ Probes:
         - subprogram: {subprogram: 25}
           events:
             - Kind: Entry
-              Type: 1525 EventRootType Probe[main.testSingleInt8]
+              Type: 1526 EventRootType Probe[main.testSingleInt8]
               InjectionPoints: [{PC: "0xcdace0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4781,7 +4781,7 @@ Probes:
         - subprogram: {subprogram: 22}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testSingleRune]
+              Type: 1523 EventRootType Probe[main.testSingleRune]
               InjectionPoints: [{PC: "0xcdac80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4803,7 +4803,7 @@ Probes:
         - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1735 EventRootType Probe[main.testSingleString]
+              Type: 1736 EventRootType Probe[main.testSingleString]
               InjectionPoints: [{PC: "0xce5860", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4825,7 +4825,7 @@ Probes:
         - subprogram: {subprogram: 29}
           events:
             - Kind: Entry
-              Type: 1529 EventRootType Probe[main.testSingleUint]
+              Type: 1530 EventRootType Probe[main.testSingleUint]
               InjectionPoints: [{PC: "0xcdad60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4847,7 +4847,7 @@ Probes:
         - subprogram: {subprogram: 31}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testSingleUint16]
+              Type: 1532 EventRootType Probe[main.testSingleUint16]
               InjectionPoints: [{PC: "0xcdada0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4869,7 +4869,7 @@ Probes:
         - subprogram: {subprogram: 32}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testSingleUint32]
+              Type: 1533 EventRootType Probe[main.testSingleUint32]
               InjectionPoints: [{PC: "0xcdadc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4891,7 +4891,7 @@ Probes:
         - subprogram: {subprogram: 33}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testSingleUint64]
+              Type: 1534 EventRootType Probe[main.testSingleUint64]
               InjectionPoints: [{PC: "0xcdade0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4913,7 +4913,7 @@ Probes:
         - subprogram: {subprogram: 30}
           events:
             - Kind: Entry
-              Type: 1530 EventRootType Probe[main.testSingleUint8]
+              Type: 1531 EventRootType Probe[main.testSingleUint8]
               InjectionPoints: [{PC: "0xcdad80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4935,7 +4935,7 @@ Probes:
         - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1731 EventRootType Probe[main.testSliceEmptyStructs]
+              Type: 1732 EventRootType Probe[main.testSliceEmptyStructs]
               InjectionPoints: [{PC: "0xce5020", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4957,7 +4957,7 @@ Probes:
         - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1722 EventRootType Probe[main.testSliceOfSlices]
+              Type: 1723 EventRootType Probe[main.testSliceOfSlices]
               InjectionPoints: [{PC: "0xce4f20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4979,7 +4979,7 @@ Probes:
         - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testSmallMap]
+              Type: 1584 EventRootType Probe[main.testSmallMap]
               InjectionPoints: [{PC: "0xcdffc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5000,11 +5000,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1667 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1668 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xce2f8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1668 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1669 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xce302d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5025,11 +5025,11 @@ Probes:
         - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1712 EventRootType Probe[main.testStackArgRegReturns]
+              Type: 1713 EventRootType Probe[main.testStackArgRegReturns]
               InjectionPoints: [{PC: "0xce46ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1713 EventRootType Probe[main.testStackArgRegReturns]Return
+              Type: 1714 EventRootType Probe[main.testStackArgRegReturns]Return
               InjectionPoints: [{PC: "0xce473c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5051,7 +5051,7 @@ Probes:
         - subprogram: {subprogram: 3}
           events:
             - Kind: Entry
-              Type: 1503 EventRootType Probe[main.testStringArray]
+              Type: 1504 EventRootType Probe[main.testStringArray]
               InjectionPoints: [{PC: "0xcda6a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5073,7 +5073,7 @@ Probes:
         - subprogram: {subprogram: 97}
           events:
             - Kind: Entry
-              Type: 1614 EventRootType Probe[main.testStringPointer]
+              Type: 1615 EventRootType Probe[main.testStringPointer]
               InjectionPoints: [{PC: "0xce2220", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5095,7 +5095,7 @@ Probes:
         - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1726 EventRootType Probe[main.testStringSlice]
+              Type: 1727 EventRootType Probe[main.testStringSlice]
               InjectionPoints: [{PC: "0xce4fa0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5117,7 +5117,7 @@ Probes:
         - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 1546 EventRootType Probe[main.testStringType1]
+              Type: 1547 EventRootType Probe[main.testStringType1]
               InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5139,7 +5139,7 @@ Probes:
         - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testStringType2]
+              Type: 1548 EventRootType Probe[main.testStringType2]
               InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5161,11 +5161,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1754 EventRootType Probe[main.testStruct]
+              Type: 1755 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0xce5c40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1755 EventRootType Probe[main.testStruct]Return
+              Type: 1756 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0xce5c62", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5192,7 +5192,7 @@ Probes:
         - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1723 EventRootType Probe[main.testStructSlice]
+              Type: 1724 EventRootType Probe[main.testStructSlice]
               InjectionPoints: [{PC: "0xce4f40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5219,7 +5219,7 @@ Probes:
         - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testStructWithAny]
+              Type: 1578 EventRootType Probe[main.testStructWithAny]
               InjectionPoints: [{PC: "0xcdf820", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5240,11 +5240,11 @@ Probes:
         - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1716 EventRootType Probe[main.testStructWithArrayArg]
+              Type: 1717 EventRootType Probe[main.testStructWithArrayArg]
               InjectionPoints: [{PC: "0xce486e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1717 EventRootType Probe[main.testStructWithArrayArg]Return
+              Type: 1718 EventRootType Probe[main.testStructWithArrayArg]Return
               InjectionPoints: [{PC: "0xce491c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5266,11 +5266,11 @@ Probes:
         - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1750 EventRootType Probe[main.testStructWithCyclicMaps]
+              Type: 1751 EventRootType Probe[main.testStructWithCyclicMaps]
               InjectionPoints: [{PC: "0xce5b00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1751 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              Type: 1752 EventRootType Probe[main.testStructWithCyclicMaps]Return
               InjectionPoints: [{PC: "0xce5b1e", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5291,7 +5291,7 @@ Probes:
         - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1749 EventRootType Probe[main.testStructWithCyclicSlices]
+              Type: 1750 EventRootType Probe[main.testStructWithCyclicSlices]
               InjectionPoints: [{PC: "0xce5ae0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5318,7 +5318,7 @@ Probes:
         - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 1578 EventRootType Probe[main.testStructWithMap]
+              Type: 1579 EventRootType Probe[main.testStructWithMap]
               InjectionPoints: [{PC: "0xcdff20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5351,7 +5351,7 @@ Probes:
         - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1732 EventRootType Probe[main.testSubslices]
+              Type: 1733 EventRootType Probe[main.testSubslices]
               InjectionPoints: [{PC: "0xce5040", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5391,7 +5391,7 @@ Probes:
         - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1748 EventRootType Probe[main.testSubstrings]
+              Type: 1749 EventRootType Probe[main.testSubstrings]
               InjectionPoints: [{PC: "0xce5960", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5423,7 +5423,7 @@ Probes:
         - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 1551 EventRootType Probe[main.testTakeContext]
+              Type: 1552 EventRootType Probe[main.testTakeContext]
               InjectionPoints: [{PC: "0xcdbb80", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
@@ -5439,11 +5439,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1655 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1656 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xce2eae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1656 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1657 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xce2f4f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5464,11 +5464,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1657 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1658 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xce2eae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1658 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1659 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xce2f4f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5491,11 +5491,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1660 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xce2eae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1660 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1661 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xce2f4f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5527,7 +5527,7 @@ Probes:
         - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1736 EventRootType Probe[main.testThreeStrings]
+              Type: 1737 EventRootType Probe[main.testThreeStrings]
               InjectionPoints: [{PC: "0xce5880", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5559,11 +5559,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1737 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1738 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0xce58a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1738 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1739 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0xce58be", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5593,11 +5593,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1739 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1740 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0xce58a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1740 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1741 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0xce58be", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5629,7 +5629,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1741 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1742 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0xce58c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5659,7 +5659,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1742 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1743 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0xce58c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5679,6 +5679,72 @@ Probes:
                   DSL: a.c
                   EventKind: Entry
                   EventExpressionIndex: 2
+    - id: testTimeFixedZone
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeFixedZone}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 166}
+          events:
+            - Kind: Entry
+              Type: 1765 EventRootType Probe[main.testTimeFixedZone]
+              InjectionPoints: [{PC: "0xce6fc0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeMonotonic
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeMonotonic}
+      tags: ['foo:bar']
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 167}
+          events:
+            - Kind: Entry
+              Type: 1766 EventRootType Probe[main.testTimeMonotonic]
+              InjectionPoints: [{PC: "0xce6fe0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{c}'
+            Segments:
+                - JSON: {Ref: c}
+                  DSL: c
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeUTC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeUTC}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 165}
+          events:
+            - Kind: Entry
+              Type: 1764 EventRootType Probe[main.testTimeUTC]
+              InjectionPoints: [{PC: "0xce6fa0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -5691,7 +5757,7 @@ Probes:
         - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 1536 EventRootType Probe[main.testTypeAlias]
+              Type: 1537 EventRootType Probe[main.testTypeAlias]
               InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5713,7 +5779,7 @@ Probes:
         - subprogram: {subprogram: 12}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testUint16Array]
+              Type: 1513 EventRootType Probe[main.testUint16Array]
               InjectionPoints: [{PC: "0xcda7c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5735,7 +5801,7 @@ Probes:
         - subprogram: {subprogram: 13}
           events:
             - Kind: Entry
-              Type: 1513 EventRootType Probe[main.testUint32Array]
+              Type: 1514 EventRootType Probe[main.testUint32Array]
               InjectionPoints: [{PC: "0xcda7e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5757,7 +5823,7 @@ Probes:
         - subprogram: {subprogram: 14}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testUint64Array]
+              Type: 1515 EventRootType Probe[main.testUint64Array]
               InjectionPoints: [{PC: "0xcda800", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5779,7 +5845,7 @@ Probes:
         - subprogram: {subprogram: 11}
           events:
             - Kind: Entry
-              Type: 1511 EventRootType Probe[main.testUint8Array]
+              Type: 1512 EventRootType Probe[main.testUint8Array]
               InjectionPoints: [{PC: "0xcda7a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5801,7 +5867,7 @@ Probes:
         - subprogram: {subprogram: 10}
           events:
             - Kind: Entry
-              Type: 1510 EventRootType Probe[main.testUintArray]
+              Type: 1511 EventRootType Probe[main.testUintArray]
               InjectionPoints: [{PC: "0xcda780", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5823,7 +5889,7 @@ Probes:
         - subprogram: {subprogram: 96}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[main.testUintPointer]
+              Type: 1614 EventRootType Probe[main.testUintPointer]
               InjectionPoints: [{PC: "0xce2140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5845,7 +5911,7 @@ Probes:
         - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1720 EventRootType Probe[main.testUintSlice]
+              Type: 1721 EventRootType Probe[main.testUintSlice]
               InjectionPoints: [{PC: "0xce4ee0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5867,7 +5933,7 @@ Probes:
         - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1746 EventRootType Probe[main.testUnitializedString]
+              Type: 1747 EventRootType Probe[main.testUnitializedString]
               InjectionPoints: [{PC: "0xce5920", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5889,7 +5955,7 @@ Probes:
         - subprogram: {subprogram: 95}
           events:
             - Kind: Entry
-              Type: 1612 EventRootType Probe[main.testUnsafePointer]
+              Type: 1613 EventRootType Probe[main.testUnsafePointer]
               InjectionPoints: [{PC: "0xce2100", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5911,7 +5977,7 @@ Probes:
         - subprogram: {subprogram: 20}
           events:
             - Kind: Entry
-              Type: 1520 EventRootType Probe[main.testVeryLargeArray]
+              Type: 1521 EventRootType Probe[main.testVeryLargeArray]
               InjectionPoints: [{PC: "0xcda8e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5933,7 +5999,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1729 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1730 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0xce5000", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5955,7 +6021,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1730 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1731 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0xce5000", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5974,18 +6040,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 195}
+        - subprogram: {subprogram: 198}
           events:
             - Kind: Entry
-              Type: 1827 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1831 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0xcdf62a"
                   Frameless: false
-                - PC: "0xce8c03"
+                - PC: "0xce8d83"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1828 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1832 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0xcdf665", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -6007,11 +6073,11 @@ Probes:
         - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1718 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              Type: 1719 EventRootType Probe[main.testZeroSizeArgAndReturn]
               InjectionPoints: [{PC: "0xce494e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1719 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              Type: 1720 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
               InjectionPoints: [{PC: "0xce49cc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -9915,130 +9981,187 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 165
-      Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce7fa0..0xce7fa4]
+      Name: main.testTimeUTC
+      OutOfLinePCRanges: [0xce6fa0..0xce6fa1]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 328 BaseType go.shape.int
+        - Name: x
+          Type: 328 GoTimeType time.Time
           Locations:
-            - Range: 0xce7fa0..0xce7fa4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xce6fa0..0xce6fa1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0xce7fa0..0xce7fa3
-              Pieces: []
-            - Range: 0xce7fa3..0xce7fa4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+          DictIndex: -1
+      DictRegister: null
     - ID: 166
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce7fc0..0xce7fcc]
+      Name: main.testTimeFixedZone
+      OutOfLinePCRanges: [0xce6fc0..0xce6fc1]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 330 GoStringHeaderType go.shape.string
+        - Name: x
+          Type: 328 GoTimeType time.Time
           Locations:
-            - Range: 0xce7fc0..0xce7fcb
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce7fcb..0xce7fcc
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xce7fc0..0xce7fcb
-              Pieces: []
-            - Range: 0xce7fcb..0xce7fcc
+            - Range: 0xce6fc0..0xce6fc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 167
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce7fe0..0xce7fe4]
+      Name: main.testTimeMonotonic
+      OutOfLinePCRanges: [0xce6fe0..0xce6fe1]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+        - Name: c
+          Type: 331 StructureType main.timeCapture
           Locations:
-            - Range: 0xce7fe0..0xce7fe4
+            - Range: 0xce6fe0..0xce6fe1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 168
+      Name: main.wrapBox[go.shape.int]
+      OutOfLinePCRanges: [0xce8120..0xce8124]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 332 BaseType go.shape.int
+          Locations:
+            - Range: 0xce8120..0xce8124
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 BaseType go.shape.int
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce7fe0..0xce7fe3
+            - Range: 0xce8120..0xce8123
               Pieces: []
-            - Range: 0xce7fe3..0xce7fe4
+            - Range: 0xce8123..0xce8124
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 168
-      Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce8000..0xce800c]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xce8000..0xce800b
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce800b..0xce800c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 330 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0xce8000..0xce800b
-              Pieces: []
-            - Range: 0xce800b..0xce800c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0xce8140..0xce814c]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 334 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xce8140..0xce814b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xce814b..0xce814c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xce8140..0xce814b
+              Pieces: []
+            - Range: 0xce814b..0xce814c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0xce8160..0xce8164]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0xce8160..0xce8164
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 BaseType go.shape.int
+          Locations:
+            - Range: 0xce8160..0xce8163
+              Pieces: []
+            - Range: 0xce8163..0xce8164
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 171
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0xce8180..0xce818c]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xce8180..0xce818b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xce818b..0xce818c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 334 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xce8180..0xce818b
+              Pieces: []
+            - Range: 0xce818b..0xce818c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce8080..0xce81b6]
+      OutOfLinePCRanges: [0xce8200..0xce8336]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 332 GoSliceHeaderType []go.shape.int
+          Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce8080..0xce80b3
+            - Range: 0xce8200..0xce8233
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10046,7 +10169,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce80b3..0xce80bb
+            - Range: 0xce8233..0xce823b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10054,7 +10177,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce80bb..0xce81b6
+            - Range: 0xce823b..0xce8336
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10065,20 +10188,20 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 334 GoSubroutineType func(go.shape.int) bool
+          Type: 338 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce8080..0xce80bb
+            - Range: 0xce8200..0xce823b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce80bb..0xce81b6
+            - Range: 0xce823b..0xce8336
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 332 GoSliceHeaderType []go.shape.int
+          Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce8080..0xce8174
+            - Range: 0xce8200..0xce82f4
               Pieces: []
-            - Range: 0xce8174..0xce8175
+            - Range: 0xce82f4..0xce82f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10086,14 +10209,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce8175..0xce81b6
+            - Range: 0xce82f5..0xce8336
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 332 GoSliceHeaderType []go.shape.int
+          Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce80bb..0xce80d9
+            - Range: 0xce823b..0xce8259
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10101,7 +10224,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce80d9..0xce80e1
+            - Range: 0xce8259..0xce8261
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10109,7 +10232,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce80e1..0xce80e9
+            - Range: 0xce8261..0xce8269
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10117,7 +10240,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce80e9..0xce80e9
+            - Range: 0xce8269..0xce8269
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10125,7 +10248,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce80e9..0xce8113
+            - Range: 0xce8269..0xce8293
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10133,7 +10256,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce8113..0xce816b
+            - Range: 0xce8293..0xce82eb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10141,7 +10264,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce816b..0xce81b6
+            - Range: 0xce82eb..0xce8336
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10152,207 +10275,207 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xce8106..0xce8113
+            - Range: 0xce8286..0xce8293
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8113..0xce816b
+            - Range: 0xce8293..0xce82eb
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 170
+    - ID: 173
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce81c0..0xce8204]
+      OutOfLinePCRanges: [0xce8340..0xce8384]
       InlinePCRanges: []
       Variables:
         - Name: box
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce81c0..0xce81d9
+            - Range: 0xce8340..0xce8359
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
-          Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
+          Type: 339 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce81c0..0xce81d9
+            - Range: 0xce8340..0xce8359
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce81c0..0xce81d9
+            - Range: 0xce8340..0xce8359
               Pieces: []
-            - Range: 0xce81d9..0xce81da
+            - Range: 0xce8359..0xce835a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce81da..0xce8204
+            - Range: 0xce835a..0xce8384
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce84a0..0xce84a4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce84a0..0xce84a4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce84a0..0xce84a3
-              Pieces: []
-            - Range: 0xce84a3..0xce84a4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce84c0..0xce84c4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 336 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0xce84c0..0xce84c4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0xce84c0..0xce84c3
-              Pieces: []
-            - Range: 0xce84c3..0xce84c4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 173
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce84e0..0xce84e4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 338 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0xce84e0..0xce84e4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 338 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0xce84e0..0xce84e3
-              Pieces: []
-            - Range: 0xce84e3..0xce84e4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 174
-      Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce8500..0xce8511]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0xce8620..0xce8624]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 340 StructureType main.largeGenericType[go.shape.string]
+        - Name: p
+          Type: 337 PointerType *go.shape.int
           Locations:
-            - Range: 0xce8500..0xce8511
-              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+            - Range: 0xce8620..0xce8624
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 337 PointerType *go.shape.int
           Locations:
-            - Range: 0xce8500..0xce8510
+            - Range: 0xce8620..0xce8623
               Pieces: []
-            - Range: 0xce8510..0xce8511
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xce8623..0xce8624
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
-      Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce85a0..0xce85a9]
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0xce8640..0xce8644]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 342 StructureType main.largeGenericType[go.shape.int]
+        - Name: p
+          Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce85a0..0xce85a9
-              Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
+            - Range: 0xce8640..0xce8644
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 BaseType go.shape.int
+          Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce85a0..0xce85a8
+            - Range: 0xce8640..0xce8643
               Pieces: []
-            - Range: 0xce85a8..0xce85a9
+            - Range: 0xce8643..0xce8644
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 176
-      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce8660..0xce8668]
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0xce8660..0xce8664]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xce8660..0xce8664
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xce8660..0xce8663
+              Pieces: []
+            - Range: 0xce8663..0xce8664
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 177
+      Name: main.largeGenericType[go.shape.string].LargeGet
+      OutOfLinePCRanges: [0xce8680..0xce8691]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Type: 344 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce8660..0xce8668
+            - Range: 0xce8680..0xce8691
+              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 334 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xce8680..0xce8690
+              Pieces: []
+            - Range: 0xce8690..0xce8691
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 178
+      Name: main.largeGenericType[go.shape.int].LargeGet
+      OutOfLinePCRanges: [0xce8720..0xce8729]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 346 StructureType main.largeGenericType[go.shape.int]
+          Locations:
+            - Range: 0xce8720..0xce8729
+              Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 BaseType go.shape.int
+          Locations:
+            - Range: 0xce8720..0xce8728
+              Pieces: []
+            - Range: 0xce8728..0xce8729
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 179
+      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
+      OutOfLinePCRanges: [0xce87e0..0xce87e8]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 347 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Locations:
+            - Range: 0xce87e0..0xce87e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xce8660..0xce8668
+            - Range: 0xce87e0..0xce87e8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 345 BaseType go.shape.bool
+          Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xce8660..0xce8668
+            - Range: 0xce87e0..0xce87e8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 177
+    - ID: 180
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce8700..0xce876e]
+      OutOfLinePCRanges: [0xce8880..0xce88ee]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
+          Type: 350 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce8700..0xce876e
+            - Range: 0xce8880..0xce88ee
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce8700..0xce876e
+            - Range: 0xce8880..0xce88ee
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10361,22 +10484,22 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xce8700..0xce876e
+            - Range: 0xce8880..0xce88ee
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 178
+    - ID: 181
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce8800..0xce8808]
+      OutOfLinePCRanges: [0xce8980..0xce8988]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce8800..0xce8808
+            - Range: 0xce8980..0xce8988
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10385,27 +10508,27 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 345 BaseType go.shape.bool
+          Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xce8800..0xce8808
+            - Range: 0xce8980..0xce8988
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 345 BaseType go.shape.bool
+          Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0xce8800..0xce8807
+            - Range: 0xce8980..0xce8987
               Pieces: []
-            - Range: 0xce8807..0xce8808
+            - Range: 0xce8987..0xce8988
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce8800..0xce8807
+            - Range: 0xce8980..0xce8987
               Pieces: []
-            - Range: 0xce8807..0xce8808
+            - Range: 0xce8987..0xce8988
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10414,28 +10537,28 @@ Subprograms:
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 179
+    - ID: 182
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce8820..0xce882f]
+      OutOfLinePCRanges: [0xce89a0..0xce89af]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xce8820..0xce882e
+            - Range: 0xce89a0..0xce89ae
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce8820..0xce882b
+            - Range: 0xce89a0..0xce89ab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce882b..0xce882f
+            - Range: 0xce89ab..0xce89af
               Pieces:
                 - Size: 8
                   Op: null
@@ -10444,11 +10567,11 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce8820..0xce882e
+            - Range: 0xce89a0..0xce89ae
               Pieces: []
-            - Range: 0xce882e..0xce882f
+            - Range: 0xce89ae..0xce89af
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10457,58 +10580,58 @@ Subprograms:
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xce8820..0xce882e
+            - Range: 0xce89a0..0xce89ae
               Pieces: []
-            - Range: 0xce882e..0xce882f
+            - Range: 0xce89ae..0xce89af
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 180
+    - ID: 183
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce8840..0xce887a]
+      OutOfLinePCRanges: [0xce89c0..0xce89fa]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 348 StructureType go.shape.struct { main.i int }
+          Type: 352 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce8840..0xce8859
+            - Range: 0xce89c0..0xce89d9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce8840..0xce8859
+            - Range: 0xce89c0..0xce89d9
               Pieces: []
-            - Range: 0xce8859..0xce885a
+            - Range: 0xce89d9..0xce89da
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce885a..0xce887a
+            - Range: 0xce89da..0xce89fa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 184
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce8880..0xce88cd]
+      OutOfLinePCRanges: [0xce8a00..0xce8a4d]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 349 StructureType go.shape.struct { main.s string }
+          Type: 353 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce8880..0xce889f
+            - Range: 0xce8a00..0xce8a1f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce889f..0xce88a2
+            - Range: 0xce8a1f..0xce8a22
               Pieces:
                 - Size: 8
                   Op: null
@@ -10519,37 +10642,37 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce8880..0xce88a2
+            - Range: 0xce8a00..0xce8a22
               Pieces: []
-            - Range: 0xce88a2..0xce88a3
+            - Range: 0xce8a22..0xce8a23
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce88a3..0xce88cd
+            - Range: 0xce8a23..0xce8a4d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 182
+    - ID: 185
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce88e0..0xce88e8]
+      OutOfLinePCRanges: [0xce8a60..0xce8a68]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 350 PointerType *go.shape.string
+          Type: 354 PointerType *go.shape.string
           Locations:
-            - Range: 0xce88e0..0xce88e7
+            - Range: 0xce8a60..0xce8a67
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce88e0..0xce88e7
+            - Range: 0xce8a60..0xce8a67
               Pieces: []
-            - Range: 0xce88e7..0xce88e8
+            - Range: 0xce8a67..0xce8a68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10558,24 +10681,24 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 183
+    - ID: 186
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce8900..0xce8957]
+      OutOfLinePCRanges: [0xce8a80..0xce8ad7]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce8900..0xce893d
+            - Range: 0xce8a80..0xce8abd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce8900..0xce8951
+            - Range: 0xce8a80..0xce8ad1
               Pieces: []
-            - Range: 0xce8951..0xce8952
+            - Range: 0xce8ad1..0xce8ad2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10589,20 +10712,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce8952..0xce8957
+            - Range: 0xce8ad2..0xce8ad7
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 184
+    - ID: 187
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce8960..0xce8984]
+      OutOfLinePCRanges: [0xce8ae0..0xce8b04]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 332 GoSliceHeaderType []go.shape.int
+          Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce8960..0xce8984
+            - Range: 0xce8ae0..0xce8b04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10613,35 +10736,35 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xce8960..0xce8984
+            - Range: 0xce8ae0..0xce8b04
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce8960..0xce8980
+            - Range: 0xce8ae0..0xce8b00
               Pieces: []
-            - Range: 0xce8980..0xce8981
+            - Range: 0xce8b00..0xce8b01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8981..0xce8983
+            - Range: 0xce8b01..0xce8b03
               Pieces: []
-            - Range: 0xce8983..0xce8984
+            - Range: 0xce8b03..0xce8b04
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 185
+    - ID: 188
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce89a0..0xce8a5f]
+      OutOfLinePCRanges: [0xce8b20..0xce8bdf]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 353 GoSliceHeaderType []go.shape.string
+          Type: 357 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce89a0..0xce89bd
+            - Range: 0xce8b20..0xce8b3d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10649,7 +10772,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce89bd..0xce89bf
+            - Range: 0xce8b3d..0xce8b3f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10660,15 +10783,15 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce89a0..0xce89ec
+            - Range: 0xce8b20..0xce8b6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce89ec..0xce8a5f
+            - Range: 0xce8b6c..0xce8bdf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10679,28 +10802,28 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce89a0..0xce8a0b
+            - Range: 0xce8b20..0xce8b8b
               Pieces: []
-            - Range: 0xce8a0b..0xce8a0c
+            - Range: 0xce8b8b..0xce8b8c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8a0c..0xce8a13
+            - Range: 0xce8b8c..0xce8b93
               Pieces: []
-            - Range: 0xce8a13..0xce8a14
+            - Range: 0xce8b93..0xce8b94
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8a14..0xce8a5f
+            - Range: 0xce8b94..0xce8bdf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce89cf..0xce89e1
+            - Range: 0xce8b4f..0xce8b61
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce89e1..0xce89ec
+            - Range: 0xce8b61..0xce8b6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10709,56 +10832,56 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 186
+    - ID: 189
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce8a60..0xce8a67]
+      OutOfLinePCRanges: [0xce8be0..0xce8be7]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 354 StructureType main.typeWithGenerics[go.shape.int]
+          Type: 358 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce8a60..0xce8a66
+            - Range: 0xce8be0..0xce8be6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0xce8a60..0xce8a67
+            - Range: 0xce8be0..0xce8be7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce8a60..0xce8a66
+            - Range: 0xce8be0..0xce8be6
               Pieces: []
-            - Range: 0xce8a66..0xce8a67
+            - Range: 0xce8be6..0xce8be7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
-    - ID: 187
+    - ID: 190
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce8ae0..0xce8b4c]
+      OutOfLinePCRanges: [0xce8c60..0xce8ccc]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 355 StructureType main.typeWithGenerics[go.shape.string]
+          Type: 359 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce8ae0..0xce8b00
+            - Range: 0xce8c60..0xce8c80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce8b00..0xce8b08
+            - Range: 0xce8c80..0xce8c88
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce8b08..0xce8b0d
+            - Range: 0xce8c88..0xce8c8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10767,9 +10890,9 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce8ae0..0xce8b0d
+            - Range: 0xce8c60..0xce8c8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10780,22 +10903,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce8ae0..0xce8b0d
+            - Range: 0xce8c60..0xce8c8d
               Pieces: []
-            - Range: 0xce8b0d..0xce8b0e
+            - Range: 0xce8c8d..0xce8c8e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8b0e..0xce8b4c
+            - Range: 0xce8c8e..0xce8ccc
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 188
+    - ID: 191
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0xcd97e0..0xcd9925]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 356 GoSliceHeaderType []go.shape.float64
+          Type: 360 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xcd97e0..0xcd9813
               Pieces:
@@ -10824,7 +10947,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 359 GoSubroutineType func(go.shape.float64) bool
+          Type: 363 GoSubroutineType func(go.shape.float64) bool
           Locations:
             - Range: 0xcd97e0..0xcd981b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
@@ -10833,7 +10956,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 356 GoSliceHeaderType []go.shape.float64
+          Type: 360 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xcd97e0..0xcd98dc
               Pieces: []
@@ -10850,7 +10973,7 @@ Subprograms:
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 356 GoSliceHeaderType []go.shape.float64
+          Type: 360 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xcd981b..0xcd9839
               Pieces:
@@ -10911,7 +11034,7 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 358 BaseType go.shape.float64
+          Type: 362 BaseType go.shape.float64
           Locations:
             - Range: 0xcd986b..0xcd9879
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
@@ -10920,7 +11043,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 189
+    - ID: 192
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcdef40..0xcdefa2]
       InlinePCRanges:
@@ -10951,7 +11074,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 193
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10959,7 +11082,7 @@ Subprograms:
           RootRanges: [0xcdf180..0xcdf245]
       Variables: []
       DictRegister: null
-    - ID: 191
+    - ID: 194
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10967,7 +11090,7 @@ Subprograms:
           RootRanges: [0xcdf2e0..0xcdf3e5]
       Variables: []
       DictRegister: null
-    - ID: 192
+    - ID: 195
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10975,7 +11098,7 @@ Subprograms:
           RootRanges: [0xcdf2e0..0xcdf3e5]
       Variables: []
       DictRegister: null
-    - ID: 193
+    - ID: 196
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10990,7 +11113,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 194
+    - ID: 197
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11009,15 +11132,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 195
+    - ID: 198
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcdf620..0xcdf686]
       InlinePCRanges:
-        - Ranges: [0xce8c03..0xce8c31]
-          RootRanges: [0xce8be0..0xce8c5f]
+        - Ranges: [0xce8d83..0xce8db1]
+          RootRanges: [0xce8d60..0xce8ddf]
       Variables:
         - Name: b
-          Type: 360 StructureType main.firstBehavior
+          Type: 364 StructureType main.firstBehavior
           Locations:
             - Range: 0xcdf620..0xcdf63e
               Pieces:
@@ -11043,7 +11166,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 196
+    - ID: 199
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11055,31 +11178,31 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1401
+      ID: 1402
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 141
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 142 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1406
+      ID: 1407
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1407 PointerType *main.deepSlice3
+      Pointee: 1408 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1441
+      ID: 1442
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1442 PointerType *main.deepSlice8
+      Pointee: 1443 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1447
+      ID: 1448
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1448 PointerType *main.deepSlice9
+      Pointee: 1449 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 155
       Name: '**main.stringType2'
@@ -11087,7 +11210,7 @@ Types:
       GoKind: 22
       Pointee: 156 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1386
+      ID: 1397
       Name: '**main.t'
       ByteSize: 8
       Pointee: 255 PointerType *main.t
@@ -11125,40 +11248,40 @@ Types:
       ByteSize: 8
       Pointee: 209 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 380
+      ID: 384
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 381 PointerType *table<context.canceler,struct {}>
+      Pointee: 385 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 149
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 150 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1414
+      ID: 1415
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1415 PointerType *table<int,*main.deepMap3>
+      Pointee: 1416 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1458
+      ID: 1459
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1459 PointerType *table<int,*main.deepMap8>
+      Pointee: 1460 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1473
+      ID: 1474
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1474 PointerType *table<int,*main.deepMap9>
+      Pointee: 1475 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 176
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 177 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1488
+      ID: 1489
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1489 PointerType *table<int,interface {}>
+      Pointee: 1490 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 243
       Name: '**table<int,struct {}>'
@@ -11170,10 +11293,10 @@ Types:
       ByteSize: 8
       Pointee: 214 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 689 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 696 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 203
       Name: '**table<string,[]main.structWithMap>'
@@ -11185,35 +11308,35 @@ Types:
       ByteSize: 8
       Pointee: 192 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 407
+      ID: 408
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 408 PointerType *table<string,float64>
+      Pointee: 409 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1137
+      ID: 1148
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1138 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1149 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 186
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 187 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 402
+      ID: 403
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 403 PointerType *table<string,interface {}>
+      Pointee: 404 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 181
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 182 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 397
+      ID: 398
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 398 PointerType *table<string,string>
+      Pointee: 399 PointerType *table<string,string>
     - __kind: PointerType
       ID: 238
       Name: '**table<struct {},int>'
@@ -11265,150 +11388,150 @@ Types:
       ByteSize: 8
       Pointee: 219 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1404
+      ID: 1405
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1403 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1404 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 433
+      ID: 434
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 432 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 433 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1410
+      ID: 1411
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1409 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1410 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1445
+      ID: 1446
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1444 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1445 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1451
+      ID: 1452
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1450 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1451 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 428
+      ID: 429
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 427 GoSliceDataType []*runtime.p.array
+      Pointee: 428 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 430
+      ID: 431
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 429 GoSliceDataType []*string.array
+      Pointee: 430 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 593
+      ID: 594
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 592 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 593 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 591
+      ID: 592
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 590 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 591 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 589
+      ID: 590
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 588 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 589 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 587
+      ID: 588
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 586 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 587 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 585
+      ID: 586
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 584 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 585 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 573
+      ID: 574
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 572 GoSliceDataType [][]uint.array
+      Pointee: 573 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 577
+      ID: 578
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 576 GoSliceDataType []bool.array
+      Pointee: 577 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1174
+      ID: 1185
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1173 GoSliceDataType []float64.array
+      Pointee: 1184 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 683 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 690 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 691 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 648 GoSliceDataType []go.shape.float64.array
+      Pointee: 655 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 644 GoSliceDataType []go.shape.int.array
+      Pointee: 651 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 646 GoSliceDataType []go.shape.string.array
+      Pointee: 653 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
-      ID: 1454
+      ID: 1455
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1453 GoSliceDataType []interface {}.array
+      Pointee: 1454 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 282
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 583
+      ID: 584
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 582 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 583 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 693 GoSliceDataType []main.structWithMap.array
+      Pointee: 700 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 575
+      ID: 576
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 574 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 575 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11417,111 +11540,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 445
+      ID: 446
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 444 GoSliceDataType []string.array
+      Pointee: 445 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 581
+      ID: 582
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 580 GoSliceDataType []struct {}.array
+      Pointee: 581 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 1397
+      ID: 703
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 1396 GoSliceDataType []time.zone.array
+      Pointee: 702 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 1399
+      ID: 705
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 1398 GoSliceDataType []time.zoneTrans.array
+      Pointee: 704 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 266
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 264 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 571
+      ID: 572
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 570 GoSliceDataType []uint.array
+      Pointee: 571 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 579
+      ID: 580
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 578 GoSliceDataType []uint16.array
+      Pointee: 579 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 423
+      ID: 424
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 422 GoSliceDataType []uint8.array
+      Pointee: 423 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 425
+      ID: 426
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 424 GoSliceDataType []uintptr.array
+      Pointee: 425 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1304
+      ID: 1315
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1996928
       GoKind: 22
-      Pointee: 1305 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1316 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 942
+      ID: 953
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 943 GoSliceHeaderType archive/tar.headerError
+      Pointee: 954 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 945
+      ID: 956
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 944 GoSliceDataType archive/tar.headerError.array
+      Pointee: 955 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1239
+      ID: 1250
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1443456
       GoKind: 22
-      Pointee: 1240 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1251 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1187
+      ID: 1198
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 935936
       GoKind: 22
-      Pointee: 1188 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1199 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1189
+      ID: 1200
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 936032
       GoKind: 22
-      Pointee: 1190 StructureType archive/zip.dirWriter
+      Pointee: 1201 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1283
+      ID: 1294
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1915072
       GoKind: 22
-      Pointee: 1284 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1295 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1215
+      ID: 1226
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1063104
       GoKind: 22
-      Pointee: 1216 StructureType archive/zip.nopCloser
+      Pointee: 1227 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1217
+      ID: 1228
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1063360
       GoKind: 22
-      Pointee: 1218 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1229 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -11530,491 +11653,491 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1262
+      ID: 1273
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2185728
       GoKind: 22
-      Pointee: 1263 UnresolvedPointeeType bufio.Reader
+      Pointee: 1274 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1293
+      ID: 1304
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1960576
       GoKind: 22
-      Pointee: 1294 UnresolvedPointeeType bufio.Writer
+      Pointee: 1305 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1342
+      ID: 1353
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2278592
       GoKind: 22
-      Pointee: 1343 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1354 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 850
+      ID: 861
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 741 BaseType compress/flate.CorruptInputError
+      Pointee: 752 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 851
+      ID: 862
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 742 GoStringHeaderType compress/flate.InternalError
+      Pointee: 753 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 744
+      ID: 755
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 743 GoStringDataType compress/flate.InternalError.str
+      Pointee: 754 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1237
+      ID: 1248
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1433056
       GoKind: 22
-      Pointee: 1238 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1249 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1183
+      ID: 1194
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1195 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1259
+      ID: 1270
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1736736
       GoKind: 22
-      Pointee: 1260 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1271 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1434
+      ID: 1435
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1560000
       GoKind: 22
-      Pointee: 371 StructureType context.backgroundCtx
+      Pointee: 375 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 361
+      ID: 365
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1734432
       GoKind: 22
-      Pointee: 362 StructureType context.cancelCtx
+      Pointee: 366 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1058
+      ID: 1069
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1197376
       GoKind: 22
-      Pointee: 1059 StructureType context.deadlineExceededError
+      Pointee: 1070 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1429
+      ID: 1430
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1421056
       GoKind: 22
-      Pointee: 372 StructureType context.emptyCtx
+      Pointee: 376 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 363
+      ID: 367
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1421216
       GoKind: 22
-      Pointee: 364 StructureType context.stopCtx
+      Pointee: 368 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 365
+      ID: 369
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1734624
       GoKind: 22
-      Pointee: 366 StructureType context.timerCtx
+      Pointee: 370 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1435
+      ID: 1436
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1560160
       GoKind: 22
-      Pointee: 388 StructureType context.todoCtx
+      Pointee: 389 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 367
+      ID: 371
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1559680
       GoKind: 22
-      Pointee: 368 StructureType context.valueCtx
+      Pointee: 372 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 369
+      ID: 373
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1559840
       GoKind: 22
-      Pointee: 370 StructureType context.withoutCancelCtx
+      Pointee: 374 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 934
+      ID: 945
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930368
       GoKind: 22
-      Pointee: 755 BaseType crypto/aes.KeySizeError
+      Pointee: 766 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 935
+      ID: 946
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930560
       GoKind: 22
-      Pointee: 756 BaseType crypto/des.KeySizeError
+      Pointee: 767 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 936
+      ID: 947
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930848
       GoKind: 22
-      Pointee: 757 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 768 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1254
+      ID: 1265
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1677088
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1266 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1039
+      ID: 1050
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1070912
       GoKind: 22
-      Pointee: 1040 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 1051 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1285
+      ID: 1296
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1915584
       GoKind: 22
-      Pointee: 1286 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1297 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1315
+      ID: 1326
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2130880
       GoKind: 22
-      Pointee: 1316 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1327 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1289
+      ID: 1300
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1916096
       GoKind: 22
-      Pointee: 1290 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1301 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1287
+      ID: 1298
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1915840
       GoKind: 22
-      Pointee: 1288 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1299 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1281
+      ID: 1292
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1913280
       GoKind: 22
-      Pointee: 1282 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1293 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 937
+      ID: 948
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 931136
       GoKind: 22
-      Pointee: 758 BaseType crypto/rc4.KeySizeError
+      Pointee: 769 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1302
+      ID: 1313
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1994048
       GoKind: 22
-      Pointee: 1303 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1314 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1277
+      ID: 1288
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1882656
       GoKind: 22
-      Pointee: 1278 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1289 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 858
+      ID: 869
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 745 BaseType crypto/tls.AlertError
+      Pointee: 756 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1028
+      ID: 1039
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1051456
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1040 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1368
+      ID: 1379
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2390112
       GoKind: 22
-      Pointee: 1369 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1380 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 854
+      ID: 865
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 919616
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 866 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 852
+      ID: 863
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 919520
       GoKind: 22
-      Pointee: 853 StructureType crypto/tls.RecordHeaderError
+      Pointee: 864 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1027
+      ID: 1038
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1049792
       GoKind: 22
-      Pointee: 982 BaseType crypto/tls.alert
+      Pointee: 993 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1247
+      ID: 1258
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1568480
       GoKind: 22
-      Pointee: 1248 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1259 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 856
+      ID: 867
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 857 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 868 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1252
+      ID: 1263
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1651744
       GoKind: 22
-      Pointee: 1253 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1264 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1125
+      ID: 1136
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1433536
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1137 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1139
+      ID: 1150
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2053216
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1151 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 928
+      ID: 939
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 929312
       GoKind: 22
-      Pointee: 929 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 940 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 922
+      ID: 933
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 928832
       GoKind: 22
-      Pointee: 923 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 934 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 924
+      ID: 935
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 928928
       GoKind: 22
-      Pointee: 925 StructureType crypto/x509.HostnameError
+      Pointee: 936 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 921
+      ID: 932
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 928736
       GoKind: 22
-      Pointee: 754 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 765 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1033
+      ID: 1044
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1057216
       GoKind: 22
-      Pointee: 1034 StructureType crypto/x509.SystemRootsError
+      Pointee: 1045 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 930
+      ID: 941
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 929408
       GoKind: 22
-      Pointee: 931 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 942 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 926
+      ID: 937
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 929216
       GoKind: 22
-      Pointee: 927 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 938 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 946
+      ID: 957
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 936224
       GoKind: 22
-      Pointee: 947 StructureType encoding/asn1.StructuralError
+      Pointee: 958 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 950
+      ID: 961
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 936416
       GoKind: 22
-      Pointee: 951 StructureType encoding/asn1.SyntaxError
+      Pointee: 962 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 948
+      ID: 959
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 936320
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 960 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 841
+      ID: 852
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 915488
       GoKind: 22
-      Pointee: 736 BaseType encoding/base64.CorruptInputError
+      Pointee: 747 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1205
+      ID: 1216
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1046208
       GoKind: 22
-      Pointee: 1206 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1217 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 844
+      ID: 855
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 916352
       GoKind: 22
-      Pointee: 737 BaseType encoding/hex.InvalidByteError
+      Pointee: 748 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 812
+      ID: 823
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 910304
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 824 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1017
+      ID: 1028
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1042368
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1029 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 804
+      ID: 815
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 909920
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 816 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 810
+      ID: 821
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 910208
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 822 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 808
+      ID: 819
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 820 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 806
+      ID: 817
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 910016
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 818 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1348
+      ID: 1359
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2304128
       GoKind: 22
-      Pointee: 1349 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1360 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 814
+      ID: 825
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 815 StructureType encoding/json.jsonError
+      Pointee: 826 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1213
+      ID: 1224
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1060032
       GoKind: 22
-      Pointee: 1214 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1225 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 916
+      ID: 927
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 917 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 928 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 914
+      ID: 925
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 927680
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 926 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 918
+      ID: 929
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927872
       GoKind: 22
-      Pointee: 751 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 762 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 753
+      ID: 764
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 752 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 763 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 919
+      ID: 930
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 927968
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 931 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1326
+      ID: 1337
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2170720
       GoKind: 22
-      Pointee: 1327 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1338 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -12023,19 +12146,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 780
+      ID: 791
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType errors.errorString
+      Pointee: 792 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 984
+      ID: 995
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1028160
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType errors.joinError
+      Pointee: 996 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -12051,913 +12174,913 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 1336
+      ID: 1347
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2270912
       GoKind: 22
-      Pointee: 1337 UnresolvedPointeeType fmt.pp
+      Pointee: 1348 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 986
+      ID: 997
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1028288
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType fmt.wrapError
+      Pointee: 998 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 988
+      ID: 999
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1028416
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 1000 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 842
+      ID: 853
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915872
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 854 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 823
+      ID: 834
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 913088
       GoKind: 22
-      Pointee: 824 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 835 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 825
+      ID: 836
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 913184
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 837 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1151
+      ID: 1162
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 912896
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1163 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 829
+      ID: 840
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 913472
       GoKind: 22
-      Pointee: 830 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 841 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1153
+      ID: 1164
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 912992
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1165 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 827
+      ID: 838
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 913280
       GoKind: 22
-      Pointee: 730 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 741 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 732
+      ID: 743
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 731 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 742 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 822
+      ID: 833
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 912800
       GoKind: 22
-      Pointee: 727 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 738 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 729
+      ID: 740
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 728 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 739 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 828
+      ID: 839
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 913376
       GoKind: 22
-      Pointee: 733 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 744 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 735
+      ID: 746
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 745 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1225
+      ID: 1236
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1214656
       GoKind: 22
-      Pointee: 1226 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1237 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1312
+      ID: 1323
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2067904
       GoKind: 22
-      Pointee: 1313 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1324 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 940
+      ID: 951
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 934688
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 952 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 389
+      ID: 390
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2289344
       GoKind: 22
-      Pointee: 390 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 391 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 415
+      ID: 416
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2018080
       GoKind: 22
-      Pointee: 416 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 417 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 410
+      ID: 411
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1197632
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 413
+      ID: 414
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1197760
       GoKind: 22
-      Pointee: 414 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1427
+      ID: 1428
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1198400
       GoKind: 22
-      Pointee: 1428 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1429 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 701
+      ID: 712
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1198528
       GoKind: 22
-      Pointee: 702 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 713 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 417
+      ID: 418
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2236224
       GoKind: 22
-      Pointee: 418 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 419 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1093
+      ID: 1104
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1218240
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1105 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1344
+      ID: 1355
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2280640
       GoKind: 22
-      Pointee: 1345 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1356 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1430
+      ID: 1431
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1427296
       GoKind: 22
-      Pointee: 1431 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 1432 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 865
+      ID: 876
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 923264
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 877 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 872
+      ID: 883
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 924320
       GoKind: 22
-      Pointee: 873 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 884 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 867
+      ID: 878
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 750 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 761 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 870
+      ID: 881
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 924224
       GoKind: 22
-      Pointee: 871 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 882 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 868
+      ID: 879
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 924128
       GoKind: 22
-      Pointee: 869 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 880 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 888
+      ID: 899
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 926240
       GoKind: 22
-      Pointee: 889 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 900 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 892
+      ID: 903
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 926432
       GoKind: 22
-      Pointee: 893 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 904 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 890
+      ID: 901
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 926336
       GoKind: 22
-      Pointee: 891 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 902 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 886
+      ID: 897
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 926144
       GoKind: 22
-      Pointee: 887 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 898 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1176
+      ID: 1187
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1175 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1186 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 900
+      ID: 911
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 901 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 912 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 894
+      ID: 905
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 926528
       GoKind: 22
-      Pointee: 895 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 906 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 898
+      ID: 909
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 926720
       GoKind: 22
-      Pointee: 899 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 910 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 896
+      ID: 907
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 926624
       GoKind: 22
-      Pointee: 897 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 908 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 902
+      ID: 913
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 903 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 914 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 908
+      ID: 919
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 909 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 920 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 910
+      ID: 921
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 927296
       GoKind: 22
-      Pointee: 911 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 922 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 906
+      ID: 917
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 927104
       GoKind: 22
-      Pointee: 907 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 918 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 904
+      ID: 915
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 927008
       GoKind: 22
-      Pointee: 905 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 916 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 912
+      ID: 923
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 927488
       GoKind: 22
-      Pointee: 913 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 924 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 831
+      ID: 842
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 914624
       GoKind: 22
-      Pointee: 832 StructureType github.com/cihub/seelog.baseError
+      Pointee: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1265
+      ID: 1276
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1812992
       GoKind: 22
-      Pointee: 1266 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1277 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 833
+      ID: 844
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 914720
       GoKind: 22
-      Pointee: 834 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 845 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1245
+      ID: 1256
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1566560
       GoKind: 22
-      Pointee: 1246 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1257 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1201
+      ID: 1212
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1045056
       GoKind: 22
-      Pointee: 1202 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1213 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1235
+      ID: 1246
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1430976
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1247 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 837
+      ID: 848
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 914912
       GoKind: 22
-      Pointee: 838 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 849 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1300
+      ID: 1311
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1985696
       GoKind: 22
-      Pointee: 1301 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1312 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1319
+      ID: 1330
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2143520
       GoKind: 22
-      Pointee: 1314 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1325 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1318
+      ID: 1329
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2143136
       GoKind: 22
-      Pointee: 1317 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1328 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1203
+      ID: 1214
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1045184
       GoKind: 22
-      Pointee: 1204 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1215 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 835
+      ID: 846
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 914816
       GoKind: 22
-      Pointee: 836 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 847 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 839
+      ID: 850
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 840 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 851 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1267
+      ID: 1278
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1814784
       GoKind: 22
-      Pointee: 1268 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1279 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1308
+      ID: 1319
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2022400
       GoKind: 22
-      Pointee: 1309 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1320 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1310
+      ID: 1321
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2052896
       GoKind: 22
-      Pointee: 1311 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1322 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1127
+      ID: 1138
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1445856
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1139 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1043
+      ID: 1054
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1071680
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1055 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1041
+      ID: 1052
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1071552
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1053 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1045
+      ID: 1056
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1075648
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1057 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1047
+      ID: 1058
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1075776
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1059 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1256
+      ID: 1267
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1679392
       GoKind: 22
-      Pointee: 1257 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1268 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1035
+      ID: 1046
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1057856
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1047 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 845
+      ID: 856
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 846 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 857 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1360
+      ID: 1371
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2366560
       GoKind: 22
-      Pointee: 1361 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1372 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1101
+      ID: 1112
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1227712
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1113 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1070
+      ID: 1081
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1205824
       GoKind: 22
-      Pointee: 1071 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1082 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1064
+      ID: 1075
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1205440
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1076 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1003
+      ID: 1014
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1036608
       GoKind: 22
-      Pointee: 1004 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1015 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1076
+      ID: 1087
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1206208
       GoKind: 22
-      Pointee: 1077 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1002
+      ID: 1013
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1036480
       GoKind: 22
-      Pointee: 981 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 992 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1068
+      ID: 1079
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1205696
       GoKind: 22
-      Pointee: 1069 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1080 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1066
+      ID: 1077
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1205568
       GoKind: 22
-      Pointee: 1067 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1078 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1074
+      ID: 1085
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1206080
       GoKind: 22
-      Pointee: 1075 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1072
+      ID: 1083
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1205952
       GoKind: 22
-      Pointee: 1073 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1364
+      ID: 1375
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2379168
       GoKind: 22
-      Pointee: 1365 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1376 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1080
+      ID: 1091
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1206592
       GoKind: 22
-      Pointee: 1081 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1092 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1007
+      ID: 1018
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1036864
       GoKind: 22
-      Pointee: 1008 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1019 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1005
+      ID: 1016
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1036736
       GoKind: 22
-      Pointee: 1006 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1017 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1078
+      ID: 1089
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1206464
       GoKind: 22
-      Pointee: 1079 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 962
+      ID: 973
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 949184
       GoKind: 22
-      Pointee: 763 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 774 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 765
+      ID: 776
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 764 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 775 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 357
+      ID: 361
       Name: '*go.shape.float64'
       ByteSize: 8
       GoRuntimeType: 482240
       GoKind: 22
-      Pointee: 358 BaseType go.shape.float64
+      Pointee: 362 BaseType go.shape.float64
     - __kind: PointerType
-      ID: 333
+      ID: 337
       Name: '*go.shape.int'
       ByteSize: 8
       GoRuntimeType: 481792
       GoKind: 22
-      Pointee: 328 BaseType go.shape.int
+      Pointee: 332 BaseType go.shape.int
     - __kind: PointerType
-      ID: 350
+      ID: 354
       Name: '*go.shape.string'
       ByteSize: 8
       GoRuntimeType: 481856
       GoKind: 22
-      Pointee: 330 GoStringHeaderType go.shape.string
+      Pointee: 334 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 642 GoStringDataType go.shape.string.str
+      Pointee: 649 GoStringDataType go.shape.string.str
     - __kind: PointerType
-      ID: 336
+      ID: 340
       Name: '*go.shape.struct { Name string }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 337 StructureType go.shape.struct { Name string }
+      Pointee: 341 StructureType go.shape.struct { Name string }
     - __kind: PointerType
-      ID: 338
+      ID: 342
       Name: '*go.shape.struct { X int; Y int }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 339 StructureType go.shape.struct { X int; Y int }
+      Pointee: 343 StructureType go.shape.struct { X int; Y int }
     - __kind: PointerType
-      ID: 351
+      ID: 355
       Name: '*go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+      Pointee: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1142
+      ID: 1153
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1677856
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1154 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1051
+      ID: 1062
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1090496
       GoKind: 22
-      Pointee: 1052 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1063 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1231
+      ID: 1242
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1267648
       GoKind: 22
-      Pointee: 1232 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1243 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1324
+      ID: 1335
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2158880
       GoKind: 22
-      Pointee: 1325 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1336 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1219
+      ID: 1230
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1092800
       GoKind: 22
-      Pointee: 1220 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1231 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 963
+      ID: 974
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 950432
       GoKind: 22
-      Pointee: 766 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 777 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1109
+      ID: 1120
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1269312
       GoKind: 22
-      Pointee: 1110 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1121 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 966
+      ID: 977
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 950720
       GoKind: 22
-      Pointee: 967 StructureType golang.org/x/net/http2.connError
+      Pointee: 978 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 965
+      ID: 976
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 950624
       GoKind: 22
-      Pointee: 770 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 781 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 772
+      ID: 783
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 771 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 782 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 969
+      ID: 980
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 950912
       GoKind: 22
-      Pointee: 776 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 787 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 778
+      ID: 789
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 777 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 788 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 968
+      ID: 979
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 950816
       GoKind: 22
-      Pointee: 773 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 784 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 775
+      ID: 786
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 774 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 785 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 964
+      ID: 975
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 950528
       GoKind: 22
-      Pointee: 767 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 778 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 769
+      ID: 780
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 768 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 779 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1322
+      ID: 1333
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2156960
       GoKind: 22
-      Pointee: 1323 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1334 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 970
+      ID: 981
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 951008
       GoKind: 22
-      Pointee: 971 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 982 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 972
+      ID: 983
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 951104
       GoKind: 22
-      Pointee: 779 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 790 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 958
+      ID: 969
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 944384
       GoKind: 22
-      Pointee: 959 StructureType google.golang.org/grpc.dropError
+      Pointee: 970 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1107
+      ID: 1118
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1266368
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1119 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1129
+      ID: 1140
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1453216
       GoKind: 22
-      Pointee: 1130 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1141 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 960
+      ID: 971
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 947456
       GoKind: 22
-      Pointee: 961 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 972 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1271
+      ID: 1282
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1820608
       GoKind: 22
-      Pointee: 1272 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1283 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1229
+      ID: 1240
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1262912
       GoKind: 22
-      Pointee: 1230 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1241 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1049
+      ID: 1060
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1084736
       GoKind: 22
-      Pointee: 1050 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1061 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1191
+      ID: 1202
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 947552
       GoKind: 22
-      Pointee: 1192 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1203 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 938
+      ID: 949
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 932576
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 950 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1037
+      ID: 1048
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1061440
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1049 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1105
+      ID: 1116
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1234240
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1117 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1103
+      ID: 1114
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1233984
       GoKind: 22
-      Pointee: 1104 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1115 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 952
+      ID: 963
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 937280
       GoKind: 22
-      Pointee: 953 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 964 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 954
+      ID: 965
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 955 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 966 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 880
+      ID: 891
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 892 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1279
+      ID: 1290
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1911232
       GoKind: 22
-      Pointee: 1280 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1291 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 973
+      ID: 984
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 951872
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType html/template.Error
+      Pointee: 985 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -13001,127 +13124,127 @@ Types:
       GoKind: 22
       Pointee: 164 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 1131
+      ID: 1142
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2223232
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType internal/abi.Type
+      Pointee: 1143 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 932
+      ID: 943
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 929984
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 944 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 848
+      ID: 859
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 917792
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 860 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1181
+      ID: 1192
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 916928
       GoKind: 22
-      Pointee: 1182 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1193 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1099
+      ID: 1110
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1219520
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1111 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1366
+      ID: 1377
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2384832
       GoKind: 22
-      Pointee: 1367 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1378 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1097
+      ID: 1108
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1219392
       GoKind: 22
-      Pointee: 1098 StructureType internal/poll.errNetClosing
+      Pointee: 1109 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 787
+      ID: 798
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 905408
       GoKind: 22
-      Pointee: 788 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 799 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 847
+      ID: 858
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 738 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 749 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 740
+      ID: 751
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 739 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 750 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 1021
+      ID: 1032
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1048384
       GoKind: 22
-      Pointee: 1022 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 1033 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1223
+      ID: 1234
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1197120
       GoKind: 22
-      Pointee: 1224 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1235 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1221
+      ID: 1232
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1196736
       GoKind: 22
-      Pointee: 1222 StructureType io.discard
+      Pointee: 1233 StructureType io.discard
     - __kind: PointerType
-      ID: 1195
+      ID: 1206
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1029184
       GoKind: 22
-      Pointee: 1196 UnresolvedPointeeType io.multiWriter
+      Pointee: 1207 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1095
+      ID: 1106
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1218880
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1107 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1269
+      ID: 1280
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1815008
       GoKind: 22
-      Pointee: 1270 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1281 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 343
+      ID: 347
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 344 StructureType main.Pair[go.shape.int,go.shape.bool]
+      Pointee: 348 StructureType main.Pair[go.shape.int,go.shape.bool]
     - __kind: PointerType
-      ID: 346
+      ID: 350
       Name: '*main.Pair[go.shape.string,go.shape.int]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 347 StructureType main.Pair[go.shape.string,go.shape.int]
+      Pointee: 351 StructureType main.Pair[go.shape.string,go.shape.int]
     - __kind: PointerType
       ID: 323
       Name: '*main.anotherStruct'
@@ -13129,19 +13252,19 @@ Types:
       GoKind: 22
       Pointee: 324 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 440
+      ID: 441
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 388160
       GoKind: 22
-      Pointee: 441 StructureType main.deepMap2
+      Pointee: 442 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1422
+      ID: 1423
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 388096
       GoKind: 22
-      Pointee: 1423 UnresolvedPointeeType main.deepMap3
+      Pointee: 1424 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 151
       Name: '*main.deepMap7'
@@ -13150,19 +13273,19 @@ Types:
       GoKind: 22
       Pointee: 152 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1466
+      ID: 1467
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 387776
       GoKind: 22
-      Pointee: 1467 StructureType main.deepMap8
+      Pointee: 1468 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1481
+      ID: 1482
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 387712
       GoKind: 22
-      Pointee: 1482 StructureType main.deepMap9
+      Pointee: 1483 StructureType main.deepMap9
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr2'
@@ -13171,12 +13294,12 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1370
+      ID: 1381
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 388672
       GoKind: 22
-      Pointee: 1371 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1382 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 137
       Name: '*main.deepPtr7'
@@ -13185,33 +13308,33 @@ Types:
       GoKind: 22
       Pointee: 138 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1436
+      ID: 1437
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 388352
       GoKind: 22
-      Pointee: 1437 StructureType main.deepPtr8
+      Pointee: 1438 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1438
+      ID: 1439
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 388288
       GoKind: 22
-      Pointee: 1439 StructureType main.deepPtr9
+      Pointee: 1440 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 142
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 389312
       GoKind: 22
-      Pointee: 431 StructureType main.deepSlice2
+      Pointee: 432 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1407
+      ID: 1408
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 389248
       GoKind: 22
-      Pointee: 1408 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1409 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepSlice7'
@@ -13220,19 +13343,19 @@ Types:
       GoKind: 22
       Pointee: 144 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1442
+      ID: 1443
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 388928
       GoKind: 22
-      Pointee: 1443 StructureType main.deepSlice8
+      Pointee: 1444 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1448
+      ID: 1449
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 388864
       GoKind: 22
-      Pointee: 1449 StructureType main.deepSlice9
+      Pointee: 1450 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 327
       Name: '*main.emptyStruct'
@@ -13247,14 +13370,14 @@ Types:
       GoKind: 22
       Pointee: 167 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1383
+      ID: 1394
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 900704
       GoKind: 22
-      Pointee: 360 StructureType main.firstBehavior
+      Pointee: 364 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1498
+      ID: 1499
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 389696
@@ -13280,19 +13403,19 @@ Types:
       GoKind: 22
       Pointee: 160 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1384
+      ID: 1395
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 900800
       GoKind: 22
-      Pointee: 1385 StructureType main.secondBehavior
+      Pointee: 1396 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1376
+      ID: 1387
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 900896
       GoKind: 22
-      Pointee: 1377 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1388 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 153
       Name: '*main.stringType1'
@@ -13300,28 +13423,28 @@ Types:
       GoKind: 22
       Pointee: 154 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1373
+      ID: 1384
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1372 GoStringDataType main.stringType1.str
+      Pointee: 1383 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 156
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1374 GoStringHeaderType main.stringType2
+      Pointee: 1385 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1500
+      ID: 1501
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1499 GoStringDataType main.stringType2.str
+      Pointee: 1500 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 280
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 278 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 494
+      ID: 495
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 387648
@@ -13345,10 +13468,10 @@ Types:
       GoKind: 22
       Pointee: 256 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1388
+      ID: 1399
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1387 GoSliceDataType main.t.array
+      Pointee: 1398 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 275
       Name: '*main.threeStringStruct'
@@ -13376,40 +13499,40 @@ Types:
       ByteSize: 8
       Pointee: 207 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 378
+      ID: 382
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 379 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 383 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 147
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 148 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1412
+      ID: 1413
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1413 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1414 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1456
+      ID: 1457
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1457 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1458 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1471
+      ID: 1472
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1472 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1473 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 174
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 175 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1486
+      ID: 1487
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1487 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1488 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 241
       Name: '*map<int,struct {}>'
@@ -13421,10 +13544,10 @@ Types:
       ByteSize: 8
       Pointee: 212 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 686
+      ID: 693
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 687 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 694 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 201
       Name: '*map<string,[]main.structWithMap>'
@@ -13436,35 +13559,35 @@ Types:
       ByteSize: 8
       Pointee: 190 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 405
+      ID: 406
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 406 GoSwissMapHeaderType map<string,float64>
+      Pointee: 407 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1135
+      ID: 1146
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1136 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1147 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 184
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 185 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 400
+      ID: 401
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 401 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 402 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 179
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 180 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 395
+      ID: 396
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 396 GoSwissMapHeaderType map<string,string>
+      Pointee: 397 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 236
       Name: '*map<struct {},int>'
@@ -13522,728 +13645,728 @@ Types:
       GoKind: 22
       Pointee: 183 GoMapType map[string]int
     - __kind: PointerType
-      ID: 884
+      ID: 895
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 885 StructureType math/big.ErrNaN
+      Pointee: 896 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1185
+      ID: 1196
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 1186 StructureType mime/multipart.writerOnly·1
+      Pointee: 1197 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1087
+      ID: 1098
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1212480
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType net.AddrError
+      Pointee: 1099 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1118
+      ID: 1129
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1429216
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType net.DNSError
+      Pointee: 1130 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1330
+      ID: 1341
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2243104
       GoKind: 22
-      Pointee: 1331 UnresolvedPointeeType net.IPConn
+      Pointee: 1342 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1116
+      ID: 1127
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1428896
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType net.OpError
+      Pointee: 1128 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1089
+      ID: 1100
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1212608
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType net.ParseError
+      Pointee: 1101 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1340
+      ID: 1351
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2271936
       GoKind: 22
-      Pointee: 1341 UnresolvedPointeeType net.TCPConn
+      Pointee: 1352 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1350
+      ID: 1361
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2317440
       GoKind: 22
-      Pointee: 1351 UnresolvedPointeeType net.UDPConn
+      Pointee: 1362 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1338
+      ID: 1349
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2271424
       GoKind: 22
-      Pointee: 1339 UnresolvedPointeeType net.UnixConn
+      Pointee: 1350 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1086
+      ID: 1097
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1211712
       GoKind: 22
-      Pointee: 1055 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1066 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1057
+      ID: 1068
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1056 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1067 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1019
+      ID: 1030
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1043264
       GoKind: 22
-      Pointee: 1020 StructureType net.canceledError
+      Pointee: 1031 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1306
+      ID: 1317
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2019808
       GoKind: 22
-      Pointee: 1307 UnresolvedPointeeType net.conn
+      Pointee: 1318 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1160
+      ID: 1171
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1857120
       GoKind: 22
-      Pointee: 1161 StructureType net.dialResult·1
+      Pointee: 1172 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1352
+      ID: 1363
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2321696
       GoKind: 22
-      Pointee: 1353 UnresolvedPointeeType net.netFD
+      Pointee: 1364 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 816
+      ID: 827
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 911648
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType net.notFoundError
+      Pointee: 828 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1432
+      ID: 1433
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1429056
       GoKind: 22
-      Pointee: 1433 StructureType net.onlyValuesCtx
+      Pointee: 1434 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 818
+      ID: 829
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 912320
       GoKind: 22
-      Pointee: 819 StructureType net.result·2
+      Pointee: 830 StructureType net.result·2
     - __kind: PointerType
-      ID: 1334
+      ID: 1345
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2257952
       GoKind: 22
-      Pointee: 1335 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1346 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1332
+      ID: 1343
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2257472
       GoKind: 22
-      Pointee: 1333 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1344 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1091
+      ID: 1102
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1213248
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType net.temporaryError
+      Pointee: 1103 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1120
+      ID: 1131
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1429376
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType net.timeoutError
+      Pointee: 1132 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1009
+      ID: 1020
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1039296
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1021 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1177
+      ID: 1188
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 907424
       GoKind: 22
-      Pointee: 1178 StructureType net/http.bufioFlushWriter
+      Pointee: 1189 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 793
+      ID: 804
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 908096
       GoKind: 22
-      Pointee: 708 BaseType net/http.http2ConnectionError
+      Pointee: 719 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 794
+      ID: 805
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 908192
       GoKind: 22
-      Pointee: 795 StructureType net/http.http2GoAwayError
+      Pointee: 806 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1112
+      ID: 1123
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1425216
       GoKind: 22
-      Pointee: 1113 StructureType net/http.http2StreamError
+      Pointee: 1124 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 798
+      ID: 809
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 908768
       GoKind: 22
-      Pointee: 799 StructureType net/http.http2connError
+      Pointee: 810 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1241
+      ID: 1252
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1563680
       GoKind: 22
-      Pointee: 1242 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1253 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 797
+      ID: 808
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908672
       GoKind: 22
-      Pointee: 712 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 723 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 714
+      ID: 725
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 713 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 724 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 801
+      ID: 812
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 908960
       GoKind: 22
-      Pointee: 718 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 729 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 720
+      ID: 731
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 719 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 730 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 800
+      ID: 811
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 715 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 726 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 717
+      ID: 728
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 716 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 727 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1084
+      ID: 1095
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1208512
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1096 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1015
+      ID: 1026
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1039936
       GoKind: 22
-      Pointee: 1016 StructureType net/http.http2noCachedConnError
+      Pointee: 1027 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1295
+      ID: 1306
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1961856
       GoKind: 22
-      Pointee: 1296 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1307 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 796
+      ID: 807
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908576
       GoKind: 22
-      Pointee: 709 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 720 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 711
+      ID: 722
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 710 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 721 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1179
+      ID: 1190
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 909056
       GoKind: 22
-      Pointee: 1180 StructureType net/http.http2stickyErrWriter
+      Pointee: 1191 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1011
+      ID: 1022
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1039552
       GoKind: 22
-      Pointee: 1012 StructureType net/http.nothingWrittenError
+      Pointee: 1023 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1243
+      ID: 1254
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2186976
       GoKind: 22
-      Pointee: 1244 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1255 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1199
+      ID: 1210
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1039424
       GoKind: 22
-      Pointee: 1200 StructureType net/http.persistConnWriter
+      Pointee: 1211 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1233
+      ID: 1244
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1425376
       GoKind: 22
-      Pointee: 1234 StructureType net/http.readWriteCloserBody
+      Pointee: 1245 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 802
+      ID: 813
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 909152
       GoKind: 22
-      Pointee: 803 StructureType net/http.requestBodyReadError
+      Pointee: 814 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1114
+      ID: 1125
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1426496
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1126 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1082
+      ID: 1093
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1208384
       GoKind: 22
-      Pointee: 1083 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1094 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1013
+      ID: 1024
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1039680
       GoKind: 22
-      Pointee: 1014 StructureType net/http.transportReadFromServerError
+      Pointee: 1025 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1275
+      ID: 1286
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1853984
       GoKind: 22
-      Pointee: 1276 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1287 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 791
+      ID: 802
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 907328
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 803 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1297
+      ID: 1308
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1963904
       GoKind: 22
-      Pointee: 1298 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1309 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1209
+      ID: 1220
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1052608
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1221 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 876
+      ID: 887
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 924512
       GoKind: 22
-      Pointee: 877 StructureType net/netip.parseAddrError
+      Pointee: 888 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 874
+      ID: 885
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 875 StructureType net/netip.parsePrefixError
+      Pointee: 886 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1249
+      ID: 1260
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2129472
       GoKind: 22
-      Pointee: 1250 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1261 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1211
+      ID: 1222
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1057472
       GoKind: 22
-      Pointee: 1212 StructureType net/smtp.dataCloser
+      Pointee: 1223 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 860
+      ID: 871
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 920576
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType net/textproto.Error
+      Pointee: 872 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 859
+      ID: 870
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 920480
       GoKind: 22
-      Pointee: 746 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 757 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 748
+      ID: 759
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 747 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 758 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1207
+      ID: 1218
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1051840
       GoKind: 22
-      Pointee: 1208 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1219 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1122
+      ID: 1133
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1429696
       GoKind: 22
-      Pointee: 1123 UnresolvedPointeeType net/url.Error
+      Pointee: 1134 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 820
+      ID: 831
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 912416
       GoKind: 22
-      Pointee: 721 GoStringHeaderType net/url.EscapeError
+      Pointee: 732 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 723
+      ID: 734
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 722 GoStringDataType net/url.EscapeError.str
+      Pointee: 733 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 821
+      ID: 832
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 912512
       GoKind: 22
-      Pointee: 724 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 735 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 726
+      ID: 737
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 725 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 736 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 540
+      ID: 541
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 541 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 542 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 532
+      ID: 533
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 533 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 534 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 480
+      ID: 481
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 481 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 482 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 499
+      ID: 500
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 500 StructureType noalg.map.group[bool]main.node
+      Pointee: 501 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 652
+      ID: 659
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 653 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 660 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 436
+      ID: 437
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 437 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 438 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1418
+      ID: 1419
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1419 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1420 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1462
+      ID: 1463
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1463 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1464 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1477
+      ID: 1478
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1478 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 448
+      ID: 449
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 449 StructureType noalg.map.group[int]int
+      Pointee: 450 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1492
+      ID: 1493
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1493 StructureType noalg.map.group[int]interface {}
+      Pointee: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 556
+      ID: 557
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 557 StructureType noalg.map.group[int]struct {}
+      Pointee: 558 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 507
+      ID: 508
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 508 StructureType noalg.map.group[int]uint8
+      Pointee: 509 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 697
+      ID: 708
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 698 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 489
+      ID: 490
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 490 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 491 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 472
+      ID: 473
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 473 StructureType noalg.map.group[string][]string
+      Pointee: 474 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 677
+      ID: 684
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 678 StructureType noalg.map.group[string]float64
+      Pointee: 685 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1167
+      ID: 1178
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1168 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 464
+      ID: 465
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 465 StructureType noalg.map.group[string]int
+      Pointee: 466 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 669
+      ID: 676
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 670 StructureType noalg.map.group[string]interface {}
+      Pointee: 677 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 456
+      ID: 457
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 457 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 458 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 661
+      ID: 668
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 662 StructureType noalg.map.group[string]string
+      Pointee: 669 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 548
+      ID: 549
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 549 StructureType noalg.map.group[struct {}]int
+      Pointee: 550 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 596
+      ID: 597
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 597 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 604
+      ID: 605
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 605 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 612
+      ID: 613
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 613 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 620
+      ID: 621
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 628
+      ID: 629
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 636
+      ID: 637
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 564
+      ID: 565
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 565 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 566 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 523
+      ID: 524
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 524 StructureType noalg.map.group[uint8][4]int
+      Pointee: 525 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 515
+      ID: 516
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 516 StructureType noalg.map.group[uint8]uint8
+      Pointee: 517 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1358
+      ID: 1369
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2361184
       GoKind: 22
-      Pointee: 1359 UnresolvedPointeeType os.File
+      Pointee: 1370 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 992
+      ID: 1003
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1032896
       GoKind: 22
-      Pointee: 993 UnresolvedPointeeType os.LinkError
+      Pointee: 1004 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1060
+      ID: 1071
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1201600
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType os.SyscallError
+      Pointee: 1072 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1356
+      ID: 1367
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2359712
       GoKind: 22
-      Pointee: 1357 StructureType os.fileWithoutReadFrom
+      Pointee: 1368 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1354
+      ID: 1365
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2358976
       GoKind: 22
-      Pointee: 1355 StructureType os.fileWithoutWriteTo
+      Pointee: 1366 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1023
+      ID: 1034
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1048512
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType os/exec.Error
+      Pointee: 1035 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1163
+      ID: 1174
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2100032
       GoKind: 22
-      Pointee: 1164 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1175 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1227
+      ID: 1238
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1220416
       GoKind: 22
-      Pointee: 1228 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1239 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1025
+      ID: 1036
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1048640
       GoKind: 22
-      Pointee: 1026 StructureType os/exec.wrappedError
+      Pointee: 1037 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 957
+      ID: 968
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 942464
       GoKind: 22
-      Pointee: 760 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 771 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 762
+      ID: 773
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 761 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 772 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 956
+      ID: 967
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 942368
       GoKind: 22
-      Pointee: 759 BaseType os/user.UnknownUserIdError
+      Pointee: 770 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 789
+      ID: 800
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 906080
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType reflect.ValueError
+      Pointee: 801 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 882
+      ID: 893
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 925184
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 894 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 996
+      ID: 1007
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1033920
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1008 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 1000
+      ID: 1011
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1035712
       GoKind: 22
-      Pointee: 1001 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1012 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14259,12 +14382,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 998
+      ID: 1009
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1034048
       GoKind: 22
-      Pointee: 999 StructureType runtime.boundsError
+      Pointee: 1010 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -14280,24 +14403,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1062
+      ID: 1073
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1204032
       GoKind: 22
-      Pointee: 1063 StructureType runtime.errorAddressString
+      Pointee: 1074 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 994
+      ID: 1005
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1033536
       GoKind: 22
-      Pointee: 975 GoStringHeaderType runtime.errorString
+      Pointee: 986 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 977
+      ID: 988
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 976 GoStringDataType runtime.errorString.str
+      Pointee: 987 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -14318,19 +14441,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1035072
       GoKind: 22
-      Pointee: 426 UnresolvedPointeeType runtime.p
+      Pointee: 427 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 995
+      ID: 1006
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1033664
       GoKind: 22
-      Pointee: 978 GoStringHeaderType runtime.plainError
+      Pointee: 989 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 980
+      ID: 991
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 979 GoStringDataType runtime.plainError.str
+      Pointee: 990 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14346,12 +14469,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 785
+      ID: 796
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 22
-      Pointee: 786 StructureType runtime.synctestDeadlockError
+      Pointee: 797 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -14367,12 +14490,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 990
+      ID: 1001
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1031744
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType strconv.NumError
+      Pointee: 1002 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -14381,31 +14504,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 421
+      ID: 422
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 420 GoStringDataType string.str
+      Pointee: 421 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1291
+      ID: 1302
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1960064
       GoKind: 22
-      Pointee: 1292 UnresolvedPointeeType strings.Builder
+      Pointee: 1303 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1197
+      ID: 1208
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1031872
       GoKind: 22
-      Pointee: 1198 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1209 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1193
+      ID: 1204
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 976416
       GoKind: 22
-      Pointee: 1194 StructureType struct { io.Writer }
+      Pointee: 1205 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 273
       Name: '*struct {}'
@@ -14414,233 +14537,233 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType struct {}
     - __kind: PointerType
-      ID: 1124
+      ID: 1135
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1431936
       GoKind: 22
-      Pointee: 1111 BaseType syscall.Errno
+      Pointee: 1122 BaseType syscall.Errno
     - __kind: PointerType
       ID: 234
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 538 StructureType table<[4]int,[4]int>
+      Pointee: 539 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 229
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 530 StructureType table<[4]int,uint8>
+      Pointee: 531 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 197
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 478 StructureType table<[4]string,[2]int>
+      Pointee: 479 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 209
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 497 StructureType table<bool,main.node>
+      Pointee: 498 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 381
+      ID: 385
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 650 StructureType table<context.canceler,struct {}>
+      Pointee: 657 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 150
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 434 StructureType table<int,*main.deepMap2>
+      Pointee: 435 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1415
+      ID: 1416
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1416 StructureType table<int,*main.deepMap3>
+      Pointee: 1417 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1459
+      ID: 1460
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1460 StructureType table<int,*main.deepMap8>
+      Pointee: 1461 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1474
+      ID: 1475
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1475 StructureType table<int,*main.deepMap9>
+      Pointee: 1476 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 177
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 446 StructureType table<int,int>
+      Pointee: 447 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1489
+      ID: 1490
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1490 StructureType table<int,interface {}>
+      Pointee: 1491 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 244
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 554 StructureType table<int,struct {}>
+      Pointee: 555 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 214
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 505 StructureType table<int,uint8>
+      Pointee: 506 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 695 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 706 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 204
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 487 StructureType table<string,[]main.structWithMap>
+      Pointee: 488 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 192
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 470 StructureType table<string,[]string>
+      Pointee: 471 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 408
+      ID: 409
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 675 StructureType table<string,float64>
+      Pointee: 682 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1138
+      ID: 1149
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1165 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1176 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 187
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 462 StructureType table<string,int>
+      Pointee: 463 StructureType table<string,int>
     - __kind: PointerType
-      ID: 403
+      ID: 404
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 667 StructureType table<string,interface {}>
+      Pointee: 674 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 182
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 454 StructureType table<string,main.nestedStruct>
+      Pointee: 455 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 659 StructureType table<string,string>
+      Pointee: 666 StructureType table<string,string>
     - __kind: PointerType
       ID: 239
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 546 StructureType table<struct {},int>
+      Pointee: 547 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 296
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 594 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 595 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 301
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 602 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 603 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 306
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 610 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 611 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 311
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 618 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 619 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 316
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 626 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 627 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 321
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 634 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 635 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 249
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 562 StructureType table<struct {},struct {}>
+      Pointee: 563 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 224
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 521 StructureType table<uint8,[4]int>
+      Pointee: 522 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 219
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 513 StructureType table<uint8,uint8>
+      Pointee: 514 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1328
+      ID: 1339
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2171104
       GoKind: 22
-      Pointee: 1329 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1340 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1053
+      ID: 1064
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1094336
       GoKind: 22
-      Pointee: 1054 StructureType text/template.ExecError
+      Pointee: 1065 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 386
+      ID: 329
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1626976
       GoKind: 22
-      Pointee: 387 StructureType time.Location
+      Pointee: 330 StructureType time.Location
     - __kind: PointerType
-      ID: 783
+      ID: 794
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 903392
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType time.ParseError
+      Pointee: 795 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 383
+      ID: 387
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1033280
       GoKind: 22
-      Pointee: 384 StructureType time.Timer
+      Pointee: 388 StructureType time.Timer
     - __kind: PointerType
-      ID: 782
+      ID: 793
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 903296
       GoKind: 22
-      Pointee: 705 GoStringHeaderType time.fileSizeError
+      Pointee: 716 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 707
+      ID: 718
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 706 GoStringDataType time.fileSizeError.str
+      Pointee: 717 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 1391
+      ID: 644
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394880
       GoKind: 22
-      Pointee: 1392 StructureType time.zone
+      Pointee: 645 StructureType time.zone
     - __kind: PointerType
-      ID: 1394
+      ID: 647
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394944
       GoKind: 22
-      Pointee: 1395 StructureType time.zoneTrans
+      Pointee: 648 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -14684,49 +14807,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 878
+      ID: 889
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 924608
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 890 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1320
+      ID: 1331
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2146592
       GoKind: 22
-      Pointee: 1321 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1332 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 862
+      ID: 873
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 920768
       GoKind: 22
-      Pointee: 863 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 874 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 864
+      ID: 875
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 749 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 760 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1030
+      ID: 1041
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1052352
       GoKind: 22
-      Pointee: 1031 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1042 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1032
+      ID: 1043
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1052480
       GoKind: 22
-      Pointee: 983 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 994 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1389
+      ID: 1400
       Name: <-chan time.Time
       GoRuntimeType: 600352
       GoKind: 18
@@ -14739,7 +14862,7 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 1773
+      ID: 1777
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14755,10 +14878,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 356 GoSliceHeaderType []go.shape.float64
+            Type: 360 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14768,10 +14891,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 356 GoSliceHeaderType []go.shape.float64
+            Type: 360 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14781,17 +14904,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 359 GoSubroutineType func(go.shape.float64) bool
+            Type: 363 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 1, name: pred}
+                  Variable: {subprogram: 191, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1774
+      ID: 1778
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14801,17 +14924,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 356 GoSliceHeaderType []go.shape.float64
+            Type: 360 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 2, name: ~r0}
+                  Variable: {subprogram: 191, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1771
+      ID: 1775
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14827,10 +14950,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14840,10 +14963,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14853,17 +14976,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 334 GoSubroutineType func(go.shape.int) bool
+            Type: 338 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: pred}
+                  Variable: {subprogram: 172, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1772
+      ID: 1776
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14873,20 +14996,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 2, name: ~r0}
+                  Variable: {subprogram: 172, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1829
+      ID: 1833
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1775
+      ID: 1779
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14902,10 +15025,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14915,10 +15038,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14928,17 +15051,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
+            Type: 339 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: f}
+                  Variable: {subprogram: 173, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1776
+      ID: 1780
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14948,17 +15071,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 2, name: ~r0}
+                  Variable: {subprogram: 173, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1787
+      ID: 1791
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14977,10 +15100,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14990,10 +15113,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
+            Type: 347 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: x}
+                  Variable: {subprogram: 179, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15003,10 +15126,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15016,20 +15139,20 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 345 BaseType go.shape.bool
+            Type: 349 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 2, name: v}
+                  Variable: {subprogram: 179, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1788
+      ID: 1792
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1789
+      ID: 1793
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15048,10 +15171,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15061,10 +15184,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
+            Type: 350 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: x}
+                  Variable: {subprogram: 180, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15074,10 +15197,10 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15087,20 +15210,20 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 2, name: v}
+                  Variable: {subprogram: 180, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1790
+      ID: 1794
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1827
+      ID: 1831
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15109,17 +15232,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 360 StructureType main.firstBehavior
+            Type: 364 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 0, name: b}
+                  Variable: {subprogram: 198, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1828
+      ID: 1832
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15131,14 +15254,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 1, name: ~r0}
+                  Variable: {subprogram: 198, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1803
+      ID: 1807
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15154,10 +15277,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15167,10 +15290,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15180,17 +15303,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1807
+      ID: 1811
       Name: Probe[main.genericContains[go.shape.int]]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15206,10 +15329,10 @@ Types:
           Offset: 17
           Kind: local
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15219,17 +15342,17 @@ Types:
           Offset: 41
           Kind: local
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1804
+      ID: 1808
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15241,14 +15364,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 187, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1805
+      ID: 1809
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15264,10 +15387,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15277,10 +15400,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 353 GoSliceHeaderType []go.shape.string
+            Type: 357 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: haystack}
+                  Variable: {subprogram: 188, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15290,17 +15413,17 @@ Types:
           Offset: 57
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1808
+      ID: 1812
       Name: Probe[main.genericContains[go.shape.string]]Line
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15310,17 +15433,17 @@ Types:
           Offset: 9
           Kind: local
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1806
+      ID: 1810
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15332,14 +15455,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 2, name: ~r0}
+                  Variable: {subprogram: 188, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1799
+      ID: 1803
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15349,10 +15472,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 350 PointerType *go.shape.string
+            Type: 354 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15362,17 +15485,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 350 PointerType *go.shape.string
+            Type: 354 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1800
+      ID: 1804
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15382,17 +15505,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: ~r0}
+                  Variable: {subprogram: 185, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1801
+      ID: 1805
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15402,10 +15525,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15415,17 +15538,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1802
+      ID: 1806
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15435,17 +15558,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: ~r0}
+                  Variable: {subprogram: 186, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1795
+      ID: 1799
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15455,10 +15578,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 348 StructureType go.shape.struct { main.i int }
+            Type: 352 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15468,17 +15591,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 348 StructureType go.shape.struct { main.i int }
+            Type: 352 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1796
+      ID: 1800
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15490,14 +15613,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: ~r0}
+                  Variable: {subprogram: 183, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1797
+      ID: 1801
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15507,10 +15630,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 349 StructureType go.shape.struct { main.s string }
+            Type: 353 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15520,17 +15643,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 349 StructureType go.shape.struct { main.s string }
+            Type: 353 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1798
+      ID: 1802
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15542,14 +15665,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: ~r0}
+                  Variable: {subprogram: 184, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1777
+      ID: 1781
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15559,10 +15682,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 333 PointerType *go.shape.int
+            Type: 337 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15572,17 +15695,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 333 PointerType *go.shape.int
+            Type: 337 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1778
+      ID: 1782
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15592,17 +15715,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 333 PointerType *go.shape.int
+            Type: 337 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 174, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1779
+      ID: 1783
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15612,10 +15735,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 336 PointerType *go.shape.struct { Name string }
+            Type: 340 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15625,17 +15748,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 336 PointerType *go.shape.struct { Name string }
+            Type: 340 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1780
+      ID: 1784
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15645,17 +15768,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 PointerType *go.shape.struct { Name string }
+            Type: 340 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: ~r0}
+                  Variable: {subprogram: 175, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1781
+      ID: 1785
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15665,10 +15788,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 338 PointerType *go.shape.struct { X int; Y int }
+            Type: 342 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15678,17 +15801,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 338 PointerType *go.shape.struct { X int; Y int }
+            Type: 342 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1782
+      ID: 1786
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15698,17 +15821,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 338 PointerType *go.shape.struct { X int; Y int }
+            Type: 342 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: ~r0}
+                  Variable: {subprogram: 176, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1793
+      ID: 1797
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15724,10 +15847,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15737,10 +15860,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15750,17 +15873,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: b}
+                  Variable: {subprogram: 182, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1794
+      ID: 1798
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15776,10 +15899,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15789,17 +15912,17 @@ Types:
           Offset: 33
           Kind: return
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 3, name: ~r1}
+                  Variable: {subprogram: 182, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1791
+      ID: 1795
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15815,10 +15938,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15828,10 +15951,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15841,17 +15964,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 345 BaseType go.shape.bool
+            Type: 349 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: b}
+                  Variable: {subprogram: 181, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1792
+      ID: 1796
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15867,10 +15990,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 345 BaseType go.shape.bool
+            Type: 349 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
@@ -15880,17 +16003,17 @@ Types:
           Offset: 18
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 3, name: ~r1}
+                  Variable: {subprogram: 181, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1785
+      ID: 1789
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15900,10 +16023,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 342 StructureType main.largeGenericType[go.shape.int]
+            Type: 346 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
@@ -15913,17 +16036,17 @@ Types:
           Offset: 145
           Kind: argument
           Expression:
-            Type: 342 StructureType main.largeGenericType[go.shape.int]
+            Type: 346 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1786
+      ID: 1790
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15933,17 +16056,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: ~r0}
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1783
+      ID: 1787
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15953,10 +16076,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 340 StructureType main.largeGenericType[go.shape.string]
+            Type: 344 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
@@ -15966,17 +16089,17 @@ Types:
           Offset: 153
           Kind: argument
           Expression:
-            Type: 340 StructureType main.largeGenericType[go.shape.string]
+            Type: 344 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1784
+      ID: 1788
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15986,17 +16109,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: ~r0}
+                  Variable: {subprogram: 177, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1767
+      ID: 1771
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16006,10 +16129,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16019,17 +16142,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1768
+      ID: 1772
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16039,17 +16162,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1769
+      ID: 1773
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16059,10 +16182,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16072,17 +16195,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1770
+      ID: 1774
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16092,20 +16215,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1733
+      ID: 1734
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1734
+      ID: 1735
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16124,7 +16247,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16156,7 +16279,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16175,7 +16298,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16207,7 +16330,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16226,7 +16349,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1704
+      ID: 1705
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16258,7 +16381,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1705
+      ID: 1706
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16277,7 +16400,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16309,7 +16432,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -16341,7 +16464,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16373,7 +16496,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16405,7 +16528,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16437,7 +16560,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16469,7 +16592,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16501,7 +16624,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -16520,7 +16643,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16552,10 +16675,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16587,7 +16710,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1501
+      ID: 1502
       Name: Probe[main.testByteArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16619,7 +16742,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testChannel]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16651,7 +16774,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1602
+      ID: 1603
       Name: Probe[main.testCombinedByte]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16709,7 +16832,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       ExprStatusArraySize: 1
@@ -16741,7 +16864,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1604
+      ID: 1605
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -16786,7 +16909,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[main.testConflictingReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16818,7 +16941,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.testConflictingReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16850,7 +16973,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testCycle]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16882,7 +17005,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16914,7 +17037,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16946,7 +17069,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16978,7 +17101,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17010,7 +17133,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17042,7 +17165,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17074,7 +17197,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1724
+      ID: 1725
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -17132,7 +17255,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1721
+      ID: 1722
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17164,7 +17287,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1747
+      ID: 1748
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17196,7 +17319,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1762
+      ID: 1763
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17228,7 +17351,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1761
+      ID: 1762
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -17260,7 +17383,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testErrorAtLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17318,7 +17441,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testError]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17350,7 +17473,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17382,10 +17505,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -17417,10 +17540,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17452,7 +17575,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17484,7 +17607,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1570
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17503,7 +17626,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testFrameless]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17535,7 +17658,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17554,7 +17677,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17586,10 +17709,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17621,13 +17744,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1819
+      ID: 1823
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17685,28 +17808,28 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1820
+      ID: 1824
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1821
+      ID: 1825
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1822
+      ID: 1826
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1823
+      ID: 1827
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1816
+      ID: 1820
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17718,7 +17841,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17731,14 +17854,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1813
+      ID: 1817
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17750,14 +17873,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1814
+      ID: 1818
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17769,14 +17892,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1815
+      ID: 1819
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17788,7 +17911,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17801,14 +17924,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1818
+      ID: 1822
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17820,7 +17943,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17833,17 +17956,17 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1817
+      ID: 1821
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1824
+      ID: 1828
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17855,7 +17978,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17868,14 +17991,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1825
+      ID: 1829
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17887,7 +18010,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17900,14 +18023,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1826
+      ID: 1830
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17919,7 +18042,7 @@ Types:
             Type: 168 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
@@ -17932,14 +18055,14 @@ Types:
             Type: 168 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17971,7 +18094,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18003,7 +18126,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18035,7 +18158,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -18067,7 +18190,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testIntArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18099,7 +18222,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18131,7 +18254,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1702
+      ID: 1703
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -18163,7 +18286,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1703
+      ID: 1704
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18182,7 +18305,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18214,40 +18337,8 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1548
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1549
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
     - __kind: EventRootType
       ID: 1550
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -18281,7 +18372,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1708
+      ID: 1551
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1709
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -18521,7 +18644,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1709
+      ID: 1710
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18540,7 +18663,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testManyPointers]
       ByteSize: 1121
       ExprStatusArraySize: 1
@@ -18572,7 +18695,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testManyStrings]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -18604,7 +18727,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18636,7 +18759,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1589
+      ID: 1590
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18668,7 +18791,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18700,7 +18823,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18732,7 +18855,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18764,7 +18887,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18796,7 +18919,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18828,7 +18951,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18854,38 +18977,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1587
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 200 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 200 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18924,7 +19015,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1589
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 200 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 200 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1597
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18956,7 +19079,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18988,7 +19111,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19020,7 +19143,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19052,7 +19175,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19084,7 +19207,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19116,7 +19239,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19148,7 +19271,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19180,7 +19303,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19212,7 +19335,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19240,38 +19363,6 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1744
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -19308,7 +19399,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1710
+      ID: 1746
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1711
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -19548,7 +19671,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1711
+      ID: 1712
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19567,7 +19690,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1714
+      ID: 1715
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19625,7 +19748,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1715
+      ID: 1716
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19657,7 +19780,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1706
+      ID: 1707
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -19715,7 +19838,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1707
+      ID: 1708
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19734,7 +19857,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19754,6 +19877,143 @@ Types:
           DictIndex: -1
         - Name: i
           Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1650
+      Name: Probe[main.testMultipleNamedReturn]
+    - __kind: EventRootType
+      ID: 1652
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1654
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1656
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1658
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1660
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -19767,21 +20027,63 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1649
-      Name: Probe[main.testMultipleNamedReturn]
-    - __kind: EventRootType
-      ID: 1651
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: return
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1651
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19789,57 +20091,57 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1653
-      Name: Probe[main.testMultipleNamedReturn]
+      Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result
           Offset: 17
-          Kind: template_segment
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 25
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19847,185 +20149,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1655
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1657
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1659
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1648
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1650
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1652
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result
-          Offset: 17
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 25
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1654
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20109,7 +20232,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1656
+      ID: 1657
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20141,7 +20264,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20173,7 +20296,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20218,7 +20341,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 63
       ExprStatusArraySize: 3
@@ -20354,7 +20477,42 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1644
+      Name: Probe[main.testNamedReturn]
+    - __kind: EventRootType
+      ID: 1646
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20387,41 +20545,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1643
-      Name: Probe[main.testNamedReturn]
-    - __kind: EventRootType
-      ID: 1645
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: i
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1642
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20440,7 +20563,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20459,7 +20582,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20491,7 +20614,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1756
+      ID: 1757
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20523,7 +20646,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1757
+      ID: 1758
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20550,10 +20673,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1758
+      ID: 1759
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1759
+      ID: 1760
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20580,7 +20703,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20638,7 +20761,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1725
+      ID: 1726
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -20696,7 +20819,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1727
+      ID: 1728
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -20780,7 +20903,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1728
+      ID: 1729
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -20812,7 +20935,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1743
+      ID: 1744
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20844,7 +20967,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20876,7 +20999,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20908,7 +21031,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20940,7 +21063,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       ExprStatusArraySize: 1
@@ -20998,7 +21121,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1636
+      ID: 1637
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21030,7 +21153,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21062,7 +21185,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1638
+      ID: 1639
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21081,10 +21204,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21103,10 +21226,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1684
+      ID: 1685
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1685
+      ID: 1686
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -21125,10 +21248,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21147,10 +21270,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1688
+      ID: 1689
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1689
+      ID: 1690
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -21273,10 +21396,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1700
+      ID: 1701
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1701
+      ID: 1702
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -21308,10 +21431,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21343,7 +21466,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -21375,7 +21498,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21394,7 +21517,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21413,7 +21536,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21432,7 +21555,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1631
+      ID: 1632
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21464,7 +21587,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21509,7 +21632,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21554,7 +21677,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21586,7 +21709,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21618,7 +21741,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21637,29 +21760,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.testReturnsInt]
     - __kind: EventRootType
-      ID: 1619
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1621
+      ID: 1620
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21678,7 +21782,26 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1623
+      ID: 1622
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1624
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21710,7 +21833,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21729,7 +21852,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21761,7 +21884,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21793,7 +21916,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21812,7 +21935,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21844,7 +21967,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21863,10 +21986,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21885,10 +22008,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1674
+      ID: 1675
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -22115,10 +22238,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1686
+      ID: 1687
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1687
+      ID: 1688
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22137,10 +22260,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1692
+      ID: 1693
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1693
+      ID: 1694
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -22211,10 +22334,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1698
+      ID: 1699
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1699
+      ID: 1700
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -22246,7 +22369,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.testReturnsNamedDeferLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22304,10 +22427,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1696
+      ID: 1697
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1697
+      ID: 1698
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22326,10 +22449,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1672
+      ID: 1673
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1673
+      ID: 1674
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -22439,10 +22562,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1694
+      ID: 1695
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1695
+      ID: 1696
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22461,10 +22584,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1690
+      ID: 1691
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1691
+      ID: 1692
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -22483,7 +22606,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22515,7 +22638,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22547,7 +22670,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22579,13 +22702,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testSingleFloat32]
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testSingleFloat64]
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22617,7 +22740,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22649,7 +22772,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22681,7 +22804,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22739,7 +22862,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22771,7 +22894,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22803,7 +22926,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1735
+      ID: 1736
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22835,7 +22958,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22867,7 +22990,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22899,7 +23022,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22931,7 +23054,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22963,7 +23086,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22995,7 +23118,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1731
+      ID: 1732
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23027,7 +23150,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1722
+      ID: 1723
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23059,7 +23182,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23091,7 +23214,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23110,10 +23233,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.testSomeNamedReturn]
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23132,7 +23255,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23164,7 +23287,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23222,7 +23345,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23241,7 +23364,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23299,7 +23422,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23344,7 +23467,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1712
+      ID: 1713
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -23376,7 +23499,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1713
+      ID: 1714
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23421,7 +23544,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1503
+      ID: 1504
       Name: Probe[main.testStringArray]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23453,7 +23576,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23485,7 +23608,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1726
+      ID: 1727
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23517,7 +23640,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testStringType1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23549,7 +23672,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testStringType2]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23581,7 +23704,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1723
+      ID: 1724
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23639,7 +23762,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1578
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23671,7 +23794,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1716
+      ID: 1717
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23703,7 +23826,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1717
+      ID: 1718
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23735,7 +23858,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1750
+      ID: 1751
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -23767,10 +23890,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1751
+      ID: 1752
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1749
+      ID: 1750
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -23802,7 +23925,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23834,7 +23957,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1752
+      ID: 1753
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23853,7 +23976,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1754
+      ID: 1755
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -23885,13 +24008,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1753
+      ID: 1754
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1755
+      ID: 1756
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1732
+      ID: 1733
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -23975,7 +24098,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1748
+      ID: 1749
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24059,7 +24182,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testTakeContext]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24078,7 +24201,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1760
+      ID: 1761
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -24097,7 +24220,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1741
+      ID: 1742
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24129,7 +24252,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1742
+      ID: 1743
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24186,7 +24309,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1737
+      ID: 1738
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24218,7 +24341,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1739
+      ID: 1740
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24263,13 +24386,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1738
+      ID: 1739
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1740
+      ID: 1741
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1736
+      ID: 1737
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24353,7 +24476,103 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
+      ID: 1765
+      Name: Probe[main.testTimeFixedZone]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 328 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 328 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1766
+      Name: Probe[main.testTimeMonotonic]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 331 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: c
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 331 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1764
+      Name: Probe[main.testTimeUTC]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 328 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 328 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1537
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24385,7 +24604,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24417,7 +24636,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24449,7 +24668,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24481,7 +24700,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24513,7 +24732,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testUintArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24545,7 +24764,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24577,7 +24796,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1720
+      ID: 1721
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24609,7 +24828,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1746
+      ID: 1747
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24641,7 +24860,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24673,7 +24892,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       ExprStatusArraySize: 1
@@ -24701,38 +24920,6 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1729
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 264 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 264 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -24769,7 +24956,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1718
+      ID: 1731
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 264 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 264 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1719
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24827,7 +25046,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1719
+      ID: 1720
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24859,7 +25078,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1809
+      ID: 1813
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -24875,10 +25094,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24888,10 +25107,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 354 StructureType main.typeWithGenerics[go.shape.int]
+            Type: 358 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 0, name: x}
+                  Variable: {subprogram: 189, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24901,17 +25120,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1810
+      ID: 1814
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24923,14 +25142,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 2, name: ~r0}
+                  Variable: {subprogram: 189, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1811
+      ID: 1815
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -24946,10 +25165,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24959,10 +25178,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 355 StructureType main.typeWithGenerics[go.shape.string]
+            Type: 359 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24972,17 +25191,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1812
+      ID: 1816
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24994,14 +25213,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 2, name: ~r0}
+                  Variable: {subprogram: 190, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1763
+      ID: 1767
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25011,10 +25230,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25024,17 +25243,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1764
+      ID: 1768
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25044,17 +25263,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1765
+      ID: 1769
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25064,10 +25283,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25077,17 +25296,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1766
+      ID: 1770
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25097,10 +25316,10 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25130,7 +25349,7 @@ Types:
       HasCount: true
       Element: 95 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 341
+      ID: 345
       Name: '[16]uint8'
       ByteSize: 16
       GoRuntimeType: 684128
@@ -25351,7 +25570,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 527
+      ID: 528
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 686816
@@ -25360,7 +25579,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 484
+      ID: 485
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 687104
@@ -25386,7 +25605,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1155
+      ID: 1166
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 688640
@@ -25395,7 +25614,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1375
+      ID: 1386
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25421,7 +25640,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1400
+      ID: 1401
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 484288
@@ -25429,20 +25648,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1401 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1402 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1403 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1404 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1403
+      ID: 1404
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 140
       Name: '[]*main.deepSlice2'
@@ -25459,15 +25678,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 432 GoSliceDataType []*main.deepSlice2.array
+      Data: 433 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 432
+      ID: 433
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 142 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1405
+      ID: 1406
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 480192
@@ -25475,22 +25694,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1406 PointerType **main.deepSlice3
+          Type: 1407 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1409 GoSliceDataType []*main.deepSlice3.array
+      Data: 1410 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1409
+      ID: 1410
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1407 PointerType *main.deepSlice3
+      Element: 1408 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1440
+      ID: 1441
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 479872
@@ -25498,22 +25717,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1441 PointerType **main.deepSlice8
+          Type: 1442 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1444 GoSliceDataType []*main.deepSlice8.array
+      Data: 1445 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1444
+      ID: 1445
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1442 PointerType *main.deepSlice8
+      Element: 1443 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1446
+      ID: 1447
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 479808
@@ -25521,20 +25740,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1447 PointerType **main.deepSlice9
+          Type: 1448 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1450 GoSliceDataType []*main.deepSlice9.array
+      Data: 1451 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1450
+      ID: 1451
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1448 PointerType *main.deepSlice9
+      Element: 1449 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 64
       Name: '[]*runtime.p'
@@ -25551,9 +25770,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 427 GoSliceDataType []*runtime.p.array
+      Data: 428 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 427
+      ID: 428
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25574,201 +25793,201 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 429 GoSliceDataType []*string.array
+      Data: 430 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 429
+      ID: 430
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 97 PointerType *string
     - __kind: GoSliceDataType
-      ID: 544
+      ID: 545
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 234 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 536
+      ID: 537
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 229 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 485
+      ID: 486
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 197 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 503
+      ID: 504
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 209 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 657
+      ID: 664
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 381 PointerType *table<context.canceler,struct {}>
+      Element: 385 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 442
+      ID: 443
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 150 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1424
+      ID: 1425
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1415 PointerType *table<int,*main.deepMap3>
+      Element: 1416 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1468
+      ID: 1469
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1459 PointerType *table<int,*main.deepMap8>
+      Element: 1460 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1483
+      ID: 1484
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1474 PointerType *table<int,*main.deepMap9>
+      Element: 1475 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 452
+      ID: 453
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 177 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1496
+      ID: 1497
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1489 PointerType *table<int,interface {}>
+      Element: 1490 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 560
+      ID: 561
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 244 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 511
+      ID: 512
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 214 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 703
+      ID: 714
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 689 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 696 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 496
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 204 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 477
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 192 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 681
+      ID: 688
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 408 PointerType *table<string,float64>
+      Element: 409 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1171
+      ID: 1182
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1138 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1149 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 468
+      ID: 469
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 187 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 673
+      ID: 680
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 403 PointerType *table<string,interface {}>
+      Element: 404 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 461
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 182 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 672
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 398 PointerType *table<string,string>
+      Element: 399 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 552
+      ID: 553
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 239 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 600
+      ID: 601
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 296 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 608
+      ID: 609
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 301 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 616
+      ID: 617
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 306 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 624
+      ID: 625
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 311 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 632
+      ID: 633
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 316 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 640
+      ID: 641
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 321 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 568
+      ID: 569
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 249 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 528
+      ID: 529
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 224 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 520
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -25788,9 +26007,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 592 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 593 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 592
+      ID: 593
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25810,9 +26029,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 590 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 591 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 590
+      ID: 591
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25832,9 +26051,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 588 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 589 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 588
+      ID: 589
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25854,9 +26073,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 586 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 587 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 586
+      ID: 587
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25876,9 +26095,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 584 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 585 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 584
+      ID: 585
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25898,9 +26117,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 572 GoSliceDataType [][]uint.array
+      Data: 573 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 572
+      ID: 573
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25921,15 +26140,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 576 GoSliceDataType []bool.array
+      Data: 577 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 576
+      ID: 577
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1150
+      ID: 1161
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 490560
@@ -25944,15 +26163,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1173 GoSliceDataType []float64.array
+      Data: 1184 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1173
+      ID: 1184
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 409
+      ID: 410
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 483840
@@ -25960,22 +26179,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 410 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 683 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 690 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 690
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 411 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 412
+      ID: 413
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 484032
@@ -25983,22 +26202,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 413 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 414 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 691 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 691
+      ID: 698
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 414 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 356
+      ID: 360
       Name: '[]go.shape.float64'
       ByteSize: 24
       GoRuntimeType: 486400
@@ -26006,66 +26225,66 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 357 PointerType *go.shape.float64
+          Type: 361 PointerType *go.shape.float64
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 648 GoSliceDataType []go.shape.float64.array
+      Data: 655 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 648
+      ID: 655
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 358 BaseType go.shape.float64
+      Element: 362 BaseType go.shape.float64
     - __kind: GoSliceHeaderType
-      ID: 332
+      ID: 336
       Name: '[]go.shape.int'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 333 PointerType *go.shape.int
+          Type: 337 PointerType *go.shape.int
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 644 GoSliceDataType []go.shape.int.array
+      Data: 651 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 644
+      ID: 651
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 328 BaseType go.shape.int
+      Element: 332 BaseType go.shape.int
     - __kind: GoSliceHeaderType
-      ID: 353
+      ID: 357
       Name: '[]go.shape.string'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 350 PointerType *go.shape.string
+          Type: 354 PointerType *go.shape.string
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 646 GoSliceDataType []go.shape.string.array
+      Data: 653 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 646
+      ID: 653
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 330 GoStringHeaderType go.shape.string
+      Element: 334 GoStringHeaderType go.shape.string
     - __kind: GoSliceHeaderType
-      ID: 1452
+      ID: 1453
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 491008
@@ -26080,9 +26299,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1453 GoSliceDataType []interface {}.array
+      Data: 1454 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1453
+      ID: 1454
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26102,15 +26321,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 582 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 583 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 582
+      ID: 583
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 278 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 493
+      ID: 494
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 480832
@@ -26118,16 +26337,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 494 PointerType *main.structWithMap
+          Type: 495 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 693 GoSliceDataType []main.structWithMap.array
+      Data: 700 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 693
+      ID: 700
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26147,205 +26366,205 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 574 GoSliceDataType []main.structWithNoStrings.array
+      Data: 575 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 574
+      ID: 575
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 269 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 545
+      ID: 546
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 541 StructureType noalg.map.group[[4]int][4]int
+      Element: 542 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 537
+      ID: 538
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 533 StructureType noalg.map.group[[4]int]uint8
+      Element: 534 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 487
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 481 StructureType noalg.map.group[[4]string][2]int
+      Element: 482 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 504
+      ID: 505
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 500 StructureType noalg.map.group[bool]main.node
+      Element: 501 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 658
+      ID: 665
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 653 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 660 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 444
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 437 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 438 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1425
+      ID: 1426
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1419 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1420 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1469
+      ID: 1470
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1463 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1464 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1484
+      ID: 1485
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1478 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 454
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 449 StructureType noalg.map.group[int]int
+      Element: 450 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1497
+      ID: 1498
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1493 StructureType noalg.map.group[int]interface {}
+      Element: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 561
+      ID: 562
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 557 StructureType noalg.map.group[int]struct {}
+      Element: 558 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 512
+      ID: 513
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 508 StructureType noalg.map.group[int]uint8
+      Element: 509 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 704
+      ID: 715
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 698 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 497
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 490 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 491 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 478
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 473 StructureType noalg.map.group[string][]string
+      Element: 474 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 682
+      ID: 689
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 678 StructureType noalg.map.group[string]float64
+      Element: 685 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1172
+      ID: 1183
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1168 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 470
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 465 StructureType noalg.map.group[string]int
+      Element: 466 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 674
+      ID: 681
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 670 StructureType noalg.map.group[string]interface {}
+      Element: 677 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 462
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 457 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 458 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 666
+      ID: 673
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 662 StructureType noalg.map.group[string]string
+      Element: 669 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 553
+      ID: 554
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 549 StructureType noalg.map.group[struct {}]int
+      Element: 550 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 601
+      ID: 602
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 597 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 609
+      ID: 610
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 605 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 617
+      ID: 618
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 613 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 625
+      ID: 626
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 633
+      ID: 634
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 641
+      ID: 642
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 569
+      ID: 570
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 565 StructureType noalg.map.group[struct {}]struct {}
+      Element: 566 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 530
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 524 StructureType noalg.map.group[uint8][4]int
+      Element: 525 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 521
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 516 StructureType noalg.map.group[uint8]uint8
+      Element: 517 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -26366,9 +26585,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 444 GoSliceDataType []string.array
+      Data: 445 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 444
+      ID: 445
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26388,14 +26607,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 580 GoSliceDataType []struct {}.array
+      Data: 581 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 580
+      ID: 581
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 127 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 1390
+      ID: 643
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489216
@@ -26403,22 +26622,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1391 PointerType *time.zone
+          Type: 644 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1396 GoSliceDataType []time.zone.array
+      Data: 702 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 1396
+      ID: 702
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 1392 StructureType time.zone
+      Element: 645 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 1393
+      ID: 646
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489280
@@ -26426,20 +26645,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1394 PointerType *time.zoneTrans
+          Type: 647 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1398 GoSliceDataType []time.zoneTrans.array
+      Data: 704 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 1398
+      ID: 704
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 1395 StructureType time.zoneTrans
+      Element: 648 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 264
       Name: '[]uint'
@@ -26456,9 +26675,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 570 GoSliceDataType []uint.array
+      Data: 571 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 570
+      ID: 571
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26479,9 +26698,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 578 GoSliceDataType []uint16.array
+      Data: 579 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 578
+      ID: 579
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26502,9 +26721,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 422 GoSliceDataType []uint8.array
+      Data: 423 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 422
+      ID: 423
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26525,19 +26744,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 424 GoSliceDataType []uintptr.array
+      Data: 425 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 424
+      ID: 425
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1305
+      ID: 1316
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 943
+      ID: 954
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 935840
@@ -26552,33 +26771,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 944 GoSliceDataType archive/tar.headerError.array
+      Data: 955 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 944
+      ID: 955
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1240
+      ID: 1251
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1188
+      ID: 1199
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1190
+      ID: 1201
       Name: archive/zip.dirWriter
       GoRuntimeType: 1126528
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1284
+      ID: 1295
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1216
+      ID: 1227
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1574400
@@ -26588,7 +26807,7 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1218
+      ID: 1229
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26598,15 +26817,15 @@ Types:
       GoRuntimeType: 588320
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1263
+      ID: 1274
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1294
+      ID: 1305
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1343
+      ID: 1354
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -26632,13 +26851,13 @@ Types:
       GoRuntimeType: 588064
       GoKind: 15
     - __kind: BaseType
-      ID: 741
+      ID: 752
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 838720
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 742
+      ID: 753
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 838816
@@ -26646,26 +26865,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 744 PointerType *compress/flate.InternalError.str
+          Type: 755 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 743 GoStringDataType compress/flate.InternalError.str
+      Data: 754 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 743
+      ID: 754
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1238
+      ID: 1249
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1195
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1260
+      ID: 1271
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -26682,19 +26901,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 371
+      ID: 375
       Name: context.backgroundCtx
       GoRuntimeType: 1809184
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 372 StructureType context.emptyCtx
+          Type: 376 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 362
+      ID: 366
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1976192
@@ -26705,23 +26924,23 @@ Types:
           Type: 157 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 373 StructureType sync.Mutex
+          Type: 377 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 376 StructureType sync/atomic.Value
+          Type: 380 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 377 GoMapType map[context.canceler]struct {}
+          Type: 381 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 376 StructureType sync/atomic.Value
+          Type: 380 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 15 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 656
+      ID: 663
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1117184
@@ -26734,13 +26953,13 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1059
+      ID: 1070
       Name: context.deadlineExceededError
       GoRuntimeType: 1472640
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 376
       Name: context.emptyCtx
       GoRuntimeType: 1604192
       GoKind: 25
@@ -26749,7 +26968,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 364
+      ID: 368
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1834432
@@ -26760,11 +26979,11 @@ Types:
           Type: 157 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 382 GoSubroutineType func() bool
+          Type: 386 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 370
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1622944
@@ -26772,29 +26991,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 362 StructureType context.cancelCtx
+          Type: 366 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 383 PointerType *time.Timer
+          Type: 387 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 385 StructureType time.Time
+          Type: 328 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 388
+      ID: 389
       Name: context.todoCtx
       GoRuntimeType: 1809408
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 372 StructureType context.emptyCtx
+          Type: 376 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 372
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1846816
@@ -26812,7 +27031,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 374
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1808960
@@ -26824,87 +27043,87 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 755
+      ID: 766
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 841312
       GoKind: 2
     - __kind: BaseType
-      ID: 756
+      ID: 767
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 841408
       GoKind: 2
     - __kind: BaseType
-      ID: 757
+      ID: 768
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 841504
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1266
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 1040
+      ID: 1051
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1296384
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1286
+      ID: 1297
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1316
+      ID: 1327
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1290
+      ID: 1301
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1288
+      ID: 1299
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1282
+      ID: 1293
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 758
+      ID: 769
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 841600
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1303
+      ID: 1314
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1278
+      ID: 1289
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 745
+      ID: 756
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 839296
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1040
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1369
+      ID: 1380
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 866
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 853
+      ID: 864
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1740960
@@ -26915,38 +27134,38 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1155 ArrayType [5]uint8
+          Type: 1166 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 982
+      ID: 993
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 998784
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1248
+      ID: 1259
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 857
+      ID: 868
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1253
+      ID: 1264
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1137
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1151
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 929
+      ID: 940
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1743840
@@ -26954,21 +27173,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1139 PointerType *crypto/x509.Certificate
+          Type: 1150 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1158 BaseType crypto/x509.InvalidReason
+          Type: 1169 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 923
+      ID: 934
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1124096
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 925
+      ID: 936
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1608512
@@ -26976,24 +27195,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1139 PointerType *crypto/x509.Certificate
+          Type: 1150 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 754
+      ID: 765
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 840928
       GoKind: 2
     - __kind: BaseType
-      ID: 1158
+      ID: 1169
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 593504
       GoKind: 2
     - __kind: StructureType
-      ID: 1034
+      ID: 1045
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1570400
@@ -27003,13 +27222,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 931
+      ID: 942
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1124352
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 927
+      ID: 938
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1743648
@@ -27017,15 +27236,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1139 PointerType *crypto/x509.Certificate
+          Type: 1150 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1139 PointerType *crypto/x509.Certificate
+          Type: 1150 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 947
+      ID: 958
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1444096
@@ -27035,7 +27254,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 951
+      ID: 962
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1444256
@@ -27045,55 +27264,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 960
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 736
+      ID: 747
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 838240
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1206
+      ID: 1217
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 737
+      ID: 748
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 838432
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 824
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1029
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 816
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 822
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 820
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 818
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1349
+      ID: 1360
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 815
+      ID: 826
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1427936
@@ -27103,19 +27322,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1214
+      ID: 1225
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 917
+      ID: 928
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 926
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 751
+      ID: 762
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 840832
@@ -27123,22 +27342,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 753 PointerType *encoding/xml.UnmarshalError.str
+          Type: 764 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 752 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 763 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 752
+      ID: 763
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 931
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1327
+      ID: 1338
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27155,11 +27374,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 792
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 996
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27175,15 +27394,15 @@ Types:
       GoRuntimeType: 588256
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1337
+      ID: 1348
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 998
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 1000
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27193,7 +27412,7 @@ Types:
       GoRuntimeType: 478272
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 382
+      ID: 386
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 599200
@@ -27205,44 +27424,44 @@ Types:
       GoRuntimeType: 853408
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 359
+      ID: 363
       Name: func(go.shape.float64) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 334
+      ID: 338
       Name: func(go.shape.int) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 335
+      ID: 339
       Name: func(go.shape.int) go.shape.string
       ByteSize: 8
       GoKind: 19
     - __kind: StructureType
-      ID: 329
+      ID: 333
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
     - __kind: StructureType
-      ID: 331
+      ID: 335
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 854
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 824
+      ID: 835
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1739808
@@ -27250,7 +27469,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1148 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1159 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27258,25 +27477,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 837
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1163
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 830
+      ID: 841
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1119872
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1165
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 730
+      ID: 741
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 837664
@@ -27284,18 +27503,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 732 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 743 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 731 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 742 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 731
+      ID: 742
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1148
+      ID: 1159
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2230400
@@ -27303,7 +27522,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1149 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1160 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27318,7 +27537,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1150 GoSliceHeaderType []float64
+          Type: 1161 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -27327,10 +27546,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1151 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1162 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1153 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1164 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 161 GoSliceHeaderType []string
@@ -27344,13 +27563,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 1149
+      ID: 1160
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 589920
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 727
+      ID: 738
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 837568
@@ -27358,18 +27577,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 729 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 740 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 728 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 739 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 728
+      ID: 739
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 733
+      ID: 744
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 837760
@@ -27377,30 +27596,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 746 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 745 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 734
+      ID: 745
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1226
+      ID: 1237
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1313
+      ID: 1324
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 952
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 390
+      ID: 391
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2351072
@@ -27408,7 +27627,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 391 StructureType sync.RWMutex
+          Type: 392 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -27429,13 +27648,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 399 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 400 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 404 GoMapType map[string]float64
+          Type: 405 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -27450,10 +27669,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 409 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 412 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 413 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27465,7 +27684,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 415 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -27488,7 +27707,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 416
+      ID: 417
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2228160
@@ -27499,13 +27718,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 417 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 418 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 392 StructureType sync/atomic.Int32
+          Type: 393 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27514,16 +27733,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 419 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 420 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 391 StructureType sync.RWMutex
+          Type: 392 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -27532,12 +27751,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 409 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 411
+      ID: 412
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1922432
@@ -27554,7 +27773,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27562,20 +27781,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 399
+      ID: 400
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1289600
       GoKind: 21
-      HeaderType: 401 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 402 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1402
+      ID: 1403
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 587104
       GoKind: 10
     - __kind: StructureType
-      ID: 414
+      ID: 415
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1759744
@@ -27589,16 +27808,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 685 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 692 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 690 GoMapType map[string]interface {}
+          Type: 697 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1428
+      ID: 1429
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 713
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1922688
@@ -27606,7 +27825,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1426 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1427 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27621,15 +27840,15 @@ Types:
           Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1427 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1428 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1426
+      ID: 1427
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 993696
       GoKind: 5
     - __kind: StructureType
-      ID: 418
+      ID: 419
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2115424
@@ -27637,16 +27856,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 391 StructureType sync.RWMutex
+          Type: 392 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1400 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1401 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -27661,12 +27880,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1402 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1403 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 419
+      ID: 420
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 901952
@@ -27675,15 +27894,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1105
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1345
+      ID: 1356
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1431
+      ID: 1432
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1636960
@@ -27693,29 +27912,29 @@ Types:
           Offset: 0
           Type: 157 GoInterfaceType context.Context
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 877
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 873
+      ID: 884
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1123328
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 750
+      ID: 761
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 839968
       GoKind: 2
     - __kind: StructureType
-      ID: 871
+      ID: 882
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1123200
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 869
+      ID: 880
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1606592
@@ -27728,7 +27947,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 889
+      ID: 900
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1607392
@@ -27741,7 +27960,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 893
+      ID: 904
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1743072
@@ -27757,7 +27976,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 891
+      ID: 902
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1438016
@@ -27767,7 +27986,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 887
+      ID: 898
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1437696
@@ -27777,14 +27996,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1134
+      ID: 1145
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1509280
       GoKind: 21
-      HeaderType: 1136 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1147 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1157
+      ID: 1168
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1055936
@@ -27799,15 +28018,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1175 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1186 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1175
+      ID: 1186
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 901
+      ID: 912
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1607712
@@ -27815,12 +28034,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1134 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1145 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1134 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1145 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 895
+      ID: 906
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1438176
@@ -27830,7 +28049,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 899
+      ID: 910
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1743264
@@ -27841,12 +28060,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1157 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1157 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 897
+      ID: 908
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1607552
@@ -27859,7 +28078,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 903
+      ID: 914
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1438336
@@ -27867,9 +28086,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 385 StructureType time.Time
+          Type: 328 GoTimeType time.Time
     - __kind: StructureType
-      ID: 909
+      ID: 920
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1608032
@@ -27882,7 +28101,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 911
+      ID: 922
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1438656
@@ -27892,7 +28111,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 907
+      ID: 918
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1607872
@@ -27905,7 +28124,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 905
+      ID: 916
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1438496
@@ -27915,7 +28134,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 913
+      ID: 924
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1608192
@@ -27928,7 +28147,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 832
+      ID: 843
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1430176
@@ -27938,11 +28157,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1266
+      ID: 1277
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 845
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1430336
@@ -27950,21 +28169,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 832 StructureType github.com/cihub/seelog.baseError
+          Type: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1246
+      ID: 1257
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1202
+      ID: 1213
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1247
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 838
+      ID: 849
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1430656
@@ -27972,13 +28191,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 832 StructureType github.com/cihub/seelog.baseError
+          Type: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1301
+      ID: 1312
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1314
+      ID: 1325
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2117888
@@ -27986,12 +28205,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1300 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1311 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 1317
+      ID: 1328
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2142752
@@ -27999,7 +28218,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1300 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1311 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28007,11 +28226,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1204
+      ID: 1215
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 836
+      ID: 847
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1430496
@@ -28019,9 +28238,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 832 StructureType github.com/cihub/seelog.baseError
+          Type: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 840
+      ID: 851
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1430816
@@ -28029,64 +28248,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 832 StructureType github.com/cihub/seelog.baseError
+          Type: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1268
+      ID: 1279
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1309
+      ID: 1320
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1311
+      ID: 1322
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1139
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1055
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1053
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1057
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1059
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1257
+      ID: 1268
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1047
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 846
+      ID: 857
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1431776
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1361
+      ID: 1372
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1113
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1071
+      ID: 1082
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1852192
@@ -28102,11 +28321,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1076
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1004
+      ID: 1015
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1712512
@@ -28119,7 +28338,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 1077
+      ID: 1088
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1852640
@@ -28135,13 +28354,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 981
+      ID: 992
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 995616
       GoKind: 8
     - __kind: StructureType
-      ID: 1069
+      ID: 1080
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1851968
@@ -28157,13 +28376,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1159
+      ID: 1170
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 835936
       GoKind: 8
     - __kind: StructureType
-      ID: 1067
+      ID: 1078
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1851744
@@ -28171,15 +28390,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1159 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1170 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1159 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1170 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1075
+      ID: 1086
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1765504
@@ -28192,7 +28411,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1073
+      ID: 1084
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1852416
@@ -28208,11 +28427,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1365
+      ID: 1376
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1081
+      ID: 1092
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1632736
@@ -28222,19 +28441,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1008
+      ID: 1019
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1290112
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1006
+      ID: 1017
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1289984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1079
+      ID: 1090
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1765696
@@ -28247,7 +28466,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 763
+      ID: 774
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 843424
@@ -28255,36 +28474,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 765 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 776 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 764 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 775 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 764
+      ID: 775
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 345
+      ID: 349
       Name: go.shape.bool
       ByteSize: 1
       GoRuntimeType: 600160
       GoKind: 1
     - __kind: BaseType
-      ID: 358
+      ID: 362
       Name: go.shape.float64
       ByteSize: 8
       GoRuntimeType: 600224
       GoKind: 14
     - __kind: BaseType
-      ID: 328
+      ID: 332
       Name: go.shape.int
       ByteSize: 8
       GoRuntimeType: 600032
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 330
+      ID: 334
       Name: go.shape.string
       ByteSize: 16
       GoRuntimeType: 600096
@@ -28292,18 +28511,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 643 PointerType *go.shape.string.str
+          Type: 650 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 642 GoStringDataType go.shape.string.str
+      Data: 649 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 642
+      ID: 649
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 337
+      ID: 341
       Name: go.shape.struct { Name string }
       ByteSize: 16
       GoKind: 25
@@ -28312,7 +28531,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 339
+      ID: 343
       Name: go.shape.struct { X int; Y int }
       ByteSize: 16
       GoKind: 25
@@ -28324,13 +28543,13 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 348
+      ID: 352
       Name: go.shape.struct { main.i int }
       ByteSize: 8
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 349
+      ID: 353
       Name: go.shape.struct { main.s string }
       ByteSize: 16
       GoKind: 25
@@ -28339,7 +28558,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 352
+      ID: 356
       Name: go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
       ByteSize: 48
       GoKind: 25
@@ -28354,11 +28573,11 @@ Types:
           Offset: 32
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1154
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1052
+      ID: 1063
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1455936
@@ -28368,7 +28587,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1232
+      ID: 1243
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1688224
@@ -28376,13 +28595,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1258 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1269 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1325
+      ID: 1336
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1258
+      ID: 1269
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1134080
@@ -28395,7 +28614,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1220
+      ID: 1231
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1579200
@@ -28405,19 +28624,19 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 766
+      ID: 777
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 844000
       GoKind: 10
     - __kind: BaseType
-      ID: 1141
+      ID: 1152
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1009248
       GoKind: 10
     - __kind: StructureType
-      ID: 1110
+      ID: 1121
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1891392
@@ -28428,12 +28647,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1141 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1152 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 967
+      ID: 978
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1615232
@@ -28441,12 +28660,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1141 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1152 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 770
+      ID: 781
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 844192
@@ -28454,18 +28673,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 772 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 783 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 771 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 782 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 771
+      ID: 782
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 776
+      ID: 787
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 844384
@@ -28473,18 +28692,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 778 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 789 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 777 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 788 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 777
+      ID: 788
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 773
+      ID: 784
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 844288
@@ -28492,18 +28711,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 775 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 786 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 774 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 785 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 774
+      ID: 785
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 767
+      ID: 778
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 844096
@@ -28511,22 +28730,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 769 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 780 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 768 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 779 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 768
+      ID: 779
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1323
+      ID: 1334
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 971
+      ID: 982
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1456576
@@ -28536,13 +28755,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 779
+      ID: 790
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 844480
       GoKind: 2
     - __kind: StructureType
-      ID: 959
+      ID: 970
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1451616
@@ -28552,11 +28771,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1119
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1130
+      ID: 1141
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1919168
@@ -28572,7 +28791,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 961
+      ID: 972
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1614752
@@ -28585,7 +28804,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1272
+      ID: 1283
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1977216
@@ -28593,16 +28812,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1299 GoInterfaceType io.Reader
+          Type: 1310 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1230
+      ID: 1241
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1050
+      ID: 1061
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1576800
@@ -28612,29 +28831,29 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1192
+      ID: 1203
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 950
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1049
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1117
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1104
+      ID: 1115
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1520000
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 953
+      ID: 964
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1444896
@@ -28644,7 +28863,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 955
+      ID: 966
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1445056
@@ -28654,463 +28873,463 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 892
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 539
+      ID: 540
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 540 PointerType *noalg.map.group[[4]int][4]int
+          Type: 541 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 541 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 545 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 542 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 546 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 531
+      ID: 532
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 532 PointerType *noalg.map.group[[4]int]uint8
+          Type: 533 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 533 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 537 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 534 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 538 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 479
+      ID: 480
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 480 PointerType *noalg.map.group[[4]string][2]int
+          Type: 481 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 481 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 486 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 482 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 487 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 498
+      ID: 499
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 499 PointerType *noalg.map.group[bool]main.node
+          Type: 500 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 500 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 504 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 501 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 505 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 651
+      ID: 658
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 652 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 659 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 653 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 658 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 660 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 665 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 435
+      ID: 436
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 436 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 437 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 437 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 443 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 438 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 444 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1417
+      ID: 1418
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1418 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1419 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1419 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1425 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1420 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1426 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1461
+      ID: 1462
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1462 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1463 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1463 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1469 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1464 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1470 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1476
+      ID: 1477
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1477 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1478 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1478 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1484 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1479 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1485 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 447
+      ID: 448
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 448 PointerType *noalg.map.group[int]int
+          Type: 449 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 449 StructureType noalg.map.group[int]int
-      GroupSliceType: 453 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 450 StructureType noalg.map.group[int]int
+      GroupSliceType: 454 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1491
+      ID: 1492
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1492 PointerType *noalg.map.group[int]interface {}
+          Type: 1493 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1493 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1497 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1494 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1498 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 555
+      ID: 556
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 556 PointerType *noalg.map.group[int]struct {}
+          Type: 557 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 557 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 561 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 558 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 562 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 506
+      ID: 507
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 507 PointerType *noalg.map.group[int]uint8
+          Type: 508 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 508 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 512 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 509 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 513 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 696
+      ID: 707
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 697 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 708 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 698 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 704 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 715 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 488
+      ID: 489
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 489 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 490 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 490 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 496 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 491 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 497 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 471
+      ID: 472
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 472 PointerType *noalg.map.group[string][]string
+          Type: 473 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 473 StructureType noalg.map.group[string][]string
-      GroupSliceType: 477 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 474 StructureType noalg.map.group[string][]string
+      GroupSliceType: 478 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 676
+      ID: 683
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 677 PointerType *noalg.map.group[string]float64
+          Type: 684 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 678 StructureType noalg.map.group[string]float64
-      GroupSliceType: 682 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 685 StructureType noalg.map.group[string]float64
+      GroupSliceType: 689 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1166
+      ID: 1177
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1167 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1178 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1168 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1172 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1183 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 463
+      ID: 464
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 464 PointerType *noalg.map.group[string]int
+          Type: 465 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 465 StructureType noalg.map.group[string]int
-      GroupSliceType: 469 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 466 StructureType noalg.map.group[string]int
+      GroupSliceType: 470 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 668
+      ID: 675
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 669 PointerType *noalg.map.group[string]interface {}
+          Type: 676 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 670 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 674 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 677 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 681 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 455
+      ID: 456
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 456 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 457 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 457 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 461 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 458 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 462 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 660
+      ID: 667
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 661 PointerType *noalg.map.group[string]string
+          Type: 668 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 662 StructureType noalg.map.group[string]string
-      GroupSliceType: 666 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 669 StructureType noalg.map.group[string]string
+      GroupSliceType: 673 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 547
+      ID: 548
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 548 PointerType *noalg.map.group[struct {}]int
+          Type: 549 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 549 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 553 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 550 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 554 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 595
+      ID: 596
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 596 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 597 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 597 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 601 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 602 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 603
+      ID: 604
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 604 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 605 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 605 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 609 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 610 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 611
+      ID: 612
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 612 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 613 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 613 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 617 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 618 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 619
+      ID: 620
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 620 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 621 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 625 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 626 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 627
+      ID: 628
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 628 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 629 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 633 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 634 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 635
+      ID: 636
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 636 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 637 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 641 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 642 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 563
+      ID: 564
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 564 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 565 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 565 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 569 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 566 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 570 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 522
+      ID: 523
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 523 PointerType *noalg.map.group[uint8][4]int
+          Type: 524 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 524 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 529 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 525 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 530 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 514
+      ID: 515
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 515 PointerType *noalg.map.group[uint8]uint8
+          Type: 516 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 516 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 520 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 517 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 521 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1280
+      ID: 1291
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 985
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29157,11 +29376,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1143
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 944
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29187,29 +29406,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 860
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1182
+      ID: 1193
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1111
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1367
+      ID: 1378
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1098
+      ID: 1109
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1498880
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 788
+      ID: 799
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29290,7 +29509,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 738
+      ID: 749
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 838624
@@ -29298,18 +29517,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 740 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 751 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 739 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 750 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 739
+      ID: 750
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1022
+      ID: 1033
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1568160
@@ -29317,9 +29536,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 1131 PointerType *internal/abi.Type
+          Type: 1142 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 375
+      ID: 379
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1496320
@@ -29332,11 +29551,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1224
+      ID: 1235
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1264
+      ID: 1275
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1196864
@@ -29349,7 +29568,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1299
+      ID: 1310
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1029312
@@ -29362,7 +29581,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1251
+      ID: 1262
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1116672
@@ -29388,47 +29607,47 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1222
+      ID: 1233
       Name: io.discard
       GoRuntimeType: 1472320
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1196
+      ID: 1207
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1107
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1270
+      ID: 1281
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 344
+      ID: 348
       Name: main.Pair[go.shape.int,go.shape.bool]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
         - Name: Value
           Offset: 8
-          Type: 345 BaseType go.shape.bool
+          Type: 349 BaseType go.shape.bool
     - __kind: StructureType
-      ID: 347
+      ID: 351
       Name: main.Pair[go.shape.string,go.shape.int]
       ByteSize: 24
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
         - Name: Value
           Offset: 16
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
     - __kind: StructureType
       ID: 322
       Name: main.aStruct
@@ -29455,7 +29674,7 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1498 PointerType *main.nestedStruct
+          Type: 1499 PointerType *main.nestedStruct
     - __kind: GoInterfaceType
       ID: 169
       Name: main.behavior
@@ -29496,7 +29715,7 @@ Types:
           Offset: 0
           Type: 146 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 441
+      ID: 442
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1193024
@@ -29504,9 +29723,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1411 GoMapType map[int]*main.deepMap3
+          Type: 1412 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1423
+      ID: 1424
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -29518,9 +29737,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1455 GoMapType map[int]*main.deepMap8
+          Type: 1456 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1467
+      ID: 1468
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1192256
@@ -29528,9 +29747,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1470 GoMapType map[int]*main.deepMap9
+          Type: 1471 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1482
+      ID: 1483
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1192128
@@ -29538,7 +29757,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1485 GoMapType map[int]interface {}
+          Type: 1486 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 134
       Name: main.deepPtr1
@@ -29558,9 +29777,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1370 PointerType *main.deepPtr3
+          Type: 1381 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1371
+      ID: 1382
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -29572,9 +29791,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1436 PointerType *main.deepPtr8
+          Type: 1437 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1437
+      ID: 1438
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1193408
@@ -29582,9 +29801,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1438 PointerType *main.deepPtr9
+          Type: 1439 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1439
+      ID: 1440
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1193280
@@ -29604,7 +29823,7 @@ Types:
           Offset: 0
           Type: 140 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 431
+      ID: 432
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1195328
@@ -29612,9 +29831,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1405 GoSliceHeaderType []*main.deepSlice3
+          Type: 1406 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1408
+      ID: 1409
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -29626,9 +29845,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1440 GoSliceHeaderType []*main.deepSlice8
+          Type: 1441 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1443
+      ID: 1444
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1194560
@@ -29636,9 +29855,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1446 GoSliceHeaderType []*main.deepSlice9
+          Type: 1447 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1449
+      ID: 1450
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1194432
@@ -29646,7 +29865,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1452 GoSliceHeaderType []interface {}
+          Type: 1453 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 326
       Name: main.emptyStruct
@@ -29664,16 +29883,16 @@ Types:
           Type: 162 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 373 StructureType sync.Mutex
+          Type: 377 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1378 StructureType sync.Once
+          Type: 1389 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1380 StructureType sync.WaitGroup
+          Type: 1391 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 392 StructureType sync/atomic.Int32
+          Type: 393 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 162
       Name: main.esotericStack
@@ -29703,7 +29922,7 @@ Types:
           Offset: 56
           Type: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 360
+      ID: 364
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1420576
@@ -29713,71 +29932,71 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 342
+      ID: 346
       Name: main.largeGenericType[go.shape.int]
       ByteSize: 136
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
     - __kind: StructureType
-      ID: 340
+      ID: 344
       Name: main.largeGenericType[go.shape.string]
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 257
       Name: main.largeStruct
@@ -30091,9 +30310,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1375 ArrayType [63]uint64
+          Type: 1386 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1385
+      ID: 1396
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1420736
@@ -30113,7 +30332,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1377
+      ID: 1388
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30124,31 +30343,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1373 PointerType *main.stringType1.str
+          Type: 1384 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1372 GoStringDataType main.stringType1.str
+      Data: 1383 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1372
+      ID: 1383
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1374
+      ID: 1385
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1500 PointerType *main.stringType2.str
+          Type: 1501 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1499 GoStringDataType main.stringType2.str
+      Data: 1500 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1499
+      ID: 1500
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -30264,16 +30483,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1386 PointerType **main.t
+          Type: 1397 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1387 GoSliceDataType main.t.array
+      Data: 1398 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1387
+      ID: 1398
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -30329,29 +30548,38 @@ Types:
         - Name: c
           Offset: 32
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 331
+      Name: main.timeCapture
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: monotonicNow
+          Offset: 0
+          Type: 328 GoTimeType time.Time
     - __kind: BaseType
       ID: 129
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 354
+      ID: 358
       Name: main.typeWithGenerics[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
     - __kind: StructureType
-      ID: 355
+      ID: 359
       Name: main.typeWithGenerics[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 262
       Name: main.wideStruct
@@ -30424,8 +30652,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 544 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 541 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 545 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 542 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 227
       Name: map<[4]int,uint8>
@@ -30459,8 +30687,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 536 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 533 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 537 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 534 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 195
       Name: map<[4]string,[2]int>
@@ -30494,8 +30722,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 485 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 481 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 486 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 482 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 207
       Name: map<bool,main.node>
@@ -30529,10 +30757,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 503 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 500 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 504 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 501 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 379
+      ID: 383
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -30545,7 +30773,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 380 PointerType **table<context.canceler,struct {}>
+          Type: 384 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30564,8 +30792,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 657 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 653 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 664 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 660 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 148
       Name: map<int,*main.deepMap2>
@@ -30599,10 +30827,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 442 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 437 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 443 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 438 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1413
+      ID: 1414
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -30615,7 +30843,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1414 PointerType **table<int,*main.deepMap3>
+          Type: 1415 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30634,10 +30862,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1424 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1419 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1425 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1420 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1457
+      ID: 1458
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -30650,7 +30878,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1458 PointerType **table<int,*main.deepMap8>
+          Type: 1459 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30669,10 +30897,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1468 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1463 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1469 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1464 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1472
+      ID: 1473
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -30685,7 +30913,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1473 PointerType **table<int,*main.deepMap9>
+          Type: 1474 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30704,8 +30932,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1483 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1478 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1484 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 175
       Name: map<int,int>
@@ -30739,10 +30967,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 452 GoSliceDataType []*table<int,int>.array
-      GroupType: 449 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 453 GoSliceDataType []*table<int,int>.array
+      GroupType: 450 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1487
+      ID: 1488
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -30755,7 +30983,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1488 PointerType **table<int,interface {}>
+          Type: 1489 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30774,8 +31002,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1496 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1493 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1497 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 242
       Name: map<int,struct {}>
@@ -30809,8 +31037,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 560 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 557 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 561 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 558 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 212
       Name: map<int,uint8>
@@ -30844,10 +31072,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 511 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 508 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 512 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 509 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 687
+      ID: 694
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -30860,7 +31088,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 688 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 695 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30879,8 +31107,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 703 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 698 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 714 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 202
       Name: map<string,[]main.structWithMap>
@@ -30914,8 +31142,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 495 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 490 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 496 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 491 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 190
       Name: map<string,[]string>
@@ -30949,10 +31177,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 476 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 473 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 477 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 474 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 406
+      ID: 407
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -30965,7 +31193,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 407 PointerType **table<string,float64>
+          Type: 408 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30984,10 +31212,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 681 GoSliceDataType []*table<string,float64>.array
-      GroupType: 678 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 688 GoSliceDataType []*table<string,float64>.array
+      GroupType: 685 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1136
+      ID: 1147
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31000,7 +31228,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1137 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1148 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31019,8 +31247,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1171 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1168 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1182 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 185
       Name: map<string,int>
@@ -31054,10 +31282,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 468 GoSliceDataType []*table<string,int>.array
-      GroupType: 465 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 469 GoSliceDataType []*table<string,int>.array
+      GroupType: 466 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 401
+      ID: 402
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31070,7 +31298,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 402 PointerType **table<string,interface {}>
+          Type: 403 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31089,8 +31317,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 673 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 670 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 680 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 677 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 180
       Name: map<string,main.nestedStruct>
@@ -31124,10 +31352,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 460 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 457 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 461 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 458 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 396
+      ID: 397
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31140,7 +31368,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 397 PointerType **table<string,string>
+          Type: 398 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31159,8 +31387,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 665 GoSliceDataType []*table<string,string>.array
-      GroupType: 662 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 672 GoSliceDataType []*table<string,string>.array
+      GroupType: 669 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 237
       Name: map<struct {},int>
@@ -31194,8 +31422,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 552 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 549 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 553 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 550 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 294
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31229,8 +31457,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 600 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 597 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 601 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 299
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31264,8 +31492,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 608 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 605 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 609 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 304
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31299,8 +31527,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 616 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 613 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 617 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 309
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31334,8 +31562,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 624 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 625 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 314
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31369,8 +31597,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 632 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 633 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 319
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31404,8 +31632,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 640 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 641 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 247
       Name: map<struct {},struct {}>
@@ -31439,8 +31667,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 568 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 565 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 569 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 566 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 222
       Name: map<uint8,[4]int>
@@ -31474,8 +31702,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 528 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 524 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 529 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 525 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 217
       Name: map<uint8,uint8>
@@ -31509,8 +31737,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 519 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 516 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 520 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 517 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 230
       Name: map[[4]int][4]int
@@ -31540,12 +31768,12 @@ Types:
       GoKind: 21
       HeaderType: 207 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 377
+      ID: 381
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1138304
       GoKind: 21
-      HeaderType: 379 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 383 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 146
       Name: map[int]*main.deepMap2
@@ -31554,26 +31782,26 @@ Types:
       GoKind: 21
       HeaderType: 148 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1411
+      ID: 1412
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1135872
       GoKind: 21
-      HeaderType: 1413 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1414 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1455
+      ID: 1456
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1135232
       GoKind: 21
-      HeaderType: 1457 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1458 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1470
+      ID: 1471
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1135104
       GoKind: 21
-      HeaderType: 1472 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1473 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 173
       Name: map[int]int
@@ -31582,12 +31810,12 @@ Types:
       GoKind: 21
       HeaderType: 175 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1485
+      ID: 1486
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1134976
       GoKind: 21
-      HeaderType: 1487 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1488 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 240
       Name: map[int]struct {}
@@ -31603,12 +31831,12 @@ Types:
       GoKind: 21
       HeaderType: 212 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 685
+      ID: 692
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1138560
       GoKind: 21
-      HeaderType: 687 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 694 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 200
       Name: map[string][]main.structWithMap
@@ -31624,12 +31852,12 @@ Types:
       GoKind: 21
       HeaderType: 190 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 404
+      ID: 405
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1138432
       GoKind: 21
-      HeaderType: 406 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 407 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 183
       Name: map[string]int
@@ -31638,12 +31866,12 @@ Types:
       GoKind: 21
       HeaderType: 185 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 690
+      ID: 697
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1134848
       GoKind: 21
-      HeaderType: 401 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 402 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 178
       Name: map[string]main.nestedStruct
@@ -31652,12 +31880,12 @@ Types:
       GoKind: 21
       HeaderType: 180 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 394
+      ID: 395
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1138176
       GoKind: 21
-      HeaderType: 396 GoSwissMapHeaderType map<string,string>
+      HeaderType: 397 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 235
       Name: map[struct {}]int
@@ -31723,7 +31951,7 @@ Types:
       GoKind: 21
       HeaderType: 217 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 885
+      ID: 896
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1437216
@@ -31733,7 +31961,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1186
+      ID: 1197
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1434016
@@ -31743,11 +31971,11 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1099
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1156
+      ID: 1167
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1605312
@@ -31760,35 +31988,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1130
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1331
+      ID: 1342
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1128
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1101
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1341
+      ID: 1352
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1351
+      ID: 1362
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1339
+      ID: 1350
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1055
+      ID: 1066
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1119488
@@ -31796,28 +32024,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1057 PointerType *net.UnknownNetworkError.str
+          Type: 1068 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1056 GoStringDataType net.UnknownNetworkError.str
+      Data: 1067 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1056
+      ID: 1067
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1020
+      ID: 1031
       Name: net.canceledError
       GoRuntimeType: 1291008
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1307
+      ID: 1318
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1161
+      ID: 1172
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2117184
@@ -31825,7 +32053,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -31836,27 +32064,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1353
+      ID: 1364
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1347
+      ID: 1358
       Name: net.noReadFrom
       GoRuntimeType: 1119744
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1346
+      ID: 1357
       Name: net.noWriteTo
       GoRuntimeType: 1119616
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 828
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1433
+      ID: 1434
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1770496
@@ -31869,7 +32097,7 @@ Types:
           Offset: 16
           Type: 157 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 819
+      ID: 830
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1739616
@@ -31877,7 +32105,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1144 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1155 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -31885,7 +32113,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1335
+      ID: 1346
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2300192
@@ -31893,12 +32121,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1347 StructureType net.noReadFrom
+          Type: 1358 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1340 PointerType *net.TCPConn
+          Type: 1351 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1333
+      ID: 1344
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2299648
@@ -31906,24 +32134,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1346 StructureType net.noWriteTo
+          Type: 1357 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1340 PointerType *net.TCPConn
+          Type: 1351 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1103
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1132
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1021
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1178
+      ID: 1189
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1425696
@@ -31933,19 +32161,19 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 708
+      ID: 719
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 836416
       GoKind: 10
     - __kind: BaseType
-      ID: 1133
+      ID: 1144
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 995712
       GoKind: 10
     - __kind: StructureType
-      ID: 795
+      ID: 806
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1738272
@@ -31956,12 +32184,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1133 BaseType net/http.http2ErrCode
+          Type: 1144 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1113
+      ID: 1124
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1909696
@@ -31972,12 +32200,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1133 BaseType net/http.http2ErrCode
+          Type: 1144 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 799
+      ID: 810
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1604992
@@ -31985,16 +32213,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1133 BaseType net/http.http2ErrCode
+          Type: 1144 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1242
+      ID: 1253
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 712
+      ID: 723
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836608
@@ -32002,18 +32230,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 714 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 725 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 713 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 724 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 713
+      ID: 724
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 718
+      ID: 729
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836800
@@ -32021,18 +32249,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 720 PointerType *net/http.http2headerFieldNameError.str
+          Type: 731 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 719 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 730 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 719
+      ID: 730
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 715
+      ID: 726
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836704
@@ -32040,32 +32268,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 717 PointerType *net/http.http2headerFieldValueError.str
+          Type: 728 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 716 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 727 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 716
+      ID: 727
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1096
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1016
+      ID: 1027
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1290368
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1296
+      ID: 1307
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 709
+      ID: 720
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836512
@@ -32073,18 +32301,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 711 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 722 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 710 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 721 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 710
+      ID: 721
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1180
+      ID: 1191
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1835552
@@ -32092,18 +32320,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1273 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1284 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1274 BaseType time.Duration
+          Type: 1285 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 108 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1273
+      ID: 1284
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1424896
@@ -32116,14 +32344,14 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1261
+      ID: 1272
       Name: net/http.incomparable
       GoRuntimeType: 907136
       GoKind: 17
       HasCount: true
       Element: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1012
+      ID: 1023
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1564320
@@ -32133,11 +32361,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1244
+      ID: 1255
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1200
+      ID: 1211
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1564160
@@ -32145,9 +32373,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1243 PointerType *net/http.persistConn
+          Type: 1254 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1234
+      ID: 1245
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1810976
@@ -32155,15 +32383,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1261 ArrayType net/http.incomparable
+          Type: 1272 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1262 PointerType *bufio.Reader
+          Type: 1273 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1264 GoInterfaceType io.ReadWriteCloser
+          Type: 1275 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 803
+      ID: 814
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1426656
@@ -32173,17 +32401,17 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1126
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1083
+      ID: 1094
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1485440
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1014
+      ID: 1025
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1564480
@@ -32193,7 +32421,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1276
+      ID: 1287
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2036192
@@ -32201,16 +32429,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 803
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1298
+      ID: 1309
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2051936
@@ -32218,13 +32446,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1293 PointerType *bufio.Writer
+          Type: 1304 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1221
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 888
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1742688
@@ -32240,7 +32468,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 875
+      ID: 886
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1606752
@@ -32253,11 +32481,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1250
+      ID: 1261
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1212
+      ID: 1223
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1608672
@@ -32265,16 +32493,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1249 PointerType *net/smtp.Client
+          Type: 1260 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1251 GoInterfaceType io.WriteCloser
+          Type: 1262 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 872
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 746
+      ID: 757
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 839392
@@ -32282,26 +32510,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 748 PointerType *net/textproto.ProtocolError.str
+          Type: 759 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 747 GoStringDataType net/textproto.ProtocolError.str
+      Data: 758 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 747
+      ID: 758
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1208
+      ID: 1219
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1123
+      ID: 1134
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 721
+      ID: 732
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 837280
@@ -32309,18 +32537,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 723 PointerType *net/url.EscapeError.str
+          Type: 734 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 722 GoStringDataType net/url.EscapeError.str
+      Data: 733 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 722
+      ID: 733
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 724
+      ID: 735
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 837376
@@ -32328,299 +32556,299 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 726 PointerType *net/url.InvalidHostError.str
+          Type: 737 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 725 GoStringDataType net/url.InvalidHostError.str
+      Data: 736 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 725
+      ID: 736
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 542
+      ID: 543
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 686912
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 543 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 544 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 534
+      ID: 535
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 687008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 535 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 536 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 482
+      ID: 483
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 687296
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 483 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 484 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 501
+      ID: 502
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 687392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 502 StructureType noalg.struct { key bool; elem main.node }
+      Element: 503 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 654
+      ID: 661
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 692864
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 655 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 662 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 438
+      ID: 439
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 686144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 439 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 440 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1420
+      ID: 1421
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 686048
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1421 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1422 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1464
+      ID: 1465
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 685568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1465 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1466 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1479
+      ID: 1480
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 685472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1480 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1481 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 450
+      ID: 451
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 684224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 451 StructureType noalg.struct { key int; elem int }
+      Element: 452 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1494
+      ID: 1495
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 685376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1495 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1496 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 558
+      ID: 559
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 687488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 559 StructureType noalg.struct { key int; elem struct {} }
+      Element: 560 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 509
+      ID: 510
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 687584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 510 StructureType noalg.struct { key int; elem uint8 }
+      Element: 511 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 699
+      ID: 710
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 693504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 700 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 711 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 491
+      ID: 492
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 687680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 492 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 493 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 474
+      ID: 475
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 687776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 475 StructureType noalg.struct { key string; elem []string }
+      Element: 476 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 679
+      ID: 686
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 680 StructureType noalg.struct { key string; elem float64 }
+      Element: 687 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1169
+      ID: 1180
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 763232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1170 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1181 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 466
+      ID: 467
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 687872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 467 StructureType noalg.struct { key string; elem int }
+      Element: 468 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 671
+      ID: 678
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 684992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 672 StructureType noalg.struct { key string; elem interface {} }
+      Element: 679 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 458
+      ID: 459
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 687968
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 459 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 460 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 663
+      ID: 670
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 691136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 664 StructureType noalg.struct { key string; elem string }
+      Element: 671 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 550
+      ID: 551
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 688064
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 551 StructureType noalg.struct { key struct {}; elem int }
+      Element: 552 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 598
+      ID: 599
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 599 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 600 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 606
+      ID: 607
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 607 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 608 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 614
+      ID: 615
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 615 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 616 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 622
+      ID: 623
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 623 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 624 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 630
+      ID: 631
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 631 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 632 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 638
+      ID: 639
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 639 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 640 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 566
+      ID: 567
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 567 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 568 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 525
+      ID: 526
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 688256
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 526 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 527 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 517
+      ID: 518
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 688352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 518 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 519 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 541
+      ID: 542
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1302656
@@ -32631,9 +32859,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 542 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 543 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 533
+      ID: 534
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1302912
@@ -32644,9 +32872,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 534 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 535 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 481
+      ID: 482
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1303168
@@ -32657,9 +32885,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 482 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 483 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 500
+      ID: 501
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1303424
@@ -32670,9 +32898,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 501 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 502 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 653
+      ID: 660
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1307520
@@ -32683,9 +32911,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 654 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 661 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 437
+      ID: 438
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1302400
@@ -32696,9 +32924,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 438 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 439 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1419
+      ID: 1420
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1302144
@@ -32709,9 +32937,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1420 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1421 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1463
+      ID: 1464
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1300864
@@ -32722,9 +32950,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1464 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1465 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1478
+      ID: 1479
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1300608
@@ -32735,9 +32963,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1479 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1480 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 449
+      ID: 450
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1299328
@@ -32748,9 +32976,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 450 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 451 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1493
+      ID: 1494
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1300352
@@ -32761,9 +32989,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1494 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1495 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 557
+      ID: 558
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1303680
@@ -32774,9 +33002,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 558 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 559 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 508
+      ID: 509
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1303936
@@ -32787,9 +33015,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 509 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 510 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 698
+      ID: 709
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1308416
@@ -32800,9 +33028,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 699 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 710 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 490
+      ID: 491
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1304192
@@ -32813,9 +33041,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 491 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 492 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 473
+      ID: 474
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1304448
@@ -32826,9 +33054,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 474 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 475 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 678
+      ID: 685
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1308160
@@ -32839,9 +33067,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 679 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 686 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1168
+      ID: 1179
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1366144
@@ -32852,9 +33080,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1169 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1180 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 465
+      ID: 466
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1304704
@@ -32865,9 +33093,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 466 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 467 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 670
+      ID: 677
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1300096
@@ -32878,9 +33106,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 671 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 678 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 457
+      ID: 458
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1304960
@@ -32891,9 +33119,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 458 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 459 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 662
+      ID: 669
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1306752
@@ -32904,9 +33132,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 663 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 670 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 549
+      ID: 550
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1305216
@@ -32917,9 +33145,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 550 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 551 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 597
+      ID: 598
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -32929,9 +33157,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 598 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 599 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 605
+      ID: 606
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32941,9 +33169,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 606 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 607 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 613
+      ID: 614
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32953,9 +33181,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 614 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 615 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 621
+      ID: 622
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32965,9 +33193,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 622 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 623 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 629
+      ID: 630
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32977,9 +33205,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 630 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 631 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 637
+      ID: 638
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32989,9 +33217,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 638 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 639 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 565
+      ID: 566
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1305472
@@ -33002,9 +33230,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 566 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 567 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 524
+      ID: 525
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1305728
@@ -33015,9 +33243,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 525 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 526 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 516
+      ID: 517
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1305984
@@ -33028,9 +33256,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 517 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 518 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 543
+      ID: 544
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1302528
@@ -33038,12 +33266,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 527 ArrayType [4]int
+          Type: 528 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 527 ArrayType [4]int
+          Type: 528 ArrayType [4]int
     - __kind: StructureType
-      ID: 535
+      ID: 536
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1302784
@@ -33051,12 +33279,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 527 ArrayType [4]int
+          Type: 528 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 483
+      ID: 484
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1303040
@@ -33064,12 +33292,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 484 ArrayType [4]string
+          Type: 485 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 115 ArrayType [2]int
     - __kind: StructureType
-      ID: 502
+      ID: 503
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1303296
@@ -33082,7 +33310,7 @@ Types:
           Offset: 8
           Type: 253 StructureType main.node
     - __kind: StructureType
-      ID: 655
+      ID: 662
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1307392
@@ -33090,12 +33318,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 656 GoInterfaceType context.canceler
+          Type: 663 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 439
+      ID: 440
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1302272
@@ -33106,9 +33334,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 440 PointerType *main.deepMap2
+          Type: 441 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1421
+      ID: 1422
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1302016
@@ -33119,9 +33347,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1422 PointerType *main.deepMap3
+          Type: 1423 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1465
+      ID: 1466
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1300736
@@ -33132,9 +33360,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1466 PointerType *main.deepMap8
+          Type: 1467 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1480
+      ID: 1481
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1300480
@@ -33145,9 +33373,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1481 PointerType *main.deepMap9
+          Type: 1482 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 451
+      ID: 452
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1299200
@@ -33160,7 +33388,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 1495
+      ID: 1496
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1300224
@@ -33173,7 +33401,7 @@ Types:
           Offset: 8
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 559
+      ID: 560
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1303552
@@ -33186,7 +33414,7 @@ Types:
           Offset: 8
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 510
+      ID: 511
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1303808
@@ -33199,7 +33427,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 700
+      ID: 711
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1308288
@@ -33210,9 +33438,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 701 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 712 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 492
+      ID: 493
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1304064
@@ -33223,9 +33451,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 493 GoSliceHeaderType []main.structWithMap
+          Type: 494 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 475
+      ID: 476
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1304320
@@ -33238,7 +33466,7 @@ Types:
           Offset: 16
           Type: 161 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 680
+      ID: 687
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1308032
@@ -33251,7 +33479,7 @@ Types:
           Offset: 16
           Type: 17 BaseType float64
     - __kind: StructureType
-      ID: 1170
+      ID: 1181
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1366016
@@ -33262,9 +33490,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1157 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 467
+      ID: 468
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1304576
@@ -33277,7 +33505,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 672
+      ID: 679
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1299968
@@ -33290,7 +33518,7 @@ Types:
           Offset: 16
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 459
+      ID: 460
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1304832
@@ -33303,7 +33531,7 @@ Types:
           Offset: 16
           Type: 125 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 664
+      ID: 671
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1306624
@@ -33316,7 +33544,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 551
+      ID: 552
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1305088
@@ -33329,7 +33557,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 599
+      ID: 600
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33341,7 +33569,7 @@ Types:
           Offset: 0
           Type: 291 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 607
+      ID: 608
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33353,7 +33581,7 @@ Types:
           Offset: 0
           Type: 292 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 615
+      ID: 616
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33365,7 +33593,7 @@ Types:
           Offset: 0
           Type: 297 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 623
+      ID: 624
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33377,7 +33605,7 @@ Types:
           Offset: 0
           Type: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 631
+      ID: 632
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33389,7 +33617,7 @@ Types:
           Offset: 0
           Type: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 639
+      ID: 640
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33401,7 +33629,7 @@ Types:
           Offset: 0
           Type: 312 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 567
+      ID: 568
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1305344
       GoKind: 25
@@ -33413,7 +33641,7 @@ Types:
           Offset: 0
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 526
+      ID: 527
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1305600
@@ -33424,9 +33652,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 527 ArrayType [4]int
+          Type: 528 ArrayType [4]int
     - __kind: StructureType
-      ID: 518
+      ID: 519
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1305856
@@ -33439,19 +33667,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1359
+      ID: 1370
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 993
+      ID: 1004
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1072
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1357
+      ID: 1368
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2370560
@@ -33459,12 +33687,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1363 StructureType os.noReadFrom
+          Type: 1374 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1358 PointerType *os.File
+          Type: 1369 PointerType *os.File
     - __kind: StructureType
-      ID: 1355
+      ID: 1366
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2369760
@@ -33472,36 +33700,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1362 StructureType os.noWriteTo
+          Type: 1373 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1358 PointerType *os.File
+          Type: 1369 PointerType *os.File
     - __kind: StructureType
-      ID: 1363
+      ID: 1374
       Name: os.noReadFrom
       GoRuntimeType: 1117952
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1362
+      ID: 1373
       Name: os.noWriteTo
       GoRuntimeType: 1117824
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1035
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1164
+      ID: 1175
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1228
+      ID: 1239
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1026
+      ID: 1037
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1713088
@@ -33514,7 +33742,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 760
+      ID: 771
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 842656
@@ -33522,36 +33750,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 762 PointerType *os/user.UnknownGroupIdError.str
+          Type: 773 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 761 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 772 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 761
+      ID: 772
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 759
+      ID: 770
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 842560
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 801
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 894
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 1008
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1001
+      ID: 1012
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33563,7 +33791,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 999
+      ID: 1010
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1898560
@@ -33580,9 +33808,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1162 BaseType runtime.boundsErrorCode
+          Type: 1173 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1162
+      ID: 1173
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 588448
@@ -33602,7 +33830,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1063
+      ID: 1074
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1763584
@@ -33615,7 +33843,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 975
+      ID: 986
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 994752
@@ -33623,13 +33851,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 977 PointerType *runtime.errorString.str
+          Type: 988 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 976 GoStringDataType runtime.errorString.str
+      Data: 987 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 976
+      ID: 987
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34256,7 +34484,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 426
+      ID: 427
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -34292,7 +34520,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 978
+      ID: 989
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 994848
@@ -34300,13 +34528,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 980 PointerType *runtime.plainError.str
+          Type: 991 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 979 GoStringDataType runtime.plainError.str
+      Data: 990 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 979
+      ID: 990
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34347,7 +34575,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 786
+      ID: 797
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1604672
@@ -34405,7 +34633,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 1002
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -34417,26 +34645,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 421 PointerType *string.str
+          Type: 422 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 420 GoStringDataType string.str
+      Data: 421 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 420
+      ID: 421
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1292
+      ID: 1303
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1198
+      ID: 1209
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1194
+      ID: 1205
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1463936
@@ -34452,7 +34680,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 373
+      ID: 377
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1475360
@@ -34460,12 +34688,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 374 StructureType sync.noCopy
+          Type: 378 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 375 StructureType internal/sync.Mutex
+          Type: 379 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1378
+      ID: 1389
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1625440
@@ -34473,15 +34701,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 374 StructureType sync.noCopy
+          Type: 378 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1379 StructureType sync/atomic.Bool
+          Type: 1390 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 373 StructureType sync.Mutex
+          Type: 377 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 391
+      ID: 392
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1849504
@@ -34489,7 +34717,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 373 StructureType sync.Mutex
+          Type: 377 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -34498,12 +34726,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 392 StructureType sync/atomic.Int32
+          Type: 393 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 392 StructureType sync/atomic.Int32
+          Type: 393 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1380
+      ID: 1391
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1625248
@@ -34511,21 +34739,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 374 StructureType sync.noCopy
+          Type: 378 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1381 StructureType sync/atomic.Uint64
+          Type: 1392 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 374
+      ID: 378
       Name: sync.noCopy
       GoRuntimeType: 994368
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1379
+      ID: 1390
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1476480
@@ -34533,12 +34761,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 393 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 392
+      ID: 393
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1476640
@@ -34546,12 +34774,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 393 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1381
+      ID: 1392
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1625824
@@ -34559,15 +34787,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 393 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1382 StructureType sync/atomic.align64
+          Type: 1393 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 376
+      ID: 380
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1201088
@@ -34577,25 +34805,25 @@ Types:
           Offset: 0
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1382
+      ID: 1393
       Name: sync/atomic.align64
       GoRuntimeType: 994560
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 393
+      ID: 394
       Name: sync/atomic.noCopy
       GoRuntimeType: 994464
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1111
+      ID: 1122
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1292416
       GoKind: 12
     - __kind: StructureType
-      ID: 538
+      ID: 539
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -34617,9 +34845,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 539 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 540 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 530
+      ID: 531
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34641,9 +34869,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 531 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 532 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 478
+      ID: 479
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -34665,9 +34893,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 479 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 480 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 497
+      ID: 498
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -34689,9 +34917,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 498 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 499 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -34713,9 +34941,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 651 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 658 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 434
+      ID: 435
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -34737,9 +34965,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 435 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 436 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1416
+      ID: 1417
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -34761,9 +34989,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1417 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1418 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1460
+      ID: 1461
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -34785,9 +35013,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1461 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1462 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1475
+      ID: 1476
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -34809,9 +35037,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1476 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1477 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 446
+      ID: 447
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -34833,9 +35061,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 447 GoSwissMapGroupsType groupReference<int,int>
+          Type: 448 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1490
+      ID: 1491
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -34857,9 +35085,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1491 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1492 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 554
+      ID: 555
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -34881,9 +35109,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 555 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 556 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 505
+      ID: 506
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34905,9 +35133,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 506 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 507 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 695
+      ID: 706
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -34929,9 +35157,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 696 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 707 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 487
+      ID: 488
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -34953,9 +35181,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 488 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 489 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 470
+      ID: 471
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -34977,9 +35205,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 471 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 472 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 675
+      ID: 682
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35001,9 +35229,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 676 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 683 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1165
+      ID: 1176
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35025,9 +35253,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1166 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1177 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 462
+      ID: 463
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35049,9 +35277,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 463 GoSwissMapGroupsType groupReference<string,int>
+          Type: 464 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35073,9 +35301,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 668 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 675 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 454
+      ID: 455
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35097,9 +35325,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 455 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 456 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 659
+      ID: 666
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35121,9 +35349,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 660 GoSwissMapGroupsType groupReference<string,string>
+          Type: 667 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 546
+      ID: 547
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35145,9 +35373,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 547 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 548 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 594
+      ID: 595
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35169,9 +35397,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 595 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 596 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 602
+      ID: 603
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35193,9 +35421,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 603 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 604 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 610
+      ID: 611
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35217,9 +35445,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 611 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 612 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 618
+      ID: 619
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35241,9 +35469,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 619 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 620 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 626
+      ID: 627
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35265,9 +35493,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 627 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 628 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 634
+      ID: 635
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35289,9 +35517,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 635 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 636 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 562
+      ID: 563
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35313,9 +35541,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 563 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 564 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 521
+      ID: 522
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35337,9 +35565,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 522 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 523 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 513
+      ID: 514
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35361,13 +35589,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 514 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 515 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1329
+      ID: 1340
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1054
+      ID: 1065
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1717504
@@ -35380,13 +35608,13 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 1274
+      ID: 1285
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1924224
       GoKind: 6
     - __kind: StructureType
-      ID: 387
+      ID: 330
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1980800
@@ -35397,10 +35625,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 1390 GoSliceHeaderType []time.zone
+          Type: 643 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 1393 GoSliceHeaderType []time.zoneTrans
+          Type: 646 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -35412,13 +35640,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 1391 PointerType *time.zone
+          Type: 644 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 795
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 385
+    - __kind: GoTimeType
+      ID: 328
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2383872
@@ -35432,9 +35660,17 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 386 PointerType *time.Location
+          Type: 329 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 384
+      ID: 388
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1477600
@@ -35442,12 +35678,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1389 GoChannelType <-chan time.Time
+          Type: 1400 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 705
+      ID: 716
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 834880
@@ -35455,18 +35691,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 707 PointerType *time.fileSizeError.str
+          Type: 718 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 706 GoStringDataType time.fileSizeError.str
+      Data: 717 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 706
+      ID: 717
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1392
+      ID: 645
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1626784
@@ -35482,7 +35718,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1395
+      ID: 648
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1762240
@@ -35543,7 +35779,7 @@ Types:
       GoRuntimeType: 588384
       GoKind: 26
     - __kind: StructureType
-      ID: 1144
+      ID: 1155
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2073664
@@ -35554,10 +35790,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1145 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1156 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1146 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1157 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -35572,18 +35808,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1147 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1158 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1147
+      ID: 1158
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1000416
       GoKind: 9
     - __kind: StructureType
-      ID: 1145
+      ID: 1156
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1937024
@@ -35608,21 +35844,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 890
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1146
+      ID: 1157
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 592032
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1321
+      ID: 1332
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 863
+      ID: 874
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1434336
@@ -35632,13 +35868,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 749
+      ID: 760
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 839488
       GoKind: 2
     - __kind: StructureType
-      ID: 1031
+      ID: 1042
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1713280
@@ -35651,12 +35887,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 983
+      ID: 994
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 999264
       GoKind: 5
-MaxTypeID: 1829
+MaxTypeID: 1833
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -12,11 +12,11 @@ Probes:
         - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1735 EventRootType Probe[main.stackC]
+              Type: 1736 EventRootType Probe[main.stackC]
               InjectionPoints: [{PC: "0xcf1c4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1736 EventRootType Probe[main.stackC]Return
+              Type: 1737 EventRootType Probe[main.stackC]Return
               InjectionPoints: [{PC: "0xcf1c85", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -32,11 +32,11 @@ Probes:
         - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 1574 EventRootType Probe[main.testAny]
+              Type: 1575 EventRootType Probe[main.testAny]
               InjectionPoints: [{PC: "0xcebb8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1575 EventRootType Probe[main.testAny]Return
+              Type: 1576 EventRootType Probe[main.testAny]Return
               InjectionPoints: [{PC: "0xcebbc5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -58,11 +58,11 @@ Probes:
         - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testAnyPtr]
+              Type: 1578 EventRootType Probe[main.testAnyPtr]
               InjectionPoints: [{PC: "0xcebc2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1578 EventRootType Probe[main.testAnyPtr]Return
+              Type: 1579 EventRootType Probe[main.testAnyPtr]Return
               InjectionPoints: [{PC: "0xcebc5d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -83,11 +83,11 @@ Probes:
         - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1706 EventRootType Probe[main.testArrayArgAndReturn]
+              Type: 1707 EventRootType Probe[main.testArrayArgAndReturn]
               InjectionPoints: [{PC: "0xcf024e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1707 EventRootType Probe[main.testArrayArgAndReturn]Return
+              Type: 1708 EventRootType Probe[main.testArrayArgAndReturn]Return
               InjectionPoints: [{PC: "0xcf030a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -109,7 +109,7 @@ Probes:
         - subprogram: {subprogram: 19}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testArrayEmptyStructs]
+              Type: 1523 EventRootType Probe[main.testArrayEmptyStructs]
               InjectionPoints: [{PC: "0xce6ba0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -131,7 +131,7 @@ Probes:
         - subprogram: {subprogram: 15}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testArrayOfArrays]
+              Type: 1519 EventRootType Probe[main.testArrayOfArrays]
               InjectionPoints: [{PC: "0xce6b20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -153,7 +153,7 @@ Probes:
         - subprogram: {subprogram: 17}
           events:
             - Kind: Entry
-              Type: 1520 EventRootType Probe[main.testArrayOfArraysOfArrays]
+              Type: 1521 EventRootType Probe[main.testArrayOfArraysOfArrays]
               InjectionPoints: [{PC: "0xce6b60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -175,7 +175,7 @@ Probes:
         - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testArrayOfMaps]
+              Type: 1587 EventRootType Probe[main.testArrayOfMaps]
               InjectionPoints: [{PC: "0xcec4c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -197,7 +197,7 @@ Probes:
         - subprogram: {subprogram: 16}
           events:
             - Kind: Entry
-              Type: 1519 EventRootType Probe[main.testArrayOfStrings]
+              Type: 1520 EventRootType Probe[main.testArrayOfStrings]
               InjectionPoints: [{PC: "0xce6b40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -218,7 +218,7 @@ Probes:
         - subprogram: {subprogram: 18}
           events:
             - Kind: Entry
-              Type: 1521 EventRootType Probe[main.testArrayOfStructs]
+              Type: 1522 EventRootType Probe[main.testArrayOfStructs]
               InjectionPoints: [{PC: "0xce6b80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -240,11 +240,11 @@ Probes:
         - subprogram: {subprogram: 90}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testAtomicAdd]
+              Type: 1609 EventRootType Probe[main.testAtomicAdd]
               InjectionPoints: [{PC: "0xcee2e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1609 EventRootType Probe[main.testAtomicAdd]Return
+              Type: 1610 EventRootType Probe[main.testAtomicAdd]Return
               InjectionPoints: [{PC: "0xcee2f2", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -266,7 +266,7 @@ Probes:
         - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 1540 EventRootType Probe[main.testBigStruct]
+              Type: 1541 EventRootType Probe[main.testBigStruct]
               InjectionPoints: [{PC: "0xce72e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -288,7 +288,7 @@ Probes:
         - subprogram: {subprogram: 4}
           events:
             - Kind: Entry
-              Type: 1507 EventRootType Probe[main.testBoolArray]
+              Type: 1508 EventRootType Probe[main.testBoolArray]
               InjectionPoints: [{PC: "0xce69c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -310,7 +310,7 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 1504 EventRootType Probe[main.testByteArray]
+              Type: 1505 EventRootType Probe[main.testByteArray]
               InjectionPoints: [{PC: "0xce6960", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -337,7 +337,7 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1751 EventRootType Probe[main.testStruct]
+              Type: 1752 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0xcf2080", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
@@ -353,10 +353,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1810 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1814 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xceb3ae"
                   Frameless: false
@@ -383,10 +383,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1811 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1815 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xceb3ae"
                   Frameless: false
@@ -402,7 +402,7 @@ Probes:
                 Type: 6 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 189, index: 0, name: x}
+                      Variable: {subprogram: 192, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -429,10 +429,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1812 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1816 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xceb3ae"
                   Frameless: false
@@ -469,7 +469,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.testCombinedString]
+              Type: 1606 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0xcedf40", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
@@ -488,7 +488,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testCombinedString]
+              Type: 1607 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0xcedf40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -514,7 +514,7 @@ Probes:
         - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1757 EventRootType Probe[main.testTenStrings]
+              Type: 1758 EventRootType Probe[main.testTenStrings]
               InjectionPoints: [{PC: "0xcf2160", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
@@ -552,7 +552,7 @@ Probes:
         - subprogram: {subprogram: 91}
           events:
             - Kind: Entry
-              Type: 1610 EventRootType Probe[main.testChannel]
+              Type: 1611 EventRootType Probe[main.testChannel]
               InjectionPoints: [{PC: "0xcee300", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -582,7 +582,7 @@ Probes:
         - subprogram: {subprogram: 87}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testCombinedByte]
+              Type: 1605 EventRootType Probe[main.testCombinedByte]
               InjectionPoints: [{PC: "0xcedf00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -611,11 +611,11 @@ Probes:
         - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1671 EventRootType Probe[main.testConflictingReturn]
+              Type: 1672 EventRootType Probe[main.testConflictingReturn]
               InjectionPoints: [{PC: "0xcef48e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1672 EventRootType Probe[main.testConflictingReturn]Return
+              Type: 1673 EventRootType Probe[main.testConflictingReturn]Return
               InjectionPoints: [{PC: "0xcef551", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -637,7 +637,7 @@ Probes:
         - subprogram: {subprogram: 99}
           events:
             - Kind: Entry
-              Type: 1618 EventRootType Probe[main.testCycle]
+              Type: 1619 EventRootType Probe[main.testCycle]
               InjectionPoints: [{PC: "0xcee6c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -659,7 +659,7 @@ Probes:
         - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 1546 EventRootType Probe[main.testDeepMap1]
+              Type: 1547 EventRootType Probe[main.testDeepMap1]
               InjectionPoints: [{PC: "0xce77c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -681,7 +681,7 @@ Probes:
         - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testDeepMap7]
+              Type: 1548 EventRootType Probe[main.testDeepMap7]
               InjectionPoints: [{PC: "0xce77e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -703,7 +703,7 @@ Probes:
         - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 1542 EventRootType Probe[main.testDeepPtr1]
+              Type: 1543 EventRootType Probe[main.testDeepPtr1]
               InjectionPoints: [{PC: "0xce74c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -725,7 +725,7 @@ Probes:
         - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testDeepPtr7]
+              Type: 1544 EventRootType Probe[main.testDeepPtr7]
               InjectionPoints: [{PC: "0xce74e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -747,7 +747,7 @@ Probes:
         - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 1544 EventRootType Probe[main.testDeepSlice1]
+              Type: 1545 EventRootType Probe[main.testDeepSlice1]
               InjectionPoints: [{PC: "0xce7640", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -769,7 +769,7 @@ Probes:
         - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testDeepSlice7]
+              Type: 1546 EventRootType Probe[main.testDeepSlice7]
               InjectionPoints: [{PC: "0xce7660", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -791,7 +791,7 @@ Probes:
         - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1723 EventRootType Probe[main.testEmptySlice]
+              Type: 1724 EventRootType Probe[main.testEmptySlice]
               InjectionPoints: [{PC: "0xcf13a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -818,7 +818,7 @@ Probes:
         - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1726 EventRootType Probe[main.testEmptySliceOfStructs]
+              Type: 1727 EventRootType Probe[main.testEmptySliceOfStructs]
               InjectionPoints: [{PC: "0xcf1400", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -846,7 +846,7 @@ Probes:
         - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1747 EventRootType Probe[main.testEmptyString]
+              Type: 1748 EventRootType Probe[main.testEmptyString]
               InjectionPoints: [{PC: "0xcf1d80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -868,7 +868,7 @@ Probes:
         - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1758 EventRootType Probe[main.testEmptyStruct]
+              Type: 1759 EventRootType Probe[main.testEmptyStruct]
               InjectionPoints: [{PC: "0xcf21c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -889,7 +889,7 @@ Probes:
         - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1759 EventRootType Probe[main.testEmptyStructPointer]
+              Type: 1760 EventRootType Probe[main.testEmptyStructPointer]
               InjectionPoints: [{PC: "0xcf21e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -911,7 +911,7 @@ Probes:
         - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 1576 EventRootType Probe[main.testError]
+              Type: 1577 EventRootType Probe[main.testError]
               InjectionPoints: [{PC: "0xcebc00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -945,7 +945,7 @@ Probes:
         - subprogram: {subprogram: 38}
           events:
             - Kind: Line
-              Type: 1541 EventRootType Probe[main.testErrorAtLine]Line
+              Type: 1542 EventRootType Probe[main.testErrorAtLine]Line
               InjectionPoints: [{PC: "0xce7394", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -973,11 +973,11 @@ Probes:
         - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.testEsotericHeap]
+              Type: 1559 EventRootType Probe[main.testEsotericHeap]
               InjectionPoints: [{PC: "0xce9f8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1559 EventRootType Probe[main.testEsotericHeap]Return
+              Type: 1560 EventRootType Probe[main.testEsotericHeap]Return
               InjectionPoints: [{PC: "0xce9fcc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -999,11 +999,11 @@ Probes:
         - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.testEsotericStack]
+              Type: 1557 EventRootType Probe[main.testEsotericStack]
               InjectionPoints: [{PC: "0xce9e6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.testEsotericStack]Return
+              Type: 1558 EventRootType Probe[main.testEsotericStack]Return
               InjectionPoints: [{PC: "0xce9efb", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1025,11 +1025,11 @@ Probes:
         - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.testFrameless]
+              Type: 1569 EventRootType Probe[main.testFrameless]
               InjectionPoints: [{PC: "0xceb860", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1569 EventRootType Probe[main.testFrameless]Return
+              Type: 1570 EventRootType Probe[main.testFrameless]Return
               InjectionPoints: [{PC: "0xceb865", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -1051,11 +1051,11 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 1570 EventRootType Probe[main.testFramelessArray]
+              Type: 1571 EventRootType Probe[main.testFramelessArray]
               InjectionPoints: [{PC: "0xceb884", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1571 EventRootType Probe[main.testFramelessArray]Return
+              Type: 1572 EventRootType Probe[main.testFramelessArray]Return
               InjectionPoints: [{PC: "0xceb8c5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1080,7 +1080,7 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Line
-              Type: 1572 EventRootType Probe[main.testFramelessArray]Line
+              Type: 1573 EventRootType Probe[main.testFramelessArray]Line
               InjectionPoints: [{PC: "0xceb888", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1099,15 +1099,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1796 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf4ae0", Frameless: true}]
+              Type: 1800 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0xcf4c60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1797 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf4ae7", Frameless: true}]
+              Type: 1801 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf4c67", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1117,15 +1117,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1798 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xcf4b04", Frameless: false}]
+              Type: 1802 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0xcf4c84", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1799 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xcf4b55", Frameless: false}]
+              Type: 1803 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0xcf4cd5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1144,15 +1144,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1792 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xcf4a4a", Frameless: false}]
+              Type: 1796 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0xcf4bca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1793 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xcf4a59", Frameless: false}]
+              Type: 1797 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0xcf4bd9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1162,15 +1162,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1794 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xcf4a8a", Frameless: false}]
+              Type: 1798 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0xcf4c0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1795 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xcf4aa2", Frameless: false}]
+              Type: 1799 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0xcf4c22", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1189,18 +1189,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1800 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf4b60", Frameless: true}]
+              Type: 1804 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf4ce0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1801 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1805 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xcf4b80"
+                - PC: "0xcf4d00"
                   Frameless: true
-                - PC: "0xcf4b83"
+                - PC: "0xcf4d03"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1211,18 +1211,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1802 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf4baa", Frameless: false}]
+              Type: 1806 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0xcf4d2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1803 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1807 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xcf4c0b"
+                - PC: "0xcf4d8b"
                   Frameless: false
-                - PC: "0xcf4c13"
+                - PC: "0xcf4d93"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1245,11 +1245,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Line
-              Type: 1804 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xcf4b65", Frameless: true}]
+              Type: 1808 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0xcf4ce5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1257,11 +1257,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1805 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xcf4bbf", Frameless: false}]
+              Type: 1809 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0xcf4d3f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1278,15 +1278,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1780 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xcf4700", Frameless: true}]
+              Type: 1784 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0xcf4880", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1781 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf4710", Frameless: true}]
+              Type: 1785 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0xcf4890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1296,15 +1296,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1782 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xcf47e0", Frameless: true}]
+              Type: 1786 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0xcf4960", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1783 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf47e8", Frameless: true}]
+              Type: 1787 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0xcf4968", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1324,15 +1324,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 169}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1768 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf4233", Frameless: false}]
+              Type: 1772 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf43b3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1769 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf43ba", Frameless: false}]
+              Type: 1773 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xcf453a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1342,14 +1342,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1770 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1774 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0xce5af3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1771 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1775 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0xce5c7a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1370,15 +1370,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1772 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf442a", Frameless: false}]
+              Type: 1776 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xcf45aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1773 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf4439", Frameless: false}]
+              Type: 1777 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf45b9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1397,15 +1397,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1806 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xcf4c60", Frameless: true}]
+              Type: 1810 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0xcf4de0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1807 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xcf4c66", Frameless: true}]
+              Type: 1811 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0xcf4de6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1415,15 +1415,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1808 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xcf4cca", Frameless: false}]
+              Type: 1812 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0xcf4e4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1809 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xcf4ced", Frameless: false}]
+              Type: 1813 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0xcf4e6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1442,15 +1442,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
+        - subprogram: {subprogram: 170}
           events:
             - Kind: Entry
-              Type: 1764 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf4180", Frameless: true}]
+              Type: 1768 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf4300", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1765 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf4183", Frameless: true}]
+              Type: 1769 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xcf4303", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1460,15 +1460,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 168}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1766 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf41a0", Frameless: true}]
+              Type: 1770 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0xcf4320", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1767 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf41ab", Frameless: true}]
+              Type: 1771 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf432b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1487,15 +1487,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1784 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xcf48a0", Frameless: true}]
+              Type: 1788 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0xcf4a20", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1785 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf48a7", Frameless: true}]
+              Type: 1789 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0xcf4a27", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1505,15 +1505,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1786 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xcf492a", Frameless: false}]
+              Type: 1790 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0xcf4aaa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1787 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf4953", Frameless: false}]
+              Type: 1791 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0xcf4ad3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1532,15 +1532,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1774 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf46a0", Frameless: true}]
+              Type: 1778 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf4820", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1775 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf46a3", Frameless: true}]
+              Type: 1779 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xcf4823", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1550,15 +1550,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1776 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xcf46c0", Frameless: true}]
+              Type: 1780 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0xcf4840", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1777 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xcf46c3", Frameless: true}]
+              Type: 1781 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0xcf4843", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1568,15 +1568,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1778 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xcf46e0", Frameless: true}]
+              Type: 1782 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0xcf4860", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1779 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xcf46e3", Frameless: true}]
+              Type: 1783 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0xcf4863", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1595,15 +1595,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1788 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xcf4a00", Frameless: true}]
+              Type: 1792 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0xcf4b80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1789 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xcf4a07", Frameless: true}]
+              Type: 1793 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0xcf4b87", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1613,15 +1613,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1790 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf4a20", Frameless: true}]
+              Type: 1794 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xcf4ba0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1791 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf4a2e", Frameless: true}]
+              Type: 1795 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf4bae", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1640,15 +1640,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1760 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf4140", Frameless: true}]
+              Type: 1764 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf42c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1761 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf4143", Frameless: true}]
+              Type: 1765 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xcf42c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1658,15 +1658,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1762 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf4160", Frameless: true}]
+              Type: 1766 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0xcf42e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1763 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf416b", Frameless: true}]
+              Type: 1767 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf42eb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1688,11 +1688,11 @@ Probes:
         - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.testInlinedBA]
+              Type: 1561 EventRootType Probe[main.testInlinedBA]
               InjectionPoints: [{PC: "0xceb54a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1561 EventRootType Probe[main.testInlinedBA]Return
+              Type: 1562 EventRootType Probe[main.testInlinedBA]Return
               InjectionPoints: [{PC: "0xceb5ae", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1719,11 +1719,11 @@ Probes:
         - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.testInlinedBB]
+              Type: 1563 EventRootType Probe[main.testInlinedBB]
               InjectionPoints: [{PC: "0xceb5ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1563 EventRootType Probe[main.testInlinedBB]Return
+              Type: 1564 EventRootType Probe[main.testInlinedBB]Return
               InjectionPoints: [{PC: "0xceb67e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1750,11 +1750,11 @@ Probes:
         - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.testInlinedBBA]
+              Type: 1565 EventRootType Probe[main.testInlinedBBA]
               InjectionPoints: [{PC: "0xceb6ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1565 EventRootType Probe[main.testInlinedBBA]Return
+              Type: 1566 EventRootType Probe[main.testInlinedBBA]Return
               InjectionPoints: [{PC: "0xceb70b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1773,10 +1773,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1816 EventRootType Probe[main.testInlinedBBB]
+              Type: 1820 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0xceb646", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1794,11 +1794,11 @@ Probes:
         - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.testInlinedBC]
+              Type: 1567 EventRootType Probe[main.testInlinedBC]
               InjectionPoints: [{PC: "0xceb74e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1567 EventRootType Probe[main.testInlinedBC]Return
+              Type: 1568 EventRootType Probe[main.testInlinedBC]Return
               InjectionPoints: [{PC: "0xceb833", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1813,10 +1813,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Entry
-              Type: 1817 EventRootType Probe[main.testInlinedBCA]
+              Type: 1821 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0xceb753", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1834,10 +1834,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Line
-              Type: 1818 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1822 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0xceb753", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1852,10 +1852,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Entry
-              Type: 1819 EventRootType Probe[main.testInlinedBCB]
+              Type: 1823 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0xceb7fb", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1873,10 +1873,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Line
-              Type: 1820 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1824 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0xceb7fb", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1891,10 +1891,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 196}
+        - subprogram: {subprogram: 199}
           events:
             - Kind: Entry
-              Type: 1826 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1830 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0xce5601"
                   Frameless: true
@@ -1914,10 +1914,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1813 EventRootType Probe[main.testInlinedPrint]
+              Type: 1817 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0xceb3aa"
                   Frameless: false
@@ -1931,7 +1931,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1814 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1818 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0xceb3ea", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1953,10 +1953,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1815 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1819 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xceb3ae"
                   Frameless: false
@@ -1985,10 +1985,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Entry
-              Type: 1821 EventRootType Probe[main.testInlinedSq]
+              Type: 1825 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0xceb861", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2010,10 +2010,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Line
-              Type: 1822 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1826 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0xceb861", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2033,10 +2033,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 194}
+        - subprogram: {subprogram: 197}
           events:
             - Kind: Entry
-              Type: 1823 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1827 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0xceb8ad"
                   Frameless: false
@@ -2062,7 +2062,7 @@ Probes:
         - subprogram: {subprogram: 7}
           events:
             - Kind: Entry
-              Type: 1510 EventRootType Probe[main.testInt16Array]
+              Type: 1511 EventRootType Probe[main.testInt16Array]
               InjectionPoints: [{PC: "0xce6a20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2084,7 +2084,7 @@ Probes:
         - subprogram: {subprogram: 8}
           events:
             - Kind: Entry
-              Type: 1511 EventRootType Probe[main.testInt32Array]
+              Type: 1512 EventRootType Probe[main.testInt32Array]
               InjectionPoints: [{PC: "0xce6a40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2106,7 +2106,7 @@ Probes:
         - subprogram: {subprogram: 9}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testInt64Array]
+              Type: 1513 EventRootType Probe[main.testInt64Array]
               InjectionPoints: [{PC: "0xce6a60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2128,7 +2128,7 @@ Probes:
         - subprogram: {subprogram: 6}
           events:
             - Kind: Entry
-              Type: 1509 EventRootType Probe[main.testInt8Array]
+              Type: 1510 EventRootType Probe[main.testInt8Array]
               InjectionPoints: [{PC: "0xce6a00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2150,7 +2150,7 @@ Probes:
         - subprogram: {subprogram: 5}
           events:
             - Kind: Entry
-              Type: 1508 EventRootType Probe[main.testIntArray]
+              Type: 1509 EventRootType Probe[main.testIntArray]
               InjectionPoints: [{PC: "0xce69e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2172,7 +2172,7 @@ Probes:
         - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.testInterface]
+              Type: 1574 EventRootType Probe[main.testInterface]
               InjectionPoints: [{PC: "0xcebb60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2193,11 +2193,11 @@ Probes:
         - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1704 EventRootType Probe[main.testLargeArgAndReturn]
+              Type: 1705 EventRootType Probe[main.testLargeArgAndReturn]
               InjectionPoints: [{PC: "0xcf00ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1705 EventRootType Probe[main.testLargeArgAndReturn]Return
+              Type: 1706 EventRootType Probe[main.testLargeArgAndReturn]Return
               InjectionPoints: [{PC: "0xcf022d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2219,7 +2219,7 @@ Probes:
         - subprogram: {subprogram: 93}
           events:
             - Kind: Entry
-              Type: 1612 EventRootType Probe[main.testLinkedList]
+              Type: 1613 EventRootType Probe[main.testLinkedList]
               InjectionPoints: [{PC: "0xcee4e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2244,7 +2244,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1550 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1551 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xce785a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2266,7 +2266,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1551 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1552 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xce791f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2288,7 +2288,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1552 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1553 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0xce79e5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2331,11 +2331,11 @@ Probes:
         - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1710 EventRootType Probe[main.testManyArgsArrayReturn]
+              Type: 1711 EventRootType Probe[main.testManyArgsArrayReturn]
               InjectionPoints: [{PC: "0xcf0573", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1711 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              Type: 1712 EventRootType Probe[main.testManyArgsArrayReturn]Return
               InjectionPoints: [{PC: "0xcf07a2", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2398,7 +2398,7 @@ Probes:
         - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 1554 EventRootType Probe[main.testManyPointers]
+              Type: 1555 EventRootType Probe[main.testManyPointers]
               InjectionPoints: [{PC: "0xce7fc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2422,7 +2422,7 @@ Probes:
         - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 1555 EventRootType Probe[main.testManyStrings]
+              Type: 1556 EventRootType Probe[main.testManyStrings]
               InjectionPoints: [{PC: "0xce9b60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2444,7 +2444,7 @@ Probes:
         - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testMapArrayToArray]
+              Type: 1585 EventRootType Probe[main.testMapArrayToArray]
               InjectionPoints: [{PC: "0xcec480", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2466,7 +2466,7 @@ Probes:
         - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testMapEmbeddedMaps]
+              Type: 1592 EventRootType Probe[main.testMapEmbeddedMaps]
               InjectionPoints: [{PC: "0xcec540", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2488,7 +2488,7 @@ Probes:
         - subprogram: {subprogram: 84}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testMapEmptyKey]
+              Type: 1602 EventRootType Probe[main.testMapEmptyKey]
               InjectionPoints: [{PC: "0xcec680", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2510,7 +2510,7 @@ Probes:
         - subprogram: {subprogram: 86}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.testMapEmptyKeyAndValue]
+              Type: 1604 EventRootType Probe[main.testMapEmptyKeyAndValue]
               InjectionPoints: [{PC: "0xcec6c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2532,7 +2532,7 @@ Probes:
         - subprogram: {subprogram: 85}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testMapEmptyValue]
+              Type: 1603 EventRootType Probe[main.testMapEmptyValue]
               InjectionPoints: [{PC: "0xcec6a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2554,7 +2554,7 @@ Probes:
         - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testMapIntToInt]
+              Type: 1589 EventRootType Probe[main.testMapIntToInt]
               InjectionPoints: [{PC: "0xcec500", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2576,7 +2576,7 @@ Probes:
         - subprogram: {subprogram: 83}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testMapLargeKeyLargeValue]
+              Type: 1601 EventRootType Probe[main.testMapLargeKeyLargeValue]
               InjectionPoints: [{PC: "0xcec660", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2598,7 +2598,7 @@ Probes:
         - subprogram: {subprogram: 82}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testMapLargeKeySmallValue]
+              Type: 1600 EventRootType Probe[main.testMapLargeKeySmallValue]
               InjectionPoints: [{PC: "0xcec640", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2622,7 +2622,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testMapMassive]
+              Type: 1590 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0xcec520", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2646,7 +2646,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testMapMassive]
+              Type: 1591 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0xcec520", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2668,7 +2668,7 @@ Probes:
         - subprogram: {subprogram: 81}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testMapSmallKeyLargeValue]
+              Type: 1599 EventRootType Probe[main.testMapSmallKeyLargeValue]
               InjectionPoints: [{PC: "0xcec620", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2690,7 +2690,7 @@ Probes:
         - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testMapSmallKeySmallValue]
+              Type: 1598 EventRootType Probe[main.testMapSmallKeySmallValue]
               InjectionPoints: [{PC: "0xcec600", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2712,7 +2712,7 @@ Probes:
         - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testMapStringToInt]
+              Type: 1583 EventRootType Probe[main.testMapStringToInt]
               InjectionPoints: [{PC: "0xcec440", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2734,7 +2734,7 @@ Probes:
         - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testMapStringToSlice]
+              Type: 1584 EventRootType Probe[main.testMapStringToSlice]
               InjectionPoints: [{PC: "0xcec460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2756,7 +2756,7 @@ Probes:
         - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testMapStringToStruct]
+              Type: 1582 EventRootType Probe[main.testMapStringToStruct]
               InjectionPoints: [{PC: "0xcec420", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2778,7 +2778,7 @@ Probes:
         - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.testMapWithLinkedList]
+              Type: 1593 EventRootType Probe[main.testMapWithLinkedList]
               InjectionPoints: [{PC: "0xcec560", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2800,7 +2800,7 @@ Probes:
         - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+              Type: 1596 EventRootType Probe[main.testMapWithSmallKeyAndValue]
               InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2822,7 +2822,7 @@ Probes:
         - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+              Type: 1597 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
               InjectionPoints: [{PC: "0xcec5e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2844,7 +2844,7 @@ Probes:
         - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 1593 EventRootType Probe[main.testMapWithSmallValue]
+              Type: 1594 EventRootType Probe[main.testMapWithSmallValue]
               InjectionPoints: [{PC: "0xcec580", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2868,7 +2868,7 @@ Probes:
         - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testMapWithSmallValueMassive]
+              Type: 1595 EventRootType Probe[main.testMapWithSmallValueMassive]
               InjectionPoints: [{PC: "0xcec5a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2890,7 +2890,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1744 EventRootType Probe[main.testMassiveString]
+              Type: 1745 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0xcf1d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2913,7 +2913,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1745 EventRootType Probe[main.testMassiveString]
+              Type: 1746 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0xcf1d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2960,11 +2960,11 @@ Probes:
         - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1712 EventRootType Probe[main.testMixedArgsStackReturn]
+              Type: 1713 EventRootType Probe[main.testMixedArgsStackReturn]
               InjectionPoints: [{PC: "0xcf0833", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1713 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              Type: 1714 EventRootType Probe[main.testMixedArgsStackReturn]Return
               InjectionPoints: [{PC: "0xcf0a62", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3030,11 +3030,11 @@ Probes:
         - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1716 EventRootType Probe[main.testMultipleArrayArgs]
+              Type: 1717 EventRootType Probe[main.testMultipleArrayArgs]
               InjectionPoints: [{PC: "0xcf0bae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1717 EventRootType Probe[main.testMultipleArrayArgs]Return
+              Type: 1718 EventRootType Probe[main.testMultipleArrayArgs]Return
               InjectionPoints: [{PC: "0xcf0c7d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3065,11 +3065,11 @@ Probes:
         - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1708 EventRootType Probe[main.testMultipleLargeArgs]
+              Type: 1709 EventRootType Probe[main.testMultipleLargeArgs]
               InjectionPoints: [{PC: "0xcf032e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1709 EventRootType Probe[main.testMultipleLargeArgs]Return
+              Type: 1710 EventRootType Probe[main.testMultipleLargeArgs]Return
               InjectionPoints: [{PC: "0xcf054b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3095,11 +3095,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1649 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1650 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcef2ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1650 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1651 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcef36f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3135,7 +3135,7 @@ Probes:
         - subprogram: {subprogram: 89}
           events:
             - Kind: Entry
-              Type: 1607 EventRootType Probe[main.testMultipleSimpleParams]
+              Type: 1608 EventRootType Probe[main.testMultipleSimpleParams]
               InjectionPoints: [{PC: "0xcee0c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3176,11 +3176,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1643 EventRootType Probe[main.testNamedReturn]
+              Type: 1644 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xcef22a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1644 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1645 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xcef29b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3204,11 +3204,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1645 EventRootType Probe[main.testNamedReturn]
+              Type: 1646 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xcef22a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1646 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1647 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xcef29b", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
@@ -3227,11 +3227,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1651 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1652 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcef2ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1652 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1653 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcef36f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
@@ -3251,11 +3251,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1653 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1654 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcef2ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1654 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1655 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcef36f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3288,11 +3288,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1647 EventRootType Probe[main.testNamedReturn]
+              Type: 1648 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0xcef22a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1648 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1649 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0xcef29b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3320,7 +3320,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1753 EventRootType Probe[main.testNestedPointer]
+              Type: 1754 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xcf2140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3345,7 +3345,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1754 EventRootType Probe[main.testNestedPointer]
+              Type: 1755 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xcf2140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3376,7 +3376,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1755 EventRootType Probe[main.testNestedPointer]
+              Type: 1756 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xcf2140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3401,7 +3401,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1756 EventRootType Probe[main.testNestedPointer]
+              Type: 1757 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0xcf2140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3428,7 +3428,7 @@ Probes:
         - subprogram: {subprogram: 98}
           events:
             - Kind: Entry
-              Type: 1617 EventRootType Probe[main.testNilPointer]
+              Type: 1618 EventRootType Probe[main.testNilPointer]
               InjectionPoints: [{PC: "0xcee680", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3455,7 +3455,7 @@ Probes:
         - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1730 EventRootType Probe[main.testNilSlice]
+              Type: 1731 EventRootType Probe[main.testNilSlice]
               InjectionPoints: [{PC: "0xcf1480", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3482,7 +3482,7 @@ Probes:
         - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1727 EventRootType Probe[main.testNilSliceOfStructs]
+              Type: 1728 EventRootType Probe[main.testNilSliceOfStructs]
               InjectionPoints: [{PC: "0xcf1420", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3517,7 +3517,7 @@ Probes:
         - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1729 EventRootType Probe[main.testNilSliceWithOtherParams]
+              Type: 1730 EventRootType Probe[main.testNilSliceWithOtherParams]
               InjectionPoints: [{PC: "0xcf1460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3549,7 +3549,7 @@ Probes:
         - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1743 EventRootType Probe[main.testOneStringInStructPointer]
+              Type: 1744 EventRootType Probe[main.testOneStringInStructPointer]
               InjectionPoints: [{PC: "0xcf1d20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3571,7 +3571,7 @@ Probes:
         - subprogram: {subprogram: 94}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[main.testPointerLoop]
+              Type: 1614 EventRootType Probe[main.testPointerLoop]
               InjectionPoints: [{PC: "0xcee500", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3593,7 +3593,7 @@ Probes:
         - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testPointerToMap]
+              Type: 1588 EventRootType Probe[main.testPointerToMap]
               InjectionPoints: [{PC: "0xcec4e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3615,7 +3615,7 @@ Probes:
         - subprogram: {subprogram: 92}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[main.testPointerToSimpleStruct]
+              Type: 1612 EventRootType Probe[main.testPointerToSimpleStruct]
               InjectionPoints: [{PC: "0xcee4c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3639,11 +3639,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.testReturnsInt]
+              Type: 1620 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xceeaea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1620 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1621 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xceeb3b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
@@ -3663,11 +3663,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1663 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1664 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xcef3ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1664 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1665 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xcef44d", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3712,11 +3712,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1629 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1630 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xceec0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1630 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1631 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xceecc5", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3758,11 +3758,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.testReturnsInt]
+              Type: 1622 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xceeaea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1622 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1623 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xceeb3b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3807,11 +3807,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1631 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1632 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xceec0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1632 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1633 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xceecc5", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3855,11 +3855,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1665 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1666 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xcef3ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1666 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1667 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xcef44d", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
@@ -3876,11 +3876,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1667 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1668 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xcef3ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1668 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1669 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xcef44d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3902,11 +3902,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1623 EventRootType Probe[main.testReturnsInt]
+              Type: 1624 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xceeaea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1624 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1625 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xceeb3b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3929,11 +3929,11 @@ Probes:
         - subprogram: {subprogram: 105}
           events:
             - Kind: Entry
-              Type: 1639 EventRootType Probe[main.testReturnsAny]
+              Type: 1640 EventRootType Probe[main.testReturnsAny]
               InjectionPoints: [{PC: "0xceeece", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1640 EventRootType Probe[main.testReturnsAny]Return
+              Type: 1641 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
                 - PC: "0xceef75"
                   Frameless: false
@@ -3968,11 +3968,11 @@ Probes:
         - subprogram: {subprogram: 104}
           events:
             - Kind: Entry
-              Type: 1637 EventRootType Probe[main.testReturnsAnyAndError]
+              Type: 1638 EventRootType Probe[main.testReturnsAnyAndError]
               InjectionPoints: [{PC: "0xceed6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1638 EventRootType Probe[main.testReturnsAnyAndError]Return
+              Type: 1639 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
                 - PC: "0xceedc4"
                   Frameless: false
@@ -4006,11 +4006,11 @@ Probes:
         - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1682 EventRootType Probe[main.testReturnsArray]
+              Type: 1683 EventRootType Probe[main.testReturnsArray]
               InjectionPoints: [{PC: "0xcefb4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1683 EventRootType Probe[main.testReturnsArray]Return
+              Type: 1684 EventRootType Probe[main.testReturnsArray]Return
               InjectionPoints: [{PC: "0xcefbaf", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4027,11 +4027,11 @@ Probes:
         - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1684 EventRootType Probe[main.testReturnsArrayOne]
+              Type: 1685 EventRootType Probe[main.testReturnsArrayOne]
               InjectionPoints: [{PC: "0xcefbca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1685 EventRootType Probe[main.testReturnsArrayOne]Return
+              Type: 1686 EventRootType Probe[main.testReturnsArrayOne]Return
               InjectionPoints: [{PC: "0xcefc0b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4048,11 +4048,11 @@ Probes:
         - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1686 EventRootType Probe[main.testReturnsArrayZero]
+              Type: 1687 EventRootType Probe[main.testReturnsArrayZero]
               InjectionPoints: [{PC: "0xcefc2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1687 EventRootType Probe[main.testReturnsArrayZero]Return
+              Type: 1688 EventRootType Probe[main.testReturnsArrayZero]Return
               InjectionPoints: [{PC: "0xcefc66", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4069,11 +4069,11 @@ Probes:
         - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1690 EventRootType Probe[main.testReturnsBacktrackInt]
+              Type: 1691 EventRootType Probe[main.testReturnsBacktrackInt]
               InjectionPoints: [{PC: "0xcefd0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1691 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              Type: 1692 EventRootType Probe[main.testReturnsBacktrackInt]Return
               InjectionPoints: [{PC: "0xcefd8a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4090,11 +4090,11 @@ Probes:
         - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1702 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              Type: 1703 EventRootType Probe[main.testReturnsBoolAndUintptr]
               InjectionPoints: [{PC: "0xcf006a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1703 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              Type: 1704 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
               InjectionPoints: [{PC: "0xcf00b0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4111,11 +4111,11 @@ Probes:
         - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1678 EventRootType Probe[main.testReturnsComplex]
+              Type: 1679 EventRootType Probe[main.testReturnsComplex]
               InjectionPoints: [{PC: "0xcefa0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1679 EventRootType Probe[main.testReturnsComplex]Return
+              Type: 1680 EventRootType Probe[main.testReturnsComplex]Return
               InjectionPoints: [{PC: "0xcefa66", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4133,11 +4133,11 @@ Probes:
         - subprogram: {subprogram: 103}
           events:
             - Kind: Entry
-              Type: 1635 EventRootType Probe[main.testReturnsError]
+              Type: 1636 EventRootType Probe[main.testReturnsError]
               InjectionPoints: [{PC: "0xceecea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1636 EventRootType Probe[main.testReturnsError]Return
+              Type: 1637 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
                 - PC: "0xceed24"
                   Frameless: false
@@ -4162,11 +4162,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1625 EventRootType Probe[main.testReturnsInt]
+              Type: 1626 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0xceeaea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1626 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1627 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0xceeb3b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4187,11 +4187,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1633 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1634 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0xceec0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1634 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1635 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0xceecc5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4212,11 +4212,11 @@ Probes:
         - subprogram: {subprogram: 101}
           events:
             - Kind: Entry
-              Type: 1627 EventRootType Probe[main.testReturnsIntPointer]
+              Type: 1628 EventRootType Probe[main.testReturnsIntPointer]
               InjectionPoints: [{PC: "0xceeb6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1628 EventRootType Probe[main.testReturnsIntPointer]Return
+              Type: 1629 EventRootType Probe[main.testReturnsIntPointer]Return
               InjectionPoints: [{PC: "0xceebd4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4238,11 +4238,11 @@ Probes:
         - subprogram: {subprogram: 106}
           events:
             - Kind: Entry
-              Type: 1641 EventRootType Probe[main.testReturnsInterface]
+              Type: 1642 EventRootType Probe[main.testReturnsInterface]
               InjectionPoints: [{PC: "0xcef0ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1642 EventRootType Probe[main.testReturnsInterface]Return
+              Type: 1643 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
                 - PC: "0xcef19d"
                   Frameless: false
@@ -4267,11 +4267,11 @@ Probes:
         - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1680 EventRootType Probe[main.testReturnsLargeStruct]
+              Type: 1681 EventRootType Probe[main.testReturnsLargeStruct]
               InjectionPoints: [{PC: "0xcefa8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1681 EventRootType Probe[main.testReturnsLargeStruct]Return
+              Type: 1682 EventRootType Probe[main.testReturnsLargeStruct]Return
               InjectionPoints: [{PC: "0xcefb23", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4288,11 +4288,11 @@ Probes:
         - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1676 EventRootType Probe[main.testReturnsManyFloats]
+              Type: 1677 EventRootType Probe[main.testReturnsManyFloats]
               InjectionPoints: [{PC: "0xcef90e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1677 EventRootType Probe[main.testReturnsManyFloats]Return
+              Type: 1678 EventRootType Probe[main.testReturnsManyFloats]Return
               InjectionPoints: [{PC: "0xcef9e7", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4309,11 +4309,11 @@ Probes:
         - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1694 EventRootType Probe[main.testReturnsMixed]
+              Type: 1695 EventRootType Probe[main.testReturnsMixed]
               InjectionPoints: [{PC: "0xcefe8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1695 EventRootType Probe[main.testReturnsMixed]Return
+              Type: 1696 EventRootType Probe[main.testReturnsMixed]Return
               InjectionPoints: [{PC: "0xcefeec", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4330,11 +4330,11 @@ Probes:
         - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1688 EventRootType Probe[main.testReturnsMixedStruct]
+              Type: 1689 EventRootType Probe[main.testReturnsMixedStruct]
               InjectionPoints: [{PC: "0xcefc8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1689 EventRootType Probe[main.testReturnsMixedStruct]Return
+              Type: 1690 EventRootType Probe[main.testReturnsMixedStruct]Return
               InjectionPoints: [{PC: "0xcefcd8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4351,11 +4351,11 @@ Probes:
         - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1700 EventRootType Probe[main.testReturnsMultipleFloats]
+              Type: 1701 EventRootType Probe[main.testReturnsMultipleFloats]
               InjectionPoints: [{PC: "0xceffea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1701 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              Type: 1702 EventRootType Probe[main.testReturnsMultipleFloats]Return
               InjectionPoints: [{PC: "0xcf0036", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4375,7 +4375,7 @@ Probes:
         - subprogram: {subprogram: 111}
           events:
             - Kind: Line
-              Type: 1673 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              Type: 1674 EventRootType Probe[main.testReturnsNamedDeferLine]Line
               InjectionPoints: [{PC: "0xcef68f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4396,11 +4396,11 @@ Probes:
         - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1698 EventRootType Probe[main.testReturnsOnlyFloat]
+              Type: 1699 EventRootType Probe[main.testReturnsOnlyFloat]
               InjectionPoints: [{PC: "0xceff8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1699 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              Type: 1700 EventRootType Probe[main.testReturnsOnlyFloat]Return
               InjectionPoints: [{PC: "0xceffce", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4417,11 +4417,11 @@ Probes:
         - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1674 EventRootType Probe[main.testReturnsPrimitives]
+              Type: 1675 EventRootType Probe[main.testReturnsPrimitives]
               InjectionPoints: [{PC: "0xcef88a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1675 EventRootType Probe[main.testReturnsPrimitives]Return
+              Type: 1676 EventRootType Probe[main.testReturnsPrimitives]Return
               InjectionPoints: [{PC: "0xcef8f1", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4438,11 +4438,11 @@ Probes:
         - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1696 EventRootType Probe[main.testReturnsStructWithArray]
+              Type: 1697 EventRootType Probe[main.testReturnsStructWithArray]
               InjectionPoints: [{PC: "0xceff0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1697 EventRootType Probe[main.testReturnsStructWithArray]Return
+              Type: 1698 EventRootType Probe[main.testReturnsStructWithArray]Return
               InjectionPoints: [{PC: "0xceff6f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4459,11 +4459,11 @@ Probes:
         - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1692 EventRootType Probe[main.testReturnsWideStruct]
+              Type: 1693 EventRootType Probe[main.testReturnsWideStruct]
               InjectionPoints: [{PC: "0xcefdae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1693 EventRootType Probe[main.testReturnsWideStruct]Return
+              Type: 1694 EventRootType Probe[main.testReturnsWideStruct]Return
               InjectionPoints: [{PC: "0xcefe52", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4481,7 +4481,7 @@ Probes:
         - subprogram: {subprogram: 2}
           events:
             - Kind: Entry
-              Type: 1505 EventRootType Probe[main.testRuneArray]
+              Type: 1506 EventRootType Probe[main.testRuneArray]
               InjectionPoints: [{PC: "0xce6980", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4516,11 +4516,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1655 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1656 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcef2ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1656 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1657 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcef36f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4566,7 +4566,7 @@ Probes:
         - subprogram: {subprogram: 23}
           events:
             - Kind: Entry
-              Type: 1526 EventRootType Probe[main.testSingleBool]
+              Type: 1527 EventRootType Probe[main.testSingleBool]
               InjectionPoints: [{PC: "0xce6fe0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4588,7 +4588,7 @@ Probes:
         - subprogram: {subprogram: 21}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testSingleByte]
+              Type: 1525 EventRootType Probe[main.testSingleByte]
               InjectionPoints: [{PC: "0xce6fa0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4610,7 +4610,7 @@ Probes:
         - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testSingleFloat32]
+              Type: 1538 EventRootType Probe[main.testSingleFloat32]
               InjectionPoints: [{PC: "0xce7140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4628,7 +4628,7 @@ Probes:
         - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 1538 EventRootType Probe[main.testSingleFloat64]
+              Type: 1539 EventRootType Probe[main.testSingleFloat64]
               InjectionPoints: [{PC: "0xce7160", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4646,7 +4646,7 @@ Probes:
         - subprogram: {subprogram: 24}
           events:
             - Kind: Entry
-              Type: 1527 EventRootType Probe[main.testSingleInt]
+              Type: 1528 EventRootType Probe[main.testSingleInt]
               InjectionPoints: [{PC: "0xce7000", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4668,7 +4668,7 @@ Probes:
         - subprogram: {subprogram: 26}
           events:
             - Kind: Entry
-              Type: 1529 EventRootType Probe[main.testSingleInt16]
+              Type: 1530 EventRootType Probe[main.testSingleInt16]
               InjectionPoints: [{PC: "0xce7040", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4691,7 +4691,7 @@ Probes:
         - subprogram: {subprogram: 27}
           events:
             - Kind: Entry
-              Type: 1530 EventRootType Probe[main.testSingleInt32]
+              Type: 1531 EventRootType Probe[main.testSingleInt32]
               InjectionPoints: [{PC: "0xce7060", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4713,7 +4713,7 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testSingleInt64]
+              Type: 1532 EventRootType Probe[main.testSingleInt64]
               InjectionPoints: [{PC: "0xce7080", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4742,7 +4742,7 @@ Probes:
         - subprogram: {subprogram: 25}
           events:
             - Kind: Entry
-              Type: 1528 EventRootType Probe[main.testSingleInt8]
+              Type: 1529 EventRootType Probe[main.testSingleInt8]
               InjectionPoints: [{PC: "0xce7020", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4773,7 +4773,7 @@ Probes:
         - subprogram: {subprogram: 22}
           events:
             - Kind: Entry
-              Type: 1525 EventRootType Probe[main.testSingleRune]
+              Type: 1526 EventRootType Probe[main.testSingleRune]
               InjectionPoints: [{PC: "0xce6fc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4795,7 +4795,7 @@ Probes:
         - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1737 EventRootType Probe[main.testSingleString]
+              Type: 1738 EventRootType Probe[main.testSingleString]
               InjectionPoints: [{PC: "0xcf1ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4817,7 +4817,7 @@ Probes:
         - subprogram: {subprogram: 29}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testSingleUint]
+              Type: 1533 EventRootType Probe[main.testSingleUint]
               InjectionPoints: [{PC: "0xce70a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4839,7 +4839,7 @@ Probes:
         - subprogram: {subprogram: 31}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testSingleUint16]
+              Type: 1535 EventRootType Probe[main.testSingleUint16]
               InjectionPoints: [{PC: "0xce70e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4861,7 +4861,7 @@ Probes:
         - subprogram: {subprogram: 32}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testSingleUint32]
+              Type: 1536 EventRootType Probe[main.testSingleUint32]
               InjectionPoints: [{PC: "0xce7100", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4883,7 +4883,7 @@ Probes:
         - subprogram: {subprogram: 33}
           events:
             - Kind: Entry
-              Type: 1536 EventRootType Probe[main.testSingleUint64]
+              Type: 1537 EventRootType Probe[main.testSingleUint64]
               InjectionPoints: [{PC: "0xce7120", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4905,7 +4905,7 @@ Probes:
         - subprogram: {subprogram: 30}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testSingleUint8]
+              Type: 1534 EventRootType Probe[main.testSingleUint8]
               InjectionPoints: [{PC: "0xce70c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4927,7 +4927,7 @@ Probes:
         - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1733 EventRootType Probe[main.testSliceEmptyStructs]
+              Type: 1734 EventRootType Probe[main.testSliceEmptyStructs]
               InjectionPoints: [{PC: "0xcf14c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4949,7 +4949,7 @@ Probes:
         - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1724 EventRootType Probe[main.testSliceOfSlices]
+              Type: 1725 EventRootType Probe[main.testSliceOfSlices]
               InjectionPoints: [{PC: "0xcf13c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4971,7 +4971,7 @@ Probes:
         - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testSmallMap]
+              Type: 1586 EventRootType Probe[main.testSmallMap]
               InjectionPoints: [{PC: "0xcec4a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4992,11 +4992,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1669 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1670 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0xcef3ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1670 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1671 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0xcef44d", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5017,11 +5017,11 @@ Probes:
         - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1714 EventRootType Probe[main.testStackArgRegReturns]
+              Type: 1715 EventRootType Probe[main.testStackArgRegReturns]
               InjectionPoints: [{PC: "0xcf0b0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1715 EventRootType Probe[main.testStackArgRegReturns]Return
+              Type: 1716 EventRootType Probe[main.testStackArgRegReturns]Return
               InjectionPoints: [{PC: "0xcf0b7e", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5043,7 +5043,7 @@ Probes:
         - subprogram: {subprogram: 3}
           events:
             - Kind: Entry
-              Type: 1506 EventRootType Probe[main.testStringArray]
+              Type: 1507 EventRootType Probe[main.testStringArray]
               InjectionPoints: [{PC: "0xce69a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5065,7 +5065,7 @@ Probes:
         - subprogram: {subprogram: 97}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testStringPointer]
+              Type: 1617 EventRootType Probe[main.testStringPointer]
               InjectionPoints: [{PC: "0xcee640", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5087,7 +5087,7 @@ Probes:
         - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1728 EventRootType Probe[main.testStringSlice]
+              Type: 1729 EventRootType Probe[main.testStringSlice]
               InjectionPoints: [{PC: "0xcf1440", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5109,7 +5109,7 @@ Probes:
         - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 1548 EventRootType Probe[main.testStringType1]
+              Type: 1549 EventRootType Probe[main.testStringType1]
               InjectionPoints: [{PC: "0xce7800", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5131,7 +5131,7 @@ Probes:
         - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 1549 EventRootType Probe[main.testStringType2]
+              Type: 1550 EventRootType Probe[main.testStringType2]
               InjectionPoints: [{PC: "0xce7820", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5153,7 +5153,7 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1752 EventRootType Probe[main.testStruct]
+              Type: 1753 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0xcf2080", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5180,7 +5180,7 @@ Probes:
         - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1725 EventRootType Probe[main.testStructSlice]
+              Type: 1726 EventRootType Probe[main.testStructSlice]
               InjectionPoints: [{PC: "0xcf13e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5207,7 +5207,7 @@ Probes:
         - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testStructWithAny]
+              Type: 1580 EventRootType Probe[main.testStructWithAny]
               InjectionPoints: [{PC: "0xcebc80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5228,11 +5228,11 @@ Probes:
         - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1718 EventRootType Probe[main.testStructWithArrayArg]
+              Type: 1719 EventRootType Probe[main.testStructWithArrayArg]
               InjectionPoints: [{PC: "0xcf0cae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1719 EventRootType Probe[main.testStructWithArrayArg]Return
+              Type: 1720 EventRootType Probe[main.testStructWithArrayArg]Return
               InjectionPoints: [{PC: "0xcf0d64", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5254,7 +5254,7 @@ Probes:
         - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1750 EventRootType Probe[main.testStructWithCyclicMaps]
+              Type: 1751 EventRootType Probe[main.testStructWithCyclicMaps]
               InjectionPoints: [{PC: "0xcf1f40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5275,7 +5275,7 @@ Probes:
         - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1749 EventRootType Probe[main.testStructWithCyclicSlices]
+              Type: 1750 EventRootType Probe[main.testStructWithCyclicSlices]
               InjectionPoints: [{PC: "0xcf1f20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5302,7 +5302,7 @@ Probes:
         - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testStructWithMap]
+              Type: 1581 EventRootType Probe[main.testStructWithMap]
               InjectionPoints: [{PC: "0xcec400", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5335,7 +5335,7 @@ Probes:
         - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1734 EventRootType Probe[main.testSubslices]
+              Type: 1735 EventRootType Probe[main.testSubslices]
               InjectionPoints: [{PC: "0xcf14e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5375,7 +5375,7 @@ Probes:
         - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1748 EventRootType Probe[main.testSubstrings]
+              Type: 1749 EventRootType Probe[main.testSubstrings]
               InjectionPoints: [{PC: "0xcf1da0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5407,7 +5407,7 @@ Probes:
         - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testTakeContext]
+              Type: 1554 EventRootType Probe[main.testTakeContext]
               InjectionPoints: [{PC: "0xce7e60", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
@@ -5423,11 +5423,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1657 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1658 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcef2ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1658 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1659 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcef36f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5448,11 +5448,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1660 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcef2ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1660 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1661 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcef36f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5475,11 +5475,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1661 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1662 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0xcef2ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1662 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1663 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0xcef36f", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5511,7 +5511,7 @@ Probes:
         - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1738 EventRootType Probe[main.testThreeStrings]
+              Type: 1739 EventRootType Probe[main.testThreeStrings]
               InjectionPoints: [{PC: "0xcf1cc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5543,7 +5543,7 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1739 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1740 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0xcf1ce0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5573,7 +5573,7 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1740 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1741 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0xcf1ce0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5605,7 +5605,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1741 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1742 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0xcf1d00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5635,7 +5635,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1742 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1743 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0xcf1d00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5655,6 +5655,72 @@ Probes:
                   DSL: a.c
                   EventKind: Entry
                   EventExpressionIndex: 2
+    - id: testTimeFixedZone
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeFixedZone}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 166}
+          events:
+            - Kind: Entry
+              Type: 1762 EventRootType Probe[main.testTimeFixedZone]
+              InjectionPoints: [{PC: "0xcf32e0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeMonotonic
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeMonotonic}
+      tags: ['foo:bar']
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 167}
+          events:
+            - Kind: Entry
+              Type: 1763 EventRootType Probe[main.testTimeMonotonic]
+              InjectionPoints: [{PC: "0xcf3300", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{c}'
+            Segments:
+                - JSON: {Ref: c}
+                  DSL: c
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeUTC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeUTC}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 165}
+          events:
+            - Kind: Entry
+              Type: 1761 EventRootType Probe[main.testTimeUTC]
+              InjectionPoints: [{PC: "0xcf32c0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -5667,7 +5733,7 @@ Probes:
         - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 1539 EventRootType Probe[main.testTypeAlias]
+              Type: 1540 EventRootType Probe[main.testTypeAlias]
               InjectionPoints: [{PC: "0xce7180", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5689,7 +5755,7 @@ Probes:
         - subprogram: {subprogram: 12}
           events:
             - Kind: Entry
-              Type: 1515 EventRootType Probe[main.testUint16Array]
+              Type: 1516 EventRootType Probe[main.testUint16Array]
               InjectionPoints: [{PC: "0xce6ac0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5711,7 +5777,7 @@ Probes:
         - subprogram: {subprogram: 13}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testUint32Array]
+              Type: 1517 EventRootType Probe[main.testUint32Array]
               InjectionPoints: [{PC: "0xce6ae0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5733,7 +5799,7 @@ Probes:
         - subprogram: {subprogram: 14}
           events:
             - Kind: Entry
-              Type: 1517 EventRootType Probe[main.testUint64Array]
+              Type: 1518 EventRootType Probe[main.testUint64Array]
               InjectionPoints: [{PC: "0xce6b00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5755,7 +5821,7 @@ Probes:
         - subprogram: {subprogram: 11}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testUint8Array]
+              Type: 1515 EventRootType Probe[main.testUint8Array]
               InjectionPoints: [{PC: "0xce6aa0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5777,7 +5843,7 @@ Probes:
         - subprogram: {subprogram: 10}
           events:
             - Kind: Entry
-              Type: 1513 EventRootType Probe[main.testUintArray]
+              Type: 1514 EventRootType Probe[main.testUintArray]
               InjectionPoints: [{PC: "0xce6a80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5799,7 +5865,7 @@ Probes:
         - subprogram: {subprogram: 96}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[main.testUintPointer]
+              Type: 1616 EventRootType Probe[main.testUintPointer]
               InjectionPoints: [{PC: "0xcee560", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5821,7 +5887,7 @@ Probes:
         - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1722 EventRootType Probe[main.testUintSlice]
+              Type: 1723 EventRootType Probe[main.testUintSlice]
               InjectionPoints: [{PC: "0xcf1380", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5843,7 +5909,7 @@ Probes:
         - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1746 EventRootType Probe[main.testUnitializedString]
+              Type: 1747 EventRootType Probe[main.testUnitializedString]
               InjectionPoints: [{PC: "0xcf1d60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5865,7 +5931,7 @@ Probes:
         - subprogram: {subprogram: 95}
           events:
             - Kind: Entry
-              Type: 1614 EventRootType Probe[main.testUnsafePointer]
+              Type: 1615 EventRootType Probe[main.testUnsafePointer]
               InjectionPoints: [{PC: "0xcee520", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5887,7 +5953,7 @@ Probes:
         - subprogram: {subprogram: 20}
           events:
             - Kind: Entry
-              Type: 1523 EventRootType Probe[main.testVeryLargeArray]
+              Type: 1524 EventRootType Probe[main.testVeryLargeArray]
               InjectionPoints: [{PC: "0xce6be0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5909,7 +5975,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1731 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1732 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0xcf14a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5931,7 +5997,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1732 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1733 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0xcf14a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5950,18 +6016,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 195}
+        - subprogram: {subprogram: 198}
           events:
             - Kind: Entry
-              Type: 1824 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1828 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0xceba8a"
                   Frameless: false
-                - PC: "0xcf4dba"
+                - PC: "0xcf4f3a"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1825 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1829 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0xcebac5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5983,11 +6049,11 @@ Probes:
         - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1720 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              Type: 1721 EventRootType Probe[main.testZeroSizeArgAndReturn]
               InjectionPoints: [{PC: "0xcf0d8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1721 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              Type: 1722 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
               InjectionPoints: [{PC: "0xcf0e0c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -9893,130 +9959,187 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 165
-      Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xcf4140..0xcf4144]
+      Name: main.testTimeUTC
+      OutOfLinePCRanges: [0xcf32c0..0xcf32c1]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 334 BaseType go.shape.int
+        - Name: x
+          Type: 334 GoTimeType time.Time
           Locations:
-            - Range: 0xcf4140..0xcf4144
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcf32c0..0xcf32c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0xcf4140..0xcf4143
-              Pieces: []
-            - Range: 0xcf4143..0xcf4144
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+          DictIndex: -1
+      DictRegister: null
     - ID: 166
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xcf4160..0xcf416c]
+      Name: main.testTimeFixedZone
+      OutOfLinePCRanges: [0xcf32e0..0xcf32e1]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 336 GoStringHeaderType go.shape.string
+        - Name: x
+          Type: 334 GoTimeType time.Time
           Locations:
-            - Range: 0xcf4160..0xcf416b
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf416b..0xcf416c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xcf4160..0xcf416b
-              Pieces: []
-            - Range: 0xcf416b..0xcf416c
+            - Range: 0xcf32e0..0xcf32e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 167
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xcf4180..0xcf4184]
+      Name: main.testTimeMonotonic
+      OutOfLinePCRanges: [0xcf3300..0xcf3301]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+        - Name: c
+          Type: 337 StructureType main.timeCapture
           Locations:
-            - Range: 0xcf4180..0xcf4184
+            - Range: 0xcf3300..0xcf3301
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 168
+      Name: main.wrapBox[go.shape.int]
+      OutOfLinePCRanges: [0xcf42c0..0xcf42c4]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 338 BaseType go.shape.int
+          Locations:
+            - Range: 0xcf42c0..0xcf42c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 334 BaseType go.shape.int
+          Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf4180..0xcf4183
+            - Range: 0xcf42c0..0xcf42c3
               Pieces: []
-            - Range: 0xcf4183..0xcf4184
+            - Range: 0xcf42c3..0xcf42c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 168
-      Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xcf41a0..0xcf41ac]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xcf41a0..0xcf41ab
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf41ab..0xcf41ac
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 336 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0xcf41a0..0xcf41ab
-              Pieces: []
-            - Range: 0xcf41ab..0xcf41ac
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0xcf42e0..0xcf42ec]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 340 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xcf42e0..0xcf42eb
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcf42eb..0xcf42ec
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xcf42e0..0xcf42eb
+              Pieces: []
+            - Range: 0xcf42eb..0xcf42ec
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0xcf4300..0xcf4304]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0xcf4300..0xcf4304
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 338 BaseType go.shape.int
+          Locations:
+            - Range: 0xcf4300..0xcf4303
+              Pieces: []
+            - Range: 0xcf4303..0xcf4304
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 171
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0xcf4320..0xcf432c]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xcf4320..0xcf432b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcf432b..0xcf432c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 340 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xcf4320..0xcf432b
+              Pieces: []
+            - Range: 0xcf432b..0xcf432c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xcf4220..0xcf4405]
+      OutOfLinePCRanges: [0xcf43a0..0xcf4585]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 338 GoSliceHeaderType []go.shape.int
+          Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf4220..0xcf425e
+            - Range: 0xcf43a0..0xcf43de
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10024,7 +10147,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf425e..0xcf4269
+            - Range: 0xcf43de..0xcf43e9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10032,7 +10155,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xcf4269..0xcf4405
+            - Range: 0xcf43e9..0xcf4585
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10043,20 +10166,20 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 340 GoSubroutineType func(go.shape.int) bool
+          Type: 344 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xcf4220..0xcf4269
+            - Range: 0xcf43a0..0xcf43e9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf4269..0xcf4405
+            - Range: 0xcf43e9..0xcf4585
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 338 GoSliceHeaderType []go.shape.int
+          Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf4220..0xcf43ba
+            - Range: 0xcf43a0..0xcf453a
               Pieces: []
-            - Range: 0xcf43ba..0xcf43bb
+            - Range: 0xcf453a..0xcf453b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10064,14 +10187,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf43bb..0xcf4405
+            - Range: 0xcf453b..0xcf4585
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 338 GoSliceHeaderType []go.shape.int
+          Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf4269..0xcf4296
+            - Range: 0xcf43e9..0xcf4416
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10079,7 +10202,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf4296..0xcf4296
+            - Range: 0xcf4416..0xcf4416
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10087,7 +10210,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf4296..0xcf42cc
+            - Range: 0xcf4416..0xcf444c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10095,7 +10218,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf42cc..0xcf4385
+            - Range: 0xcf444c..0xcf4505
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10103,7 +10226,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf4385..0xcf4396
+            - Range: 0xcf4505..0xcf4516
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10111,7 +10234,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf4396..0xcf43a8
+            - Range: 0xcf4516..0xcf4528
               Pieces:
                 - Size: 8
                   Op: null
@@ -10119,7 +10242,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf43b1..0xcf43b7
+            - Range: 0xcf4531..0xcf4537
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10127,7 +10250,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf43b7..0xcf4405
+            - Range: 0xcf4537..0xcf4585
               Pieces:
                 - Size: 8
                   Op: null
@@ -10138,207 +10261,207 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcf42bf..0xcf42cc
+            - Range: 0xcf443f..0xcf444c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf42cc..0xcf4385
+            - Range: 0xcf444c..0xcf4505
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 170
+    - ID: 173
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf4420..0xcf4464]
+      OutOfLinePCRanges: [0xcf45a0..0xcf45e4]
       InlinePCRanges: []
       Variables:
         - Name: box
-          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf4420..0xcf4439
+            - Range: 0xcf45a0..0xcf45b9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
-          Type: 341 GoSubroutineType func(go.shape.int) go.shape.string
+          Type: 345 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xcf4420..0xcf4439
+            - Range: 0xcf45a0..0xcf45b9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf4420..0xcf4439
+            - Range: 0xcf45a0..0xcf45b9
               Pieces: []
-            - Range: 0xcf4439..0xcf443a
+            - Range: 0xcf45b9..0xcf45ba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf443a..0xcf4464
+            - Range: 0xcf45ba..0xcf45e4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xcf46a0..0xcf46a4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 339 PointerType *go.shape.int
-          Locations:
-            - Range: 0xcf46a0..0xcf46a4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 339 PointerType *go.shape.int
-          Locations:
-            - Range: 0xcf46a0..0xcf46a3
-              Pieces: []
-            - Range: 0xcf46a3..0xcf46a4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xcf46c0..0xcf46c4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 342 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0xcf46c0..0xcf46c4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 342 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0xcf46c0..0xcf46c3
-              Pieces: []
-            - Range: 0xcf46c3..0xcf46c4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 173
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xcf46e0..0xcf46e4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 344 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0xcf46e0..0xcf46e4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 344 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0xcf46e0..0xcf46e3
-              Pieces: []
-            - Range: 0xcf46e3..0xcf46e4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 174
-      Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xcf4700..0xcf4711]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0xcf4820..0xcf4824]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 346 StructureType main.largeGenericType[go.shape.string]
+        - Name: p
+          Type: 343 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf4700..0xcf4711
-              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+            - Range: 0xcf4820..0xcf4824
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 343 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf4700..0xcf4710
+            - Range: 0xcf4820..0xcf4823
               Pieces: []
-            - Range: 0xcf4710..0xcf4711
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcf4823..0xcf4824
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
-      Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xcf47e0..0xcf47e9]
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0xcf4840..0xcf4844]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 348 StructureType main.largeGenericType[go.shape.int]
+        - Name: p
+          Type: 346 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcf47e0..0xcf47e9
-              Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
+            - Range: 0xcf4840..0xcf4844
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 334 BaseType go.shape.int
+          Type: 346 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcf47e0..0xcf47e8
+            - Range: 0xcf4840..0xcf4843
               Pieces: []
-            - Range: 0xcf47e8..0xcf47e9
+            - Range: 0xcf4843..0xcf4844
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 176
-      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xcf48a0..0xcf48a8]
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0xcf4860..0xcf4864]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 348 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xcf4860..0xcf4864
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 348 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0xcf4860..0xcf4863
+              Pieces: []
+            - Range: 0xcf4863..0xcf4864
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 177
+      Name: main.largeGenericType[go.shape.string].LargeGet
+      OutOfLinePCRanges: [0xcf4880..0xcf4891]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 349 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Type: 350 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xcf48a0..0xcf48a8
+            - Range: 0xcf4880..0xcf4891
+              Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 340 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xcf4880..0xcf4890
+              Pieces: []
+            - Range: 0xcf4890..0xcf4891
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 178
+      Name: main.largeGenericType[go.shape.int].LargeGet
+      OutOfLinePCRanges: [0xcf4960..0xcf4969]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 352 StructureType main.largeGenericType[go.shape.int]
+          Locations:
+            - Range: 0xcf4960..0xcf4969
+              Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 338 BaseType go.shape.int
+          Locations:
+            - Range: 0xcf4960..0xcf4968
+              Pieces: []
+            - Range: 0xcf4968..0xcf4969
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 179
+      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
+      OutOfLinePCRanges: [0xcf4a20..0xcf4a28]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 353 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Locations:
+            - Range: 0xcf4a20..0xcf4a28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcf48a0..0xcf48a8
+            - Range: 0xcf4a20..0xcf4a28
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 351 BaseType go.shape.bool
+          Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf48a0..0xcf48a8
+            - Range: 0xcf4a20..0xcf4a28
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 177
+    - ID: 180
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xcf4920..0xcf498e]
+      OutOfLinePCRanges: [0xcf4aa0..0xcf4b0e]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 352 PointerType *main.Pair[go.shape.string,go.shape.int]
+          Type: 356 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xcf4920..0xcf498e
+            - Range: 0xcf4aa0..0xcf4b0e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4920..0xcf498e
+            - Range: 0xcf4aa0..0xcf4b0e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10347,22 +10470,22 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcf4920..0xcf498e
+            - Range: 0xcf4aa0..0xcf4b0e
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 178
+    - ID: 181
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xcf4a00..0xcf4a08]
+      OutOfLinePCRanges: [0xcf4b80..0xcf4b88]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4a00..0xcf4a08
+            - Range: 0xcf4b80..0xcf4b88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10371,27 +10494,27 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 351 BaseType go.shape.bool
+          Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf4a00..0xcf4a08
+            - Range: 0xcf4b80..0xcf4b88
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 351 BaseType go.shape.bool
+          Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf4a00..0xcf4a07
+            - Range: 0xcf4b80..0xcf4b87
               Pieces: []
-            - Range: 0xcf4a07..0xcf4a08
+            - Range: 0xcf4b87..0xcf4b88
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4a00..0xcf4a07
+            - Range: 0xcf4b80..0xcf4b87
               Pieces: []
-            - Range: 0xcf4a07..0xcf4a08
+            - Range: 0xcf4b87..0xcf4b88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10400,28 +10523,28 @@ Subprograms:
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 179
+    - ID: 182
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf4a20..0xcf4a2f]
+      OutOfLinePCRanges: [0xcf4ba0..0xcf4baf]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcf4a20..0xcf4a2e
+            - Range: 0xcf4ba0..0xcf4bae
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4a20..0xcf4a2b
+            - Range: 0xcf4ba0..0xcf4bab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf4a2b..0xcf4a2f
+            - Range: 0xcf4bab..0xcf4baf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10430,11 +10553,11 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4a20..0xcf4a2e
+            - Range: 0xcf4ba0..0xcf4bae
               Pieces: []
-            - Range: 0xcf4a2e..0xcf4a2f
+            - Range: 0xcf4bae..0xcf4baf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10443,58 +10566,58 @@ Subprograms:
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcf4a20..0xcf4a2e
+            - Range: 0xcf4ba0..0xcf4bae
               Pieces: []
-            - Range: 0xcf4a2e..0xcf4a2f
+            - Range: 0xcf4bae..0xcf4baf
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 180
+    - ID: 183
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xcf4a40..0xcf4a7a]
+      OutOfLinePCRanges: [0xcf4bc0..0xcf4bfa]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 354 StructureType go.shape.struct { main.i int }
+          Type: 358 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xcf4a40..0xcf4a59
+            - Range: 0xcf4bc0..0xcf4bd9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf4a40..0xcf4a59
+            - Range: 0xcf4bc0..0xcf4bd9
               Pieces: []
-            - Range: 0xcf4a59..0xcf4a5a
+            - Range: 0xcf4bd9..0xcf4bda
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf4a5a..0xcf4a7a
+            - Range: 0xcf4bda..0xcf4bfa
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 184
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xcf4a80..0xcf4acd]
+      OutOfLinePCRanges: [0xcf4c00..0xcf4c4d]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 355 StructureType go.shape.struct { main.s string }
+          Type: 359 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xcf4a80..0xcf4a9f
+            - Range: 0xcf4c00..0xcf4c1f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf4a9f..0xcf4aa2
+            - Range: 0xcf4c1f..0xcf4c22
               Pieces:
                 - Size: 8
                   Op: null
@@ -10505,37 +10628,37 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf4a80..0xcf4aa2
+            - Range: 0xcf4c00..0xcf4c22
               Pieces: []
-            - Range: 0xcf4aa2..0xcf4aa3
+            - Range: 0xcf4c22..0xcf4c23
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf4aa3..0xcf4acd
+            - Range: 0xcf4c23..0xcf4c4d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 182
+    - ID: 185
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xcf4ae0..0xcf4ae8]
+      OutOfLinePCRanges: [0xcf4c60..0xcf4c68]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 356 PointerType *go.shape.string
+          Type: 360 PointerType *go.shape.string
           Locations:
-            - Range: 0xcf4ae0..0xcf4ae7
+            - Range: 0xcf4c60..0xcf4c67
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4ae0..0xcf4ae7
+            - Range: 0xcf4c60..0xcf4c67
               Pieces: []
-            - Range: 0xcf4ae7..0xcf4ae8
+            - Range: 0xcf4c67..0xcf4c68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10544,24 +10667,24 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 183
+    - ID: 186
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xcf4b00..0xcf4b5b]
+      OutOfLinePCRanges: [0xcf4c80..0xcf4cdb]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 357 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 361 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf4b00..0xcf4b41
+            - Range: 0xcf4c80..0xcf4cc1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 358 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf4b00..0xcf4b55
+            - Range: 0xcf4c80..0xcf4cd5
               Pieces: []
-            - Range: 0xcf4b55..0xcf4b56
+            - Range: 0xcf4cd5..0xcf4cd6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10575,20 +10698,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf4b56..0xcf4b5b
+            - Range: 0xcf4cd6..0xcf4cdb
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 184
+    - ID: 187
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xcf4b60..0xcf4b84]
+      OutOfLinePCRanges: [0xcf4ce0..0xcf4d04]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 338 GoSliceHeaderType []go.shape.int
+          Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf4b60..0xcf4b84
+            - Range: 0xcf4ce0..0xcf4d04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10599,35 +10722,35 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcf4b60..0xcf4b84
+            - Range: 0xcf4ce0..0xcf4d04
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf4b60..0xcf4b80
+            - Range: 0xcf4ce0..0xcf4d00
               Pieces: []
-            - Range: 0xcf4b80..0xcf4b81
+            - Range: 0xcf4d00..0xcf4d01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf4b81..0xcf4b83
+            - Range: 0xcf4d01..0xcf4d03
               Pieces: []
-            - Range: 0xcf4b83..0xcf4b84
+            - Range: 0xcf4d03..0xcf4d04
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 185
+    - ID: 188
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xcf4ba0..0xcf4c5f]
+      OutOfLinePCRanges: [0xcf4d20..0xcf4ddf]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 359 GoSliceHeaderType []go.shape.string
+          Type: 363 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xcf4ba0..0xcf4bbd
+            - Range: 0xcf4d20..0xcf4d3d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10635,7 +10758,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf4bbd..0xcf4bbf
+            - Range: 0xcf4d3d..0xcf4d3f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10646,15 +10769,15 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4ba0..0xcf4bec
+            - Range: 0xcf4d20..0xcf4d6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf4bec..0xcf4c5f
+            - Range: 0xcf4d6c..0xcf4ddf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10665,28 +10788,28 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf4ba0..0xcf4c0b
+            - Range: 0xcf4d20..0xcf4d8b
               Pieces: []
-            - Range: 0xcf4c0b..0xcf4c0c
+            - Range: 0xcf4d8b..0xcf4d8c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf4c0c..0xcf4c13
+            - Range: 0xcf4d8c..0xcf4d93
               Pieces: []
-            - Range: 0xcf4c13..0xcf4c14
+            - Range: 0xcf4d93..0xcf4d94
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf4c14..0xcf4c5f
+            - Range: 0xcf4d94..0xcf4ddf
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4bcf..0xcf4be1
+            - Range: 0xcf4d4f..0xcf4d61
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcf4be1..0xcf4bec
+            - Range: 0xcf4d61..0xcf4d6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10695,56 +10818,56 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 186
+    - ID: 189
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xcf4c60..0xcf4c67]
+      OutOfLinePCRanges: [0xcf4de0..0xcf4de7]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 360 StructureType main.typeWithGenerics[go.shape.int]
+          Type: 364 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xcf4c60..0xcf4c66
+            - Range: 0xcf4de0..0xcf4de6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcf4c60..0xcf4c67
+            - Range: 0xcf4de0..0xcf4de7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf4c60..0xcf4c66
+            - Range: 0xcf4de0..0xcf4de6
               Pieces: []
-            - Range: 0xcf4c66..0xcf4c67
+            - Range: 0xcf4de6..0xcf4de7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
-    - ID: 187
+    - ID: 190
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xcf4cc0..0xcf4d2c]
+      OutOfLinePCRanges: [0xcf4e40..0xcf4eac]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 361 StructureType main.typeWithGenerics[go.shape.string]
+          Type: 365 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xcf4cc0..0xcf4ce0
+            - Range: 0xcf4e40..0xcf4e60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf4ce0..0xcf4ce8
+            - Range: 0xcf4e60..0xcf4e68
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf4ce8..0xcf4ced
+            - Range: 0xcf4e68..0xcf4e6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10753,9 +10876,9 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf4cc0..0xcf4ced
+            - Range: 0xcf4e40..0xcf4e6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10766,22 +10889,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf4cc0..0xcf4ced
+            - Range: 0xcf4e40..0xcf4e6d
               Pieces: []
-            - Range: 0xcf4ced..0xcf4cee
+            - Range: 0xcf4e6d..0xcf4e6e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf4cee..0xcf4d2c
+            - Range: 0xcf4e6e..0xcf4eac
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 188
+    - ID: 191
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0xce5ae0..0xce5cc5]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 362 GoSliceHeaderType []go.shape.float64
+          Type: 366 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xce5ae0..0xce5b1e
               Pieces:
@@ -10810,7 +10933,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 365 GoSubroutineType func(go.shape.float64) bool
+          Type: 369 GoSubroutineType func(go.shape.float64) bool
           Locations:
             - Range: 0xce5ae0..0xce5b29
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
@@ -10819,7 +10942,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 362 GoSliceHeaderType []go.shape.float64
+          Type: 366 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xce5ae0..0xce5c7a
               Pieces: []
@@ -10836,7 +10959,7 @@ Subprograms:
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 362 GoSliceHeaderType []go.shape.float64
+          Type: 366 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0xce5b29..0xce5b56
               Pieces:
@@ -10905,7 +11028,7 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 364 BaseType go.shape.float64
+          Type: 368 BaseType go.shape.float64
           Locations:
             - Range: 0xce5b80..0xce5b8e
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
@@ -10914,7 +11037,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 189
+    - ID: 192
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xceb3a0..0xceb402]
       InlinePCRanges:
@@ -10945,7 +11068,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 193
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10953,7 +11076,7 @@ Subprograms:
           RootRanges: [0xceb5e0..0xceb6a5]
       Variables: []
       DictRegister: null
-    - ID: 191
+    - ID: 194
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10961,7 +11084,7 @@ Subprograms:
           RootRanges: [0xceb740..0xceb845]
       Variables: []
       DictRegister: null
-    - ID: 192
+    - ID: 195
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10969,7 +11092,7 @@ Subprograms:
           RootRanges: [0xceb740..0xceb845]
       Variables: []
       DictRegister: null
-    - ID: 193
+    - ID: 196
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10984,7 +11107,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 194
+    - ID: 197
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11003,15 +11126,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 195
+    - ID: 198
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xceba80..0xcebae6]
       InlinePCRanges:
-        - Ranges: [0xcf4dba..0xcf4de8]
-          RootRanges: [0xcf4da0..0xcf4e05]
+        - Ranges: [0xcf4f3a..0xcf4f68]
+          RootRanges: [0xcf4f20..0xcf4f85]
       Variables:
         - Name: b
-          Type: 366 StructureType main.firstBehavior
+          Type: 370 StructureType main.firstBehavior
           Locations:
             - Range: 0xceba80..0xceba9e
               Pieces:
@@ -11037,7 +11160,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 196
+    - ID: 199
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11049,31 +11172,31 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1404
+      ID: 1405
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 400 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 147
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 148 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1409
+      ID: 1410
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1410 PointerType *main.deepSlice3
+      Pointee: 1411 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1444
+      ID: 1445
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1445 PointerType *main.deepSlice8
+      Pointee: 1446 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1450
+      ID: 1451
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1451 PointerType *main.deepSlice9
+      Pointee: 1452 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 161
       Name: '**main.stringType2'
@@ -11081,7 +11204,7 @@ Types:
       GoKind: 22
       Pointee: 162 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1389
+      ID: 1400
       Name: '**main.t'
       ByteSize: 8
       Pointee: 261 PointerType *main.t
@@ -11119,40 +11242,40 @@ Types:
       ByteSize: 8
       Pointee: 215 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 386
+      ID: 390
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 387 PointerType *table<context.canceler,struct {}>
+      Pointee: 391 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 155
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 156 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1417
+      ID: 1418
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1418 PointerType *table<int,*main.deepMap3>
+      Pointee: 1419 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1461
+      ID: 1462
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1462 PointerType *table<int,*main.deepMap8>
+      Pointee: 1463 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1476
+      ID: 1477
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1477 PointerType *table<int,*main.deepMap9>
+      Pointee: 1478 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 182
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 183 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1491
+      ID: 1492
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1492 PointerType *table<int,interface {}>
+      Pointee: 1493 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 249
       Name: '**table<int,struct {}>'
@@ -11164,10 +11287,10 @@ Types:
       ByteSize: 8
       Pointee: 220 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 699 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 706 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 209
       Name: '**table<string,[]main.structWithMap>'
@@ -11179,35 +11302,35 @@ Types:
       ByteSize: 8
       Pointee: 198 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 417
+      ID: 418
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 418 PointerType *table<string,float64>
+      Pointee: 419 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1143
+      ID: 1154
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1144 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1155 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 192
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 193 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 412
+      ID: 413
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 413 PointerType *table<string,interface {}>
+      Pointee: 414 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 187
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 188 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 407
+      ID: 408
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 408 PointerType *table<string,string>
+      Pointee: 409 PointerType *table<string,string>
     - __kind: PointerType
       ID: 244
       Name: '**table<struct {},int>'
@@ -11259,150 +11382,150 @@ Types:
       ByteSize: 8
       Pointee: 225 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1407
+      ID: 1408
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1406 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1407 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 443
+      ID: 444
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 442 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 443 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1413
+      ID: 1414
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1412 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1413 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1448
+      ID: 1449
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1447 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1448 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1454
+      ID: 1455
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1453 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1454 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 438
+      ID: 439
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 437 GoSliceDataType []*runtime.p.array
+      Pointee: 438 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 440
+      ID: 441
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 439 GoSliceDataType []*string.array
+      Pointee: 440 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 603
+      ID: 604
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 602 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 603 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 296
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 293 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 601
+      ID: 602
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 600 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 601 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 294
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 291 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 599
+      ID: 600
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 598 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 599 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 292
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 289 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 597
+      ID: 598
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 596 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 597 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 595
+      ID: 596
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 594 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 595 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 583
+      ID: 584
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 582 GoSliceDataType [][]uint.array
+      Pointee: 583 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 587
+      ID: 588
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 586 GoSliceDataType []bool.array
+      Pointee: 587 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1180
+      ID: 1191
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1179 GoSliceDataType []float64.array
+      Pointee: 1190 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 700 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 701 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 708 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 659
+      ID: 666
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 658 GoSliceDataType []go.shape.float64.array
+      Pointee: 665 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 655
+      ID: 662
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 654 GoSliceDataType []go.shape.int.array
+      Pointee: 661 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 657
+      ID: 664
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 656 GoSliceDataType []go.shape.string.array
+      Pointee: 663 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
-      ID: 1457
+      ID: 1458
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1456 GoSliceDataType []interface {}.array
+      Pointee: 1457 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 288
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 593
+      ID: 594
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 592 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 593 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 703 GoSliceDataType []main.structWithMap.array
+      Pointee: 710 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 585
+      ID: 586
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 584 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 585 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -11411,111 +11534,111 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 455
+      ID: 456
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 454 GoSliceDataType []string.array
+      Pointee: 455 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 591
+      ID: 592
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 590 GoSliceDataType []struct {}.array
+      Pointee: 591 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 1400
+      ID: 713
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 1399 GoSliceDataType []time.zone.array
+      Pointee: 712 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 1402
+      ID: 715
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 1401 GoSliceDataType []time.zoneTrans.array
+      Pointee: 714 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 272
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 270 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 581
+      ID: 582
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 580 GoSliceDataType []uint.array
+      Pointee: 581 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 589
+      ID: 590
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 588 GoSliceDataType []uint16.array
+      Pointee: 589 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 433
+      ID: 434
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 432 GoSliceDataType []uint8.array
+      Pointee: 433 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 435
+      ID: 436
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 434 GoSliceDataType []uintptr.array
+      Pointee: 435 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1311
+      ID: 1322
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2017920
       GoKind: 22
-      Pointee: 1312 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1323 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 948
+      ID: 959
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 944704
       GoKind: 22
-      Pointee: 949 GoSliceHeaderType archive/tar.headerError
+      Pointee: 960 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 951
+      ID: 962
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 950 GoSliceDataType archive/tar.headerError.array
+      Pointee: 961 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1245
+      ID: 1256
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1454592
       GoKind: 22
-      Pointee: 1246 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1257 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1193
+      ID: 1204
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 944896
       GoKind: 22
-      Pointee: 1194 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1205 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1195
+      ID: 1206
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 944992
       GoKind: 22
-      Pointee: 1196 StructureType archive/zip.dirWriter
+      Pointee: 1207 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1288
+      ID: 1299
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1933952
       GoKind: 22
-      Pointee: 1289 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1300 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1221
+      ID: 1232
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1071584
       GoKind: 22
-      Pointee: 1222 StructureType archive/zip.nopCloser
+      Pointee: 1233 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1223
+      ID: 1234
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1071840
       GoKind: 22
-      Pointee: 1224 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1235 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -11524,26 +11647,26 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1269
+      ID: 1280
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2208000
       GoKind: 22
-      Pointee: 1270 UnresolvedPointeeType bufio.Reader
+      Pointee: 1281 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1300
+      ID: 1311
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1980736
       GoKind: 22
-      Pointee: 1301 UnresolvedPointeeType bufio.Writer
+      Pointee: 1312 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1347
+      ID: 1358
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2309984
       GoKind: 22
-      Pointee: 1348 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1359 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 116
       Name: '*complex128'
@@ -11552,451 +11675,451 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 861
+      ID: 872
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 926752
       GoKind: 22
-      Pointee: 752 BaseType compress/flate.CorruptInputError
+      Pointee: 763 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 862
+      ID: 873
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 926848
       GoKind: 22
-      Pointee: 753 GoStringHeaderType compress/flate.InternalError
+      Pointee: 764 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 755
+      ID: 766
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 754 GoStringDataType compress/flate.InternalError.str
+      Pointee: 765 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1243
+      ID: 1254
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1443392
       GoKind: 22
-      Pointee: 1244 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1255 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1189
+      ID: 1200
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 926944
       GoKind: 22
-      Pointee: 1190 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1201 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1265
+      ID: 1276
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1753856
       GoKind: 22
-      Pointee: 1266 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1277 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 367
+      ID: 371
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 1751744
       GoKind: 22
-      Pointee: 368 StructureType context.afterFuncCtx
+      Pointee: 372 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 1437
+      ID: 1438
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1573184
       GoKind: 22
-      Pointee: 391 StructureType context.backgroundCtx
+      Pointee: 395 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 369
+      ID: 373
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1751168
       GoKind: 22
-      Pointee: 370 StructureType context.cancelCtx
+      Pointee: 374 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1064
+      ID: 1075
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1205216
       GoKind: 22
-      Pointee: 1065 StructureType context.deadlineExceededError
+      Pointee: 1076 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1432
+      ID: 1433
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1431712
       GoKind: 22
-      Pointee: 392 StructureType context.emptyCtx
+      Pointee: 396 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 371
+      ID: 375
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1431872
       GoKind: 22
-      Pointee: 372 StructureType context.stopCtx
+      Pointee: 376 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 373
+      ID: 377
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1751360
       GoKind: 22
-      Pointee: 374 StructureType context.timerCtx
+      Pointee: 378 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1438
+      ID: 1439
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1573344
       GoKind: 22
-      Pointee: 399 StructureType context.todoCtx
+      Pointee: 400 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 375
+      ID: 379
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1572864
       GoKind: 22
-      Pointee: 376 StructureType context.valueCtx
+      Pointee: 380 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 377
+      ID: 381
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1573024
       GoKind: 22
-      Pointee: 378 StructureType context.withoutCancelCtx
+      Pointee: 382 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 940
+      ID: 951
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 763 BaseType crypto/aes.KeySizeError
+      Pointee: 774 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 941
+      ID: 952
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939520
       GoKind: 22
-      Pointee: 764 BaseType crypto/des.KeySizeError
+      Pointee: 775 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 942
+      ID: 953
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939808
       GoKind: 22
-      Pointee: 765 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 776 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1260
+      ID: 1271
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1693632
       GoKind: 22
-      Pointee: 1261 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1272 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1045
+      ID: 1056
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1079392
       GoKind: 22
-      Pointee: 1046 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 1057 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1290
+      ID: 1301
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1934464
       GoKind: 22
-      Pointee: 1291 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1302 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1322
+      ID: 1333
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2152000
       GoKind: 22
-      Pointee: 1323 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1334 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1296
+      ID: 1307
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1935232
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1292
+      ID: 1303
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1934720
       GoKind: 22
-      Pointee: 1293 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1304 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1286
+      ID: 1297
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1931904
       GoKind: 22
-      Pointee: 1287 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1298 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 943
+      ID: 954
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 940096
       GoKind: 22
-      Pointee: 766 BaseType crypto/rc4.KeySizeError
+      Pointee: 777 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1309
+      ID: 1320
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 2015616
       GoKind: 22
-      Pointee: 1310 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1321 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1294
+      ID: 1305
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1934976
       GoKind: 22
-      Pointee: 1295 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1306 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 1278
+      ID: 1289
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1836640
       GoKind: 22
-      Pointee: 1279 UnresolvedPointeeType crypto/sha3.SHAKE
+      Pointee: 1290 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
-      ID: 865
+      ID: 876
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 928288
       GoKind: 22
-      Pointee: 756 BaseType crypto/tls.AlertError
+      Pointee: 767 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1034
+      ID: 1045
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1060576
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1046 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1373
+      ID: 1384
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2412704
       GoKind: 22
-      Pointee: 1374 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1385 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 866
+      ID: 877
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 928384
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 878 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 863
+      ID: 874
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 928192
       GoKind: 22
-      Pointee: 864 StructureType crypto/tls.RecordHeaderError
+      Pointee: 875 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1033
+      ID: 1044
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1058912
       GoKind: 22
-      Pointee: 988 BaseType crypto/tls.alert
+      Pointee: 999 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1253
+      ID: 1264
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1582464
       GoKind: 22
-      Pointee: 1254 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1265 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 868
+      ID: 879
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 928480
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 880 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1258
+      ID: 1269
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1667328
       GoKind: 22
-      Pointee: 1259 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1270 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1131
+      ID: 1142
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1443872
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1143 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1145
+      ID: 1156
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2044256
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1157 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 934
+      ID: 945
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 938080
       GoKind: 22
-      Pointee: 935 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 946 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 928
+      ID: 939
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 937120
       GoKind: 22
-      Pointee: 929 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 940 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 930
+      ID: 941
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 937600
       GoKind: 22
-      Pointee: 931 StructureType crypto/x509.HostnameError
+      Pointee: 942 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 927
+      ID: 938
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 937024
       GoKind: 22
-      Pointee: 762 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 773 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1039
+      ID: 1050
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1065824
       GoKind: 22
-      Pointee: 1040 StructureType crypto/x509.SystemRootsError
+      Pointee: 1051 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 936
+      ID: 947
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 938176
       GoKind: 22
-      Pointee: 937 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 948 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 932
+      ID: 943
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 937984
       GoKind: 22
-      Pointee: 933 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 944 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 952
+      ID: 963
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 945184
       GoKind: 22
-      Pointee: 953 StructureType encoding/asn1.StructuralError
+      Pointee: 964 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 956
+      ID: 967
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 945376
       GoKind: 22
-      Pointee: 957 StructureType encoding/asn1.SyntaxError
+      Pointee: 968 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 954
+      ID: 965
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 945280
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 966 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 851
+      ID: 862
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 924064
       GoKind: 22
-      Pointee: 746 BaseType encoding/base64.CorruptInputError
+      Pointee: 757 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1211
+      ID: 1222
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1055328
       GoKind: 22
-      Pointee: 1212 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1223 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 854
+      ID: 865
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 747 BaseType encoding/hex.InvalidByteError
+      Pointee: 758 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 822
+      ID: 833
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 834 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1023
+      ID: 1034
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1051488
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1035 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 814
+      ID: 825
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 826 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 820
+      ID: 831
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 918784
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 832 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 818
+      ID: 829
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918688
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 830 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 816
+      ID: 827
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 828 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1353
+      ID: 1364
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2331104
       GoKind: 22
-      Pointee: 1354 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1365 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 824
+      ID: 835
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 825 StructureType encoding/json.jsonError
+      Pointee: 836 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1219
+      ID: 1230
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1068384
       GoKind: 22
-      Pointee: 1220 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1231 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 925
+      ID: 936
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 936256
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 937 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -12005,19 +12128,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 788
+      ID: 799
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType errors.errorString
+      Pointee: 800 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 990
+      ID: 1001
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1037024
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType errors.joinError
+      Pointee: 1002 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -12033,913 +12156,913 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 1341
+      ID: 1352
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2292544
       GoKind: 22
-      Pointee: 1342 UnresolvedPointeeType fmt.pp
+      Pointee: 1353 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 992
+      ID: 1003
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1037152
       GoKind: 22
-      Pointee: 993 UnresolvedPointeeType fmt.wrapError
+      Pointee: 1004 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 994
+      ID: 1005
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1037280
       GoKind: 22
-      Pointee: 995 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 1006 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 852
+      ID: 863
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 864 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 833
+      ID: 844
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 921664
       GoKind: 22
-      Pointee: 834 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 845 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 835
+      ID: 846
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 847 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1157
+      ID: 1168
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 921472
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1169 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 839
+      ID: 850
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 922048
       GoKind: 22
-      Pointee: 840 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 851 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1159
+      ID: 1170
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 921568
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1171 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 837
+      ID: 848
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 921856
       GoKind: 22
-      Pointee: 740 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 751 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 742
+      ID: 753
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 741 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 832
+      ID: 843
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 737 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 748 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 739
+      ID: 750
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 738 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 838
+      ID: 849
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 921952
       GoKind: 22
-      Pointee: 743 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 754 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 745
+      ID: 756
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 744 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 755 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1231
+      ID: 1242
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1222880
       GoKind: 22
-      Pointee: 1232 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1243 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1319
+      ID: 1330
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2089088
       GoKind: 22
-      Pointee: 1320 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1331 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 946
+      ID: 957
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 943648
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 958 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 400
+      ID: 401
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2309440
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 402 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 425
+      ID: 426
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2039072
       GoKind: 22
-      Pointee: 426 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 427 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 420
+      ID: 421
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1205472
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 422 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 423
+      ID: 424
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1205600
       GoKind: 22
-      Pointee: 424 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 425 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1430
+      ID: 1431
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1206240
       GoKind: 22
-      Pointee: 1431 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1432 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 711
+      ID: 722
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1206368
       GoKind: 22
-      Pointee: 712 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 723 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 427
+      ID: 428
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2258400
       GoKind: 22
-      Pointee: 428 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 429 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1099
+      ID: 1110
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1226336
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1111 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1349
+      ID: 1360
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2310528
       GoKind: 22
-      Pointee: 1350 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1361 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1433
+      ID: 1434
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1437632
       GoKind: 22
-      Pointee: 1434 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 1435 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 876
+      ID: 887
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 931936
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 888 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 883
+      ID: 894
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 932992
       GoKind: 22
-      Pointee: 884 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 895 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 878
+      ID: 889
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 932704
       GoKind: 22
-      Pointee: 761 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 772 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 881
+      ID: 892
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 932896
       GoKind: 22
-      Pointee: 882 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 893 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 879
+      ID: 890
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 932800
       GoKind: 22
-      Pointee: 880 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 891 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 899
+      ID: 910
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 934912
       GoKind: 22
-      Pointee: 900 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 911 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 903
+      ID: 914
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 935104
       GoKind: 22
-      Pointee: 904 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 915 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 901
+      ID: 912
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 935008
       GoKind: 22
-      Pointee: 902 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 913 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 897
+      ID: 908
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 898 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 909 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1182
+      ID: 1193
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1181 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1192 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 911
+      ID: 922
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 935488
       GoKind: 22
-      Pointee: 912 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 923 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 905
+      ID: 916
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 935200
       GoKind: 22
-      Pointee: 906 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 917 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 909
+      ID: 920
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 935392
       GoKind: 22
-      Pointee: 910 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 921 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 907
+      ID: 918
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 935296
       GoKind: 22
-      Pointee: 908 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 919 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 913
+      ID: 924
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 935584
       GoKind: 22
-      Pointee: 914 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 925 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 919
+      ID: 930
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 935872
       GoKind: 22
-      Pointee: 920 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 931 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 921
+      ID: 932
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 935968
       GoKind: 22
-      Pointee: 922 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 933 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 917
+      ID: 928
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 935776
       GoKind: 22
-      Pointee: 918 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 929 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 915
+      ID: 926
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 935680
       GoKind: 22
-      Pointee: 916 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 927 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 923
+      ID: 934
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 936160
       GoKind: 22
-      Pointee: 924 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 935 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 841
+      ID: 852
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 923200
       GoKind: 22
-      Pointee: 842 StructureType github.com/cihub/seelog.baseError
+      Pointee: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1272
+      ID: 1283
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1831040
       GoKind: 22
-      Pointee: 1273 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1284 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 843
+      ID: 854
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 923296
       GoKind: 22
-      Pointee: 844 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 855 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1251
+      ID: 1262
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1580544
       GoKind: 22
-      Pointee: 1252 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1263 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1207
+      ID: 1218
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1054176
       GoKind: 22
-      Pointee: 1208 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1219 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1241
+      ID: 1252
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1441312
       GoKind: 22
-      Pointee: 1242 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1253 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 847
+      ID: 858
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 923488
       GoKind: 22
-      Pointee: 848 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 859 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1307
+      ID: 1318
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 2006976
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1319 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1326
+      ID: 1337
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2165792
       GoKind: 22
-      Pointee: 1321 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1332 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1325
+      ID: 1336
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2165408
       GoKind: 22
-      Pointee: 1324 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1335 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1209
+      ID: 1220
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1054304
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1221 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 845
+      ID: 856
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 923392
       GoKind: 22
-      Pointee: 846 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 857 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 849
+      ID: 860
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 923584
       GoKind: 22
-      Pointee: 850 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 861 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1274
+      ID: 1285
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1832832
       GoKind: 22
-      Pointee: 1275 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1286 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1315
+      ID: 1326
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2043968
       GoKind: 22
-      Pointee: 1316 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1327 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1317
+      ID: 1328
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2075040
       GoKind: 22
-      Pointee: 1318 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1329 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1133
+      ID: 1144
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1456992
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1145 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1049
+      ID: 1060
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1080160
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1061 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1047
+      ID: 1058
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1080032
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1059 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1051
+      ID: 1062
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1084128
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1063 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1053
+      ID: 1064
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1084256
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1065 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1262
+      ID: 1273
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1696512
       GoKind: 22
-      Pointee: 1263 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1274 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1041
+      ID: 1052
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1066336
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1053 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 855
+      ID: 866
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 856 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 867 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1365
+      ID: 1376
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2386432
       GoKind: 22
-      Pointee: 1366 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1377 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1107
+      ID: 1118
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1236320
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1119 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1076
+      ID: 1087
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1214048
       GoKind: 22
-      Pointee: 1077 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1070
+      ID: 1081
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1213664
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1082 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1009
+      ID: 1020
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1045600
       GoKind: 22
-      Pointee: 1010 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1021 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1082
+      ID: 1093
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1214432
       GoKind: 22
-      Pointee: 1083 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1094 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1008
+      ID: 1019
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1045472
       GoKind: 22
-      Pointee: 987 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 998 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1074
+      ID: 1085
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1213920
       GoKind: 22
-      Pointee: 1075 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1072
+      ID: 1083
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1213792
       GoKind: 22
-      Pointee: 1073 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1080
+      ID: 1091
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1214304
       GoKind: 22
-      Pointee: 1081 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1092 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1078
+      ID: 1089
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1214176
       GoKind: 22
-      Pointee: 1079 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1369
+      ID: 1380
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2400672
       GoKind: 22
-      Pointee: 1370 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1381 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1086
+      ID: 1097
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1214816
       GoKind: 22
-      Pointee: 1087 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1098 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1013
+      ID: 1024
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1045856
       GoKind: 22
-      Pointee: 1014 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1025 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1011
+      ID: 1022
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1045728
       GoKind: 22
-      Pointee: 1012 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1023 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1084
+      ID: 1095
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1214688
       GoKind: 22
-      Pointee: 1085 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1096 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 968
+      ID: 979
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 958432
       GoKind: 22
-      Pointee: 771 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 782 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 773
+      ID: 784
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 772 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 783 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 363
+      ID: 367
       Name: '*go.shape.float64'
       ByteSize: 8
       GoRuntimeType: 487968
       GoKind: 22
-      Pointee: 364 BaseType go.shape.float64
+      Pointee: 368 BaseType go.shape.float64
     - __kind: PointerType
-      ID: 339
+      ID: 343
       Name: '*go.shape.int'
       ByteSize: 8
       GoRuntimeType: 487392
       GoKind: 22
-      Pointee: 334 BaseType go.shape.int
+      Pointee: 338 BaseType go.shape.int
     - __kind: PointerType
-      ID: 356
+      ID: 360
       Name: '*go.shape.string'
       ByteSize: 8
       GoRuntimeType: 487456
       GoKind: 22
-      Pointee: 336 GoStringHeaderType go.shape.string
+      Pointee: 340 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 653
+      ID: 660
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 652 GoStringDataType go.shape.string.str
+      Pointee: 659 GoStringDataType go.shape.string.str
     - __kind: PointerType
-      ID: 342
+      ID: 346
       Name: '*go.shape.struct { Name string }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 343 StructureType go.shape.struct { Name string }
+      Pointee: 347 StructureType go.shape.struct { Name string }
     - __kind: PointerType
-      ID: 344
+      ID: 348
       Name: '*go.shape.struct { X int; Y int }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 345 StructureType go.shape.struct { X int; Y int }
+      Pointee: 349 StructureType go.shape.struct { X int; Y int }
     - __kind: PointerType
-      ID: 357
+      ID: 361
       Name: '*go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 358 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+      Pointee: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1148
+      ID: 1159
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1694976
       GoKind: 22
-      Pointee: 1149 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1160 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1057
+      ID: 1068
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1098976
       GoKind: 22
-      Pointee: 1058 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1069 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1237
+      ID: 1248
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1277280
       GoKind: 22
-      Pointee: 1238 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1249 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1331
+      ID: 1342
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2180768
       GoKind: 22
-      Pointee: 1332 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1343 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1225
+      ID: 1236
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1101280
       GoKind: 22
-      Pointee: 1226 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1237 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 969
+      ID: 980
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 959680
       GoKind: 22
-      Pointee: 774 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 785 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1115
+      ID: 1126
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1278944
       GoKind: 22
-      Pointee: 1116 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1127 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 972
+      ID: 983
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 959968
       GoKind: 22
-      Pointee: 973 StructureType golang.org/x/net/http2.connError
+      Pointee: 984 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 971
+      ID: 982
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 959872
       GoKind: 22
-      Pointee: 778 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 789 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 780
+      ID: 791
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 779 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 790 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 975
+      ID: 986
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 960160
       GoKind: 22
-      Pointee: 784 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 795 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 786
+      ID: 797
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 785 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 796 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 974
+      ID: 985
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 960064
       GoKind: 22
-      Pointee: 781 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 792 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 783
+      ID: 794
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 782 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 793 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 970
+      ID: 981
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 959776
       GoKind: 22
-      Pointee: 775 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 786 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 777
+      ID: 788
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 776 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 787 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1329
+      ID: 1340
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2178848
       GoKind: 22
-      Pointee: 1330 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1341 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 976
+      ID: 987
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 960256
       GoKind: 22
-      Pointee: 977 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 988 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 978
+      ID: 989
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 960352
       GoKind: 22
-      Pointee: 787 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 798 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 964
+      ID: 975
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 953632
       GoKind: 22
-      Pointee: 965 StructureType google.golang.org/grpc.dropError
+      Pointee: 976 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1113
+      ID: 1124
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1276000
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1125 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1135
+      ID: 1146
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1464352
       GoKind: 22
-      Pointee: 1136 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1147 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 966
+      ID: 977
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 956704
       GoKind: 22
-      Pointee: 967 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 978 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1280
+      ID: 1291
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1838880
       GoKind: 22
-      Pointee: 1281 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1292 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1235
+      ID: 1246
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1272544
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1247 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1055
+      ID: 1066
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1093216
       GoKind: 22
-      Pointee: 1056 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1067 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1197
+      ID: 1208
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 956800
       GoKind: 22
-      Pointee: 1198 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1209 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 944
+      ID: 955
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 941536
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 956 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1043
+      ID: 1054
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1069920
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1055 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1111
+      ID: 1122
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1243232
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1123 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1109
+      ID: 1120
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1242976
       GoKind: 22
-      Pointee: 1110 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1121 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 958
+      ID: 969
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 946240
       GoKind: 22
-      Pointee: 959 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 970 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 960
+      ID: 971
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 946336
       GoKind: 22
-      Pointee: 961 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 972 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 891
+      ID: 902
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 933376
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 903 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1284
+      ID: 1295
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1929856
       GoKind: 22
-      Pointee: 1285 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1296 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 979
+      ID: 990
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 961120
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType html/template.Error
+      Pointee: 991 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 106
       Name: '*int'
@@ -12983,61 +13106,61 @@ Types:
       GoKind: 22
       Pointee: 170 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 1137
+      ID: 1148
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2231264
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType internal/abi.Type
+      Pointee: 1149 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 938
+      ID: 949
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 938944
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 950 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 859
+      ID: 870
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 926464
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 871 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1187
+      ID: 1198
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 925600
       GoKind: 22
-      Pointee: 1188 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1199 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1105
+      ID: 1116
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1227616
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1117 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1371
+      ID: 1382
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2406336
       GoKind: 22
-      Pointee: 1372 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1383 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1103
+      ID: 1114
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1227488
       GoKind: 22
-      Pointee: 1104 StructureType internal/poll.errNetClosing
+      Pointee: 1115 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 797
+      ID: 808
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 913984
       GoKind: 22
-      Pointee: 798 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 809 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -13046,78 +13169,78 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 858
+      ID: 869
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 749 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 760 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 751
+      ID: 762
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 761 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 1027
+      ID: 1038
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1057504
       GoKind: 22
-      Pointee: 1028 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 1039 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 857
+      ID: 868
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 925216
       GoKind: 22
-      Pointee: 748 BaseType internal/strconv.Error
+      Pointee: 759 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 1229
+      ID: 1240
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1204960
       GoKind: 22
-      Pointee: 1230 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1241 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1227
+      ID: 1238
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1204576
       GoKind: 22
-      Pointee: 1228 StructureType io.discard
+      Pointee: 1239 StructureType io.discard
     - __kind: PointerType
-      ID: 1201
+      ID: 1212
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1038048
       GoKind: 22
-      Pointee: 1202 UnresolvedPointeeType io.multiWriter
+      Pointee: 1213 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1101
+      ID: 1112
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1226976
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1113 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1276
+      ID: 1287
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1833056
       GoKind: 22
-      Pointee: 1277 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1288 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 349
+      ID: 353
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 350 StructureType main.Pair[go.shape.int,go.shape.bool]
+      Pointee: 354 StructureType main.Pair[go.shape.int,go.shape.bool]
     - __kind: PointerType
-      ID: 352
+      ID: 356
       Name: '*main.Pair[go.shape.string,go.shape.int]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 353 StructureType main.Pair[go.shape.string,go.shape.int]
+      Pointee: 357 StructureType main.Pair[go.shape.string,go.shape.int]
     - __kind: PointerType
       ID: 329
       Name: '*main.anotherStruct'
@@ -13125,19 +13248,19 @@ Types:
       GoKind: 22
       Pointee: 330 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 450
+      ID: 451
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 393184
       GoKind: 22
-      Pointee: 451 StructureType main.deepMap2
+      Pointee: 452 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1425
+      ID: 1426
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 393120
       GoKind: 22
-      Pointee: 1426 UnresolvedPointeeType main.deepMap3
+      Pointee: 1427 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 157
       Name: '*main.deepMap7'
@@ -13146,19 +13269,19 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1469
+      ID: 1470
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 392800
       GoKind: 22
-      Pointee: 1470 StructureType main.deepMap8
+      Pointee: 1471 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1484
+      ID: 1485
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 392736
       GoKind: 22
-      Pointee: 1485 StructureType main.deepMap9
+      Pointee: 1486 StructureType main.deepMap9
     - __kind: PointerType
       ID: 141
       Name: '*main.deepPtr2'
@@ -13167,12 +13290,12 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1375
+      ID: 1386
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 393696
       GoKind: 22
-      Pointee: 1376 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1387 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepPtr7'
@@ -13181,33 +13304,33 @@ Types:
       GoKind: 22
       Pointee: 144 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1439
+      ID: 1440
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 393376
       GoKind: 22
-      Pointee: 1440 StructureType main.deepPtr8
+      Pointee: 1441 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1441
+      ID: 1442
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 393312
       GoKind: 22
-      Pointee: 1442 StructureType main.deepPtr9
+      Pointee: 1443 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 148
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 394336
       GoKind: 22
-      Pointee: 441 StructureType main.deepSlice2
+      Pointee: 442 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1410
+      ID: 1411
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 394272
       GoKind: 22
-      Pointee: 1411 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1412 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepSlice7'
@@ -13216,19 +13339,19 @@ Types:
       GoKind: 22
       Pointee: 150 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1445
+      ID: 1446
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 393952
       GoKind: 22
-      Pointee: 1446 StructureType main.deepSlice8
+      Pointee: 1447 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1451
+      ID: 1452
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 393888
       GoKind: 22
-      Pointee: 1452 StructureType main.deepSlice9
+      Pointee: 1453 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 333
       Name: '*main.emptyStruct'
@@ -13243,14 +13366,14 @@ Types:
       GoKind: 22
       Pointee: 173 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1386
+      ID: 1397
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 908992
       GoKind: 22
-      Pointee: 366 StructureType main.firstBehavior
+      Pointee: 370 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1501
+      ID: 1502
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 394720
@@ -13276,19 +13399,19 @@ Types:
       GoKind: 22
       Pointee: 166 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1387
+      ID: 1398
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 909088
       GoKind: 22
-      Pointee: 1388 StructureType main.secondBehavior
+      Pointee: 1399 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1381
+      ID: 1392
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 909184
       GoKind: 22
-      Pointee: 1382 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1393 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 159
       Name: '*main.stringType1'
@@ -13296,28 +13419,28 @@ Types:
       GoKind: 22
       Pointee: 160 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1378
+      ID: 1389
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1377 GoStringDataType main.stringType1.str
+      Pointee: 1388 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 162
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1379 GoStringHeaderType main.stringType2
+      Pointee: 1390 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1503
+      ID: 1504
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1502 GoStringDataType main.stringType2.str
+      Pointee: 1503 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 286
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 284 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 504
+      ID: 505
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 392672
@@ -13341,10 +13464,10 @@ Types:
       GoKind: 22
       Pointee: 262 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1391
+      ID: 1402
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1390 GoSliceDataType main.t.array
+      Pointee: 1401 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 281
       Name: '*main.threeStringStruct'
@@ -13372,40 +13495,40 @@ Types:
       ByteSize: 8
       Pointee: 213 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 384
+      ID: 388
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 385 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 389 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 153
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 154 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1415
+      ID: 1416
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1416 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1417 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1459
+      ID: 1460
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1460 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1461 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1474
+      ID: 1475
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1475 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1476 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 180
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 181 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1489
+      ID: 1490
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1490 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1491 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 247
       Name: '*map<int,struct {}>'
@@ -13417,10 +13540,10 @@ Types:
       ByteSize: 8
       Pointee: 218 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 697 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 704 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 207
       Name: '*map<string,[]main.structWithMap>'
@@ -13432,35 +13555,35 @@ Types:
       ByteSize: 8
       Pointee: 196 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 415
+      ID: 416
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 416 GoSwissMapHeaderType map<string,float64>
+      Pointee: 417 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1141
+      ID: 1152
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1142 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1153 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 190
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 191 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 410
+      ID: 411
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 411 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 412 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 185
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 186 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 405
+      ID: 406
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 406 GoSwissMapHeaderType map<string,string>
+      Pointee: 407 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 242
       Name: '*map<struct {},int>'
@@ -13518,728 +13641,728 @@ Types:
       GoKind: 22
       Pointee: 189 GoMapType map[string]int
     - __kind: PointerType
-      ID: 895
+      ID: 906
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 934240
       GoKind: 22
-      Pointee: 896 StructureType math/big.ErrNaN
+      Pointee: 907 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1191
+      ID: 1202
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 929056
       GoKind: 22
-      Pointee: 1192 StructureType mime/multipart.writerOnly·1
+      Pointee: 1203 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1093
+      ID: 1104
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1220704
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType net.AddrError
+      Pointee: 1105 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1124
+      ID: 1135
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1439552
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType net.DNSError
+      Pointee: 1136 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1335
+      ID: 1346
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2266176
       GoKind: 22
-      Pointee: 1336 UnresolvedPointeeType net.IPConn
+      Pointee: 1347 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1122
+      ID: 1133
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1439232
       GoKind: 22
-      Pointee: 1123 UnresolvedPointeeType net.OpError
+      Pointee: 1134 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1095
+      ID: 1106
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1220832
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType net.ParseError
+      Pointee: 1107 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1345
+      ID: 1356
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2293568
       GoKind: 22
-      Pointee: 1346 UnresolvedPointeeType net.TCPConn
+      Pointee: 1357 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1355
+      ID: 1366
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2338688
       GoKind: 22
-      Pointee: 1356 UnresolvedPointeeType net.UDPConn
+      Pointee: 1367 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1343
+      ID: 1354
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2293056
       GoKind: 22
-      Pointee: 1344 UnresolvedPointeeType net.UnixConn
+      Pointee: 1355 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1092
+      ID: 1103
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1219936
       GoKind: 22
-      Pointee: 1061 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1072 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1063
+      ID: 1074
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1062 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1073 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1025
+      ID: 1036
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1052384
       GoKind: 22
-      Pointee: 1026 StructureType net.canceledError
+      Pointee: 1037 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1313
+      ID: 1324
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2041088
       GoKind: 22
-      Pointee: 1314 UnresolvedPointeeType net.conn
+      Pointee: 1325 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1166
+      ID: 1177
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1875616
       GoKind: 22
-      Pointee: 1167 StructureType net.dialResult·1
+      Pointee: 1178 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1357
+      ID: 1368
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2342944
       GoKind: 22
-      Pointee: 1358 UnresolvedPointeeType net.netFD
+      Pointee: 1369 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 826
+      ID: 837
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 827 UnresolvedPointeeType net.notFoundError
+      Pointee: 838 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1435
+      ID: 1436
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1439392
       GoKind: 22
-      Pointee: 1436 StructureType net.onlyValuesCtx
+      Pointee: 1437 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 828
+      ID: 839
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 920896
       GoKind: 22
-      Pointee: 829 StructureType net.result·2
+      Pointee: 840 StructureType net.result·2
     - __kind: PointerType
-      ID: 1339
+      ID: 1350
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2279584
       GoKind: 22
-      Pointee: 1340 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1351 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1337
+      ID: 1348
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2279104
       GoKind: 22
-      Pointee: 1338 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1349 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1097
+      ID: 1108
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1221472
       GoKind: 22
-      Pointee: 1098 UnresolvedPointeeType net.temporaryError
+      Pointee: 1109 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1126
+      ID: 1137
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1439712
       GoKind: 22
-      Pointee: 1127 UnresolvedPointeeType net.timeoutError
+      Pointee: 1138 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1015
+      ID: 1026
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1048416
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1027 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1183
+      ID: 1194
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 1184 StructureType net/http.bufioFlushWriter
+      Pointee: 1195 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 803
+      ID: 814
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 916672
       GoKind: 22
-      Pointee: 718 BaseType net/http.http2ConnectionError
+      Pointee: 729 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 804
+      ID: 815
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 916768
       GoKind: 22
-      Pointee: 805 StructureType net/http.http2GoAwayError
+      Pointee: 816 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1118
+      ID: 1129
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1435552
       GoKind: 22
-      Pointee: 1119 StructureType net/http.http2StreamError
+      Pointee: 1130 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 808
+      ID: 819
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 917344
       GoKind: 22
-      Pointee: 809 StructureType net/http.http2connError
+      Pointee: 820 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1247
+      ID: 1258
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1577344
       GoKind: 22
-      Pointee: 1248 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1259 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 807
+      ID: 818
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 917248
       GoKind: 22
-      Pointee: 722 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 733 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 724
+      ID: 735
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 723 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 734 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 811
+      ID: 822
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 728 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 739 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 730
+      ID: 741
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 729 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 740 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 810
+      ID: 821
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 917440
       GoKind: 22
-      Pointee: 725 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 736 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 727
+      ID: 738
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 726 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 737 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1090
+      ID: 1101
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1216736
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1102 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1021
+      ID: 1032
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1048928
       GoKind: 22
-      Pointee: 1022 StructureType net/http.http2noCachedConnError
+      Pointee: 1033 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1302
+      ID: 1313
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1982016
       GoKind: 22
-      Pointee: 1303 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1314 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 806
+      ID: 817
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 917152
       GoKind: 22
-      Pointee: 719 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 730 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 721
+      ID: 732
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 720 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 731 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1185
+      ID: 1196
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 917632
       GoKind: 22
-      Pointee: 1186 StructureType net/http.http2stickyErrWriter
+      Pointee: 1197 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1017
+      ID: 1028
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1048672
       GoKind: 22
-      Pointee: 1018 StructureType net/http.nothingWrittenError
+      Pointee: 1029 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1249
+      ID: 1260
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2227520
       GoKind: 22
-      Pointee: 1250 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1261 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1205
+      ID: 1216
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1048544
       GoKind: 22
-      Pointee: 1206 StructureType net/http.persistConnWriter
+      Pointee: 1217 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1239
+      ID: 1250
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1435712
       GoKind: 22
-      Pointee: 1240 StructureType net/http.readWriteCloserBody
+      Pointee: 1251 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 812
+      ID: 823
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 917728
       GoKind: 22
-      Pointee: 813 StructureType net/http.requestBodyReadError
+      Pointee: 824 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1120
+      ID: 1131
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1436832
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1132 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1088
+      ID: 1099
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1216608
       GoKind: 22
-      Pointee: 1089 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1100 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1019
+      ID: 1030
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1048800
       GoKind: 22
-      Pointee: 1020 StructureType net/http.transportReadFromServerError
+      Pointee: 1031 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1282
+      ID: 1293
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1872032
       GoKind: 22
-      Pointee: 1283 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1294 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 801
+      ID: 812
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 813 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1304
+      ID: 1315
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1984064
       GoKind: 22
-      Pointee: 1305 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1316 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1215
+      ID: 1226
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1061600
       GoKind: 22
-      Pointee: 1216 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1227 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 887
+      ID: 898
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 933184
       GoKind: 22
-      Pointee: 888 StructureType net/netip.parseAddrError
+      Pointee: 899 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 885
+      ID: 896
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 933088
       GoKind: 22
-      Pointee: 886 StructureType net/netip.parsePrefixError
+      Pointee: 897 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1255
+      ID: 1266
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2150592
       GoKind: 22
-      Pointee: 1256 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1267 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1217
+      ID: 1228
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1065952
       GoKind: 22
-      Pointee: 1218 StructureType net/smtp.dataCloser
+      Pointee: 1229 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 871
+      ID: 882
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 929248
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType net/textproto.Error
+      Pointee: 883 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 870
+      ID: 881
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 929152
       GoKind: 22
-      Pointee: 757 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 768 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 759
+      ID: 770
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 758 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 769 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1213
+      ID: 1224
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1061088
       GoKind: 22
-      Pointee: 1214 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1225 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1128
+      ID: 1139
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1440032
       GoKind: 22
-      Pointee: 1129 UnresolvedPointeeType net/url.Error
+      Pointee: 1140 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 830
+      ID: 841
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 920992
       GoKind: 22
-      Pointee: 731 GoStringHeaderType net/url.EscapeError
+      Pointee: 742 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 733
+      ID: 744
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 732 GoStringDataType net/url.EscapeError.str
+      Pointee: 743 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 831
+      ID: 842
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 921088
       GoKind: 22
-      Pointee: 734 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 745 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 736
+      ID: 747
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 735 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 746 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 550
+      ID: 551
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 551 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 552 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 542
+      ID: 543
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 543 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 544 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 490
+      ID: 491
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 491 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 492 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 509
+      ID: 510
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 510 StructureType noalg.map.group[bool]main.node
+      Pointee: 511 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 663 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 670 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 446
+      ID: 447
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 447 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 448 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1421
+      ID: 1422
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1422 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1423 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1465
+      ID: 1466
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1466 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1467 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1480
+      ID: 1481
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1481 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 458
+      ID: 459
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 459 StructureType noalg.map.group[int]int
+      Pointee: 460 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1495
+      ID: 1496
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1496 StructureType noalg.map.group[int]interface {}
+      Pointee: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 566
+      ID: 567
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 567 StructureType noalg.map.group[int]struct {}
+      Pointee: 568 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 517
+      ID: 518
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 518 StructureType noalg.map.group[int]uint8
+      Pointee: 519 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 707
+      ID: 718
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 708 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 499
+      ID: 500
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 500 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 501 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 482
+      ID: 483
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 483 StructureType noalg.map.group[string][]string
+      Pointee: 484 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 688 StructureType noalg.map.group[string]float64
+      Pointee: 695 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1173
+      ID: 1184
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1174 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 474
+      ID: 475
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 475 StructureType noalg.map.group[string]int
+      Pointee: 476 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 680 StructureType noalg.map.group[string]interface {}
+      Pointee: 687 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 466
+      ID: 467
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 467 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 468 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 671
+      ID: 678
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 672 StructureType noalg.map.group[string]string
+      Pointee: 679 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 558
+      ID: 559
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 559 StructureType noalg.map.group[struct {}]int
+      Pointee: 560 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 606
+      ID: 607
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 607 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 614
+      ID: 615
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 615 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 622
+      ID: 623
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 623 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 630
+      ID: 631
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 638
+      ID: 639
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 646
+      ID: 647
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 574
+      ID: 575
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 575 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 576 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 533
+      ID: 534
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 534 StructureType noalg.map.group[uint8][4]int
+      Pointee: 535 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 525
+      ID: 526
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 526 StructureType noalg.map.group[uint8]uint8
+      Pointee: 527 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1363
+      ID: 1374
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2381056
       GoKind: 22
-      Pointee: 1364 UnresolvedPointeeType os.File
+      Pointee: 1375 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 998
+      ID: 1009
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1041760
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType os.LinkError
+      Pointee: 1010 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1066
+      ID: 1077
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1209440
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType os.SyscallError
+      Pointee: 1078 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1361
+      ID: 1372
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2380320
       GoKind: 22
-      Pointee: 1362 StructureType os.fileWithoutReadFrom
+      Pointee: 1373 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1359
+      ID: 1370
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2379584
       GoKind: 22
-      Pointee: 1360 StructureType os.fileWithoutWriteTo
+      Pointee: 1371 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1029
+      ID: 1040
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1057632
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType os/exec.Error
+      Pointee: 1041 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1169
+      ID: 1180
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2121504
       GoKind: 22
-      Pointee: 1170 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1181 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1233
+      ID: 1244
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1228640
       GoKind: 22
-      Pointee: 1234 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1245 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1031
+      ID: 1042
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1057760
       GoKind: 22
-      Pointee: 1032 StructureType os/exec.wrappedError
+      Pointee: 1043 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 963
+      ID: 974
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 951712
       GoKind: 22
-      Pointee: 768 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 779 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 770
+      ID: 781
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 769 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 780 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 962
+      ID: 973
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 951616
       GoKind: 22
-      Pointee: 767 BaseType os/user.UnknownUserIdError
+      Pointee: 778 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 799
+      ID: 810
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 914656
       GoKind: 22
-      Pointee: 800 UnresolvedPointeeType reflect.ValueError
+      Pointee: 811 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 893
+      ID: 904
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 933856
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 905 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 1002
+      ID: 1013
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1044064
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1014 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 1006
+      ID: 1017
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1044704
       GoKind: 22
-      Pointee: 1007 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1018 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -14255,12 +14378,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 1004
+      ID: 1015
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1044192
       GoKind: 22
-      Pointee: 1005 StructureType runtime.boundsError
+      Pointee: 1016 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -14276,24 +14399,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1068
+      ID: 1079
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1212256
       GoKind: 22
-      Pointee: 1069 StructureType runtime.errorAddressString
+      Pointee: 1080 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 1000
+      ID: 1011
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1042400
       GoKind: 22
-      Pointee: 981 GoStringHeaderType runtime.errorString
+      Pointee: 992 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 983
+      ID: 994
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 982 GoStringDataType runtime.errorString.str
+      Pointee: 993 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -14314,19 +14437,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1043808
       GoKind: 22
-      Pointee: 436 UnresolvedPointeeType runtime.p
+      Pointee: 437 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 1001
+      ID: 1012
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1042528
       GoKind: 22
-      Pointee: 984 GoStringHeaderType runtime.plainError
+      Pointee: 995 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 986
+      ID: 997
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 985 GoStringDataType runtime.plainError.str
+      Pointee: 996 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -14342,12 +14465,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 795
+      ID: 806
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 913696
       GoKind: 22
-      Pointee: 796 StructureType runtime.synctestDeadlockError
+      Pointee: 807 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -14370,12 +14493,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 996
+      ID: 1007
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1040608
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType strconv.NumError
+      Pointee: 1008 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -14384,31 +14507,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 431
+      ID: 432
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 430 GoStringDataType string.str
+      Pointee: 431 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1298
+      ID: 1309
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1980224
       GoKind: 22
-      Pointee: 1299 UnresolvedPointeeType strings.Builder
+      Pointee: 1310 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1203
+      ID: 1214
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1040736
       GoKind: 22
-      Pointee: 1204 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1215 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1199
+      ID: 1210
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 986144
       GoKind: 22
-      Pointee: 1200 StructureType struct { io.Writer }
+      Pointee: 1211 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 279
       Name: '*struct {}'
@@ -14417,240 +14540,240 @@ Types:
       GoKind: 22
       Pointee: 133 StructureType struct {}
     - __kind: PointerType
-      ID: 1130
+      ID: 1141
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1442272
       GoKind: 22
-      Pointee: 1117 BaseType syscall.Errno
+      Pointee: 1128 BaseType syscall.Errno
     - __kind: PointerType
       ID: 240
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 548 StructureType table<[4]int,[4]int>
+      Pointee: 549 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 235
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 540 StructureType table<[4]int,uint8>
+      Pointee: 541 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 203
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 488 StructureType table<[4]string,[2]int>
+      Pointee: 489 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 215
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 507 StructureType table<bool,main.node>
+      Pointee: 508 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 387
+      ID: 391
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 660 StructureType table<context.canceler,struct {}>
+      Pointee: 667 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 156
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 444 StructureType table<int,*main.deepMap2>
+      Pointee: 445 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1418
+      ID: 1419
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1419 StructureType table<int,*main.deepMap3>
+      Pointee: 1420 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1462
+      ID: 1463
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1463 StructureType table<int,*main.deepMap8>
+      Pointee: 1464 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1477
+      ID: 1478
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1478 StructureType table<int,*main.deepMap9>
+      Pointee: 1479 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 183
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 456 StructureType table<int,int>
+      Pointee: 457 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1492
+      ID: 1493
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1493 StructureType table<int,interface {}>
+      Pointee: 1494 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 250
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 564 StructureType table<int,struct {}>
+      Pointee: 565 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 220
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 515 StructureType table<int,uint8>
+      Pointee: 516 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 699
+      ID: 706
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 705 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 716 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 210
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 497 StructureType table<string,[]main.structWithMap>
+      Pointee: 498 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 198
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 480 StructureType table<string,[]string>
+      Pointee: 481 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 418
+      ID: 419
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 685 StructureType table<string,float64>
+      Pointee: 692 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1144
+      ID: 1155
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1171 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1182 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 193
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 472 StructureType table<string,int>
+      Pointee: 473 StructureType table<string,int>
     - __kind: PointerType
-      ID: 413
+      ID: 414
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 677 StructureType table<string,interface {}>
+      Pointee: 684 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 188
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 464 StructureType table<string,main.nestedStruct>
+      Pointee: 465 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 408
+      ID: 409
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 669 StructureType table<string,string>
+      Pointee: 676 StructureType table<string,string>
     - __kind: PointerType
       ID: 245
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 556 StructureType table<struct {},int>
+      Pointee: 557 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 302
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 604 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 605 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 307
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 612 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 613 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 312
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 620 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 621 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 317
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 628 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 629 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 322
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 636 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 637 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 327
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 644 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 645 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 255
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 572 StructureType table<struct {},struct {}>
+      Pointee: 573 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 230
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 531 StructureType table<uint8,[4]int>
+      Pointee: 532 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 225
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 523 StructureType table<uint8,uint8>
+      Pointee: 524 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1333
+      ID: 1344
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2192992
       GoKind: 22
-      Pointee: 1334 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1345 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1059
+      ID: 1070
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1102816
       GoKind: 22
-      Pointee: 1060 StructureType text/template.ExecError
+      Pointee: 1071 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 397
+      ID: 335
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1642560
       GoKind: 22
-      Pointee: 398 StructureType time.Location
+      Pointee: 336 StructureType time.Location
     - __kind: PointerType
-      ID: 793
+      ID: 804
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 911776
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType time.ParseError
+      Pointee: 805 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 394
+      ID: 398
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1042144
       GoKind: 22
-      Pointee: 395 StructureType time.Timer
+      Pointee: 399 StructureType time.Timer
     - __kind: PointerType
-      ID: 790
+      ID: 801
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 715 GoStringHeaderType time.fileSizeError
+      Pointee: 726 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 717
+      ID: 728
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 716 GoStringDataType time.fileSizeError.str
+      Pointee: 727 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 791
+      ID: 802
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType time.parseDurationError
+      Pointee: 803 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 1394
+      ID: 654
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399904
       GoKind: 22
-      Pointee: 1395 StructureType time.zone
+      Pointee: 655 StructureType time.zone
     - __kind: PointerType
-      ID: 1397
+      ID: 657
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399968
       GoKind: 22
-      Pointee: 1398 StructureType time.zoneTrans
+      Pointee: 658 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -14694,49 +14817,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 889
+      ID: 900
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 933280
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 901 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1327
+      ID: 1338
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2168480
       GoKind: 22
-      Pointee: 1328 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1339 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 873
+      ID: 884
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 929440
       GoKind: 22
-      Pointee: 874 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 885 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 875
+      ID: 886
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 929536
       GoKind: 22
-      Pointee: 760 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 771 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1036
+      ID: 1047
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1061344
       GoKind: 22
-      Pointee: 1037 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1048 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1038
+      ID: 1049
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1061472
       GoKind: 22
-      Pointee: 989 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 1000 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1392
+      ID: 1403
       Name: <-chan time.Time
       GoRuntimeType: 606528
       GoKind: 18
@@ -14749,7 +14872,7 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 1770
+      ID: 1774
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14765,10 +14888,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 362 GoSliceHeaderType []go.shape.float64
+            Type: 366 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14778,10 +14901,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 362 GoSliceHeaderType []go.shape.float64
+            Type: 366 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14791,17 +14914,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 365 GoSubroutineType func(go.shape.float64) bool
+            Type: 369 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 1, name: pred}
+                  Variable: {subprogram: 191, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1771
+      ID: 1775
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14811,17 +14934,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 362 GoSliceHeaderType []go.shape.float64
+            Type: 366 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 2, name: ~r0}
+                  Variable: {subprogram: 191, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1768
+      ID: 1772
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14837,10 +14960,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14850,10 +14973,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14863,17 +14986,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 340 GoSubroutineType func(go.shape.int) bool
+            Type: 344 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: pred}
+                  Variable: {subprogram: 172, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1769
+      ID: 1773
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14883,20 +15006,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 2, name: ~r0}
+                  Variable: {subprogram: 172, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1826
+      ID: 1830
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1772
+      ID: 1776
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14912,10 +15035,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14925,10 +15048,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14938,17 +15061,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 341 GoSubroutineType func(go.shape.int) go.shape.string
+            Type: 345 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: f}
+                  Variable: {subprogram: 173, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1773
+      ID: 1777
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14958,17 +15081,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 2, name: ~r0}
+                  Variable: {subprogram: 173, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1784
+      ID: 1788
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14987,10 +15110,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15000,10 +15123,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 349 PointerType *main.Pair[go.shape.int,go.shape.bool]
+            Type: 353 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: x}
+                  Variable: {subprogram: 179, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15013,10 +15136,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15026,20 +15149,20 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 351 BaseType go.shape.bool
+            Type: 355 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 2, name: v}
+                  Variable: {subprogram: 179, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1785
+      ID: 1789
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1786
+      ID: 1790
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15058,10 +15181,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15071,10 +15194,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 352 PointerType *main.Pair[go.shape.string,go.shape.int]
+            Type: 356 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: x}
+                  Variable: {subprogram: 180, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15084,10 +15207,10 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15097,20 +15220,20 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 2, name: v}
+                  Variable: {subprogram: 180, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1787
+      ID: 1791
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1824
+      ID: 1828
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15119,17 +15242,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 366 StructureType main.firstBehavior
+            Type: 370 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 0, name: b}
+                  Variable: {subprogram: 198, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1825
+      ID: 1829
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15141,14 +15264,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 1, name: ~r0}
+                  Variable: {subprogram: 198, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1800
+      ID: 1804
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15164,10 +15287,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15177,10 +15300,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15190,17 +15313,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1804
+      ID: 1808
       Name: Probe[main.genericContains[go.shape.int]]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15216,10 +15339,10 @@ Types:
           Offset: 17
           Kind: local
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15229,17 +15352,17 @@ Types:
           Offset: 41
           Kind: local
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1801
+      ID: 1805
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15251,14 +15374,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 187, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1802
+      ID: 1806
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15274,10 +15397,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15287,10 +15410,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 359 GoSliceHeaderType []go.shape.string
+            Type: 363 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: haystack}
+                  Variable: {subprogram: 188, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15300,17 +15423,17 @@ Types:
           Offset: 57
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1805
+      ID: 1809
       Name: Probe[main.genericContains[go.shape.string]]Line
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15320,17 +15443,17 @@ Types:
           Offset: 9
           Kind: local
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1803
+      ID: 1807
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15342,14 +15465,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 2, name: ~r0}
+                  Variable: {subprogram: 188, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1796
+      ID: 1800
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15359,10 +15482,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 356 PointerType *go.shape.string
+            Type: 360 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15372,17 +15495,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 356 PointerType *go.shape.string
+            Type: 360 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1797
+      ID: 1801
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15392,17 +15515,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: ~r0}
+                  Variable: {subprogram: 185, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1798
+      ID: 1802
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15412,10 +15535,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 357 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 361 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15425,17 +15548,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 357 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 361 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1799
+      ID: 1803
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15445,17 +15568,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 358 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: ~r0}
+                  Variable: {subprogram: 186, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1792
+      ID: 1796
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15465,10 +15588,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 354 StructureType go.shape.struct { main.i int }
+            Type: 358 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15478,17 +15601,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 354 StructureType go.shape.struct { main.i int }
+            Type: 358 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1793
+      ID: 1797
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15500,14 +15623,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: ~r0}
+                  Variable: {subprogram: 183, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1794
+      ID: 1798
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15517,10 +15640,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 355 StructureType go.shape.struct { main.s string }
+            Type: 359 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15530,17 +15653,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 355 StructureType go.shape.struct { main.s string }
+            Type: 359 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1795
+      ID: 1799
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15552,14 +15675,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: ~r0}
+                  Variable: {subprogram: 184, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1774
+      ID: 1778
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15569,10 +15692,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 339 PointerType *go.shape.int
+            Type: 343 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15582,17 +15705,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 339 PointerType *go.shape.int
+            Type: 343 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1775
+      ID: 1779
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15602,17 +15725,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 339 PointerType *go.shape.int
+            Type: 343 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 174, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1776
+      ID: 1780
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15622,10 +15745,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 342 PointerType *go.shape.struct { Name string }
+            Type: 346 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15635,17 +15758,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 342 PointerType *go.shape.struct { Name string }
+            Type: 346 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1777
+      ID: 1781
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15655,17 +15778,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 342 PointerType *go.shape.struct { Name string }
+            Type: 346 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: ~r0}
+                  Variable: {subprogram: 175, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1778
+      ID: 1782
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15675,10 +15798,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 344 PointerType *go.shape.struct { X int; Y int }
+            Type: 348 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15688,17 +15811,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 344 PointerType *go.shape.struct { X int; Y int }
+            Type: 348 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1779
+      ID: 1783
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15708,17 +15831,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 344 PointerType *go.shape.struct { X int; Y int }
+            Type: 348 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: ~r0}
+                  Variable: {subprogram: 176, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1790
+      ID: 1794
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15734,10 +15857,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15747,10 +15870,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15760,17 +15883,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: b}
+                  Variable: {subprogram: 182, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1791
+      ID: 1795
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15786,10 +15909,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15799,17 +15922,17 @@ Types:
           Offset: 33
           Kind: return
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 3, name: ~r1}
+                  Variable: {subprogram: 182, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1788
+      ID: 1792
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15825,10 +15948,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15838,10 +15961,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15851,17 +15974,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 351 BaseType go.shape.bool
+            Type: 355 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: b}
+                  Variable: {subprogram: 181, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1789
+      ID: 1793
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15877,10 +16000,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 351 BaseType go.shape.bool
+            Type: 355 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
@@ -15890,17 +16013,17 @@ Types:
           Offset: 18
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 3, name: ~r1}
+                  Variable: {subprogram: 181, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1782
+      ID: 1786
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15910,10 +16033,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 348 StructureType main.largeGenericType[go.shape.int]
+            Type: 352 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
@@ -15923,17 +16046,17 @@ Types:
           Offset: 145
           Kind: argument
           Expression:
-            Type: 348 StructureType main.largeGenericType[go.shape.int]
+            Type: 352 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1783
+      ID: 1787
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15943,17 +16066,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: ~r0}
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1780
+      ID: 1784
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15963,10 +16086,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 346 StructureType main.largeGenericType[go.shape.string]
+            Type: 350 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
@@ -15976,17 +16099,17 @@ Types:
           Offset: 153
           Kind: argument
           Expression:
-            Type: 346 StructureType main.largeGenericType[go.shape.string]
+            Type: 350 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1781
+      ID: 1785
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15996,17 +16119,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: ~r0}
+                  Variable: {subprogram: 177, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1764
+      ID: 1768
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16016,10 +16139,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16029,17 +16152,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1765
+      ID: 1769
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16049,17 +16172,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1766
+      ID: 1770
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16069,10 +16192,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16082,17 +16205,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1767
+      ID: 1771
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16102,20 +16225,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1735
+      ID: 1736
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1736
+      ID: 1737
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16134,7 +16257,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1578
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16166,7 +16289,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16185,7 +16308,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16217,7 +16340,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16236,7 +16359,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1706
+      ID: 1707
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16268,7 +16391,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1707
+      ID: 1708
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16287,7 +16410,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16319,7 +16442,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -16351,7 +16474,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16383,7 +16506,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16415,7 +16538,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16447,7 +16570,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16479,7 +16602,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16511,7 +16634,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -16530,7 +16653,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16562,7 +16685,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16594,7 +16717,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testByteArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16626,7 +16749,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testChannel]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16658,7 +16781,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1604
+      ID: 1605
       Name: Probe[main.testCombinedByte]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16716,7 +16839,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       ExprStatusArraySize: 1
@@ -16748,7 +16871,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -16793,7 +16916,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.testConflictingReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16825,7 +16948,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1672
+      ID: 1673
       Name: Probe[main.testConflictingReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16857,7 +16980,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.testCycle]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16889,7 +17012,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16921,7 +17044,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16953,7 +17076,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16985,7 +17108,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17017,7 +17140,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17049,7 +17172,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17081,7 +17204,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1726
+      ID: 1727
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -17139,7 +17262,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1723
+      ID: 1724
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17171,7 +17294,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1747
+      ID: 1748
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17203,7 +17326,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1759
+      ID: 1760
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17235,7 +17358,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1758
+      ID: 1759
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -17267,7 +17390,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testErrorAtLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17325,7 +17448,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testError]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17357,7 +17480,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17389,10 +17512,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -17424,10 +17547,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17459,7 +17582,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17491,7 +17614,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17510,7 +17633,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testFrameless]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17542,7 +17665,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1570
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17561,7 +17684,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17593,10 +17716,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17628,13 +17751,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1816
+      ID: 1820
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17692,28 +17815,28 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1817
+      ID: 1821
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1818
+      ID: 1822
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1819
+      ID: 1823
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1820
+      ID: 1824
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1813
+      ID: 1817
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17725,7 +17848,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17738,14 +17861,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1810
+      ID: 1814
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17757,14 +17880,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1811
+      ID: 1815
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17776,14 +17899,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1812
+      ID: 1816
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17795,7 +17918,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17808,14 +17931,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1815
+      ID: 1819
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17827,7 +17950,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17840,17 +17963,17 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1814
+      ID: 1818
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1821
+      ID: 1825
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17862,7 +17985,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17875,14 +17998,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1822
+      ID: 1826
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17894,7 +18017,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17907,14 +18030,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1823
+      ID: 1827
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17926,7 +18049,7 @@ Types:
             Type: 174 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
@@ -17939,14 +18062,14 @@ Types:
             Type: 174 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17978,7 +18101,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18010,7 +18133,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18042,7 +18165,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -18074,7 +18197,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testIntArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18106,7 +18229,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18138,7 +18261,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1704
+      ID: 1705
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -18170,7 +18293,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1705
+      ID: 1706
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18189,7 +18312,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18221,53 +18344,8 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1550
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1551
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: aPerArch
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: b
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
     - __kind: EventRootType
       ID: 1552
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -18314,7 +18392,52 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1710
+      ID: 1553
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: aPerArch
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: b
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1711
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -18554,7 +18677,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1711
+      ID: 1712
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18573,7 +18696,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testManyPointers]
       ByteSize: 1121
       ExprStatusArraySize: 1
@@ -18605,7 +18728,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testManyStrings]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -18637,7 +18760,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18669,7 +18792,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18701,7 +18824,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18733,7 +18856,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18765,7 +18888,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1602
+      ID: 1603
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18797,7 +18920,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
+      ID: 1589
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18829,7 +18952,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18861,7 +18984,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18887,38 +19010,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1589
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 206 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 206 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18957,7 +19048,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1591
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 206 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1599
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18989,7 +19112,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19021,7 +19144,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19053,7 +19176,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19085,7 +19208,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19117,7 +19240,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19149,7 +19272,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19181,7 +19304,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19213,7 +19336,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19245,7 +19368,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19273,38 +19396,6 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1744
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -19341,7 +19432,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1712
+      ID: 1746
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1713
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -19581,7 +19704,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1713
+      ID: 1714
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19600,7 +19723,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1716
+      ID: 1717
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19658,7 +19781,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1717
+      ID: 1718
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19690,7 +19813,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1708
+      ID: 1709
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -19748,7 +19871,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1709
+      ID: 1710
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19767,7 +19890,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19787,6 +19910,143 @@ Types:
           DictIndex: -1
         - Name: i
           Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1652
+      Name: Probe[main.testMultipleNamedReturn]
+    - __kind: EventRootType
+      ID: 1654
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1656
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1658
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1660
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1662
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -19800,21 +20060,63 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1651
-      Name: Probe[main.testMultipleNamedReturn]
-    - __kind: EventRootType
-      ID: 1653
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: return
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1653
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19822,57 +20124,57 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1655
-      Name: Probe[main.testMultipleNamedReturn]
+      Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result
           Offset: 17
-          Kind: template_segment
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 25
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19880,185 +20182,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1657
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1659
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1661
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1650
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1652
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1654
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result
-          Offset: 17
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 25
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1656
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20142,7 +20265,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20174,7 +20297,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20206,7 +20329,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20251,7 +20374,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 63
       ExprStatusArraySize: 3
@@ -20387,7 +20510,42 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1646
+      Name: Probe[main.testNamedReturn]
+    - __kind: EventRootType
+      ID: 1648
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20420,41 +20578,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1645
-      Name: Probe[main.testNamedReturn]
-    - __kind: EventRootType
-      ID: 1647
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: i
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1644
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20473,7 +20596,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20492,7 +20615,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20524,7 +20647,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1753
+      ID: 1754
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20556,7 +20679,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1754
+      ID: 1755
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20583,10 +20706,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1755
+      ID: 1756
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1756
+      ID: 1757
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20613,7 +20736,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20671,7 +20794,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1727
+      ID: 1728
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -20729,7 +20852,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1729
+      ID: 1730
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -20813,7 +20936,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1730
+      ID: 1731
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -20845,7 +20968,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1743
+      ID: 1744
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20877,7 +21000,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20909,7 +21032,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20941,7 +21064,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20973,7 +21096,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       ExprStatusArraySize: 1
@@ -21031,7 +21154,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1638
+      ID: 1639
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21063,7 +21186,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21095,7 +21218,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21114,10 +21237,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1684
+      ID: 1685
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1685
+      ID: 1686
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21136,10 +21259,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1686
+      ID: 1687
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1687
+      ID: 1688
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -21158,10 +21281,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21180,10 +21303,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1690
+      ID: 1691
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1691
+      ID: 1692
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -21306,10 +21429,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1702
+      ID: 1703
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1703
+      ID: 1704
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -21341,10 +21464,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21376,7 +21499,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -21408,7 +21531,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1636
+      ID: 1637
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21427,7 +21550,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21446,7 +21569,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1631
+      ID: 1632
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21465,7 +21588,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21497,7 +21620,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21542,7 +21665,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21587,7 +21710,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21619,7 +21742,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21651,7 +21774,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21670,29 +21793,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.testReturnsInt]
     - __kind: EventRootType
-      ID: 1621
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1623
+      ID: 1622
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21711,7 +21815,26 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1625
+      ID: 1624
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1626
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21743,7 +21866,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21762,7 +21885,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21794,7 +21917,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21826,7 +21949,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21845,7 +21968,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21877,7 +22000,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21896,10 +22019,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21918,10 +22041,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -22148,10 +22271,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1688
+      ID: 1689
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1689
+      ID: 1690
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22170,10 +22293,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1694
+      ID: 1695
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1695
+      ID: 1696
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -22244,10 +22367,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1700
+      ID: 1701
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1701
+      ID: 1702
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -22279,7 +22402,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1673
+      ID: 1674
       Name: Probe[main.testReturnsNamedDeferLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22337,10 +22460,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1698
+      ID: 1699
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1699
+      ID: 1700
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22359,10 +22482,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1674
+      ID: 1675
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -22472,10 +22595,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1696
+      ID: 1697
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1697
+      ID: 1698
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22494,10 +22617,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1692
+      ID: 1693
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1693
+      ID: 1694
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -22516,7 +22639,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22548,7 +22671,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22580,7 +22703,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22612,13 +22735,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testSingleFloat32]
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testSingleFloat64]
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22650,7 +22773,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22682,7 +22805,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22714,7 +22837,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22772,7 +22895,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22804,7 +22927,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22836,7 +22959,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1737
+      ID: 1738
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22868,7 +22991,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22900,7 +23023,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22932,7 +23055,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22964,7 +23087,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22996,7 +23119,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23028,7 +23151,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1733
+      ID: 1734
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23060,7 +23183,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1724
+      ID: 1725
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23092,7 +23215,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23124,7 +23247,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23143,10 +23266,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.testSomeNamedReturn]
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23165,7 +23288,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23197,7 +23320,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23255,7 +23378,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23274,7 +23397,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23332,7 +23455,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23377,7 +23500,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1714
+      ID: 1715
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -23409,7 +23532,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1715
+      ID: 1716
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23454,7 +23577,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testStringArray]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23486,7 +23609,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23518,7 +23641,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1728
+      ID: 1729
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23550,7 +23673,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testStringType1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23582,7 +23705,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testStringType2]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23614,7 +23737,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1725
+      ID: 1726
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23672,7 +23795,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23704,7 +23827,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1718
+      ID: 1719
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23736,7 +23859,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1719
+      ID: 1720
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23768,7 +23891,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1750
+      ID: 1751
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -23800,7 +23923,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1749
+      ID: 1750
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -23832,7 +23955,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23864,7 +23987,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1751
+      ID: 1752
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23883,7 +24006,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1752
+      ID: 1753
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -23915,7 +24038,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1734
+      ID: 1735
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -23999,7 +24122,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1748
+      ID: 1749
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24083,7 +24206,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testTakeContext]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24102,7 +24225,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1757
+      ID: 1758
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -24121,7 +24244,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1741
+      ID: 1742
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24153,7 +24276,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1742
+      ID: 1743
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24210,7 +24333,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1739
+      ID: 1740
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24242,7 +24365,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1740
+      ID: 1741
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24287,7 +24410,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1738
+      ID: 1739
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24371,7 +24494,103 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1762
+      Name: Probe[main.testTimeFixedZone]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 334 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 334 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1763
+      Name: Probe[main.testTimeMonotonic]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 337 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: c
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 337 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1761
+      Name: Probe[main.testTimeUTC]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 334 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 334 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1540
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24403,7 +24622,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24435,7 +24654,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24467,7 +24686,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24499,7 +24718,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24531,7 +24750,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testUintArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24563,7 +24782,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24595,7 +24814,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1722
+      ID: 1723
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24627,7 +24846,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1746
+      ID: 1747
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24659,7 +24878,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24691,7 +24910,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       ExprStatusArraySize: 1
@@ -24719,38 +24938,6 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1731
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 270 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 270 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -24787,7 +24974,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1720
+      ID: 1733
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 270 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 270 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1721
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24845,7 +25064,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1721
+      ID: 1722
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24877,7 +25096,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1806
+      ID: 1810
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -24893,10 +25112,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24906,10 +25125,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 360 StructureType main.typeWithGenerics[go.shape.int]
+            Type: 364 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 0, name: x}
+                  Variable: {subprogram: 189, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24919,17 +25138,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1807
+      ID: 1811
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24941,14 +25160,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 2, name: ~r0}
+                  Variable: {subprogram: 189, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1808
+      ID: 1812
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -24964,10 +25183,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24977,10 +25196,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 361 StructureType main.typeWithGenerics[go.shape.string]
+            Type: 365 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24990,17 +25209,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1809
+      ID: 1813
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -25012,14 +25231,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 2, name: ~r0}
+                  Variable: {subprogram: 190, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1760
+      ID: 1764
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25029,10 +25248,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25042,17 +25261,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1761
+      ID: 1765
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25062,17 +25281,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1762
+      ID: 1766
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25082,10 +25301,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25095,17 +25314,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1763
+      ID: 1767
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25115,10 +25334,10 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25148,7 +25367,7 @@ Types:
       HasCount: true
       Element: 98 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 347
+      ID: 351
       Name: '[16]uint8'
       ByteSize: 16
       GoRuntimeType: 690432
@@ -25369,7 +25588,7 @@ Types:
       HasCount: true
       Element: 35 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 537
+      ID: 538
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 693120
@@ -25378,7 +25597,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 494
+      ID: 495
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 693408
@@ -25404,7 +25623,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1161
+      ID: 1172
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 694944
@@ -25413,7 +25632,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1380
+      ID: 1391
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25439,7 +25658,7 @@ Types:
       HasCount: true
       Element: 91 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1403
+      ID: 1404
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 490016
@@ -25447,20 +25666,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1404 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1405 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1406 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1407 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1406
+      ID: 1407
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 400 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 146
       Name: '[]*main.deepSlice2'
@@ -25477,15 +25696,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 442 GoSliceDataType []*main.deepSlice2.array
+      Data: 443 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 442
+      ID: 443
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 148 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1408
+      ID: 1409
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -25493,22 +25712,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1409 PointerType **main.deepSlice3
+          Type: 1410 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1412 GoSliceDataType []*main.deepSlice3.array
+      Data: 1413 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1412
+      ID: 1413
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1410 PointerType *main.deepSlice3
+      Element: 1411 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1443
+      ID: 1444
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 485472
@@ -25516,22 +25735,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1444 PointerType **main.deepSlice8
+          Type: 1445 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1447 GoSliceDataType []*main.deepSlice8.array
+      Data: 1448 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1447
+      ID: 1448
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1445 PointerType *main.deepSlice8
+      Element: 1446 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1449
+      ID: 1450
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 485408
@@ -25539,20 +25758,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1450 PointerType **main.deepSlice9
+          Type: 1451 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1453 GoSliceDataType []*main.deepSlice9.array
+      Data: 1454 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1453
+      ID: 1454
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1451 PointerType *main.deepSlice9
+      Element: 1452 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 68
       Name: '[]*runtime.p'
@@ -25569,9 +25788,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 437 GoSliceDataType []*runtime.p.array
+      Data: 438 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 438
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25592,201 +25811,201 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 439 GoSliceDataType []*string.array
+      Data: 440 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 440
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 103 PointerType *string
     - __kind: GoSliceDataType
-      ID: 554
+      ID: 555
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 240 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 546
+      ID: 547
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 235 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 496
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 203 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 513
+      ID: 514
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 215 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 667
+      ID: 674
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 387 PointerType *table<context.canceler,struct {}>
+      Element: 391 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 452
+      ID: 453
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 156 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1427
+      ID: 1428
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1418 PointerType *table<int,*main.deepMap3>
+      Element: 1419 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1471
+      ID: 1472
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1462 PointerType *table<int,*main.deepMap8>
+      Element: 1463 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1486
+      ID: 1487
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1477 PointerType *table<int,*main.deepMap9>
+      Element: 1478 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 462
+      ID: 463
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 183 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1499
+      ID: 1500
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1492 PointerType *table<int,interface {}>
+      Element: 1493 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 570
+      ID: 571
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 250 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 521
+      ID: 522
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 220 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 713
+      ID: 724
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 699 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 706 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 505
+      ID: 506
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 210 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 487
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 198 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 691
+      ID: 698
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 418 PointerType *table<string,float64>
+      Element: 419 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1177
+      ID: 1188
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1144 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1155 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 479
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 193 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 690
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 413 PointerType *table<string,interface {}>
+      Element: 414 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 471
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 188 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 675
+      ID: 682
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 408 PointerType *table<string,string>
+      Element: 409 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 562
+      ID: 563
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 245 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 610
+      ID: 611
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 302 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 618
+      ID: 619
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 307 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 626
+      ID: 627
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 312 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 634
+      ID: 635
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 317 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 642
+      ID: 643
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 322 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 650
+      ID: 651
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 327 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 578
+      ID: 579
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 255 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 538
+      ID: 539
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 230 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 530
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -25806,9 +26025,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 602 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 603 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 602
+      ID: 603
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25828,9 +26047,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 600 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 601 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 600
+      ID: 601
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25850,9 +26069,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 598 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 599 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 598
+      ID: 599
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25872,9 +26091,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 596 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 597 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 596
+      ID: 597
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25894,9 +26113,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 594 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 595 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 594
+      ID: 595
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25916,9 +26135,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 582 GoSliceDataType [][]uint.array
+      Data: 583 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 582
+      ID: 583
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25939,15 +26158,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 586 GoSliceDataType []bool.array
+      Data: 587 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 586
+      ID: 587
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1156
+      ID: 1167
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -25962,15 +26181,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1179 GoSliceDataType []float64.array
+      Data: 1190 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1179
+      ID: 1190
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 15 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 419
+      ID: 420
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 489568
@@ -25978,22 +26197,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 420 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 421 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 700 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 693
+      ID: 700
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 421 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 422 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 422
+      ID: 423
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 489760
@@ -26001,22 +26220,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 423 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 424 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 701 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 708 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 701
+      ID: 708
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 424 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 425 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 362
+      ID: 366
       Name: '[]go.shape.float64'
       ByteSize: 24
       GoRuntimeType: 492128
@@ -26024,66 +26243,66 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 363 PointerType *go.shape.float64
+          Type: 367 PointerType *go.shape.float64
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 658 GoSliceDataType []go.shape.float64.array
+      Data: 665 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 658
+      ID: 665
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 364 BaseType go.shape.float64
+      Element: 368 BaseType go.shape.float64
     - __kind: GoSliceHeaderType
-      ID: 338
+      ID: 342
       Name: '[]go.shape.int'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 339 PointerType *go.shape.int
+          Type: 343 PointerType *go.shape.int
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 654 GoSliceDataType []go.shape.int.array
+      Data: 661 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 654
+      ID: 661
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 334 BaseType go.shape.int
+      Element: 338 BaseType go.shape.int
     - __kind: GoSliceHeaderType
-      ID: 359
+      ID: 363
       Name: '[]go.shape.string'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 356 PointerType *go.shape.string
+          Type: 360 PointerType *go.shape.string
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 656 GoSliceDataType []go.shape.string.array
+      Data: 663 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 656
+      ID: 663
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 336 GoStringHeaderType go.shape.string
+      Element: 340 GoStringHeaderType go.shape.string
     - __kind: GoSliceHeaderType
-      ID: 1455
+      ID: 1456
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 496736
@@ -26098,9 +26317,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1456 GoSliceDataType []interface {}.array
+      Data: 1457 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1456
+      ID: 1457
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26120,15 +26339,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 592 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 593 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 592
+      ID: 593
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 284 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 503
+      ID: 504
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 486432
@@ -26136,16 +26355,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 504 PointerType *main.structWithMap
+          Type: 505 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 703 GoSliceDataType []main.structWithMap.array
+      Data: 710 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 703
+      ID: 710
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26165,205 +26384,205 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 584 GoSliceDataType []main.structWithNoStrings.array
+      Data: 585 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 584
+      ID: 585
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 275 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 555
+      ID: 556
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 551 StructureType noalg.map.group[[4]int][4]int
+      Element: 552 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 547
+      ID: 548
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 543 StructureType noalg.map.group[[4]int]uint8
+      Element: 544 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 497
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 491 StructureType noalg.map.group[[4]string][2]int
+      Element: 492 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 515
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 510 StructureType noalg.map.group[bool]main.node
+      Element: 511 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 668
+      ID: 675
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 663 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 670 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 454
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 447 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 448 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1428
+      ID: 1429
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1422 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1423 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1472
+      ID: 1473
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1466 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1467 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1487
+      ID: 1488
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1481 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 464
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 459 StructureType noalg.map.group[int]int
+      Element: 460 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1500
+      ID: 1501
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1496 StructureType noalg.map.group[int]interface {}
+      Element: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 571
+      ID: 572
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 567 StructureType noalg.map.group[int]struct {}
+      Element: 568 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 522
+      ID: 523
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 518 StructureType noalg.map.group[int]uint8
+      Element: 519 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 725
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 708 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 507
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 500 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 501 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 488
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 483 StructureType noalg.map.group[string][]string
+      Element: 484 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 692
+      ID: 699
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 688 StructureType noalg.map.group[string]float64
+      Element: 695 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1178
+      ID: 1189
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1174 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 480
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 475 StructureType noalg.map.group[string]int
+      Element: 476 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 684
+      ID: 691
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 680 StructureType noalg.map.group[string]interface {}
+      Element: 687 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 472
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 467 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 468 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 676
+      ID: 683
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 672 StructureType noalg.map.group[string]string
+      Element: 679 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 563
+      ID: 564
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 559 StructureType noalg.map.group[struct {}]int
+      Element: 560 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 611
+      ID: 612
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 607 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 619
+      ID: 620
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 615 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 627
+      ID: 628
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 623 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 635
+      ID: 636
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 643
+      ID: 644
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 651
+      ID: 652
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 579
+      ID: 580
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 575 StructureType noalg.map.group[struct {}]struct {}
+      Element: 576 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 539
+      ID: 540
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 534 StructureType noalg.map.group[uint8][4]int
+      Element: 535 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 531
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 526 StructureType noalg.map.group[uint8]uint8
+      Element: 527 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: '[]runtime.ancestorInfo'
@@ -26384,9 +26603,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 454 GoSliceDataType []string.array
+      Data: 455 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 455
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26406,14 +26625,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 590 GoSliceDataType []struct {}.array
+      Data: 591 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 590
+      ID: 591
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 133 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 1393
+      ID: 653
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494944
@@ -26421,22 +26640,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1394 PointerType *time.zone
+          Type: 654 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1399 GoSliceDataType []time.zone.array
+      Data: 712 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 1399
+      ID: 712
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 1395 StructureType time.zone
+      Element: 655 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 1396
+      ID: 656
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 495008
@@ -26444,20 +26663,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1397 PointerType *time.zoneTrans
+          Type: 657 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1401 GoSliceDataType []time.zoneTrans.array
+      Data: 714 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 1401
+      ID: 714
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 1398 StructureType time.zoneTrans
+      Element: 658 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 270
       Name: '[]uint'
@@ -26474,9 +26693,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 580 GoSliceDataType []uint.array
+      Data: 581 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 580
+      ID: 581
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26497,9 +26716,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 588 GoSliceDataType []uint16.array
+      Data: 589 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 588
+      ID: 589
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26520,9 +26739,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 432 GoSliceDataType []uint8.array
+      Data: 433 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 432
+      ID: 433
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26543,19 +26762,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 434 GoSliceDataType []uintptr.array
+      Data: 435 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 434
+      ID: 435
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1312
+      ID: 1323
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 949
+      ID: 960
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 944800
@@ -26570,33 +26789,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 950 GoSliceDataType archive/tar.headerError.array
+      Data: 961 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 950
+      ID: 961
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1246
+      ID: 1257
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1194
+      ID: 1205
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1196
+      ID: 1207
       Name: archive/zip.dirWriter
       GoRuntimeType: 1134944
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1289
+      ID: 1300
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1222
+      ID: 1233
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1588544
@@ -26606,7 +26825,7 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1224
+      ID: 1235
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26616,15 +26835,15 @@ Types:
       GoRuntimeType: 594048
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1270
+      ID: 1281
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1301
+      ID: 1312
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1348
+      ID: 1359
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -26650,13 +26869,13 @@ Types:
       GoRuntimeType: 593792
       GoKind: 15
     - __kind: BaseType
-      ID: 752
+      ID: 763
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 753
+      ID: 764
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 845760
@@ -26664,26 +26883,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 755 PointerType *compress/flate.InternalError.str
+          Type: 766 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 754 GoStringDataType compress/flate.InternalError.str
+      Data: 765 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 754
+      ID: 765
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1244
+      ID: 1255
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1190
+      ID: 1201
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1266
+      ID: 1277
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -26700,7 +26919,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 372
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 1751552
@@ -26708,29 +26927,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 370 StructureType context.cancelCtx
+          Type: 374 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 388 StructureType sync.Once
+          Type: 392 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 391
+      ID: 395
       Name: context.backgroundCtx
       GoRuntimeType: 1827232
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 392 StructureType context.emptyCtx
+          Type: 396 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 374
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1996608
@@ -26741,23 +26960,23 @@ Types:
           Type: 163 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 379 StructureType sync.Mutex
+          Type: 383 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 382 StructureType sync/atomic.Value
+          Type: 386 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 383 GoMapType map[context.canceler]struct {}
+          Type: 387 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 382 StructureType sync/atomic.Value
+          Type: 386 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 17 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 666
+      ID: 673
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1125472
@@ -26770,13 +26989,13 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1065
+      ID: 1076
       Name: context.deadlineExceededError
       GoRuntimeType: 1483904
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 392
+      ID: 396
       Name: context.emptyCtx
       GoRuntimeType: 1619136
       GoKind: 25
@@ -26785,7 +27004,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 376
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1852704
@@ -26796,11 +27015,11 @@ Types:
           Type: 163 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 393 GoSubroutineType func() bool
+          Type: 397 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 374
+      ID: 378
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1638528
@@ -26808,29 +27027,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 370 StructureType context.cancelCtx
+          Type: 374 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 394 PointerType *time.Timer
+          Type: 398 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 396 StructureType time.Time
+          Type: 334 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 399
+      ID: 400
       Name: context.todoCtx
       GoRuntimeType: 1827456
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 392 StructureType context.emptyCtx
+          Type: 396 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 376
+      ID: 380
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1864864
@@ -26848,7 +27067,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 378
+      ID: 382
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1827008
@@ -26860,91 +27079,91 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 763
+      ID: 774
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 848256
       GoKind: 2
     - __kind: BaseType
-      ID: 764
+      ID: 775
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 848352
       GoKind: 2
     - __kind: BaseType
-      ID: 765
+      ID: 776
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 848448
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1261
+      ID: 1272
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 1046
+      ID: 1057
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1306912
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1291
+      ID: 1302
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1323
+      ID: 1334
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1308
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1293
+      ID: 1304
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1287
+      ID: 1298
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 766
+      ID: 777
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 848544
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1310
+      ID: 1321
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1295
+      ID: 1306
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1279
+      ID: 1290
       Name: crypto/sha3.SHAKE
       ByteSize: 8
     - __kind: BaseType
-      ID: 756
+      ID: 767
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 846240
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1046
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1374
+      ID: 1385
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 878
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 875
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1758464
@@ -26955,38 +27174,38 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1161 ArrayType [5]uint8
+          Type: 1172 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 988
+      ID: 999
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1007840
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1254
+      ID: 1265
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 880
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1259
+      ID: 1270
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1143
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1157
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 935
+      ID: 946
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1761344
@@ -26994,21 +27213,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1145 PointerType *crypto/x509.Certificate
+          Type: 1156 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1164 BaseType crypto/x509.InvalidReason
+          Type: 1175 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 929
+      ID: 940
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1132384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 931
+      ID: 942
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1623776
@@ -27016,24 +27235,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1145 PointerType *crypto/x509.Certificate
+          Type: 1156 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 762
+      ID: 773
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 847776
       GoKind: 2
     - __kind: BaseType
-      ID: 1164
+      ID: 1175
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 599104
       GoKind: 2
     - __kind: StructureType
-      ID: 1040
+      ID: 1051
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1584384
@@ -27043,13 +27262,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 937
+      ID: 948
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1132640
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 933
+      ID: 944
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1761152
@@ -27057,15 +27276,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1145 PointerType *crypto/x509.Certificate
+          Type: 1156 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1145 PointerType *crypto/x509.Certificate
+          Type: 1156 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 953
+      ID: 964
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1455232
@@ -27075,7 +27294,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 957
+      ID: 968
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1455392
@@ -27085,55 +27304,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 966
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 746
+      ID: 757
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 845088
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1212
+      ID: 1223
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 747
+      ID: 758
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 845280
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 834
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1035
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 826
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 832
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 830
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 828
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1354
+      ID: 1365
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 836
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1438272
@@ -27143,11 +27362,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1220
+      ID: 1231
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 937
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27164,11 +27383,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 800
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 1002
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27184,15 +27403,15 @@ Types:
       GoRuntimeType: 593984
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1342
+      ID: 1353
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 993
+      ID: 1004
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 995
+      ID: 1006
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27202,7 +27421,7 @@ Types:
       GoRuntimeType: 483872
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 393
+      ID: 397
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 604800
@@ -27214,44 +27433,44 @@ Types:
       GoRuntimeType: 860448
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 365
+      ID: 369
       Name: func(go.shape.float64) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 340
+      ID: 344
       Name: func(go.shape.int) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 341
+      ID: 345
       Name: func(go.shape.int) go.shape.string
       ByteSize: 8
       GoKind: 19
     - __kind: StructureType
-      ID: 335
+      ID: 339
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
     - __kind: StructureType
-      ID: 337
+      ID: 341
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 864
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 845
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1757312
@@ -27259,7 +27478,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1154 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1165 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27267,25 +27486,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 847
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1169
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 840
+      ID: 851
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1128160
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1171
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 740
+      ID: 751
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 844512
@@ -27293,18 +27512,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 742 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 753 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 741 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 741
+      ID: 752
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1154
+      ID: 1165
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2253024
@@ -27312,7 +27531,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1155 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1166 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27327,7 +27546,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1156 GoSliceHeaderType []float64
+          Type: 1167 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -27336,10 +27555,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1157 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1168 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1159 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1170 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 167 GoSliceHeaderType []string
@@ -27353,13 +27572,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 1155
+      ID: 1166
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 595584
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 737
+      ID: 748
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 844416
@@ -27367,18 +27586,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 739 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 750 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 738 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 738
+      ID: 749
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 743
+      ID: 754
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 844608
@@ -27386,30 +27605,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 745 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 756 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 744 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 755 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 744
+      ID: 755
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1232
+      ID: 1243
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1320
+      ID: 1331
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 958
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 401
+      ID: 402
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2371648
@@ -27417,7 +27636,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 402 StructureType sync.RWMutex
+          Type: 403 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -27438,13 +27657,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 409 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 410 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 414 GoMapType map[string]float64
+          Type: 415 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -27459,10 +27678,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 419 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 420 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 422 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 423 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27474,7 +27693,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 425 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 426 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -27497,7 +27716,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 426
+      ID: 427
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2250784
@@ -27508,13 +27727,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 427 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 428 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 400 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 403 StructureType sync/atomic.Int32
+          Type: 404 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27523,16 +27742,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 429 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 430 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 402 StructureType sync.RWMutex
+          Type: 403 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -27541,12 +27760,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 419 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 420 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 421
+      ID: 422
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1941312
@@ -27563,7 +27782,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27571,20 +27790,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 409
+      ID: 410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1299744
       GoKind: 21
-      HeaderType: 411 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 412 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1405
+      ID: 1406
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 592832
       GoKind: 10
     - __kind: StructureType
-      ID: 424
+      ID: 425
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1777792
@@ -27598,16 +27817,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 695 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 702 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 700 GoMapType map[string]interface {}
+          Type: 707 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1431
+      ID: 1432
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 712
+      ID: 723
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1941568
@@ -27615,7 +27834,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1429 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1430 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27630,15 +27849,15 @@ Types:
           Type: 15 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1430 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1431 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1429
+      ID: 1430
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1002752
       GoKind: 5
     - __kind: StructureType
-      ID: 428
+      ID: 429
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2136896
@@ -27646,16 +27865,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 402 StructureType sync.RWMutex
+          Type: 403 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1403 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1404 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -27670,12 +27889,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1405 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1406 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 400 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 429
+      ID: 430
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 910240
@@ -27684,15 +27903,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1111
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1350
+      ID: 1361
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1434
+      ID: 1435
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1652736
@@ -27702,29 +27921,29 @@ Types:
           Offset: 0
           Type: 163 GoInterfaceType context.Context
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 888
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 884
+      ID: 895
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1131616
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 761
+      ID: 772
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 846912
       GoKind: 2
     - __kind: StructureType
-      ID: 882
+      ID: 893
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1131488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 880
+      ID: 891
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1621696
@@ -27737,7 +27956,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 911
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1622496
@@ -27750,7 +27969,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 904
+      ID: 915
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1760576
@@ -27766,7 +27985,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 902
+      ID: 913
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1448192
@@ -27776,7 +27995,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 898
+      ID: 909
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1447872
@@ -27786,14 +28005,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1140
+      ID: 1151
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1521824
       GoKind: 21
-      HeaderType: 1142 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1153 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1163
+      ID: 1174
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1064928
@@ -27808,15 +28027,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1181 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1192 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1181
+      ID: 1192
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 912
+      ID: 923
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1622816
@@ -27824,12 +28043,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1140 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1151 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1140 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1151 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 906
+      ID: 917
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1448352
@@ -27839,7 +28058,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 910
+      ID: 921
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1760768
@@ -27850,12 +28069,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1163 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1163 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 908
+      ID: 919
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1622656
@@ -27868,7 +28087,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 914
+      ID: 925
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1448512
@@ -27876,9 +28095,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 396 StructureType time.Time
+          Type: 334 GoTimeType time.Time
     - __kind: StructureType
-      ID: 920
+      ID: 931
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1623136
@@ -27891,7 +28110,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 922
+      ID: 933
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1448832
@@ -27901,7 +28120,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 918
+      ID: 929
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1622976
@@ -27914,7 +28133,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 916
+      ID: 927
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1448672
@@ -27924,7 +28143,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 924
+      ID: 935
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1623296
@@ -27937,7 +28156,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 842
+      ID: 853
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1440512
@@ -27947,11 +28166,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1273
+      ID: 1284
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 844
+      ID: 855
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1440672
@@ -27959,21 +28178,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 842 StructureType github.com/cihub/seelog.baseError
+          Type: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1252
+      ID: 1263
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1208
+      ID: 1219
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1242
+      ID: 1253
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 848
+      ID: 859
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1440992
@@ -27981,13 +28200,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 842 StructureType github.com/cihub/seelog.baseError
+          Type: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1319
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1321
+      ID: 1332
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2139360
@@ -27995,12 +28214,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1307 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 1324
+      ID: 1335
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2165024
@@ -28008,7 +28227,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1307 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28016,11 +28235,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1221
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 846
+      ID: 857
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1440832
@@ -28028,9 +28247,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 842 StructureType github.com/cihub/seelog.baseError
+          Type: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 850
+      ID: 861
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1441152
@@ -28038,64 +28257,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 842 StructureType github.com/cihub/seelog.baseError
+          Type: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1275
+      ID: 1286
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1316
+      ID: 1327
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1318
+      ID: 1329
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1145
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1061
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1059
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1063
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1065
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1263
+      ID: 1274
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1053
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 856
+      ID: 867
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1442112
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1366
+      ID: 1377
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1119
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1077
+      ID: 1088
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1870240
@@ -28111,11 +28330,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1082
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1010
+      ID: 1021
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1730016
@@ -28128,7 +28347,7 @@ Types:
           Offset: 1
           Type: 22 BaseType int8
     - __kind: StructureType
-      ID: 1083
+      ID: 1094
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1870688
@@ -28144,13 +28363,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 987
+      ID: 998
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1004672
       GoKind: 8
     - __kind: StructureType
-      ID: 1075
+      ID: 1086
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1870016
@@ -28166,13 +28385,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1165
+      ID: 1176
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 842784
       GoKind: 8
     - __kind: StructureType
-      ID: 1073
+      ID: 1084
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1869792
@@ -28180,15 +28399,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1165 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1176 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1165 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1176 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1081
+      ID: 1092
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1783744
@@ -28201,7 +28420,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1079
+      ID: 1090
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1870464
@@ -28217,11 +28436,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1370
+      ID: 1381
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1087
+      ID: 1098
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1648704
@@ -28231,19 +28450,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1014
+      ID: 1025
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1300128
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1012
+      ID: 1023
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1300000
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1085
+      ID: 1096
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1783936
@@ -28256,7 +28475,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 771
+      ID: 782
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 850368
@@ -28264,36 +28483,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 773 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 784 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 772 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 783 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 772
+      ID: 783
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 351
+      ID: 355
       Name: go.shape.bool
       ByteSize: 1
       GoRuntimeType: 605760
       GoKind: 1
     - __kind: BaseType
-      ID: 364
+      ID: 368
       Name: go.shape.float64
       ByteSize: 8
       GoRuntimeType: 606400
       GoKind: 14
     - __kind: BaseType
-      ID: 334
+      ID: 338
       Name: go.shape.int
       ByteSize: 8
       GoRuntimeType: 605632
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 336
+      ID: 340
       Name: go.shape.string
       ByteSize: 16
       GoRuntimeType: 605696
@@ -28301,18 +28520,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 653 PointerType *go.shape.string.str
+          Type: 660 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 652 GoStringDataType go.shape.string.str
+      Data: 659 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 652
+      ID: 659
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 343
+      ID: 347
       Name: go.shape.struct { Name string }
       ByteSize: 16
       GoKind: 25
@@ -28321,7 +28540,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 345
+      ID: 349
       Name: go.shape.struct { X int; Y int }
       ByteSize: 16
       GoKind: 25
@@ -28333,13 +28552,13 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 354
+      ID: 358
       Name: go.shape.struct { main.i int }
       ByteSize: 8
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 355
+      ID: 359
       Name: go.shape.struct { main.s string }
       ByteSize: 16
       GoKind: 25
@@ -28348,7 +28567,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 358
+      ID: 362
       Name: go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
       ByteSize: 48
       GoKind: 25
@@ -28363,11 +28582,11 @@ Types:
           Offset: 32
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1149
+      ID: 1160
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1058
+      ID: 1069
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1467072
@@ -28377,7 +28596,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1238
+      ID: 1249
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1705344
@@ -28385,13 +28604,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1264 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1275 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1332
+      ID: 1343
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1264
+      ID: 1275
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1142496
@@ -28404,7 +28623,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1226
+      ID: 1237
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1593664
@@ -28414,19 +28633,19 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 774
+      ID: 785
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 850944
       GoKind: 10
     - __kind: BaseType
-      ID: 1147
+      ID: 1158
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1018400
       GoKind: 10
     - __kind: StructureType
-      ID: 1116
+      ID: 1127
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1909440
@@ -28437,12 +28656,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1147 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1158 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 973
+      ID: 984
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1630816
@@ -28450,12 +28669,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1147 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1158 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 778
+      ID: 789
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 851136
@@ -28463,18 +28682,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 780 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 791 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 779 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 790 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 779
+      ID: 790
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 784
+      ID: 795
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 851328
@@ -28482,18 +28701,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 786 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 797 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 785 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 796 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 785
+      ID: 796
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 781
+      ID: 792
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 851232
@@ -28501,18 +28720,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 783 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 794 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 782 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 793 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 782
+      ID: 793
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 775
+      ID: 786
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 851040
@@ -28520,22 +28739,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 777 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 788 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 776 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 787 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 776
+      ID: 787
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1330
+      ID: 1341
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 977
+      ID: 988
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1467712
@@ -28545,13 +28764,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 787
+      ID: 798
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 851424
       GoKind: 2
     - __kind: StructureType
-      ID: 965
+      ID: 976
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1462752
@@ -28561,11 +28780,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1125
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1136
+      ID: 1147
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1938304
@@ -28581,7 +28800,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 967
+      ID: 978
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1630336
@@ -28594,7 +28813,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1281
+      ID: 1292
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1997632
@@ -28602,16 +28821,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1306 GoInterfaceType io.Reader
+          Type: 1317 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1247
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1056
+      ID: 1067
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1591264
@@ -28621,29 +28840,29 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1198
+      ID: 1209
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 956
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1055
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1123
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1110
+      ID: 1121
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1533344
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 959
+      ID: 970
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1456032
@@ -28653,7 +28872,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 961
+      ID: 972
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1456192
@@ -28663,463 +28882,463 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 903
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 549
+      ID: 550
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 550 PointerType *noalg.map.group[[4]int][4]int
+          Type: 551 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 551 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 555 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 552 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 556 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 541
+      ID: 542
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 542 PointerType *noalg.map.group[[4]int]uint8
+          Type: 543 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 543 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 547 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 544 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 548 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 489
+      ID: 490
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 490 PointerType *noalg.map.group[[4]string][2]int
+          Type: 491 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 491 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 496 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 492 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 497 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 508
+      ID: 509
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 509 PointerType *noalg.map.group[bool]main.node
+          Type: 510 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 510 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 514 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 511 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 515 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 661
+      ID: 668
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 662 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 669 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 663 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 668 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 670 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 675 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 445
+      ID: 446
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 446 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 447 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 447 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 453 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 448 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 454 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1420
+      ID: 1421
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1421 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1422 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1422 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1428 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1423 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1429 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1464
+      ID: 1465
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1465 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1466 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1466 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1472 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1467 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1473 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1479
+      ID: 1480
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1480 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1481 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1481 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1487 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1482 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1488 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 457
+      ID: 458
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 458 PointerType *noalg.map.group[int]int
+          Type: 459 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 459 StructureType noalg.map.group[int]int
-      GroupSliceType: 463 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 460 StructureType noalg.map.group[int]int
+      GroupSliceType: 464 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1494
+      ID: 1495
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1495 PointerType *noalg.map.group[int]interface {}
+          Type: 1496 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1496 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1500 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1497 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1501 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 565
+      ID: 566
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 566 PointerType *noalg.map.group[int]struct {}
+          Type: 567 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 567 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 571 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 568 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 572 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 516
+      ID: 517
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 517 PointerType *noalg.map.group[int]uint8
+          Type: 518 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 518 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 522 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 519 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 523 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 706
+      ID: 717
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 707 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 718 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 708 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 714 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 725 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 498
+      ID: 499
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 499 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 500 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 500 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 506 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 501 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 507 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 481
+      ID: 482
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 482 PointerType *noalg.map.group[string][]string
+          Type: 483 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 483 StructureType noalg.map.group[string][]string
-      GroupSliceType: 487 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 484 StructureType noalg.map.group[string][]string
+      GroupSliceType: 488 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 686
+      ID: 693
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 687 PointerType *noalg.map.group[string]float64
+          Type: 694 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 688 StructureType noalg.map.group[string]float64
-      GroupSliceType: 692 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 695 StructureType noalg.map.group[string]float64
+      GroupSliceType: 699 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1172
+      ID: 1183
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1173 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1184 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1174 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1178 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1189 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 473
+      ID: 474
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 474 PointerType *noalg.map.group[string]int
+          Type: 475 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 475 StructureType noalg.map.group[string]int
-      GroupSliceType: 479 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 476 StructureType noalg.map.group[string]int
+      GroupSliceType: 480 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 678
+      ID: 685
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 679 PointerType *noalg.map.group[string]interface {}
+          Type: 686 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 680 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 684 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 687 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 691 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 465
+      ID: 466
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 466 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 467 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 467 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 471 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 468 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 472 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 670
+      ID: 677
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 671 PointerType *noalg.map.group[string]string
+          Type: 678 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 672 StructureType noalg.map.group[string]string
-      GroupSliceType: 676 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 679 StructureType noalg.map.group[string]string
+      GroupSliceType: 683 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 557
+      ID: 558
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 558 PointerType *noalg.map.group[struct {}]int
+          Type: 559 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 559 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 563 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 560 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 564 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 605
+      ID: 606
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 606 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 607 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 607 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 611 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 612 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 613
+      ID: 614
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 614 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 615 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 615 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 619 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 620 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 621
+      ID: 622
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 622 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 623 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 623 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 627 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 628 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 629
+      ID: 630
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 630 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 631 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 635 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 636 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 637
+      ID: 638
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 638 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 639 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 643 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 644 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 645
+      ID: 646
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 646 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 647 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 651 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 652 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 573
+      ID: 574
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 574 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 575 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 575 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 579 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 576 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 580 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 532
+      ID: 533
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 533 PointerType *noalg.map.group[uint8][4]int
+          Type: 534 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 534 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 539 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 535 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 540 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 524
+      ID: 525
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 525 PointerType *noalg.map.group[uint8]uint8
+          Type: 526 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 526 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 530 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 527 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 531 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1285
+      ID: 1296
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 991
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29166,17 +29385,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 1168
+      ID: 1179
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 596480
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1149
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 950
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29202,29 +29421,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 871
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1188
+      ID: 1199
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1117
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1372
+      ID: 1383
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1104
+      ID: 1115
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1510944
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 798
+      ID: 809
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29296,7 +29515,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 760
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 845568
@@ -29304,18 +29523,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 762 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 750 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 761 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 761
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1028
+      ID: 1039
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1582144
@@ -29323,15 +29542,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 1137 PointerType *internal/abi.Type
+          Type: 1148 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 748
+      ID: 759
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 845376
       GoKind: 2
     - __kind: StructureType
-      ID: 381
+      ID: 385
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1508384
@@ -29344,11 +29563,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1230
+      ID: 1241
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1271
+      ID: 1282
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1204704
@@ -29361,7 +29580,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1306
+      ID: 1317
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1038176
@@ -29374,7 +29593,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1257
+      ID: 1268
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1124960
@@ -29400,47 +29619,47 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1228
+      ID: 1239
       Name: io.discard
       GoRuntimeType: 1483584
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1202
+      ID: 1213
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1113
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1277
+      ID: 1288
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 350
+      ID: 354
       Name: main.Pair[go.shape.int,go.shape.bool]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
         - Name: Value
           Offset: 8
-          Type: 351 BaseType go.shape.bool
+          Type: 355 BaseType go.shape.bool
     - __kind: StructureType
-      ID: 353
+      ID: 357
       Name: main.Pair[go.shape.string,go.shape.int]
       ByteSize: 24
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
         - Name: Value
           Offset: 16
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
     - __kind: StructureType
       ID: 328
       Name: main.aStruct
@@ -29467,7 +29686,7 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1501 PointerType *main.nestedStruct
+          Type: 1502 PointerType *main.nestedStruct
     - __kind: GoInterfaceType
       ID: 175
       Name: main.behavior
@@ -29508,7 +29727,7 @@ Types:
           Offset: 0
           Type: 152 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 451
+      ID: 452
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1200864
@@ -29516,9 +29735,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1414 GoMapType map[int]*main.deepMap3
+          Type: 1415 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1426
+      ID: 1427
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -29530,9 +29749,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1458 GoMapType map[int]*main.deepMap8
+          Type: 1459 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1470
+      ID: 1471
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1200096
@@ -29540,9 +29759,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1473 GoMapType map[int]*main.deepMap9
+          Type: 1474 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1485
+      ID: 1486
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1199968
@@ -29550,7 +29769,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1488 GoMapType map[int]interface {}
+          Type: 1489 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 140
       Name: main.deepPtr1
@@ -29570,9 +29789,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1375 PointerType *main.deepPtr3
+          Type: 1386 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1376
+      ID: 1387
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -29584,9 +29803,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1439 PointerType *main.deepPtr8
+          Type: 1440 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1440
+      ID: 1441
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1201248
@@ -29594,9 +29813,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1441 PointerType *main.deepPtr9
+          Type: 1442 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1442
+      ID: 1443
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1201120
@@ -29616,7 +29835,7 @@ Types:
           Offset: 0
           Type: 146 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 441
+      ID: 442
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1203168
@@ -29624,9 +29843,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1408 GoSliceHeaderType []*main.deepSlice3
+          Type: 1409 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1411
+      ID: 1412
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -29638,9 +29857,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1443 GoSliceHeaderType []*main.deepSlice8
+          Type: 1444 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1446
+      ID: 1447
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1202400
@@ -29648,9 +29867,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1449 GoSliceHeaderType []*main.deepSlice9
+          Type: 1450 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1452
+      ID: 1453
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1202272
@@ -29658,7 +29877,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1455 GoSliceHeaderType []interface {}
+          Type: 1456 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 332
       Name: main.emptyStruct
@@ -29676,16 +29895,16 @@ Types:
           Type: 168 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 379 StructureType sync.Mutex
+          Type: 383 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 388 StructureType sync.Once
+          Type: 392 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1383 StructureType sync.WaitGroup
+          Type: 1394 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 403 StructureType sync/atomic.Int32
+          Type: 404 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 168
       Name: main.esotericStack
@@ -29715,7 +29934,7 @@ Types:
           Offset: 56
           Type: 65 GoSubroutineType func()
     - __kind: StructureType
-      ID: 366
+      ID: 370
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1431232
@@ -29725,71 +29944,71 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 348
+      ID: 352
       Name: main.largeGenericType[go.shape.int]
       ByteSize: 136
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
     - __kind: StructureType
-      ID: 346
+      ID: 350
       Name: main.largeGenericType[go.shape.string]
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 263
       Name: main.largeStruct
@@ -30103,9 +30322,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1380 ArrayType [63]uint64
+          Type: 1391 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1388
+      ID: 1399
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1431392
@@ -30125,7 +30344,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1382
+      ID: 1393
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30136,31 +30355,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1378 PointerType *main.stringType1.str
+          Type: 1389 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1377 GoStringDataType main.stringType1.str
+      Data: 1388 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1377
+      ID: 1388
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1379
+      ID: 1390
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1503 PointerType *main.stringType2.str
+          Type: 1504 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1502 GoStringDataType main.stringType2.str
+      Data: 1503 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1502
+      ID: 1503
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -30276,16 +30495,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1389 PointerType **main.t
+          Type: 1400 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1390 GoSliceDataType main.t.array
+      Data: 1401 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1390
+      ID: 1401
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -30341,29 +30560,38 @@ Types:
         - Name: c
           Offset: 32
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 337
+      Name: main.timeCapture
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: monotonicNow
+          Offset: 0
+          Type: 334 GoTimeType time.Time
     - __kind: BaseType
       ID: 135
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 360
+      ID: 364
       Name: main.typeWithGenerics[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
     - __kind: StructureType
-      ID: 361
+      ID: 365
       Name: main.typeWithGenerics[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 268
       Name: main.wideStruct
@@ -30436,8 +30664,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 554 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 551 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 555 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 552 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 233
       Name: map<[4]int,uint8>
@@ -30471,8 +30699,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 546 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 543 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 547 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 544 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 201
       Name: map<[4]string,[2]int>
@@ -30506,8 +30734,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 495 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 491 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 496 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 492 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 213
       Name: map<bool,main.node>
@@ -30541,10 +30769,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 513 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 510 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 514 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 511 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 385
+      ID: 389
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -30557,7 +30785,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 386 PointerType **table<context.canceler,struct {}>
+          Type: 390 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30576,8 +30804,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 667 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 663 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 674 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 670 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 154
       Name: map<int,*main.deepMap2>
@@ -30611,10 +30839,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 452 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 447 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 453 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 448 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1416
+      ID: 1417
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -30627,7 +30855,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1417 PointerType **table<int,*main.deepMap3>
+          Type: 1418 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30646,10 +30874,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1427 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1422 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1428 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1423 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1460
+      ID: 1461
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -30662,7 +30890,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1461 PointerType **table<int,*main.deepMap8>
+          Type: 1462 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30681,10 +30909,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1471 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1466 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1472 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1467 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1475
+      ID: 1476
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -30697,7 +30925,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1476 PointerType **table<int,*main.deepMap9>
+          Type: 1477 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30716,8 +30944,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1486 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1481 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1487 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 181
       Name: map<int,int>
@@ -30751,10 +30979,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 462 GoSliceDataType []*table<int,int>.array
-      GroupType: 459 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 463 GoSliceDataType []*table<int,int>.array
+      GroupType: 460 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1490
+      ID: 1491
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -30767,7 +30995,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1491 PointerType **table<int,interface {}>
+          Type: 1492 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30786,8 +31014,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1499 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1496 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1500 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 248
       Name: map<int,struct {}>
@@ -30821,8 +31049,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 570 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 567 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 571 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 568 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 218
       Name: map<int,uint8>
@@ -30856,10 +31084,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 521 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 518 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 522 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 519 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 697
+      ID: 704
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -30872,7 +31100,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 698 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 705 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30891,8 +31119,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 713 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 708 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 724 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 208
       Name: map<string,[]main.structWithMap>
@@ -30926,8 +31154,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 505 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 500 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 506 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 501 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 196
       Name: map<string,[]string>
@@ -30961,10 +31189,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 486 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 483 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 487 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 484 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 416
+      ID: 417
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -30977,7 +31205,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 417 PointerType **table<string,float64>
+          Type: 418 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30996,10 +31224,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 691 GoSliceDataType []*table<string,float64>.array
-      GroupType: 688 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 698 GoSliceDataType []*table<string,float64>.array
+      GroupType: 695 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1142
+      ID: 1153
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31012,7 +31240,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1143 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1154 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31031,8 +31259,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1177 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1174 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1188 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 191
       Name: map<string,int>
@@ -31066,10 +31294,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 478 GoSliceDataType []*table<string,int>.array
-      GroupType: 475 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 479 GoSliceDataType []*table<string,int>.array
+      GroupType: 476 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 411
+      ID: 412
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31082,7 +31310,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 412 PointerType **table<string,interface {}>
+          Type: 413 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31101,8 +31329,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 683 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 680 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 690 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 687 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 186
       Name: map<string,main.nestedStruct>
@@ -31136,10 +31364,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 470 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 467 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 471 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 468 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 406
+      ID: 407
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31152,7 +31380,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 407 PointerType **table<string,string>
+          Type: 408 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31171,8 +31399,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 675 GoSliceDataType []*table<string,string>.array
-      GroupType: 672 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 682 GoSliceDataType []*table<string,string>.array
+      GroupType: 679 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 243
       Name: map<struct {},int>
@@ -31206,8 +31434,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 562 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 559 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 563 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 560 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 300
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31241,8 +31469,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 610 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 607 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 611 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 305
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31276,8 +31504,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 618 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 615 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 619 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 310
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31311,8 +31539,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 626 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 623 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 627 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 315
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31346,8 +31574,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 634 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 635 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 320
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31381,8 +31609,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 642 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 643 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 325
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31416,8 +31644,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 650 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 651 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 253
       Name: map<struct {},struct {}>
@@ -31451,8 +31679,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 578 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 575 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 579 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 576 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 228
       Name: map<uint8,[4]int>
@@ -31486,8 +31714,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 538 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 534 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 539 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 535 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 223
       Name: map<uint8,uint8>
@@ -31521,8 +31749,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 529 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 526 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 530 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 527 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 236
       Name: map[[4]int][4]int
@@ -31552,12 +31780,12 @@ Types:
       GoKind: 21
       HeaderType: 213 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 383
+      ID: 387
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1146720
       GoKind: 21
-      HeaderType: 385 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 389 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 152
       Name: map[int]*main.deepMap2
@@ -31566,26 +31794,26 @@ Types:
       GoKind: 21
       HeaderType: 154 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1414
+      ID: 1415
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1144288
       GoKind: 21
-      HeaderType: 1416 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1417 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1458
+      ID: 1459
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1143648
       GoKind: 21
-      HeaderType: 1460 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1461 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1473
+      ID: 1474
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1143520
       GoKind: 21
-      HeaderType: 1475 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1476 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 179
       Name: map[int]int
@@ -31594,12 +31822,12 @@ Types:
       GoKind: 21
       HeaderType: 181 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1488
+      ID: 1489
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1143392
       GoKind: 21
-      HeaderType: 1490 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1491 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 246
       Name: map[int]struct {}
@@ -31615,12 +31843,12 @@ Types:
       GoKind: 21
       HeaderType: 218 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 695
+      ID: 702
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1146976
       GoKind: 21
-      HeaderType: 697 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 704 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 206
       Name: map[string][]main.structWithMap
@@ -31636,12 +31864,12 @@ Types:
       GoKind: 21
       HeaderType: 196 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 414
+      ID: 415
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1146848
       GoKind: 21
-      HeaderType: 416 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 417 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 189
       Name: map[string]int
@@ -31650,12 +31878,12 @@ Types:
       GoKind: 21
       HeaderType: 191 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 700
+      ID: 707
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1143264
       GoKind: 21
-      HeaderType: 411 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 412 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 184
       Name: map[string]main.nestedStruct
@@ -31664,12 +31892,12 @@ Types:
       GoKind: 21
       HeaderType: 186 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 404
+      ID: 405
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1146592
       GoKind: 21
-      HeaderType: 406 GoSwissMapHeaderType map<string,string>
+      HeaderType: 407 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 241
       Name: map[struct {}]int
@@ -31735,7 +31963,7 @@ Types:
       GoKind: 21
       HeaderType: 223 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 896
+      ID: 907
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1447392
@@ -31745,7 +31973,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1192
+      ID: 1203
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1444352
@@ -31755,11 +31983,11 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1105
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1162
+      ID: 1173
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1620416
@@ -31772,35 +32000,35 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1136
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1336
+      ID: 1347
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1123
+      ID: 1134
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1107
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1346
+      ID: 1357
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1356
+      ID: 1367
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1344
+      ID: 1355
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1061
+      ID: 1072
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1127776
@@ -31808,28 +32036,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1063 PointerType *net.UnknownNetworkError.str
+          Type: 1074 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1062 GoStringDataType net.UnknownNetworkError.str
+      Data: 1073 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1062
+      ID: 1073
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1026
+      ID: 1037
       Name: net.canceledError
       GoRuntimeType: 1301280
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1314
+      ID: 1325
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1167
+      ID: 1178
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2138656
@@ -31837,7 +32065,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -31848,27 +32076,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1358
+      ID: 1369
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1352
+      ID: 1363
       Name: net.noReadFrom
       GoRuntimeType: 1128032
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1351
+      ID: 1362
       Name: net.noWriteTo
       GoRuntimeType: 1127904
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 838
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1436
+      ID: 1437
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1788352
@@ -31881,7 +32109,7 @@ Types:
           Offset: 16
           Type: 163 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 829
+      ID: 840
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1757120
@@ -31889,7 +32117,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1150 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1161 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -31897,7 +32125,7 @@ Types:
           Offset: 96
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1340
+      ID: 1351
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2320832
@@ -31905,12 +32133,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1352 StructureType net.noReadFrom
+          Type: 1363 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1345 PointerType *net.TCPConn
+          Type: 1356 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1338
+      ID: 1349
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2320288
@@ -31918,24 +32146,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1351 StructureType net.noWriteTo
+          Type: 1362 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1345 PointerType *net.TCPConn
+          Type: 1356 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1098
+      ID: 1109
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1127
+      ID: 1138
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1027
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1184
+      ID: 1195
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1436032
@@ -31945,19 +32173,19 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 718
+      ID: 729
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 843264
       GoKind: 10
     - __kind: BaseType
-      ID: 1139
+      ID: 1150
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1004768
       GoKind: 10
     - __kind: StructureType
-      ID: 805
+      ID: 816
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1755392
@@ -31968,12 +32196,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1139 BaseType net/http.http2ErrCode
+          Type: 1150 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1119
+      ID: 1130
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1927552
@@ -31984,12 +32212,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1139 BaseType net/http.http2ErrCode
+          Type: 1150 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 809
+      ID: 820
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1620096
@@ -31997,16 +32225,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1139 BaseType net/http.http2ErrCode
+          Type: 1150 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1248
+      ID: 1259
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 722
+      ID: 733
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 843456
@@ -32014,18 +32242,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 724 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 735 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 723 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 734 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 723
+      ID: 734
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 728
+      ID: 739
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 843648
@@ -32033,18 +32261,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 730 PointerType *net/http.http2headerFieldNameError.str
+          Type: 741 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 729 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 740 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 729
+      ID: 740
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 725
+      ID: 736
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 843552
@@ -32052,32 +32280,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 727 PointerType *net/http.http2headerFieldValueError.str
+          Type: 738 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 726 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 737 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 726
+      ID: 737
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1102
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1033
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1300640
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1303
+      ID: 1314
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 719
+      ID: 730
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 843360
@@ -32085,18 +32313,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 721 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 732 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 720 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 731 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 720
+      ID: 731
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1186
+      ID: 1197
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1756160
@@ -32104,22 +32332,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1267 BaseType time.Duration
+          Type: 1278 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 113 PointerType *error
     - __kind: ArrayType
-      ID: 1268
+      ID: 1279
       Name: net/http.incomparable
       GoRuntimeType: 915712
       GoKind: 17
       HasCount: true
       Element: 65 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1018
+      ID: 1029
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1578144
@@ -32129,11 +32357,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1250
+      ID: 1261
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1206
+      ID: 1217
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1577984
@@ -32141,9 +32369,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1249 PointerType *net/http.persistConn
+          Type: 1260 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1240
+      ID: 1251
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1829248
@@ -32151,15 +32379,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1268 ArrayType net/http.incomparable
+          Type: 1279 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1269 PointerType *bufio.Reader
+          Type: 1280 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1271 GoInterfaceType io.ReadWriteCloser
+          Type: 1282 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 813
+      ID: 824
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1436992
@@ -32169,17 +32397,17 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1132
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1089
+      ID: 1100
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1497504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1020
+      ID: 1031
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1578304
@@ -32189,7 +32417,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1283
+      ID: 1294
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2058336
@@ -32197,16 +32425,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 813
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1305
+      ID: 1316
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2074080
@@ -32214,13 +32442,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1300 PointerType *bufio.Writer
+          Type: 1311 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1216
+      ID: 1227
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 899
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1760192
@@ -32236,7 +32464,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 886
+      ID: 897
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1621856
@@ -32249,11 +32477,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1256
+      ID: 1267
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1218
+      ID: 1229
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1624096
@@ -32261,16 +32489,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1255 PointerType *net/smtp.Client
+          Type: 1266 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1257 GoInterfaceType io.WriteCloser
+          Type: 1268 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 883
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 757
+      ID: 768
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 846336
@@ -32278,26 +32506,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 759 PointerType *net/textproto.ProtocolError.str
+          Type: 770 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 758 GoStringDataType net/textproto.ProtocolError.str
+      Data: 769 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 758
+      ID: 769
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1214
+      ID: 1225
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1129
+      ID: 1140
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 731
+      ID: 742
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 844128
@@ -32305,18 +32533,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 733 PointerType *net/url.EscapeError.str
+          Type: 744 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 732 GoStringDataType net/url.EscapeError.str
+      Data: 743 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 732
+      ID: 743
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 734
+      ID: 745
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 844224
@@ -32324,299 +32552,299 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 736 PointerType *net/url.InvalidHostError.str
+          Type: 747 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 735 GoStringDataType net/url.InvalidHostError.str
+      Data: 746 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 735
+      ID: 746
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 552
+      ID: 553
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 693216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 553 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 554 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 544
+      ID: 545
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 693312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 545 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 546 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 492
+      ID: 493
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 693600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 493 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 494 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 511
+      ID: 512
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 693696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 512 StructureType noalg.struct { key bool; elem main.node }
+      Element: 513 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 664
+      ID: 671
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 700032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 665 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 672 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 448
+      ID: 449
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 692448
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 449 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 450 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1423
+      ID: 1424
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 692352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1424 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1425 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1467
+      ID: 1468
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 691872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1468 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1469 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1482
+      ID: 1483
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 691776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1483 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1484 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 460
+      ID: 461
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 690528
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 461 StructureType noalg.struct { key int; elem int }
+      Element: 462 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1497
+      ID: 1498
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 691680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1498 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1499 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 568
+      ID: 569
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 693792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 569 StructureType noalg.struct { key int; elem struct {} }
+      Element: 570 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 519
+      ID: 520
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 520 StructureType noalg.struct { key int; elem uint8 }
+      Element: 521 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 709
+      ID: 720
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 700672
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 710 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 721 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 501
+      ID: 502
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 693984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 502 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 503 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 484
+      ID: 485
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 694080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 485 StructureType noalg.struct { key string; elem []string }
+      Element: 486 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 689
+      ID: 696
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 700576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 690 StructureType noalg.struct { key string; elem float64 }
+      Element: 697 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1175
+      ID: 1186
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 769984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1176 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1187 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 476
+      ID: 477
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 694176
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 477 StructureType noalg.struct { key string; elem int }
+      Element: 478 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 681
+      ID: 688
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 691296
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 682 StructureType noalg.struct { key string; elem interface {} }
+      Element: 689 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 468
+      ID: 469
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 694272
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 469 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 470 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 673
+      ID: 680
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 698304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 674 StructureType noalg.struct { key string; elem string }
+      Element: 681 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 560
+      ID: 561
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 694368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 561 StructureType noalg.struct { key struct {}; elem int }
+      Element: 562 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 608
+      ID: 609
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 609 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 610 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 616
+      ID: 617
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 617 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 618 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 624
+      ID: 625
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 625 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 626 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 632
+      ID: 633
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 633 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 634 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 640
+      ID: 641
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 641 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 642 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 648
+      ID: 649
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 649 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 650 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 576
+      ID: 577
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 694464
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 577 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 578 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 535
+      ID: 536
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 694560
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 536 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 537 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 527
+      ID: 528
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 694656
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 528 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 529 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 551
+      ID: 552
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1313184
@@ -32627,9 +32855,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 552 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 553 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 543
+      ID: 544
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1313440
@@ -32640,9 +32868,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 544 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 545 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 491
+      ID: 492
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1313696
@@ -32653,9 +32881,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 492 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 493 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 510
+      ID: 511
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1313952
@@ -32666,9 +32894,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 511 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 512 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 663
+      ID: 670
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1318048
@@ -32679,9 +32907,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 664 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 671 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 447
+      ID: 448
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1312928
@@ -32692,9 +32920,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 448 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 449 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1422
+      ID: 1423
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1312672
@@ -32705,9 +32933,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1423 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1424 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1466
+      ID: 1467
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1311392
@@ -32718,9 +32946,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1467 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1468 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1481
+      ID: 1482
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1311136
@@ -32731,9 +32959,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1482 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1483 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 459
+      ID: 460
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1309856
@@ -32744,9 +32972,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 460 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 461 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1496
+      ID: 1497
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1310880
@@ -32757,9 +32985,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1497 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1498 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 567
+      ID: 568
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1314208
@@ -32770,9 +32998,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 568 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 569 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 518
+      ID: 519
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1314464
@@ -32783,9 +33011,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 519 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 520 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 708
+      ID: 719
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1319072
@@ -32796,9 +33024,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 709 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 720 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 500
+      ID: 501
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1314720
@@ -32809,9 +33037,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 501 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 502 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 483
+      ID: 484
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1314976
@@ -32822,9 +33050,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 484 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 485 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 688
+      ID: 695
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1318816
@@ -32835,9 +33063,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 689 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 696 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1174
+      ID: 1185
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1376672
@@ -32848,9 +33076,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1175 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1186 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 475
+      ID: 476
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1315232
@@ -32861,9 +33089,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 476 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 477 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 680
+      ID: 687
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1310624
@@ -32874,9 +33102,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 681 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 688 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 467
+      ID: 468
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1315488
@@ -32887,9 +33115,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 468 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 469 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 672
+      ID: 679
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1317280
@@ -32900,9 +33128,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 673 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 680 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 559
+      ID: 560
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1315744
@@ -32913,9 +33141,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 560 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 561 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 607
+      ID: 608
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -32925,9 +33153,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 608 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 609 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 615
+      ID: 616
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32937,9 +33165,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 616 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 617 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 623
+      ID: 624
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32949,9 +33177,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 624 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 625 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 631
+      ID: 632
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32961,9 +33189,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 632 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 633 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 639
+      ID: 640
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32973,9 +33201,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 640 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 641 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 647
+      ID: 648
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -32985,9 +33213,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 648 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 649 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 575
+      ID: 576
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1316000
@@ -32998,9 +33226,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 576 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 577 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 534
+      ID: 535
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1316256
@@ -33011,9 +33239,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 535 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 536 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 526
+      ID: 527
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1316512
@@ -33024,9 +33252,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 527 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 528 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 553
+      ID: 554
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1313056
@@ -33034,12 +33262,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 537 ArrayType [4]int
+          Type: 538 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 537 ArrayType [4]int
+          Type: 538 ArrayType [4]int
     - __kind: StructureType
-      ID: 545
+      ID: 546
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1313312
@@ -33047,12 +33275,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 537 ArrayType [4]int
+          Type: 538 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 493
+      ID: 494
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1313568
@@ -33060,12 +33288,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 494 ArrayType [4]string
+          Type: 495 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 121 ArrayType [2]int
     - __kind: StructureType
-      ID: 512
+      ID: 513
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1313824
@@ -33078,7 +33306,7 @@ Types:
           Offset: 8
           Type: 259 StructureType main.node
     - __kind: StructureType
-      ID: 665
+      ID: 672
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1317920
@@ -33086,12 +33314,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 666 GoInterfaceType context.canceler
+          Type: 673 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 449
+      ID: 450
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1312800
@@ -33102,9 +33330,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 450 PointerType *main.deepMap2
+          Type: 451 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1424
+      ID: 1425
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1312544
@@ -33115,9 +33343,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1425 PointerType *main.deepMap3
+          Type: 1426 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1468
+      ID: 1469
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1311264
@@ -33128,9 +33356,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1469 PointerType *main.deepMap8
+          Type: 1470 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1483
+      ID: 1484
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1311008
@@ -33141,9 +33369,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1484 PointerType *main.deepMap9
+          Type: 1485 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 461
+      ID: 462
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1309728
@@ -33156,7 +33384,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 1498
+      ID: 1499
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1310752
@@ -33169,7 +33397,7 @@ Types:
           Offset: 8
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 569
+      ID: 570
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1314080
@@ -33182,7 +33410,7 @@ Types:
           Offset: 8
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 520
+      ID: 521
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1314336
@@ -33195,7 +33423,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 710
+      ID: 721
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1318944
@@ -33206,9 +33434,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 711 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 722 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 502
+      ID: 503
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1314592
@@ -33219,9 +33447,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 503 GoSliceHeaderType []main.structWithMap
+          Type: 504 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 485
+      ID: 486
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1314848
@@ -33234,7 +33462,7 @@ Types:
           Offset: 16
           Type: 167 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 690
+      ID: 697
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1318688
@@ -33247,7 +33475,7 @@ Types:
           Offset: 16
           Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 1176
+      ID: 1187
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1376544
@@ -33258,9 +33486,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1163 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 477
+      ID: 478
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1315104
@@ -33273,7 +33501,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 682
+      ID: 689
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1310496
@@ -33286,7 +33514,7 @@ Types:
           Offset: 16
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 469
+      ID: 470
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1315360
@@ -33299,7 +33527,7 @@ Types:
           Offset: 16
           Type: 131 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 674
+      ID: 681
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1317152
@@ -33312,7 +33540,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 561
+      ID: 562
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1315616
@@ -33325,7 +33553,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 609
+      ID: 610
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33337,7 +33565,7 @@ Types:
           Offset: 0
           Type: 297 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 617
+      ID: 618
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33349,7 +33577,7 @@ Types:
           Offset: 0
           Type: 298 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 625
+      ID: 626
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33361,7 +33589,7 @@ Types:
           Offset: 0
           Type: 303 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 633
+      ID: 634
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33373,7 +33601,7 @@ Types:
           Offset: 0
           Type: 308 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 641
+      ID: 642
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33385,7 +33613,7 @@ Types:
           Offset: 0
           Type: 313 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 649
+      ID: 650
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33397,7 +33625,7 @@ Types:
           Offset: 0
           Type: 318 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 577
+      ID: 578
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1315872
       GoKind: 25
@@ -33409,7 +33637,7 @@ Types:
           Offset: 0
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 536
+      ID: 537
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1316128
@@ -33420,9 +33648,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 537 ArrayType [4]int
+          Type: 538 ArrayType [4]int
     - __kind: StructureType
-      ID: 528
+      ID: 529
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1316384
@@ -33435,19 +33663,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1364
+      ID: 1375
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1010
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1078
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1362
+      ID: 1373
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2391232
@@ -33455,12 +33683,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1368 StructureType os.noReadFrom
+          Type: 1379 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1363 PointerType *os.File
+          Type: 1374 PointerType *os.File
     - __kind: StructureType
-      ID: 1360
+      ID: 1371
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2390432
@@ -33468,36 +33696,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1367 StructureType os.noWriteTo
+          Type: 1378 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1363 PointerType *os.File
+          Type: 1374 PointerType *os.File
     - __kind: StructureType
-      ID: 1368
+      ID: 1379
       Name: os.noReadFrom
       GoRuntimeType: 1126240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1367
+      ID: 1378
       Name: os.noWriteTo
       GoRuntimeType: 1126112
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1041
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1170
+      ID: 1181
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1234
+      ID: 1245
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1032
+      ID: 1043
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1730592
@@ -33510,7 +33738,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 768
+      ID: 779
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 849600
@@ -33518,36 +33746,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 770 PointerType *os/user.UnknownGroupIdError.str
+          Type: 781 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 769 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 780 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 769
+      ID: 780
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 767
+      ID: 778
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 800
+      ID: 811
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 905
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1014
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1007
+      ID: 1018
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33559,7 +33787,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 1005
+      ID: 1016
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1916608
@@ -33576,7 +33804,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1168 BaseType internal/abi.BoundsErrorCode
+          Type: 1179 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -33592,7 +33820,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1069
+      ID: 1080
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1781632
@@ -33605,7 +33833,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 981
+      ID: 992
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1003808
@@ -33613,13 +33841,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 983 PointerType *runtime.errorString.str
+          Type: 994 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 982 GoStringDataType runtime.errorString.str
+      Data: 993 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 982
+      ID: 993
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34268,7 +34496,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 436
+      ID: 437
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -34304,7 +34532,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 984
+      ID: 995
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1003904
@@ -34312,13 +34540,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 986 PointerType *runtime.plainError.str
+          Type: 997 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 985 GoStringDataType runtime.plainError.str
+      Data: 996 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 985
+      ID: 996
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34359,7 +34587,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 796
+      ID: 807
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1619776
@@ -34431,7 +34659,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 1008
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -34443,26 +34671,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 431 PointerType *string.str
+          Type: 432 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 430 GoStringDataType string.str
+      Data: 431 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 430
+      ID: 431
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1299
+      ID: 1310
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1204
+      ID: 1215
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1200
+      ID: 1211
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1475072
@@ -34478,7 +34706,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 379
+      ID: 383
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1486624
@@ -34486,12 +34714,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 380 StructureType sync.noCopy
+          Type: 384 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 381 StructureType internal/sync.Mutex
+          Type: 385 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 388
+      ID: 392
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1641024
@@ -34499,15 +34727,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 380 StructureType sync.noCopy
+          Type: 384 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 389 StructureType sync/atomic.Bool
+          Type: 393 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 379 StructureType sync.Mutex
+          Type: 383 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 402
+      ID: 403
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1867552
@@ -34515,7 +34743,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 379 StructureType sync.Mutex
+          Type: 383 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -34524,12 +34752,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 403 StructureType sync/atomic.Int32
+          Type: 404 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 403 StructureType sync/atomic.Int32
+          Type: 404 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1383
+      ID: 1394
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1640832
@@ -34537,21 +34765,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 380 StructureType sync.noCopy
+          Type: 384 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1384 StructureType sync/atomic.Uint64
+          Type: 1395 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 380
+      ID: 384
       Name: sync.noCopy
       GoRuntimeType: 1003424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 389
+      ID: 393
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1487744
@@ -34559,12 +34787,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 390 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 403
+      ID: 404
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1487904
@@ -34572,12 +34800,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 390 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1384
+      ID: 1395
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1641408
@@ -34585,15 +34813,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 390 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1385 StructureType sync/atomic.align64
+          Type: 1396 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 382
+      ID: 386
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1208928
@@ -34603,25 +34831,25 @@ Types:
           Offset: 0
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1385
+      ID: 1396
       Name: sync/atomic.align64
       GoRuntimeType: 1003616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 390
+      ID: 394
       Name: sync/atomic.noCopy
       GoRuntimeType: 1003520
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1117
+      ID: 1128
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1302688
       GoKind: 12
     - __kind: StructureType
-      ID: 548
+      ID: 549
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -34643,9 +34871,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 549 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 550 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 540
+      ID: 541
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34667,9 +34895,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 541 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 542 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 488
+      ID: 489
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -34691,9 +34919,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 489 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 490 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 507
+      ID: 508
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -34715,9 +34943,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 508 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 509 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 660
+      ID: 667
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -34739,9 +34967,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 661 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 668 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 444
+      ID: 445
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -34763,9 +34991,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 445 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 446 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1419
+      ID: 1420
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -34787,9 +35015,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1420 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1421 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1463
+      ID: 1464
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -34811,9 +35039,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1464 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1465 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1478
+      ID: 1479
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -34835,9 +35063,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1479 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1480 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 456
+      ID: 457
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -34859,9 +35087,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 457 GoSwissMapGroupsType groupReference<int,int>
+          Type: 458 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1493
+      ID: 1494
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -34883,9 +35111,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1494 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1495 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 564
+      ID: 565
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -34907,9 +35135,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 565 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 566 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 515
+      ID: 516
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34931,9 +35159,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 516 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 517 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 705
+      ID: 716
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -34955,9 +35183,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 706 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 717 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 497
+      ID: 498
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -34979,9 +35207,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 498 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 499 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 480
+      ID: 481
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35003,9 +35231,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 481 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 482 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 685
+      ID: 692
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35027,9 +35255,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 686 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 693 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1171
+      ID: 1182
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35051,9 +35279,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1172 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1183 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 472
+      ID: 473
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35075,9 +35303,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 473 GoSwissMapGroupsType groupReference<string,int>
+          Type: 474 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 677
+      ID: 684
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35099,9 +35327,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 678 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 685 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 464
+      ID: 465
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35123,9 +35351,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 465 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 466 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 669
+      ID: 676
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35147,9 +35375,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 670 GoSwissMapGroupsType groupReference<string,string>
+          Type: 677 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 556
+      ID: 557
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35171,9 +35399,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 557 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 558 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 604
+      ID: 605
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35195,9 +35423,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 605 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 606 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 612
+      ID: 613
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35219,9 +35447,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 613 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 614 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 620
+      ID: 621
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35243,9 +35471,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 621 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 622 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 628
+      ID: 629
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35267,9 +35495,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 629 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 630 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 636
+      ID: 637
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35291,9 +35519,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 637 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 638 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 644
+      ID: 645
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35315,9 +35543,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 645 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 646 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 572
+      ID: 573
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35339,9 +35567,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 573 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 574 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 531
+      ID: 532
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35363,9 +35591,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 532 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 533 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 523
+      ID: 524
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35387,13 +35615,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 524 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 525 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1334
+      ID: 1345
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1060
+      ID: 1071
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1735008
@@ -35406,13 +35634,13 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 1267
+      ID: 1278
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1943104
       GoKind: 6
     - __kind: StructureType
-      ID: 398
+      ID: 336
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2001216
@@ -35423,10 +35651,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 1393 GoSliceHeaderType []time.zone
+          Type: 653 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 1396 GoSliceHeaderType []time.zoneTrans
+          Type: 656 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -35438,13 +35666,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 1394 PointerType *time.zone
+          Type: 654 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 805
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 396
+    - __kind: GoTimeType
+      ID: 334
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2405376
@@ -35458,9 +35686,17 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 397 PointerType *time.Location
+          Type: 335 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 395
+      ID: 399
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1489024
@@ -35468,12 +35704,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1392 GoChannelType <-chan time.Time
+          Type: 1403 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 715
+      ID: 726
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 841728
@@ -35481,22 +35717,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 717 PointerType *time.fileSizeError.str
+          Type: 728 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 716 GoStringDataType time.fileSizeError.str
+      Data: 727 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 716
+      ID: 727
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 803
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1395
+      ID: 655
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1642368
@@ -35512,7 +35748,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1398
+      ID: 658
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1780288
@@ -35573,7 +35809,7 @@ Types:
       GoRuntimeType: 594112
       GoKind: 26
     - __kind: StructureType
-      ID: 1150
+      ID: 1161
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2094848
@@ -35584,10 +35820,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1151 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1162 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1152 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1163 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -35602,18 +35838,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1153 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1164 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1153
+      ID: 1164
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1009472
       GoKind: 9
     - __kind: StructureType
-      ID: 1151
+      ID: 1162
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1956160
@@ -35638,21 +35874,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 901
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1152
+      ID: 1163
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 597824
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1328
+      ID: 1339
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 874
+      ID: 885
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1444512
@@ -35662,13 +35898,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 760
+      ID: 771
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 846432
       GoKind: 2
     - __kind: StructureType
-      ID: 1037
+      ID: 1048
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1730784
@@ -35681,12 +35917,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 989
+      ID: 1000
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1008320
       GoKind: 5
-MaxTypeID: 1826
+MaxTypeID: 1830
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,11 +12,11 @@ Probes:
         - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1508 EventRootType Probe[main.stackC]
+              Type: 1509 EventRootType Probe[main.stackC]
               InjectionPoints: [{PC: "0x8977a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1509 EventRootType Probe[main.stackC]Return
+              Type: 1510 EventRootType Probe[main.stackC]Return
               InjectionPoints: [{PC: "0x8977dc", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -32,11 +32,11 @@ Probes:
         - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 1347 EventRootType Probe[main.testAny]
+              Type: 1348 EventRootType Probe[main.testAny]
               InjectionPoints: [{PC: "0x892468", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1348 EventRootType Probe[main.testAny]Return
+              Type: 1349 EventRootType Probe[main.testAny]Return
               InjectionPoints: [{PC: "0x892494", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -58,11 +58,11 @@ Probes:
         - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 1350 EventRootType Probe[main.testAnyPtr]
+              Type: 1351 EventRootType Probe[main.testAnyPtr]
               InjectionPoints: [{PC: "0x8924e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1351 EventRootType Probe[main.testAnyPtr]Return
+              Type: 1352 EventRootType Probe[main.testAnyPtr]Return
               InjectionPoints: [{PC: "0x892514", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -83,11 +83,11 @@ Probes:
         - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]
+              Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]
               InjectionPoints: [{PC: "0x89621c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]Return
+              Type: 1481 EventRootType Probe[main.testArrayArgAndReturn]Return
               InjectionPoints: [{PC: "0x8962b4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -109,7 +109,7 @@ Probes:
         - subprogram: {subprogram: 19}
           events:
             - Kind: Entry
-              Type: 1294 EventRootType Probe[main.testArrayEmptyStructs]
+              Type: 1295 EventRootType Probe[main.testArrayEmptyStructs]
               InjectionPoints: [{PC: "0x88de70", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -131,7 +131,7 @@ Probes:
         - subprogram: {subprogram: 15}
           events:
             - Kind: Entry
-              Type: 1290 EventRootType Probe[main.testArrayOfArrays]
+              Type: 1291 EventRootType Probe[main.testArrayOfArrays]
               InjectionPoints: [{PC: "0x88de30", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -153,7 +153,7 @@ Probes:
         - subprogram: {subprogram: 17}
           events:
             - Kind: Entry
-              Type: 1292 EventRootType Probe[main.testArrayOfArraysOfArrays]
+              Type: 1293 EventRootType Probe[main.testArrayOfArraysOfArrays]
               InjectionPoints: [{PC: "0x88de50", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -175,7 +175,7 @@ Probes:
         - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 1359 EventRootType Probe[main.testArrayOfMaps]
+              Type: 1360 EventRootType Probe[main.testArrayOfMaps]
               InjectionPoints: [{PC: "0x892c70", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -197,7 +197,7 @@ Probes:
         - subprogram: {subprogram: 16}
           events:
             - Kind: Entry
-              Type: 1291 EventRootType Probe[main.testArrayOfStrings]
+              Type: 1292 EventRootType Probe[main.testArrayOfStrings]
               InjectionPoints: [{PC: "0x88de40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -218,7 +218,7 @@ Probes:
         - subprogram: {subprogram: 18}
           events:
             - Kind: Entry
-              Type: 1293 EventRootType Probe[main.testArrayOfStructs]
+              Type: 1294 EventRootType Probe[main.testArrayOfStructs]
               InjectionPoints: [{PC: "0x88de60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -240,11 +240,11 @@ Probes:
         - subprogram: {subprogram: 90}
           events:
             - Kind: Entry
-              Type: 1381 EventRootType Probe[main.testAtomicAdd]
+              Type: 1382 EventRootType Probe[main.testAtomicAdd]
               InjectionPoints: [{PC: "0x894360", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1382 EventRootType Probe[main.testAtomicAdd]Return
+              Type: 1383 EventRootType Probe[main.testAtomicAdd]Return
               InjectionPoints: [{PC: "0x89439c", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -266,11 +266,11 @@ Probes:
         - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 1312 EventRootType Probe[main.testBigStruct]
+              Type: 1313 EventRootType Probe[main.testBigStruct]
               InjectionPoints: [{PC: "0x88e3c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1313 EventRootType Probe[main.testBigStruct]Return
+              Type: 1314 EventRootType Probe[main.testBigStruct]Return
               InjectionPoints: [{PC: "0x88e3d8", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -292,7 +292,7 @@ Probes:
         - subprogram: {subprogram: 4}
           events:
             - Kind: Entry
-              Type: 1279 EventRootType Probe[main.testBoolArray]
+              Type: 1280 EventRootType Probe[main.testBoolArray]
               InjectionPoints: [{PC: "0x88dd80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -314,7 +314,7 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 1276 EventRootType Probe[main.testByteArray]
+              Type: 1277 EventRootType Probe[main.testByteArray]
               InjectionPoints: [{PC: "0x88dd50", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -341,11 +341,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1527 EventRootType Probe[main.testStruct]
+              Type: 1528 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0x897b00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1528 EventRootType Probe[main.testStruct]Return
+              Type: 1529 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0x897b1c", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1588 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1592 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x891d08"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1589 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1593 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x891d08"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 6 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 189, index: 0, name: x}
+                      Variable: {subprogram: 192, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -437,10 +437,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1590 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1594 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x891d08"
                   Frameless: false
@@ -477,7 +477,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1378 EventRootType Probe[main.testCombinedString]
+              Type: 1379 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0x894100", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
@@ -496,7 +496,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1379 EventRootType Probe[main.testCombinedString]
+              Type: 1380 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0x894100", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -522,7 +522,7 @@ Probes:
         - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testTenStrings]
+              Type: 1536 EventRootType Probe[main.testTenStrings]
               InjectionPoints: [{PC: "0x897bb0", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
@@ -560,7 +560,7 @@ Probes:
         - subprogram: {subprogram: 91}
           events:
             - Kind: Entry
-              Type: 1383 EventRootType Probe[main.testChannel]
+              Type: 1384 EventRootType Probe[main.testChannel]
               InjectionPoints: [{PC: "0x8943a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -590,7 +590,7 @@ Probes:
         - subprogram: {subprogram: 87}
           events:
             - Kind: Entry
-              Type: 1377 EventRootType Probe[main.testCombinedByte]
+              Type: 1378 EventRootType Probe[main.testCombinedByte]
               InjectionPoints: [{PC: "0x8940e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -619,11 +619,11 @@ Probes:
         - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1444 EventRootType Probe[main.testConflictingReturn]
+              Type: 1445 EventRootType Probe[main.testConflictingReturn]
               InjectionPoints: [{PC: "0x895418", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1445 EventRootType Probe[main.testConflictingReturn]Return
+              Type: 1446 EventRootType Probe[main.testConflictingReturn]Return
               InjectionPoints: [{PC: "0x8954c8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -645,7 +645,7 @@ Probes:
         - subprogram: {subprogram: 99}
           events:
             - Kind: Entry
-              Type: 1391 EventRootType Probe[main.testCycle]
+              Type: 1392 EventRootType Probe[main.testCycle]
               InjectionPoints: [{PC: "0x894650", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -667,7 +667,7 @@ Probes:
         - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 1319 EventRootType Probe[main.testDeepMap1]
+              Type: 1320 EventRootType Probe[main.testDeepMap1]
               InjectionPoints: [{PC: "0x88e8c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -689,7 +689,7 @@ Probes:
         - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 1320 EventRootType Probe[main.testDeepMap7]
+              Type: 1321 EventRootType Probe[main.testDeepMap7]
               InjectionPoints: [{PC: "0x88e8d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -711,7 +711,7 @@ Probes:
         - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 1315 EventRootType Probe[main.testDeepPtr1]
+              Type: 1316 EventRootType Probe[main.testDeepPtr1]
               InjectionPoints: [{PC: "0x88e5b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -733,7 +733,7 @@ Probes:
         - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 1316 EventRootType Probe[main.testDeepPtr7]
+              Type: 1317 EventRootType Probe[main.testDeepPtr7]
               InjectionPoints: [{PC: "0x88e5c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -755,7 +755,7 @@ Probes:
         - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 1317 EventRootType Probe[main.testDeepSlice1]
+              Type: 1318 EventRootType Probe[main.testDeepSlice1]
               InjectionPoints: [{PC: "0x88e760", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -777,7 +777,7 @@ Probes:
         - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 1318 EventRootType Probe[main.testDeepSlice7]
+              Type: 1319 EventRootType Probe[main.testDeepSlice7]
               InjectionPoints: [{PC: "0x88e770", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -799,7 +799,7 @@ Probes:
         - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1496 EventRootType Probe[main.testEmptySlice]
+              Type: 1497 EventRootType Probe[main.testEmptySlice]
               InjectionPoints: [{PC: "0x8970f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -826,7 +826,7 @@ Probes:
         - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1499 EventRootType Probe[main.testEmptySliceOfStructs]
+              Type: 1500 EventRootType Probe[main.testEmptySliceOfStructs]
               InjectionPoints: [{PC: "0x897120", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -854,7 +854,7 @@ Probes:
         - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testEmptyString]
+              Type: 1523 EventRootType Probe[main.testEmptyString]
               InjectionPoints: [{PC: "0x897880", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -876,7 +876,7 @@ Probes:
         - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1536 EventRootType Probe[main.testEmptyStruct]
+              Type: 1537 EventRootType Probe[main.testEmptyStruct]
               InjectionPoints: [{PC: "0x897c00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -897,7 +897,7 @@ Probes:
         - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testEmptyStructPointer]
+              Type: 1538 EventRootType Probe[main.testEmptyStructPointer]
               InjectionPoints: [{PC: "0x897c10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -919,7 +919,7 @@ Probes:
         - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 1349 EventRootType Probe[main.testError]
+              Type: 1350 EventRootType Probe[main.testError]
               InjectionPoints: [{PC: "0x8924c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -953,7 +953,7 @@ Probes:
         - subprogram: {subprogram: 38}
           events:
             - Kind: Line
-              Type: 1314 EventRootType Probe[main.testErrorAtLine]Line
+              Type: 1315 EventRootType Probe[main.testErrorAtLine]Line
               InjectionPoints: [{PC: "0x88e44c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -981,11 +981,11 @@ Probes:
         - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 1331 EventRootType Probe[main.testEsotericHeap]
+              Type: 1332 EventRootType Probe[main.testEsotericHeap]
               InjectionPoints: [{PC: "0x890d18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1332 EventRootType Probe[main.testEsotericHeap]Return
+              Type: 1333 EventRootType Probe[main.testEsotericHeap]Return
               InjectionPoints: [{PC: "0x890d54", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1007,11 +1007,11 @@ Probes:
         - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 1329 EventRootType Probe[main.testEsotericStack]
+              Type: 1330 EventRootType Probe[main.testEsotericStack]
               InjectionPoints: [{PC: "0x890c2c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1330 EventRootType Probe[main.testEsotericStack]Return
+              Type: 1331 EventRootType Probe[main.testEsotericStack]Return
               InjectionPoints: [{PC: "0x890c9c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1033,11 +1033,11 @@ Probes:
         - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 1341 EventRootType Probe[main.testFrameless]
+              Type: 1342 EventRootType Probe[main.testFrameless]
               InjectionPoints: [{PC: "0x892190", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1342 EventRootType Probe[main.testFrameless]Return
+              Type: 1343 EventRootType Probe[main.testFrameless]Return
               InjectionPoints: [{PC: "0x892198", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -1059,11 +1059,11 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 1343 EventRootType Probe[main.testFramelessArray]
+              Type: 1344 EventRootType Probe[main.testFramelessArray]
               InjectionPoints: [{PC: "0x8921ac", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1344 EventRootType Probe[main.testFramelessArray]Return
+              Type: 1345 EventRootType Probe[main.testFramelessArray]Return
               InjectionPoints: [{PC: "0x8921e8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1088,7 +1088,7 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Line
-              Type: 1345 EventRootType Probe[main.testFramelessArray]Line
+              Type: 1346 EventRootType Probe[main.testFramelessArray]Line
               InjectionPoints: [{PC: "0x8921ac", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1107,15 +1107,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1574 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x899f70", Frameless: true}]
+              Type: 1578 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0x89a0d0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1575 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x899f78", Frameless: true}]
+              Type: 1579 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x89a0d8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,15 +1125,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1576 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x899f90", Frameless: false}]
+              Type: 1580 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0x89a0f0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1577 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x899fcc", Frameless: false}]
+              Type: 1581 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0x89a12c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,15 +1152,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1570 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x899ed8", Frameless: false}]
+              Type: 1574 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0x89a038", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1571 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x899ee8", Frameless: false}]
+              Type: 1575 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0x89a048", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,15 +1170,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1572 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x899f28", Frameless: false}]
+              Type: 1576 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0x89a088", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1573 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x899f40", Frameless: false}]
+              Type: 1577 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0x89a0a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,18 +1197,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1578 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x899fe0", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0x89a140", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1579 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1583 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x89a008"
+                - PC: "0x89a168"
                   Frameless: true
-                - PC: "0x89a010"
+                - PC: "0x89a170"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,18 +1219,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x89a038", Frameless: false}]
+              Type: 1584 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0x89a198", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1581 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1585 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x89a098"
+                - PC: "0x89a1f8"
                   Frameless: false
-                - PC: "0x89a0a8"
+                - PC: "0x89a208"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,11 +1253,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Line
-              Type: 1582 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x899fe4", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0x89a144", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,11 +1265,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1583 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x89a048", Frameless: false}]
+              Type: 1587 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0x89a1a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,15 +1286,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x899bb0", Frameless: true}]
+              Type: 1562 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0x899d10", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1559 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x899bb8", Frameless: true}]
+              Type: 1563 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0x899d18", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,15 +1304,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x899c40", Frameless: true}]
+              Type: 1564 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0x899da0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1561 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x899c44", Frameless: true}]
+              Type: 1565 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0x899da4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,15 +1332,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 169}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1546 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x899758", Frameless: false}]
+              Type: 1550 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0x8998b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1547 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x89982c", Frameless: false}]
+              Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x89998c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1350,14 +1350,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1548 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1552 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x88ceb8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1549 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1553 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x88cf8c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1378,15 +1378,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1550 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x899888", Frameless: false}]
+              Type: 1554 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x8999e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x899898", Frameless: false}]
+              Type: 1555 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x8999f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,15 +1405,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x89a0f0", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0x89a250", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1585 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x89a0f8", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0x89a258", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,15 +1423,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x89a198", Frameless: false}]
+              Type: 1590 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0x89a2f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1587 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x89a1bc", Frameless: false}]
+              Type: 1591 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0x89a31c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,15 +1450,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
+        - subprogram: {subprogram: 170}
           events:
             - Kind: Entry
-              Type: 1542 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x8996b0", Frameless: true}]
+              Type: 1546 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0x899810", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1543 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8996b4", Frameless: true}]
+              Type: 1547 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x899814", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,15 +1468,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 168}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1544 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x8996c0", Frameless: true}]
+              Type: 1548 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0x899820", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1545 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8996cc", Frameless: true}]
+              Type: 1549 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x89982c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,15 +1495,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x899ce0", Frameless: true}]
+              Type: 1566 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0x899e40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1563 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x899ce8", Frameless: true}]
+              Type: 1567 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0x899e48", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,15 +1513,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x899d88", Frameless: false}]
+              Type: 1568 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0x899ee8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1565 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x899db4", Frameless: false}]
+              Type: 1569 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0x899f14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,15 +1540,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1552 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x899b80", Frameless: true}]
+              Type: 1556 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x899ce0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1553 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x899b84", Frameless: true}]
+              Type: 1557 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x899ce4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,15 +1558,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1554 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x899b90", Frameless: true}]
+              Type: 1558 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0x899cf0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1555 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x899b94", Frameless: true}]
+              Type: 1559 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0x899cf4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,15 +1576,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x899ba0", Frameless: true}]
+              Type: 1560 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0x899d00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x899ba4", Frameless: true}]
+              Type: 1561 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0x899d04", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,15 +1603,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x899e90", Frameless: true}]
+              Type: 1570 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0x899ff0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1567 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x899e98", Frameless: true}]
+              Type: 1571 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0x899ff8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,15 +1621,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x899ea0", Frameless: true}]
+              Type: 1572 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x89a000", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1569 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x899eb0", Frameless: true}]
+              Type: 1573 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x89a010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,15 +1648,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1538 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x899690", Frameless: true}]
+              Type: 1542 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0x8997f0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1539 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x899694", Frameless: true}]
+              Type: 1543 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x8997f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,15 +1666,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1540 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x8996a0", Frameless: true}]
+              Type: 1544 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0x899800", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1541 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8996ac", Frameless: true}]
+              Type: 1545 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x89980c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1696,11 +1696,11 @@ Probes:
         - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 1333 EventRootType Probe[main.testInlinedBA]
+              Type: 1334 EventRootType Probe[main.testInlinedBA]
               InjectionPoints: [{PC: "0x891ea8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1334 EventRootType Probe[main.testInlinedBA]Return
+              Type: 1335 EventRootType Probe[main.testInlinedBA]Return
               InjectionPoints: [{PC: "0x891f00", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1727,11 +1727,11 @@ Probes:
         - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 1335 EventRootType Probe[main.testInlinedBB]
+              Type: 1336 EventRootType Probe[main.testInlinedBB]
               InjectionPoints: [{PC: "0x891f38", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1336 EventRootType Probe[main.testInlinedBB]Return
+              Type: 1337 EventRootType Probe[main.testInlinedBB]Return
               InjectionPoints: [{PC: "0x891fc0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1758,11 +1758,11 @@ Probes:
         - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 1337 EventRootType Probe[main.testInlinedBBA]
+              Type: 1338 EventRootType Probe[main.testInlinedBBA]
               InjectionPoints: [{PC: "0x892008", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1338 EventRootType Probe[main.testInlinedBBA]Return
+              Type: 1339 EventRootType Probe[main.testInlinedBBA]Return
               InjectionPoints: [{PC: "0x892044", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1781,10 +1781,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testInlinedBBB]
+              Type: 1598 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0x891f88", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1802,11 +1802,11 @@ Probes:
         - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 1339 EventRootType Probe[main.testInlinedBC]
+              Type: 1340 EventRootType Probe[main.testInlinedBC]
               InjectionPoints: [{PC: "0x892088", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1340 EventRootType Probe[main.testInlinedBC]Return
+              Type: 1341 EventRootType Probe[main.testInlinedBC]Return
               InjectionPoints: [{PC: "0x892178", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1821,10 +1821,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testInlinedBCA]
+              Type: 1599 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0x89208c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1842,10 +1842,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Line
-              Type: 1596 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1600 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0x89208c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1860,10 +1860,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testInlinedBCB]
+              Type: 1601 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0x892140", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1881,10 +1881,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Line
-              Type: 1598 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1602 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0x892140", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1899,10 +1899,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 196}
+        - subprogram: {subprogram: 199}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1608 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x88c9e4"
                   Frameless: true
@@ -1922,10 +1922,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testInlinedPrint]
+              Type: 1595 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0x891d08"
                   Frameless: false
@@ -1939,7 +1939,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1592 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1596 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0x891d40", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1961,10 +1961,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1593 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1597 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x891d08"
                   Frameless: false
@@ -1993,10 +1993,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testInlinedSq]
+              Type: 1603 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0x892194", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2018,10 +2018,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Line
-              Type: 1600 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1604 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0x892194", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2041,10 +2041,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 194}
+        - subprogram: {subprogram: 197}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1605 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0x8921c4"
                   Frameless: false
@@ -2070,7 +2070,7 @@ Probes:
         - subprogram: {subprogram: 7}
           events:
             - Kind: Entry
-              Type: 1282 EventRootType Probe[main.testInt16Array]
+              Type: 1283 EventRootType Probe[main.testInt16Array]
               InjectionPoints: [{PC: "0x88ddb0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2092,7 +2092,7 @@ Probes:
         - subprogram: {subprogram: 8}
           events:
             - Kind: Entry
-              Type: 1283 EventRootType Probe[main.testInt32Array]
+              Type: 1284 EventRootType Probe[main.testInt32Array]
               InjectionPoints: [{PC: "0x88ddc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2114,7 +2114,7 @@ Probes:
         - subprogram: {subprogram: 9}
           events:
             - Kind: Entry
-              Type: 1284 EventRootType Probe[main.testInt64Array]
+              Type: 1285 EventRootType Probe[main.testInt64Array]
               InjectionPoints: [{PC: "0x88ddd0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2136,7 +2136,7 @@ Probes:
         - subprogram: {subprogram: 6}
           events:
             - Kind: Entry
-              Type: 1281 EventRootType Probe[main.testInt8Array]
+              Type: 1282 EventRootType Probe[main.testInt8Array]
               InjectionPoints: [{PC: "0x88dda0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2158,7 +2158,7 @@ Probes:
         - subprogram: {subprogram: 5}
           events:
             - Kind: Entry
-              Type: 1280 EventRootType Probe[main.testIntArray]
+              Type: 1281 EventRootType Probe[main.testIntArray]
               InjectionPoints: [{PC: "0x88dd90", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2180,7 +2180,7 @@ Probes:
         - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 1346 EventRootType Probe[main.testInterface]
+              Type: 1347 EventRootType Probe[main.testInterface]
               InjectionPoints: [{PC: "0x892440", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2201,11 +2201,11 @@ Probes:
         - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]
+              Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]
               InjectionPoints: [{PC: "0x896040", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]Return
+              Type: 1479 EventRootType Probe[main.testLargeArgAndReturn]Return
               InjectionPoints: [{PC: "0x896198", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2227,7 +2227,7 @@ Probes:
         - subprogram: {subprogram: 93}
           events:
             - Kind: Entry
-              Type: 1385 EventRootType Probe[main.testLinkedList]
+              Type: 1386 EventRootType Probe[main.testLinkedList]
               InjectionPoints: [{PC: "0x894560", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2252,7 +2252,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1323 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1324 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x88e91c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2274,7 +2274,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1324 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1325 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x88e9b0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2296,7 +2296,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1325 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1326 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x88ea5c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2339,11 +2339,11 @@ Probes:
         - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]
+              Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]
               InjectionPoints: [{PC: "0x89654c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              Type: 1485 EventRootType Probe[main.testManyArgsArrayReturn]Return
               InjectionPoints: [{PC: "0x8966bc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2406,7 +2406,7 @@ Probes:
         - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 1327 EventRootType Probe[main.testManyPointers]
+              Type: 1328 EventRootType Probe[main.testManyPointers]
               InjectionPoints: [{PC: "0x88f000", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2430,7 +2430,7 @@ Probes:
         - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 1328 EventRootType Probe[main.testManyStrings]
+              Type: 1329 EventRootType Probe[main.testManyStrings]
               InjectionPoints: [{PC: "0x890970", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2452,7 +2452,7 @@ Probes:
         - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 1357 EventRootType Probe[main.testMapArrayToArray]
+              Type: 1358 EventRootType Probe[main.testMapArrayToArray]
               InjectionPoints: [{PC: "0x892c50", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2474,7 +2474,7 @@ Probes:
         - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 1364 EventRootType Probe[main.testMapEmbeddedMaps]
+              Type: 1365 EventRootType Probe[main.testMapEmbeddedMaps]
               InjectionPoints: [{PC: "0x892cb0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2496,7 +2496,7 @@ Probes:
         - subprogram: {subprogram: 84}
           events:
             - Kind: Entry
-              Type: 1374 EventRootType Probe[main.testMapEmptyKey]
+              Type: 1375 EventRootType Probe[main.testMapEmptyKey]
               InjectionPoints: [{PC: "0x892d50", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2518,7 +2518,7 @@ Probes:
         - subprogram: {subprogram: 86}
           events:
             - Kind: Entry
-              Type: 1376 EventRootType Probe[main.testMapEmptyKeyAndValue]
+              Type: 1377 EventRootType Probe[main.testMapEmptyKeyAndValue]
               InjectionPoints: [{PC: "0x892d70", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2540,7 +2540,7 @@ Probes:
         - subprogram: {subprogram: 85}
           events:
             - Kind: Entry
-              Type: 1375 EventRootType Probe[main.testMapEmptyValue]
+              Type: 1376 EventRootType Probe[main.testMapEmptyValue]
               InjectionPoints: [{PC: "0x892d60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2562,7 +2562,7 @@ Probes:
         - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 1361 EventRootType Probe[main.testMapIntToInt]
+              Type: 1362 EventRootType Probe[main.testMapIntToInt]
               InjectionPoints: [{PC: "0x892c90", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2584,7 +2584,7 @@ Probes:
         - subprogram: {subprogram: 83}
           events:
             - Kind: Entry
-              Type: 1373 EventRootType Probe[main.testMapLargeKeyLargeValue]
+              Type: 1374 EventRootType Probe[main.testMapLargeKeyLargeValue]
               InjectionPoints: [{PC: "0x892d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2606,7 +2606,7 @@ Probes:
         - subprogram: {subprogram: 82}
           events:
             - Kind: Entry
-              Type: 1372 EventRootType Probe[main.testMapLargeKeySmallValue]
+              Type: 1373 EventRootType Probe[main.testMapLargeKeySmallValue]
               InjectionPoints: [{PC: "0x892d30", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2630,7 +2630,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1362 EventRootType Probe[main.testMapMassive]
+              Type: 1363 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0x892ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2654,7 +2654,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1363 EventRootType Probe[main.testMapMassive]
+              Type: 1364 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0x892ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2676,7 +2676,7 @@ Probes:
         - subprogram: {subprogram: 81}
           events:
             - Kind: Entry
-              Type: 1371 EventRootType Probe[main.testMapSmallKeyLargeValue]
+              Type: 1372 EventRootType Probe[main.testMapSmallKeyLargeValue]
               InjectionPoints: [{PC: "0x892d20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2698,7 +2698,7 @@ Probes:
         - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 1370 EventRootType Probe[main.testMapSmallKeySmallValue]
+              Type: 1371 EventRootType Probe[main.testMapSmallKeySmallValue]
               InjectionPoints: [{PC: "0x892d10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2720,7 +2720,7 @@ Probes:
         - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 1355 EventRootType Probe[main.testMapStringToInt]
+              Type: 1356 EventRootType Probe[main.testMapStringToInt]
               InjectionPoints: [{PC: "0x892c30", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2742,7 +2742,7 @@ Probes:
         - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 1356 EventRootType Probe[main.testMapStringToSlice]
+              Type: 1357 EventRootType Probe[main.testMapStringToSlice]
               InjectionPoints: [{PC: "0x892c40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2764,7 +2764,7 @@ Probes:
         - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 1354 EventRootType Probe[main.testMapStringToStruct]
+              Type: 1355 EventRootType Probe[main.testMapStringToStruct]
               InjectionPoints: [{PC: "0x892c20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2786,7 +2786,7 @@ Probes:
         - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 1365 EventRootType Probe[main.testMapWithLinkedList]
+              Type: 1366 EventRootType Probe[main.testMapWithLinkedList]
               InjectionPoints: [{PC: "0x892cc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2808,7 +2808,7 @@ Probes:
         - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 1368 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+              Type: 1369 EventRootType Probe[main.testMapWithSmallKeyAndValue]
               InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2830,7 +2830,7 @@ Probes:
         - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 1369 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+              Type: 1370 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
               InjectionPoints: [{PC: "0x892d00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2852,7 +2852,7 @@ Probes:
         - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 1366 EventRootType Probe[main.testMapWithSmallValue]
+              Type: 1367 EventRootType Probe[main.testMapWithSmallValue]
               InjectionPoints: [{PC: "0x892cd0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2876,7 +2876,7 @@ Probes:
         - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 1367 EventRootType Probe[main.testMapWithSmallValueMassive]
+              Type: 1368 EventRootType Probe[main.testMapWithSmallValueMassive]
               InjectionPoints: [{PC: "0x892ce0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2898,7 +2898,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1519 EventRootType Probe[main.testMassiveString]
+              Type: 1520 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0x897860", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2921,7 +2921,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1520 EventRootType Probe[main.testMassiveString]
+              Type: 1521 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0x897860", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2968,11 +2968,11 @@ Probes:
         - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]
+              Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]
               InjectionPoints: [{PC: "0x896740", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              Type: 1487 EventRootType Probe[main.testMixedArgsStackReturn]Return
               InjectionPoints: [{PC: "0x8968f0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3038,11 +3038,11 @@ Probes:
         - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]
+              Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]
               InjectionPoints: [{PC: "0x896a1c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]Return
+              Type: 1491 EventRootType Probe[main.testMultipleArrayArgs]Return
               InjectionPoints: [{PC: "0x896ac0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3073,11 +3073,11 @@ Probes:
         - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]
+              Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]
               InjectionPoints: [{PC: "0x8962f0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]Return
+              Type: 1483 EventRootType Probe[main.testMultipleLargeArgs]Return
               InjectionPoints: [{PC: "0x8964c0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3103,11 +3103,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1422 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x895278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x895304", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3143,7 +3143,7 @@ Probes:
         - subprogram: {subprogram: 89}
           events:
             - Kind: Entry
-              Type: 1380 EventRootType Probe[main.testMultipleSimpleParams]
+              Type: 1381 EventRootType Probe[main.testMultipleSimpleParams]
               InjectionPoints: [{PC: "0x8941c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3184,11 +3184,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1416 EventRootType Probe[main.testNamedReturn]
+              Type: 1417 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0x8951d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1417 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1418 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0x895238", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3212,11 +3212,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1418 EventRootType Probe[main.testNamedReturn]
+              Type: 1419 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0x8951d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1419 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1420 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0x895238", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
@@ -3235,11 +3235,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x895278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x895304", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
@@ -3259,11 +3259,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1427 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x895278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1427 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1428 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x895304", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3296,11 +3296,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1420 EventRootType Probe[main.testNamedReturn]
+              Type: 1421 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0x8951d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1421 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1422 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0x895238", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3328,7 +3328,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testNestedPointer]
+              Type: 1532 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0x897ba0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3353,7 +3353,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testNestedPointer]
+              Type: 1533 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0x897ba0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3384,7 +3384,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testNestedPointer]
+              Type: 1534 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0x897ba0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3409,7 +3409,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testNestedPointer]
+              Type: 1535 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0x897ba0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3436,7 +3436,7 @@ Probes:
         - subprogram: {subprogram: 98}
           events:
             - Kind: Entry
-              Type: 1390 EventRootType Probe[main.testNilPointer]
+              Type: 1391 EventRootType Probe[main.testNilPointer]
               InjectionPoints: [{PC: "0x894630", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3463,7 +3463,7 @@ Probes:
         - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1503 EventRootType Probe[main.testNilSlice]
+              Type: 1504 EventRootType Probe[main.testNilSlice]
               InjectionPoints: [{PC: "0x897160", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3490,7 +3490,7 @@ Probes:
         - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1500 EventRootType Probe[main.testNilSliceOfStructs]
+              Type: 1501 EventRootType Probe[main.testNilSliceOfStructs]
               InjectionPoints: [{PC: "0x897130", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3525,7 +3525,7 @@ Probes:
         - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1502 EventRootType Probe[main.testNilSliceWithOtherParams]
+              Type: 1503 EventRootType Probe[main.testNilSliceWithOtherParams]
               InjectionPoints: [{PC: "0x897150", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3557,7 +3557,7 @@ Probes:
         - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testOneStringInStructPointer]
+              Type: 1519 EventRootType Probe[main.testOneStringInStructPointer]
               InjectionPoints: [{PC: "0x897850", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3579,7 +3579,7 @@ Probes:
         - subprogram: {subprogram: 94}
           events:
             - Kind: Entry
-              Type: 1386 EventRootType Probe[main.testPointerLoop]
+              Type: 1387 EventRootType Probe[main.testPointerLoop]
               InjectionPoints: [{PC: "0x894570", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3601,7 +3601,7 @@ Probes:
         - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 1360 EventRootType Probe[main.testPointerToMap]
+              Type: 1361 EventRootType Probe[main.testPointerToMap]
               InjectionPoints: [{PC: "0x892c80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3623,7 +3623,7 @@ Probes:
         - subprogram: {subprogram: 92}
           events:
             - Kind: Entry
-              Type: 1384 EventRootType Probe[main.testPointerToSimpleStruct]
+              Type: 1385 EventRootType Probe[main.testPointerToSimpleStruct]
               InjectionPoints: [{PC: "0x894550", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3647,11 +3647,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1392 EventRootType Probe[main.testReturnsInt]
+              Type: 1393 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0x894a78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1393 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1394 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0x894abc", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
@@ -3671,11 +3671,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1436 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1437 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0x895348", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1437 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1438 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0x8953d4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3720,11 +3720,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1402 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1403 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0x894b98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1403 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1404 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0x894c30", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3766,11 +3766,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1394 EventRootType Probe[main.testReturnsInt]
+              Type: 1395 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0x894a78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1395 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1396 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0x894abc", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3815,11 +3815,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1404 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1405 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0x894b98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1405 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1406 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0x894c30", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3863,11 +3863,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1438 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1439 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0x895348", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1439 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1440 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0x8953d4", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
@@ -3884,11 +3884,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1440 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1441 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0x895348", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1441 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1442 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0x8953d4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3910,11 +3910,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1396 EventRootType Probe[main.testReturnsInt]
+              Type: 1397 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0x894a78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1397 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1398 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0x894abc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3937,11 +3937,11 @@ Probes:
         - subprogram: {subprogram: 105}
           events:
             - Kind: Entry
-              Type: 1412 EventRootType Probe[main.testReturnsAny]
+              Type: 1413 EventRootType Probe[main.testReturnsAny]
               InjectionPoints: [{PC: "0x894e68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1413 EventRootType Probe[main.testReturnsAny]Return
+              Type: 1414 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
                 - PC: "0x894f08"
                   Frameless: false
@@ -3976,11 +3976,11 @@ Probes:
         - subprogram: {subprogram: 104}
           events:
             - Kind: Entry
-              Type: 1410 EventRootType Probe[main.testReturnsAnyAndError]
+              Type: 1411 EventRootType Probe[main.testReturnsAnyAndError]
               InjectionPoints: [{PC: "0x894ce8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1411 EventRootType Probe[main.testReturnsAnyAndError]Return
+              Type: 1412 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
                 - PC: "0x894d54"
                   Frameless: false
@@ -4014,11 +4014,11 @@ Probes:
         - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1455 EventRootType Probe[main.testReturnsArray]
+              Type: 1456 EventRootType Probe[main.testReturnsArray]
               InjectionPoints: [{PC: "0x895a4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1456 EventRootType Probe[main.testReturnsArray]Return
+              Type: 1457 EventRootType Probe[main.testReturnsArray]Return
               InjectionPoints: [{PC: "0x895aa0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4035,11 +4035,11 @@ Probes:
         - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1457 EventRootType Probe[main.testReturnsArrayOne]
+              Type: 1458 EventRootType Probe[main.testReturnsArrayOne]
               InjectionPoints: [{PC: "0x895ad8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1458 EventRootType Probe[main.testReturnsArrayOne]Return
+              Type: 1459 EventRootType Probe[main.testReturnsArrayOne]Return
               InjectionPoints: [{PC: "0x895b14", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4056,11 +4056,11 @@ Probes:
         - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1459 EventRootType Probe[main.testReturnsArrayZero]
+              Type: 1460 EventRootType Probe[main.testReturnsArrayZero]
               InjectionPoints: [{PC: "0x895b48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1460 EventRootType Probe[main.testReturnsArrayZero]Return
+              Type: 1461 EventRootType Probe[main.testReturnsArrayZero]Return
               InjectionPoints: [{PC: "0x895b80", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4077,11 +4077,11 @@ Probes:
         - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]
+              Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]
               InjectionPoints: [{PC: "0x895c38", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              Type: 1465 EventRootType Probe[main.testReturnsBacktrackInt]Return
               InjectionPoints: [{PC: "0x895c9c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4098,11 +4098,11 @@ Probes:
         - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]
               InjectionPoints: [{PC: "0x895fc8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              Type: 1477 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
               InjectionPoints: [{PC: "0x896008", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4119,11 +4119,11 @@ Probes:
         - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1451 EventRootType Probe[main.testReturnsComplex]
+              Type: 1452 EventRootType Probe[main.testReturnsComplex]
               InjectionPoints: [{PC: "0x8958f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1452 EventRootType Probe[main.testReturnsComplex]Return
+              Type: 1453 EventRootType Probe[main.testReturnsComplex]Return
               InjectionPoints: [{PC: "0x895944", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4141,11 +4141,11 @@ Probes:
         - subprogram: {subprogram: 103}
           events:
             - Kind: Entry
-              Type: 1408 EventRootType Probe[main.testReturnsError]
+              Type: 1409 EventRootType Probe[main.testReturnsError]
               InjectionPoints: [{PC: "0x894c68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1409 EventRootType Probe[main.testReturnsError]Return
+              Type: 1410 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
                 - PC: "0x894c98"
                   Frameless: false
@@ -4170,11 +4170,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1398 EventRootType Probe[main.testReturnsInt]
+              Type: 1399 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0x894a78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1399 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1400 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0x894abc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4195,11 +4195,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1406 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1407 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0x894b98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1407 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1408 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0x894c30", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4220,11 +4220,11 @@ Probes:
         - subprogram: {subprogram: 101}
           events:
             - Kind: Entry
-              Type: 1400 EventRootType Probe[main.testReturnsIntPointer]
+              Type: 1401 EventRootType Probe[main.testReturnsIntPointer]
               InjectionPoints: [{PC: "0x894af8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1401 EventRootType Probe[main.testReturnsIntPointer]Return
+              Type: 1402 EventRootType Probe[main.testReturnsIntPointer]Return
               InjectionPoints: [{PC: "0x894b5c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4246,11 +4246,11 @@ Probes:
         - subprogram: {subprogram: 106}
           events:
             - Kind: Entry
-              Type: 1414 EventRootType Probe[main.testReturnsInterface]
+              Type: 1415 EventRootType Probe[main.testReturnsInterface]
               InjectionPoints: [{PC: "0x895068", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1415 EventRootType Probe[main.testReturnsInterface]Return
+              Type: 1416 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
                 - PC: "0x895138"
                   Frameless: false
@@ -4275,11 +4275,11 @@ Probes:
         - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]
+              Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]
               InjectionPoints: [{PC: "0x895980", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]Return
+              Type: 1455 EventRootType Probe[main.testReturnsLargeStruct]Return
               InjectionPoints: [{PC: "0x895a14", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4296,11 +4296,11 @@ Probes:
         - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1449 EventRootType Probe[main.testReturnsManyFloats]
+              Type: 1450 EventRootType Probe[main.testReturnsManyFloats]
               InjectionPoints: [{PC: "0x895838", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1450 EventRootType Probe[main.testReturnsManyFloats]Return
+              Type: 1451 EventRootType Probe[main.testReturnsManyFloats]Return
               InjectionPoints: [{PC: "0x8958bc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4317,11 +4317,11 @@ Probes:
         - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1467 EventRootType Probe[main.testReturnsMixed]
+              Type: 1468 EventRootType Probe[main.testReturnsMixed]
               InjectionPoints: [{PC: "0x895db8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1468 EventRootType Probe[main.testReturnsMixed]Return
+              Type: 1469 EventRootType Probe[main.testReturnsMixed]Return
               InjectionPoints: [{PC: "0x895e10", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4338,11 +4338,11 @@ Probes:
         - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]
+              Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]
               InjectionPoints: [{PC: "0x895bb8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]Return
+              Type: 1463 EventRootType Probe[main.testReturnsMixedStruct]Return
               InjectionPoints: [{PC: "0x895c00", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4359,11 +4359,11 @@ Probes:
         - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]
+              Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]
               InjectionPoints: [{PC: "0x895f48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              Type: 1475 EventRootType Probe[main.testReturnsMultipleFloats]Return
               InjectionPoints: [{PC: "0x895f8c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4383,7 +4383,7 @@ Probes:
         - subprogram: {subprogram: 111}
           events:
             - Kind: Line
-              Type: 1446 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              Type: 1447 EventRootType Probe[main.testReturnsNamedDeferLine]Line
               InjectionPoints: [{PC: "0x8955c8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4404,11 +4404,11 @@ Probes:
         - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]
+              Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]
               InjectionPoints: [{PC: "0x895ed8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              Type: 1473 EventRootType Probe[main.testReturnsOnlyFloat]Return
               InjectionPoints: [{PC: "0x895f18", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4425,11 +4425,11 @@ Probes:
         - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1447 EventRootType Probe[main.testReturnsPrimitives]
+              Type: 1448 EventRootType Probe[main.testReturnsPrimitives]
               InjectionPoints: [{PC: "0x8957a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1448 EventRootType Probe[main.testReturnsPrimitives]Return
+              Type: 1449 EventRootType Probe[main.testReturnsPrimitives]Return
               InjectionPoints: [{PC: "0x895800", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4446,11 +4446,11 @@ Probes:
         - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]
+              Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]
               InjectionPoints: [{PC: "0x895e4c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]Return
+              Type: 1471 EventRootType Probe[main.testReturnsStructWithArray]Return
               InjectionPoints: [{PC: "0x895ea0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4467,11 +4467,11 @@ Probes:
         - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1465 EventRootType Probe[main.testReturnsWideStruct]
+              Type: 1466 EventRootType Probe[main.testReturnsWideStruct]
               InjectionPoints: [{PC: "0x895ce0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1466 EventRootType Probe[main.testReturnsWideStruct]Return
+              Type: 1467 EventRootType Probe[main.testReturnsWideStruct]Return
               InjectionPoints: [{PC: "0x895d84", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4489,7 +4489,7 @@ Probes:
         - subprogram: {subprogram: 2}
           events:
             - Kind: Entry
-              Type: 1277 EventRootType Probe[main.testRuneArray]
+              Type: 1278 EventRootType Probe[main.testRuneArray]
               InjectionPoints: [{PC: "0x88dd60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4524,11 +4524,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1428 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1429 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x895278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1429 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x895304", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4574,7 +4574,7 @@ Probes:
         - subprogram: {subprogram: 23}
           events:
             - Kind: Entry
-              Type: 1298 EventRootType Probe[main.testSingleBool]
+              Type: 1299 EventRootType Probe[main.testSingleBool]
               InjectionPoints: [{PC: "0x88e1e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4596,7 +4596,7 @@ Probes:
         - subprogram: {subprogram: 21}
           events:
             - Kind: Entry
-              Type: 1296 EventRootType Probe[main.testSingleByte]
+              Type: 1297 EventRootType Probe[main.testSingleByte]
               InjectionPoints: [{PC: "0x88e1c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4618,7 +4618,7 @@ Probes:
         - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 1309 EventRootType Probe[main.testSingleFloat32]
+              Type: 1310 EventRootType Probe[main.testSingleFloat32]
               InjectionPoints: [{PC: "0x88e290", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4636,7 +4636,7 @@ Probes:
         - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 1310 EventRootType Probe[main.testSingleFloat64]
+              Type: 1311 EventRootType Probe[main.testSingleFloat64]
               InjectionPoints: [{PC: "0x88e2a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4654,7 +4654,7 @@ Probes:
         - subprogram: {subprogram: 24}
           events:
             - Kind: Entry
-              Type: 1299 EventRootType Probe[main.testSingleInt]
+              Type: 1300 EventRootType Probe[main.testSingleInt]
               InjectionPoints: [{PC: "0x88e1f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4676,7 +4676,7 @@ Probes:
         - subprogram: {subprogram: 26}
           events:
             - Kind: Entry
-              Type: 1301 EventRootType Probe[main.testSingleInt16]
+              Type: 1302 EventRootType Probe[main.testSingleInt16]
               InjectionPoints: [{PC: "0x88e210", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4699,7 +4699,7 @@ Probes:
         - subprogram: {subprogram: 27}
           events:
             - Kind: Entry
-              Type: 1302 EventRootType Probe[main.testSingleInt32]
+              Type: 1303 EventRootType Probe[main.testSingleInt32]
               InjectionPoints: [{PC: "0x88e220", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4721,7 +4721,7 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Entry
-              Type: 1303 EventRootType Probe[main.testSingleInt64]
+              Type: 1304 EventRootType Probe[main.testSingleInt64]
               InjectionPoints: [{PC: "0x88e230", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4750,7 +4750,7 @@ Probes:
         - subprogram: {subprogram: 25}
           events:
             - Kind: Entry
-              Type: 1300 EventRootType Probe[main.testSingleInt8]
+              Type: 1301 EventRootType Probe[main.testSingleInt8]
               InjectionPoints: [{PC: "0x88e200", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4781,7 +4781,7 @@ Probes:
         - subprogram: {subprogram: 22}
           events:
             - Kind: Entry
-              Type: 1297 EventRootType Probe[main.testSingleRune]
+              Type: 1298 EventRootType Probe[main.testSingleRune]
               InjectionPoints: [{PC: "0x88e1d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4803,7 +4803,7 @@ Probes:
         - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1510 EventRootType Probe[main.testSingleString]
+              Type: 1511 EventRootType Probe[main.testSingleString]
               InjectionPoints: [{PC: "0x897800", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4825,7 +4825,7 @@ Probes:
         - subprogram: {subprogram: 29}
           events:
             - Kind: Entry
-              Type: 1304 EventRootType Probe[main.testSingleUint]
+              Type: 1305 EventRootType Probe[main.testSingleUint]
               InjectionPoints: [{PC: "0x88e240", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4847,7 +4847,7 @@ Probes:
         - subprogram: {subprogram: 31}
           events:
             - Kind: Entry
-              Type: 1306 EventRootType Probe[main.testSingleUint16]
+              Type: 1307 EventRootType Probe[main.testSingleUint16]
               InjectionPoints: [{PC: "0x88e260", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4869,7 +4869,7 @@ Probes:
         - subprogram: {subprogram: 32}
           events:
             - Kind: Entry
-              Type: 1307 EventRootType Probe[main.testSingleUint32]
+              Type: 1308 EventRootType Probe[main.testSingleUint32]
               InjectionPoints: [{PC: "0x88e270", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4891,7 +4891,7 @@ Probes:
         - subprogram: {subprogram: 33}
           events:
             - Kind: Entry
-              Type: 1308 EventRootType Probe[main.testSingleUint64]
+              Type: 1309 EventRootType Probe[main.testSingleUint64]
               InjectionPoints: [{PC: "0x88e280", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4913,7 +4913,7 @@ Probes:
         - subprogram: {subprogram: 30}
           events:
             - Kind: Entry
-              Type: 1305 EventRootType Probe[main.testSingleUint8]
+              Type: 1306 EventRootType Probe[main.testSingleUint8]
               InjectionPoints: [{PC: "0x88e250", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4935,7 +4935,7 @@ Probes:
         - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1506 EventRootType Probe[main.testSliceEmptyStructs]
+              Type: 1507 EventRootType Probe[main.testSliceEmptyStructs]
               InjectionPoints: [{PC: "0x897180", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4957,7 +4957,7 @@ Probes:
         - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1497 EventRootType Probe[main.testSliceOfSlices]
+              Type: 1498 EventRootType Probe[main.testSliceOfSlices]
               InjectionPoints: [{PC: "0x897100", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4979,7 +4979,7 @@ Probes:
         - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 1358 EventRootType Probe[main.testSmallMap]
+              Type: 1359 EventRootType Probe[main.testSmallMap]
               InjectionPoints: [{PC: "0x892c60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5000,11 +5000,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1442 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1443 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0x895348", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1443 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1444 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0x8953d4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5025,11 +5025,11 @@ Probes:
         - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1487 EventRootType Probe[main.testStackArgRegReturns]
+              Type: 1488 EventRootType Probe[main.testStackArgRegReturns]
               InjectionPoints: [{PC: "0x896978", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1488 EventRootType Probe[main.testStackArgRegReturns]Return
+              Type: 1489 EventRootType Probe[main.testStackArgRegReturns]Return
               InjectionPoints: [{PC: "0x8969dc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5051,7 +5051,7 @@ Probes:
         - subprogram: {subprogram: 3}
           events:
             - Kind: Entry
-              Type: 1278 EventRootType Probe[main.testStringArray]
+              Type: 1279 EventRootType Probe[main.testStringArray]
               InjectionPoints: [{PC: "0x88dd70", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5073,7 +5073,7 @@ Probes:
         - subprogram: {subprogram: 97}
           events:
             - Kind: Entry
-              Type: 1389 EventRootType Probe[main.testStringPointer]
+              Type: 1390 EventRootType Probe[main.testStringPointer]
               InjectionPoints: [{PC: "0x894610", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5095,7 +5095,7 @@ Probes:
         - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1501 EventRootType Probe[main.testStringSlice]
+              Type: 1502 EventRootType Probe[main.testStringSlice]
               InjectionPoints: [{PC: "0x897140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5117,7 +5117,7 @@ Probes:
         - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 1321 EventRootType Probe[main.testStringType1]
+              Type: 1322 EventRootType Probe[main.testStringType1]
               InjectionPoints: [{PC: "0x88e8e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5139,7 +5139,7 @@ Probes:
         - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 1322 EventRootType Probe[main.testStringType2]
+              Type: 1323 EventRootType Probe[main.testStringType2]
               InjectionPoints: [{PC: "0x88e8f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5161,11 +5161,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1529 EventRootType Probe[main.testStruct]
+              Type: 1530 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0x897b00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1530 EventRootType Probe[main.testStruct]Return
+              Type: 1531 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0x897b1c", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5192,7 +5192,7 @@ Probes:
         - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1498 EventRootType Probe[main.testStructSlice]
+              Type: 1499 EventRootType Probe[main.testStructSlice]
               InjectionPoints: [{PC: "0x897110", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5219,7 +5219,7 @@ Probes:
         - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 1352 EventRootType Probe[main.testStructWithAny]
+              Type: 1353 EventRootType Probe[main.testStructWithAny]
               InjectionPoints: [{PC: "0x892540", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5240,11 +5240,11 @@ Probes:
         - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1491 EventRootType Probe[main.testStructWithArrayArg]
+              Type: 1492 EventRootType Probe[main.testStructWithArrayArg]
               InjectionPoints: [{PC: "0x896afc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1492 EventRootType Probe[main.testStructWithArrayArg]Return
+              Type: 1493 EventRootType Probe[main.testStructWithArrayArg]Return
               InjectionPoints: [{PC: "0x896b8c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5266,11 +5266,11 @@ Probes:
         - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]
+              Type: 1526 EventRootType Probe[main.testStructWithCyclicMaps]
               InjectionPoints: [{PC: "0x897a10", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1526 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              Type: 1527 EventRootType Probe[main.testStructWithCyclicMaps]Return
               InjectionPoints: [{PC: "0x897a28", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5291,7 +5291,7 @@ Probes:
         - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testStructWithCyclicSlices]
+              Type: 1525 EventRootType Probe[main.testStructWithCyclicSlices]
               InjectionPoints: [{PC: "0x897a00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5318,7 +5318,7 @@ Probes:
         - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 1353 EventRootType Probe[main.testStructWithMap]
+              Type: 1354 EventRootType Probe[main.testStructWithMap]
               InjectionPoints: [{PC: "0x892c10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5351,7 +5351,7 @@ Probes:
         - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1507 EventRootType Probe[main.testSubslices]
+              Type: 1508 EventRootType Probe[main.testSubslices]
               InjectionPoints: [{PC: "0x897190", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5391,7 +5391,7 @@ Probes:
         - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1523 EventRootType Probe[main.testSubstrings]
+              Type: 1524 EventRootType Probe[main.testSubstrings]
               InjectionPoints: [{PC: "0x897890", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5423,7 +5423,7 @@ Probes:
         - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 1326 EventRootType Probe[main.testTakeContext]
+              Type: 1327 EventRootType Probe[main.testTakeContext]
               InjectionPoints: [{PC: "0x88ee80", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
@@ -5439,11 +5439,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1431 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x895278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1431 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x895304", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5464,11 +5464,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x895278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x895304", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5491,11 +5491,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x895278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x895304", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5527,7 +5527,7 @@ Probes:
         - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1511 EventRootType Probe[main.testThreeStrings]
+              Type: 1512 EventRootType Probe[main.testThreeStrings]
               InjectionPoints: [{PC: "0x897810", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5559,11 +5559,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0x897820", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0x897838", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5593,11 +5593,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1515 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0x897820", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1515 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1516 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0x897838", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5629,7 +5629,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1517 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0x897840", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5659,7 +5659,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1517 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1518 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0x897840", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5679,6 +5679,72 @@ Probes:
                   DSL: a.c
                   EventKind: Entry
                   EventExpressionIndex: 2
+    - id: testTimeFixedZone
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeFixedZone}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 166}
+          events:
+            - Kind: Entry
+              Type: 1540 EventRootType Probe[main.testTimeFixedZone]
+              InjectionPoints: [{PC: "0x898740", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeMonotonic
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeMonotonic}
+      tags: ['foo:bar']
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 167}
+          events:
+            - Kind: Entry
+              Type: 1541 EventRootType Probe[main.testTimeMonotonic]
+              InjectionPoints: [{PC: "0x898750", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{c}'
+            Segments:
+                - JSON: {Ref: c}
+                  DSL: c
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeUTC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeUTC}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 165}
+          events:
+            - Kind: Entry
+              Type: 1539 EventRootType Probe[main.testTimeUTC]
+              InjectionPoints: [{PC: "0x898730", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -5691,7 +5757,7 @@ Probes:
         - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 1311 EventRootType Probe[main.testTypeAlias]
+              Type: 1312 EventRootType Probe[main.testTypeAlias]
               InjectionPoints: [{PC: "0x88e2b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5713,7 +5779,7 @@ Probes:
         - subprogram: {subprogram: 12}
           events:
             - Kind: Entry
-              Type: 1287 EventRootType Probe[main.testUint16Array]
+              Type: 1288 EventRootType Probe[main.testUint16Array]
               InjectionPoints: [{PC: "0x88de00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5735,7 +5801,7 @@ Probes:
         - subprogram: {subprogram: 13}
           events:
             - Kind: Entry
-              Type: 1288 EventRootType Probe[main.testUint32Array]
+              Type: 1289 EventRootType Probe[main.testUint32Array]
               InjectionPoints: [{PC: "0x88de10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5757,7 +5823,7 @@ Probes:
         - subprogram: {subprogram: 14}
           events:
             - Kind: Entry
-              Type: 1289 EventRootType Probe[main.testUint64Array]
+              Type: 1290 EventRootType Probe[main.testUint64Array]
               InjectionPoints: [{PC: "0x88de20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5779,7 +5845,7 @@ Probes:
         - subprogram: {subprogram: 11}
           events:
             - Kind: Entry
-              Type: 1286 EventRootType Probe[main.testUint8Array]
+              Type: 1287 EventRootType Probe[main.testUint8Array]
               InjectionPoints: [{PC: "0x88ddf0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5801,7 +5867,7 @@ Probes:
         - subprogram: {subprogram: 10}
           events:
             - Kind: Entry
-              Type: 1285 EventRootType Probe[main.testUintArray]
+              Type: 1286 EventRootType Probe[main.testUintArray]
               InjectionPoints: [{PC: "0x88dde0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5823,7 +5889,7 @@ Probes:
         - subprogram: {subprogram: 96}
           events:
             - Kind: Entry
-              Type: 1388 EventRootType Probe[main.testUintPointer]
+              Type: 1389 EventRootType Probe[main.testUintPointer]
               InjectionPoints: [{PC: "0x8945a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5845,7 +5911,7 @@ Probes:
         - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1495 EventRootType Probe[main.testUintSlice]
+              Type: 1496 EventRootType Probe[main.testUintSlice]
               InjectionPoints: [{PC: "0x8970e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5867,7 +5933,7 @@ Probes:
         - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1521 EventRootType Probe[main.testUnitializedString]
+              Type: 1522 EventRootType Probe[main.testUnitializedString]
               InjectionPoints: [{PC: "0x897870", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5889,7 +5955,7 @@ Probes:
         - subprogram: {subprogram: 95}
           events:
             - Kind: Entry
-              Type: 1387 EventRootType Probe[main.testUnsafePointer]
+              Type: 1388 EventRootType Probe[main.testUnsafePointer]
               InjectionPoints: [{PC: "0x894580", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5911,7 +5977,7 @@ Probes:
         - subprogram: {subprogram: 20}
           events:
             - Kind: Entry
-              Type: 1295 EventRootType Probe[main.testVeryLargeArray]
+              Type: 1296 EventRootType Probe[main.testVeryLargeArray]
               InjectionPoints: [{PC: "0x88de90", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5933,7 +5999,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0x897170", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5955,7 +6021,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1506 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0x897170", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5974,18 +6040,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 195}
+        - subprogram: {subprogram: 198}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1606 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0x892368"
                   Frameless: false
-                - PC: "0x89a2bc"
+                - PC: "0x89a41c"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1603 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1607 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0x8923a0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -6007,11 +6073,11 @@ Probes:
         - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]
               InjectionPoints: [{PC: "0x896bc8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              Type: 1495 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
               InjectionPoints: [{PC: "0x896c34", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -10157,138 +10223,195 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 165
-      Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x899690..0x8996a0]
+      Name: main.testTimeUTC
+      OutOfLinePCRanges: [0x898730..0x898740]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 323 BaseType go.shape.int
+        - Name: x
+          Type: 323 GoTimeType time.Time
           Locations:
-            - Range: 0x899690..0x8996a0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x898730..0x898740
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0x899690..0x899694
-              Pieces: []
-            - Range: 0x899694..0x899695
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899695..0x8996a0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+          DictIndex: -1
+      DictRegister: null
     - ID: 166
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x8996a0..0x8996b0]
+      Name: main.testTimeFixedZone
+      OutOfLinePCRanges: [0x898740..0x898750]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 325 GoStringHeaderType go.shape.string
+        - Name: x
+          Type: 323 GoTimeType time.Time
           Locations:
-            - Range: 0x8996a0..0x8996ac
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8996ac..0x8996b0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x8996a0..0x8996ac
-              Pieces: []
-            - Range: 0x8996ac..0x8996ad
+            - Range: 0x898740..0x898750
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8996ad..0x8996b0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 167
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x8996b0..0x8996c0]
+      Name: main.testTimeMonotonic
+      OutOfLinePCRanges: [0x898750..0x898760]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+        - Name: c
+          Type: 326 StructureType main.timeCapture
           Locations:
-            - Range: 0x8996b0..0x8996c0
+            - Range: 0x898750..0x898760
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 168
+      Name: main.wrapBox[go.shape.int]
+      OutOfLinePCRanges: [0x8997f0..0x899800]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 327 BaseType go.shape.int
+          Locations:
+            - Range: 0x8997f0..0x899800
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 323 BaseType go.shape.int
+          Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8996b0..0x8996b4
+            - Range: 0x8997f0..0x8997f4
               Pieces: []
-            - Range: 0x8996b4..0x8996b5
+            - Range: 0x8997f4..0x8997f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8996b5..0x8996c0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 168
-      Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x8996c0..0x8996d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x8996c0..0x8996cc
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8996cc..0x8996d0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 325 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x8996c0..0x8996cc
-              Pieces: []
-            - Range: 0x8996cc..0x8996cd
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8996cd..0x8996d0
+            - Range: 0x8997f5..0x899800
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0x899800..0x899810]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 329 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x899800..0x89980c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x89980c..0x899810
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x899800..0x89980c
+              Pieces: []
+            - Range: 0x89980c..0x89980d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x89980d..0x899810
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0x899810..0x899820]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0x899810..0x899820
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 327 BaseType go.shape.int
+          Locations:
+            - Range: 0x899810..0x899814
+              Pieces: []
+            - Range: 0x899814..0x899815
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x899815..0x899820
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 171
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0x899820..0x899830]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x899820..0x89982c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x89982c..0x899830
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 329 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x899820..0x89982c
+              Pieces: []
+            - Range: 0x89982c..0x89982d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x89982d..0x899830
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x899740..0x899870]
+      OutOfLinePCRanges: [0x8998a0..0x8999d0]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 327 GoSliceHeaderType []go.shape.int
+          Type: 331 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x899740..0x89976c
+            - Range: 0x8998a0..0x8998cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10296,7 +10419,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89976c..0x89977c
+            - Range: 0x8998cc..0x8998dc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10304,7 +10427,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x89977c..0x899870
+            - Range: 0x8998dc..0x8999d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10315,20 +10438,20 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 329 GoSubroutineType func(go.shape.int) bool
+          Type: 333 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x899740..0x89977c
+            - Range: 0x8998a0..0x8998dc
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x89977c..0x899870
+            - Range: 0x8998dc..0x8999d0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 327 GoSliceHeaderType []go.shape.int
+          Type: 331 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x899740..0x89982c
+            - Range: 0x8998a0..0x89998c
               Pieces: []
-            - Range: 0x89982c..0x89982d
+            - Range: 0x89998c..0x89998d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10336,14 +10459,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89982d..0x899870
+            - Range: 0x89998d..0x8999d0
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 327 GoSliceHeaderType []go.shape.int
+          Type: 331 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x89977c..0x899798
+            - Range: 0x8998dc..0x8998f8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10351,7 +10474,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x899798..0x89979c
+            - Range: 0x8998f8..0x8998fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10359,7 +10482,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x89979c..0x8997a0
+            - Range: 0x8998fc..0x899900
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10367,7 +10490,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8997a0..0x8997a0
+            - Range: 0x899900..0x899900
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10375,7 +10498,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8997a0..0x8997cc
+            - Range: 0x899900..0x89992c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10383,7 +10506,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8997cc..0x899820
+            - Range: 0x89992c..0x899980
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10391,7 +10514,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x899820..0x899870
+            - Range: 0x899980..0x8999d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10402,217 +10525,217 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0x8997bc..0x8997cc
+            - Range: 0x89991c..0x89992c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8997cc..0x899820
+            - Range: 0x89992c..0x899980
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 170
+    - ID: 173
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x899870..0x8998d0]
+      OutOfLinePCRanges: [0x8999d0..0x899a30]
       InlinePCRanges: []
       Variables:
         - Name: box
-          Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x899870..0x899898
+            - Range: 0x8999d0..0x8999f8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
-          Type: 330 GoSubroutineType func(go.shape.int) go.shape.string
+          Type: 334 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x899870..0x899898
+            - Range: 0x8999d0..0x8999f8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x899870..0x899898
+            - Range: 0x8999d0..0x8999f8
               Pieces: []
-            - Range: 0x899898..0x899899
+            - Range: 0x8999f8..0x8999f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x899899..0x8998d0
+            - Range: 0x8999f9..0x899a30
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x899b80..0x899b90]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 328 PointerType *go.shape.int
-          Locations:
-            - Range: 0x899b80..0x899b90
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 328 PointerType *go.shape.int
-          Locations:
-            - Range: 0x899b80..0x899b84
-              Pieces: []
-            - Range: 0x899b84..0x899b85
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899b85..0x899b90
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x899b90..0x899ba0]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 331 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x899b90..0x899ba0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x899b90..0x899b94
-              Pieces: []
-            - Range: 0x899b94..0x899b95
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899b95..0x899ba0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 173
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x899ba0..0x899bb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 333 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0x899ba0..0x899bb0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 333 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0x899ba0..0x899ba4
-              Pieces: []
-            - Range: 0x899ba4..0x899ba5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899ba5..0x899bb0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 174
-      Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x899bb0..0x899bc0]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0x899ce0..0x899cf0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 335 StructureType main.largeGenericType[go.shape.string]
+        - Name: p
+          Type: 332 PointerType *go.shape.int
           Locations:
-            - Range: 0x899bb0..0x899bc0
-              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+            - Range: 0x899ce0..0x899cf0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 332 PointerType *go.shape.int
           Locations:
-            - Range: 0x899bb0..0x899bb8
+            - Range: 0x899ce0..0x899ce4
               Pieces: []
-            - Range: 0x899bb8..0x899bb9
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x899bb9..0x899bc0
+            - Range: 0x899ce4..0x899ce5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x899ce5..0x899cf0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
-      Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x899c40..0x899c50]
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x899cf0..0x899d00]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 337 StructureType main.largeGenericType[go.shape.int]
+        - Name: p
+          Type: 335 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x899c40..0x899c50
-              Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
+            - Range: 0x899cf0..0x899d00
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 323 BaseType go.shape.int
+          Type: 335 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x899c40..0x899c44
+            - Range: 0x899cf0..0x899cf4
               Pieces: []
-            - Range: 0x899c44..0x899c45
+            - Range: 0x899cf4..0x899cf5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899c45..0x899c50
+            - Range: 0x899cf5..0x899d00
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 176
-      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x899ce0..0x899cf0]
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x899d00..0x899d10]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 337 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x899d00..0x899d10
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 337 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x899d00..0x899d04
+              Pieces: []
+            - Range: 0x899d04..0x899d05
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x899d05..0x899d10
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 177
+      Name: main.largeGenericType[go.shape.string].LargeGet
+      OutOfLinePCRanges: [0x899d10..0x899d20]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 338 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Type: 339 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x899ce0..0x899cf0
+            - Range: 0x899d10..0x899d20
+              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 329 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x899d10..0x899d18
+              Pieces: []
+            - Range: 0x899d18..0x899d19
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x899d19..0x899d20
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 178
+      Name: main.largeGenericType[go.shape.int].LargeGet
+      OutOfLinePCRanges: [0x899da0..0x899db0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 341 StructureType main.largeGenericType[go.shape.int]
+          Locations:
+            - Range: 0x899da0..0x899db0
+              Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 327 BaseType go.shape.int
+          Locations:
+            - Range: 0x899da0..0x899da4
+              Pieces: []
+            - Range: 0x899da4..0x899da5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x899da5..0x899db0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 179
+      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
+      OutOfLinePCRanges: [0x899e40..0x899e50]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 342 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Locations:
+            - Range: 0x899e40..0x899e50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0x899ce0..0x899cf0
+            - Range: 0x899e40..0x899e50
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 340 BaseType go.shape.bool
+          Type: 344 BaseType go.shape.bool
           Locations:
-            - Range: 0x899ce0..0x899cf0
+            - Range: 0x899e40..0x899e50
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 177
+    - ID: 180
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x899d70..0x899e00]
+      OutOfLinePCRanges: [0x899ed0..0x899f60]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 341 PointerType *main.Pair[go.shape.string,go.shape.int]
+          Type: 345 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x899d70..0x899e00
+            - Range: 0x899ed0..0x899f60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x899d70..0x899e00
+            - Range: 0x899ed0..0x899f60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10621,22 +10744,22 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0x899d70..0x899e00
+            - Range: 0x899ed0..0x899f60
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 178
+    - ID: 181
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x899e90..0x899ea0]
+      OutOfLinePCRanges: [0x899ff0..0x89a000]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x899e90..0x899ea0
+            - Range: 0x899ff0..0x89a000
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10645,61 +10768,61 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 340 BaseType go.shape.bool
+          Type: 344 BaseType go.shape.bool
           Locations:
-            - Range: 0x899e90..0x899ea0
+            - Range: 0x899ff0..0x89a000
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 340 BaseType go.shape.bool
+          Type: 344 BaseType go.shape.bool
           Locations:
-            - Range: 0x899e90..0x899e98
+            - Range: 0x899ff0..0x899ff8
               Pieces: []
-            - Range: 0x899e98..0x899e99
+            - Range: 0x899ff8..0x899ff9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x899e99..0x899ea0
+            - Range: 0x899ff9..0x89a000
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x899e90..0x899e98
+            - Range: 0x899ff0..0x899ff8
               Pieces: []
-            - Range: 0x899e98..0x899e99
+            - Range: 0x899ff8..0x899ff9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x899e99..0x899ea0
+            - Range: 0x899ff9..0x89a000
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 179
+    - ID: 182
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x899ea0..0x899ec0]
+      OutOfLinePCRanges: [0x89a000..0x89a020]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0x899ea0..0x899eb0
+            - Range: 0x89a000..0x89a010
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x899ea0..0x899eac
+            - Range: 0x89a000..0x89a00c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x899eac..0x899ec0
+            - Range: 0x89a00c..0x89a020
               Pieces:
                 - Size: 8
                   Op: null
@@ -10708,75 +10831,75 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x899ea0..0x899eb0
+            - Range: 0x89a000..0x89a010
               Pieces: []
-            - Range: 0x899eb0..0x899eb1
+            - Range: 0x89a010..0x89a011
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x899eb1..0x899ec0
+            - Range: 0x89a011..0x89a020
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0x899ea0..0x899eb0
+            - Range: 0x89a000..0x89a010
               Pieces: []
-            - Range: 0x899eb0..0x899eb1
+            - Range: 0x89a010..0x89a011
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x899eb1..0x899ec0
+            - Range: 0x89a011..0x89a020
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 180
+    - ID: 183
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x899ec0..0x899f10]
+      OutOfLinePCRanges: [0x89a020..0x89a070]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 343 StructureType go.shape.struct { main.i int }
+          Type: 347 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x899ec0..0x899ee8
+            - Range: 0x89a020..0x89a048
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x899ec0..0x899ee8
+            - Range: 0x89a020..0x89a048
               Pieces: []
-            - Range: 0x899ee8..0x899ee9
+            - Range: 0x89a048..0x89a049
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x899ee9..0x899f10
+            - Range: 0x89a049..0x89a070
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 184
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x899f10..0x899f70]
+      OutOfLinePCRanges: [0x89a070..0x89a0d0]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 344 StructureType go.shape.struct { main.s string }
+          Type: 348 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x899f10..0x899f3c
+            - Range: 0x89a070..0x89a09c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x899f3c..0x899f40
+            - Range: 0x89a09c..0x89a0a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10787,65 +10910,65 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x899f10..0x899f40
+            - Range: 0x89a070..0x89a0a0
               Pieces: []
-            - Range: 0x899f40..0x899f41
+            - Range: 0x89a0a0..0x89a0a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x899f41..0x899f70
+            - Range: 0x89a0a1..0x89a0d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 182
+    - ID: 185
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x899f70..0x899f80]
+      OutOfLinePCRanges: [0x89a0d0..0x89a0e0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 345 PointerType *go.shape.string
+          Type: 349 PointerType *go.shape.string
           Locations:
-            - Range: 0x899f70..0x899f78
+            - Range: 0x89a0d0..0x89a0d8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x899f70..0x899f78
+            - Range: 0x89a0d0..0x89a0d8
               Pieces: []
-            - Range: 0x899f78..0x899f79
+            - Range: 0x89a0d8..0x89a0d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x899f79..0x899f80
+            - Range: 0x89a0d9..0x89a0e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 183
+    - ID: 186
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x899f80..0x899fe0]
+      OutOfLinePCRanges: [0x89a0e0..0x89a140]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 346 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 350 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x899f80..0x899fbc
+            - Range: 0x89a0e0..0x89a11c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 347 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 351 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x899f80..0x899fcc
+            - Range: 0x89a0e0..0x89a12c
               Pieces: []
-            - Range: 0x899fcc..0x899fcd
+            - Range: 0x89a12c..0x89a12d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10859,20 +10982,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x899fcd..0x899fe0
+            - Range: 0x89a12d..0x89a140
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 184
+    - ID: 187
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x899fe0..0x89a020]
+      OutOfLinePCRanges: [0x89a140..0x89a180]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 327 GoSliceHeaderType []go.shape.int
+          Type: 331 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x899fe0..0x899fec
+            - Range: 0x89a140..0x89a14c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10880,7 +11003,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x899fec..0x89a020
+            - Range: 0x89a14c..0x89a180
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10891,44 +11014,44 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0x899fe0..0x89a020
+            - Range: 0x89a140..0x89a180
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x899fe0..0x89a008
+            - Range: 0x89a140..0x89a168
               Pieces: []
-            - Range: 0x89a008..0x89a009
+            - Range: 0x89a168..0x89a169
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89a009..0x89a010
+            - Range: 0x89a169..0x89a170
               Pieces: []
-            - Range: 0x89a010..0x89a011
+            - Range: 0x89a170..0x89a171
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89a011..0x89a020
+            - Range: 0x89a171..0x89a180
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0x899ffc..0x89a00c
+            - Range: 0x89a15c..0x89a16c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 185
+    - ID: 188
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x89a020..0x89a0f0]
+      OutOfLinePCRanges: [0x89a180..0x89a250]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 348 GoSliceHeaderType []go.shape.string
+          Type: 352 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x89a020..0x89a044
+            - Range: 0x89a180..0x89a1a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10936,7 +11059,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89a044..0x89a048
+            - Range: 0x89a1a4..0x89a1a8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10947,15 +11070,15 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89a020..0x89a07c
+            - Range: 0x89a180..0x89a1dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89a07c..0x89a0f0
+            - Range: 0x89a1dc..0x89a250
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10966,28 +11089,28 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x89a020..0x89a098
+            - Range: 0x89a180..0x89a1f8
               Pieces: []
-            - Range: 0x89a098..0x89a099
+            - Range: 0x89a1f8..0x89a1f9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89a099..0x89a0a8
+            - Range: 0x89a1f9..0x89a208
               Pieces: []
-            - Range: 0x89a0a8..0x89a0a9
+            - Range: 0x89a208..0x89a209
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89a0a9..0x89a0f0
+            - Range: 0x89a209..0x89a250
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89a05c..0x89a070
+            - Range: 0x89a1bc..0x89a1d0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89a070..0x89a07c
+            - Range: 0x89a1d0..0x89a1dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10996,58 +11119,58 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 186
+    - ID: 189
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x89a0f0..0x89a100]
+      OutOfLinePCRanges: [0x89a250..0x89a260]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 349 StructureType main.typeWithGenerics[go.shape.int]
+          Type: 353 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x89a0f0..0x89a0f8
+            - Range: 0x89a250..0x89a258
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
           Locations:
-            - Range: 0x89a0f0..0x89a100
+            - Range: 0x89a250..0x89a260
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x89a0f0..0x89a0f8
+            - Range: 0x89a250..0x89a258
               Pieces: []
-            - Range: 0x89a0f8..0x89a0f9
+            - Range: 0x89a258..0x89a259
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89a0f9..0x89a100
+            - Range: 0x89a259..0x89a260
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
-    - ID: 187
+    - ID: 190
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x89a180..0x89a200]
+      OutOfLinePCRanges: [0x89a2e0..0x89a360]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 350 StructureType main.typeWithGenerics[go.shape.string]
+          Type: 354 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x89a180..0x89a1ac
+            - Range: 0x89a2e0..0x89a30c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89a1ac..0x89a1b8
+            - Range: 0x89a30c..0x89a318
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89a1b8..0x89a1bc
+            - Range: 0x89a318..0x89a31c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11056,9 +11179,9 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89a180..0x89a1bc
+            - Range: 0x89a2e0..0x89a31c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11069,22 +11192,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x89a180..0x89a1bc
+            - Range: 0x89a2e0..0x89a31c
               Pieces: []
-            - Range: 0x89a1bc..0x89a1bd
+            - Range: 0x89a31c..0x89a31d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89a1bd..0x89a200
+            - Range: 0x89a31d..0x89a360
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 188
+    - ID: 191
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x88cea0..0x88cfd0]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 351 GoSliceHeaderType []go.shape.float64
+          Type: 355 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x88cea0..0x88cecc
               Pieces:
@@ -11113,7 +11236,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 354 GoSubroutineType func(go.shape.float64) bool
+          Type: 358 GoSubroutineType func(go.shape.float64) bool
           Locations:
             - Range: 0x88cea0..0x88cedc
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
@@ -11122,7 +11245,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 351 GoSliceHeaderType []go.shape.float64
+          Type: 355 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x88cea0..0x88cf8c
               Pieces: []
@@ -11139,7 +11262,7 @@ Subprograms:
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 351 GoSliceHeaderType []go.shape.float64
+          Type: 355 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x88cedc..0x88cef8
               Pieces:
@@ -11200,7 +11323,7 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 353 BaseType go.shape.float64
+          Type: 357 BaseType go.shape.float64
           Locations:
             - Range: 0x88cf1c..0x88cf2c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
@@ -11209,7 +11332,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 189
+    - ID: 192
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x891cf0..0x891d60]
       InlinePCRanges:
@@ -11240,7 +11363,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 193
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11248,7 +11371,7 @@ Subprograms:
           RootRanges: [0x891f20..0x891ff0]
       Variables: []
       DictRegister: null
-    - ID: 191
+    - ID: 194
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11256,7 +11379,7 @@ Subprograms:
           RootRanges: [0x892070..0x892190]
       Variables: []
       DictRegister: null
-    - ID: 192
+    - ID: 195
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11264,7 +11387,7 @@ Subprograms:
           RootRanges: [0x892070..0x892190]
       Variables: []
       DictRegister: null
-    - ID: 193
+    - ID: 196
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11279,7 +11402,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 194
+    - ID: 197
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11298,15 +11421,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 195
+    - ID: 198
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x892350..0x8923d0]
       InlinePCRanges:
-        - Ranges: [0x89a2bc..0x89a2f0]
-          RootRanges: [0x89a290..0x89a340]
+        - Ranges: [0x89a41c..0x89a450]
+          RootRanges: [0x89a3f0..0x89a4a0]
       Variables:
         - Name: b
-          Type: 355 StructureType main.firstBehavior
+          Type: 359 StructureType main.firstBehavior
           Locations:
             - Range: 0x892350..0x89237c
               Pieces:
@@ -11338,7 +11461,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 196
+    - ID: 199
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11350,31 +11473,31 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1201
+      ID: 1202
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 382 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 134
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 135 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1206
+      ID: 1207
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1207 PointerType *main.deepSlice3
+      Pointee: 1208 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1235
+      ID: 1236
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1236 PointerType *main.deepSlice8
+      Pointee: 1237 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1241
+      ID: 1242
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1242 PointerType *main.deepSlice9
+      Pointee: 1243 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 150
       Name: '**main.stringType2'
@@ -11382,7 +11505,7 @@ Types:
       GoKind: 22
       Pointee: 151 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1186
+      ID: 1197
       Name: '**main.t'
       ByteSize: 8
       Pointee: 250 PointerType *main.t
@@ -11394,145 +11517,145 @@ Types:
       GoKind: 22
       Pointee: 90 PointerType *string
     - __kind: PointerType
-      ID: 1204
+      ID: 1205
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1203 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1204 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 423
+      ID: 424
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 422 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 423 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1210
+      ID: 1211
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1209 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1210 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1239
+      ID: 1240
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1238 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1239 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1245
+      ID: 1246
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1244 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1245 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 420
+      ID: 421
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 419 GoSliceDataType []*string.array
+      Pointee: 420 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 489
+      ID: 490
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 488 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 285
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 282 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 487
+      ID: 488
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 486 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 283
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 280 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 485
+      ID: 486
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 484 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 281
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 278 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 483
+      ID: 484
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 482 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 279
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 276 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 481
+      ID: 482
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 480 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 469
+      ID: 470
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 468 GoSliceDataType [][]uint.array
+      Pointee: 469 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 473
+      ID: 474
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 472 GoSliceDataType []bool.array
+      Pointee: 473 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 980
+      ID: 991
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 979 GoSliceDataType []float64.array
+      Pointee: 990 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 520
+      ID: 527
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 519 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 526 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 528
+      ID: 535
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 527 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 534 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 509
+      ID: 516
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 508 GoSliceDataType []go.shape.float64.array
+      Pointee: 515 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 505
+      ID: 512
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 504 GoSliceDataType []go.shape.int.array
+      Pointee: 511 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 507
+      ID: 514
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 506 GoSliceDataType []go.shape.string.array
+      Pointee: 513 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
-      ID: 1248
+      ID: 1249
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1247 GoSliceDataType []interface {}.array
+      Pointee: 1248 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 277
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 274 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 479
+      ID: 480
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 478 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 479 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 530
+      ID: 537
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 529 GoSliceDataType []main.structWithMap.array
+      Pointee: 536 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 471
+      ID: 472
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 470 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 471 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11541,111 +11664,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 431
+      ID: 432
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 430 GoSliceDataType []string.array
+      Pointee: 431 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 477
+      ID: 478
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 476 GoSliceDataType []struct {}.array
+      Pointee: 477 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 1197
+      ID: 539
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 1196 GoSliceDataType []time.zone.array
+      Pointee: 538 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 1199
+      ID: 541
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 1198 GoSliceDataType []time.zoneTrans.array
+      Pointee: 540 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 261
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 259 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 467
+      ID: 468
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 466 GoSliceDataType []uint.array
+      Pointee: 467 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 475
+      ID: 476
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 474 GoSliceDataType []uint16.array
+      Pointee: 475 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 416
+      ID: 417
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 415 GoSliceDataType []uint8.array
+      Pointee: 416 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 418
+      ID: 419
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 417 GoSliceDataType []uintptr.array
+      Pointee: 418 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1105
+      ID: 1116
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1858656
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1117 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 760
+      ID: 771
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 861920
       GoKind: 22
-      Pointee: 761 GoSliceHeaderType archive/tar.headerError
+      Pointee: 772 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 763
+      ID: 774
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 762 GoSliceDataType archive/tar.headerError.array
+      Pointee: 773 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1045
+      ID: 1056
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1259488
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1057 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 993
+      ID: 1004
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 862112
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1005 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 995
+      ID: 1006
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 862208
       GoKind: 22
-      Pointee: 996 StructureType archive/zip.dirWriter
+      Pointee: 1007 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1092
+      ID: 1103
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1782944
       GoKind: 22
-      Pointee: 1093 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1104 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1021
+      ID: 1032
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1021472
       GoKind: 22
-      Pointee: 1022 StructureType archive/zip.nopCloser
+      Pointee: 1033 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1023
+      ID: 1034
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1021728
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1035 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -11674,40 +11797,40 @@ Types:
       ByteSize: 8
       Pointee: 204 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 373
+      ID: 377
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 374 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 378 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
       ID: 142
       Name: '*bucket<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 143 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1214
+      ID: 1215
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1215 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1252
+      ID: 1253
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1253 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1254 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1261
+      ID: 1262
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1262 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1263 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 171
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 172 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 1270
+      ID: 1271
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 1271 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1272 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 238
       Name: '*bucket<int,struct {}>'
@@ -11719,10 +11842,10 @@ Types:
       ByteSize: 8
       Pointee: 209 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 524
+      ID: 531
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 525 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 198
       Name: '*bucket<string,[]main.structWithMap>'
@@ -11734,35 +11857,35 @@ Types:
       ByteSize: 8
       Pointee: 187 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 400
+      ID: 401
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 401 GoHMapBucketType bucket<string,float64>
+      Pointee: 402 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 949
+      ID: 960
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 950 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 181
       Name: '*bucket<string,int>'
       ByteSize: 8
       Pointee: 182 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 395
+      ID: 396
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 396 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 397 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
       ID: 176
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 177 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 390
+      ID: 391
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 391 GoHMapBucketType bucket<string,string>
+      Pointee: 392 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 233
       Name: '*bucket<struct {},int>'
@@ -11814,449 +11937,449 @@ Types:
       ByteSize: 8
       Pointee: 214 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 1069
+      ID: 1080
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2039840
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType bufio.Reader
+      Pointee: 1081 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1096
+      ID: 1107
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1825152
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType bufio.Writer
+      Pointee: 1108 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1141
+      ID: 1152
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2132800
       GoKind: 22
-      Pointee: 1142 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1153 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 671
+      ID: 682
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 844448
       GoKind: 22
-      Pointee: 568 BaseType compress/flate.CorruptInputError
+      Pointee: 579 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 672
+      ID: 683
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 844544
       GoKind: 22
-      Pointee: 569 GoStringHeaderType compress/flate.InternalError
+      Pointee: 580 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 571
+      ID: 582
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType compress/flate.InternalError.str
+      Pointee: 581 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1043
+      ID: 1054
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1249728
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1055 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 989
+      ID: 1000
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 844640
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1001 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1065
+      ID: 1076
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1609952
       GoKind: 22
-      Pointee: 1066 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1077 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1228
+      ID: 1229
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1370400
       GoKind: 22
-      Pointee: 366 StructureType context.backgroundCtx
+      Pointee: 370 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 356
+      ID: 360
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1607456
       GoKind: 22
-      Pointee: 357 StructureType context.cancelCtx
+      Pointee: 361 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 872
+      ID: 883
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1110208
       GoKind: 22
-      Pointee: 873 StructureType context.deadlineExceededError
+      Pointee: 884 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1223
+      ID: 1224
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1238528
       GoKind: 22
-      Pointee: 367 StructureType context.emptyCtx
+      Pointee: 371 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 358
+      ID: 362
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1238688
       GoKind: 22
-      Pointee: 359 StructureType context.stopCtx
+      Pointee: 363 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 360
+      ID: 364
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1607648
       GoKind: 22
-      Pointee: 361 StructureType context.timerCtx
+      Pointee: 365 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1229
+      ID: 1230
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1370560
       GoKind: 22
-      Pointee: 381 StructureType context.todoCtx
+      Pointee: 382 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 362
+      ID: 366
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1370080
       GoKind: 22
-      Pointee: 363 StructureType context.valueCtx
+      Pointee: 367 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 364
+      ID: 368
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1370240
       GoKind: 22
-      Pointee: 365 StructureType context.withoutCancelCtx
+      Pointee: 369 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 753
+      ID: 764
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 856832
       GoKind: 22
-      Pointee: 582 BaseType crypto/aes.KeySizeError
+      Pointee: 593 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 754
+      ID: 765
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 857024
       GoKind: 22
-      Pointee: 583 BaseType crypto/des.KeySizeError
+      Pointee: 594 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 1055
+      ID: 1066
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1381280
       GoKind: 22
-      Pointee: 1056 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 1067 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 1080
+      ID: 1091
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1688352
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1092 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 755
+      ID: 766
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 857312
       GoKind: 22
-      Pointee: 584 BaseType crypto/rc4.KeySizeError
+      Pointee: 595 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1088
+      ID: 1099
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1780128
       GoKind: 22
-      Pointee: 1089 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1100 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1082
+      ID: 1093
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1689024
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 1094 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 1084
+      ID: 1095
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1689472
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 1096 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 677
+      ID: 688
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 846080
       GoKind: 22
-      Pointee: 572 BaseType crypto/tls.AlertError
+      Pointee: 583 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 844
+      ID: 855
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1009056
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 856 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1167
+      ID: 1178
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2241920
       GoKind: 22
-      Pointee: 1168 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1179 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 675
+      ID: 686
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 845888
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 687 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 673
+      ID: 684
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 845792
       GoKind: 22
-      Pointee: 674 StructureType crypto/tls.RecordHeaderError
+      Pointee: 685 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 843
+      ID: 854
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1007392
       GoKind: 22
-      Pointee: 800 BaseType crypto/tls.alert
+      Pointee: 811 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1053
+      ID: 1064
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1378400
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1065 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1060
+      ID: 1071
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1458560
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1072 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 939
+      ID: 950
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1250048
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 951 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 951
+      ID: 962
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1915808
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 963 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 747
+      ID: 758
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 855680
       GoKind: 22
-      Pointee: 748 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 759 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 741
+      ID: 752
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 855200
       GoKind: 22
-      Pointee: 742 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 753 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 743
+      ID: 754
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 855296
       GoKind: 22
-      Pointee: 744 StructureType crypto/x509.HostnameError
+      Pointee: 755 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 740
+      ID: 751
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 855104
       GoKind: 22
-      Pointee: 581 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 592 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 849
+      ID: 860
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1014944
       GoKind: 22
-      Pointee: 850 StructureType crypto/x509.SystemRootsError
+      Pointee: 861 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 749
+      ID: 760
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 855776
       GoKind: 22
-      Pointee: 750 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 761 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 745
+      ID: 756
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 855584
       GoKind: 22
-      Pointee: 746 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 757 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 764
+      ID: 775
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 862400
       GoKind: 22
-      Pointee: 765 StructureType encoding/asn1.StructuralError
+      Pointee: 776 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 768
+      ID: 779
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 862592
       GoKind: 22
-      Pointee: 769 StructureType encoding/asn1.SyntaxError
+      Pointee: 780 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 766
+      ID: 777
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 862496
       GoKind: 22
-      Pointee: 767 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 778 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 665
+      ID: 676
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 842144
       GoKind: 22
-      Pointee: 566 BaseType encoding/base64.CorruptInputError
+      Pointee: 577 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1011
+      ID: 1022
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1003552
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1023 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 668
+      ID: 679
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 843008
       GoKind: 22
-      Pointee: 567 BaseType encoding/hex.InvalidByteError
+      Pointee: 578 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 636
+      ID: 647
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 836864
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 648 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 835
+      ID: 846
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 999200
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 847 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 628
+      ID: 639
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 836480
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 640 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 634
+      ID: 645
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 836768
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 646 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 632
+      ID: 643
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 836672
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 644 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 630
+      ID: 641
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 836576
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 642 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1147
+      ID: 1158
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2158368
       GoKind: 22
-      Pointee: 1148 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1159 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 638
+      ID: 649
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 22
-      Pointee: 639 StructureType encoding/json.jsonError
+      Pointee: 650 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1019
+      ID: 1030
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1018016
       GoKind: 22
-      Pointee: 1020 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1031 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 735
+      ID: 746
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 854144
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 747 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 733
+      ID: 744
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 854048
       GoKind: 22
-      Pointee: 734 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 745 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 737
+      ID: 748
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 854240
       GoKind: 22
-      Pointee: 578 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 589 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 580
+      ID: 591
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 579 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 590 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 738
+      ID: 749
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 854336
       GoKind: 22
-      Pointee: 739 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 750 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1125
+      ID: 1136
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2028320
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1137 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -12265,19 +12388,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 606
+      ID: 617
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 827840
       GoKind: 22
-      Pointee: 607 UnresolvedPointeeType errors.errorString
+      Pointee: 618 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 802
+      ID: 813
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 984736
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType errors.joinError
+      Pointee: 814 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -12293,906 +12416,906 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 1135
+      ID: 1146
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2124096
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType fmt.pp
+      Pointee: 1147 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 804
+      ID: 815
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 984864
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType fmt.wrapError
+      Pointee: 816 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 806
+      ID: 817
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 984992
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 818 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 666
+      ID: 677
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 842528
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 678 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 647
+      ID: 658
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 839648
       GoKind: 22
-      Pointee: 648 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 659 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 649
+      ID: 660
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 839744
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 661 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 963
+      ID: 974
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 839456
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 975 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 653
+      ID: 664
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 840032
       GoKind: 22
-      Pointee: 654 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 665 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 965
+      ID: 976
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 839552
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 977 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 651
+      ID: 662
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 839840
       GoKind: 22
-      Pointee: 560 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 571 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 562
+      ID: 573
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 561 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 646
+      ID: 657
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 839360
       GoKind: 22
-      Pointee: 557 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 568 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 559
+      ID: 570
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 652
+      ID: 663
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 839936
       GoKind: 22
-      Pointee: 563 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 574 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 565
+      ID: 576
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1033
+      ID: 1044
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1128512
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1045 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1113
+      ID: 1124
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1930496
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1125 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 758
+      ID: 769
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 860864
       GoKind: 22
-      Pointee: 759 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 770 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 382
+      ID: 383
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2143040
       GoKind: 22
-      Pointee: 383 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 384 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 408
+      ID: 409
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1880416
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 403
+      ID: 404
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1110464
       GoKind: 22
-      Pointee: 404 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 405 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 406
+      ID: 407
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1110592
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 408 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1221
+      ID: 1222
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1111232
       GoKind: 22
-      Pointee: 1222 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1223 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 532
+      ID: 543
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1111360
       GoKind: 22
-      Pointee: 533 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 544 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 410
+      ID: 411
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2089920
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 907
+      ID: 918
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1131840
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 919 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1143
+      ID: 1154
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2134336
       GoKind: 22
-      Pointee: 1144 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1155 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1224
+      ID: 1225
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1243968
       GoKind: 22
-      Pointee: 1225 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 1226 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 684
+      ID: 695
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 849632
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 696 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 691
+      ID: 702
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 850688
       GoKind: 22
-      Pointee: 692 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 703 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 686
+      ID: 697
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 850400
       GoKind: 22
-      Pointee: 577 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 588 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 689
+      ID: 700
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 850592
       GoKind: 22
-      Pointee: 690 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 701 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 687
+      ID: 698
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 850496
       GoKind: 22
-      Pointee: 688 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 699 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 707
+      ID: 718
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 852608
       GoKind: 22
-      Pointee: 708 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 719 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 711
+      ID: 722
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 852800
       GoKind: 22
-      Pointee: 712 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 723 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 709
+      ID: 720
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 852704
       GoKind: 22
-      Pointee: 710 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 721 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 705
+      ID: 716
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 852512
       GoKind: 22
-      Pointee: 706 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 717 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 982
+      ID: 993
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 981 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 992 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 719
+      ID: 730
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 853184
       GoKind: 22
-      Pointee: 720 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 731 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 713
+      ID: 724
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 852896
       GoKind: 22
-      Pointee: 714 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 725 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 717
+      ID: 728
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 853088
       GoKind: 22
-      Pointee: 718 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 729 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 715
+      ID: 726
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 852992
       GoKind: 22
-      Pointee: 716 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 727 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 721
+      ID: 732
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 853280
       GoKind: 22
-      Pointee: 722 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 733 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 727
+      ID: 738
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 853568
       GoKind: 22
-      Pointee: 728 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 739 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 729
+      ID: 740
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 853664
       GoKind: 22
-      Pointee: 730 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 741 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 725
+      ID: 736
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 853472
       GoKind: 22
-      Pointee: 726 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 737 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 723
+      ID: 734
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 853376
       GoKind: 22
-      Pointee: 724 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 735 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 731
+      ID: 742
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 732 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 743 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 655
+      ID: 666
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 841184
       GoKind: 22
-      Pointee: 656 StructureType github.com/cihub/seelog.baseError
+      Pointee: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1072
+      ID: 1083
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1685440
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1084 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 657
+      ID: 668
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 841280
       GoKind: 22
-      Pointee: 658 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 669 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1051
+      ID: 1062
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1376800
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1063 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1007
+      ID: 1018
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1002528
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1019 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1041
+      ID: 1052
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1247648
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1053 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 661
+      ID: 672
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 841472
       GoKind: 22
-      Pointee: 662 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 673 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1103
+      ID: 1114
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1848288
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1115 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1118
+      ID: 1129
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2002976
       GoKind: 22
-      Pointee: 1115 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1126 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1117
+      ID: 1128
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2002592
       GoKind: 22
-      Pointee: 1116 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1127 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1009
+      ID: 1020
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1002656
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1021 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 659
+      ID: 670
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 841376
       GoKind: 22
-      Pointee: 660 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 671 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 663
+      ID: 674
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 841568
       GoKind: 22
-      Pointee: 664 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 675 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1076
+      ID: 1087
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1687008
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1088 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1109
+      ID: 1120
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1884736
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1121 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1111
+      ID: 1122
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1915488
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1123 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 941
+      ID: 952
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1261888
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 953 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 857
+      ID: 868
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1029408
       GoKind: 22
-      Pointee: 858 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 869 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 855
+      ID: 866
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1029280
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 867 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 859
+      ID: 870
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1033376
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 871 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 861
+      ID: 872
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1033504
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 873 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1062
+      ID: 1073
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1486592
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1074 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 851
+      ID: 862
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1015712
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 863 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 669
+      ID: 680
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 843200
       GoKind: 22
-      Pointee: 670 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 681 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1159
+      ID: 1170
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2221024
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1171 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 915
+      ID: 926
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1140800
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 927 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 884
+      ID: 895
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1119040
       GoKind: 22
-      Pointee: 885 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 896 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 878
+      ID: 889
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1118656
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 890 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 821
+      ID: 832
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 993312
       GoKind: 22
-      Pointee: 822 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 833 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 890
+      ID: 901
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1119424
       GoKind: 22
-      Pointee: 891 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 902 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 820
+      ID: 831
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 993184
       GoKind: 22
-      Pointee: 799 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 810 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 882
+      ID: 893
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1118912
       GoKind: 22
-      Pointee: 883 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 894 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 880
+      ID: 891
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1118784
       GoKind: 22
-      Pointee: 881 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 892 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 888
+      ID: 899
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1119296
       GoKind: 22
-      Pointee: 889 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 900 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 886
+      ID: 897
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1119168
       GoKind: 22
-      Pointee: 887 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 898 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1163
+      ID: 1174
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2232064
       GoKind: 22
-      Pointee: 1164 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1175 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 894
+      ID: 905
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1119808
       GoKind: 22
-      Pointee: 895 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 906 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 825
+      ID: 836
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 993568
       GoKind: 22
-      Pointee: 826 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 837 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 823
+      ID: 834
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 993440
       GoKind: 22
-      Pointee: 824 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 835 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 892
+      ID: 903
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1119680
       GoKind: 22
-      Pointee: 893 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 904 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 780
+      ID: 791
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 874496
       GoKind: 22
-      Pointee: 589 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 600 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 591
+      ID: 602
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 590 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 601 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 352
+      ID: 356
       Name: '*go.shape.float64'
       ByteSize: 8
       GoRuntimeType: 450464
       GoKind: 22
-      Pointee: 353 BaseType go.shape.float64
+      Pointee: 357 BaseType go.shape.float64
     - __kind: PointerType
-      ID: 328
+      ID: 332
       Name: '*go.shape.int'
       ByteSize: 8
       GoRuntimeType: 450080
       GoKind: 22
-      Pointee: 323 BaseType go.shape.int
+      Pointee: 327 BaseType go.shape.int
     - __kind: PointerType
-      ID: 345
+      ID: 349
       Name: '*go.shape.string'
       ByteSize: 8
       GoRuntimeType: 450144
       GoKind: 22
-      Pointee: 325 GoStringHeaderType go.shape.string
+      Pointee: 329 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 503
+      ID: 510
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 502 GoStringDataType go.shape.string.str
+      Pointee: 509 GoStringDataType go.shape.string.str
     - __kind: PointerType
-      ID: 331
+      ID: 335
       Name: '*go.shape.struct { Name string }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 332 StructureType go.shape.struct { Name string }
+      Pointee: 336 StructureType go.shape.struct { Name string }
     - __kind: PointerType
-      ID: 333
+      ID: 337
       Name: '*go.shape.struct { X int; Y int }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 334 StructureType go.shape.struct { X int; Y int }
+      Pointee: 338 StructureType go.shape.struct { X int; Y int }
     - __kind: PointerType
-      ID: 346
+      ID: 350
       Name: '*go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 347 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+      Pointee: 351 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 954
+      ID: 965
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1485056
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 966 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 865
+      ID: 876
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1048352
       GoKind: 22
-      Pointee: 866 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 877 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1039
+      ID: 1050
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1179840
       GoKind: 22
-      Pointee: 1040 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1051 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1123
+      ID: 1134
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2017952
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1135 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1025
+      ID: 1036
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1050656
       GoKind: 22
-      Pointee: 1026 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1037 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 781
+      ID: 792
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 875744
       GoKind: 22
-      Pointee: 592 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 603 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 923
+      ID: 934
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1181504
       GoKind: 22
-      Pointee: 924 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 935 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 784
+      ID: 795
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 876032
       GoKind: 22
-      Pointee: 785 StructureType golang.org/x/net/http2.connError
+      Pointee: 796 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 783
+      ID: 794
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 875936
       GoKind: 22
-      Pointee: 596 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 607 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 598
+      ID: 609
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 597 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 608 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 787
+      ID: 798
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 876224
       GoKind: 22
-      Pointee: 602 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 613 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 604
+      ID: 615
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 603 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 614 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 786
+      ID: 797
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 876128
       GoKind: 22
-      Pointee: 599 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 610 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 601
+      ID: 612
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 600 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 611 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 782
+      ID: 793
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 875840
       GoKind: 22
-      Pointee: 593 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 604 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 595
+      ID: 606
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 594 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 605 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1121
+      ID: 1132
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2016032
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1133 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 788
+      ID: 799
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 876320
       GoKind: 22
-      Pointee: 789 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 800 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 790
+      ID: 801
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 876416
       GoKind: 22
-      Pointee: 605 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 616 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 776
+      ID: 787
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 869888
       GoKind: 22
-      Pointee: 777 StructureType google.golang.org/grpc.dropError
+      Pointee: 788 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 921
+      ID: 932
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1178432
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 933 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 943
+      ID: 954
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1269248
       GoKind: 22
-      Pointee: 944 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 955 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 778
+      ID: 789
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 872768
       GoKind: 22
-      Pointee: 779 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 790 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1086
+      ID: 1097
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1693952
       GoKind: 22
-      Pointee: 1087 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1098 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1037
+      ID: 1048
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1174976
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1049 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 863
+      ID: 874
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1042592
       GoKind: 22
-      Pointee: 864 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 875 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 997
+      ID: 1008
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 872864
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1009 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 756
+      ID: 767
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 858752
       GoKind: 22
-      Pointee: 757 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 768 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 853
+      ID: 864
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1019424
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 865 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 919
+      ID: 930
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1146688
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 931 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 917
+      ID: 928
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1146432
       GoKind: 22
-      Pointee: 918 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 929 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 770
+      ID: 781
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 863456
       GoKind: 22
-      Pointee: 771 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 782 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 772
+      ID: 783
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 863552
       GoKind: 22
-      Pointee: 773 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 784 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 699
+      ID: 710
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 851072
       GoKind: 22
-      Pointee: 700 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 711 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1074
+      ID: 1085
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1686112
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1086 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 226
       Name: '*hash<[4]int,[4]int>'
@@ -13214,40 +13337,40 @@ Types:
       ByteSize: 8
       Pointee: 202 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 371
+      ID: 375
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 372 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 376 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
       ID: 140
       Name: '*hash<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 141 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1212
+      ID: 1213
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1213 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1214 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1250
+      ID: 1251
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1251 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1252 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1259
+      ID: 1260
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1260 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1261 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 169
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 170 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 1268
+      ID: 1269
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 1269 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1270 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 236
       Name: '*hash<int,struct {}>'
@@ -13259,10 +13382,10 @@ Types:
       ByteSize: 8
       Pointee: 207 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 522
+      ID: 529
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 523 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 530 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 196
       Name: '*hash<string,[]main.structWithMap>'
@@ -13274,35 +13397,35 @@ Types:
       ByteSize: 8
       Pointee: 185 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 399 GoHMapHeaderType hash<string,float64>
+      Pointee: 400 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 947
+      ID: 958
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 948 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 959 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 179
       Name: '*hash<string,int>'
       ByteSize: 8
       Pointee: 180 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 393
+      ID: 394
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 394 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 395 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
       ID: 174
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 175 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 388
+      ID: 389
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 389 GoHMapHeaderType hash<string,string>
+      Pointee: 390 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 231
       Name: '*hash<struct {},int>'
@@ -13354,12 +13477,12 @@ Types:
       ByteSize: 8
       Pointee: 212 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 791
+      ID: 802
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 877184
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType html/template.Error
+      Pointee: 803 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 96
       Name: '*int'
@@ -13403,94 +13526,94 @@ Types:
       GoKind: 22
       Pointee: 159 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 751
+      ID: 762
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 856352
       GoKind: 22
-      Pointee: 752 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 763 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 987
+      ID: 998
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 843584
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 999 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 913
+      ID: 924
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1132992
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 925 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1165
+      ID: 1176
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2236736
       GoKind: 22
-      Pointee: 1166 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1177 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 911
+      ID: 922
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1132864
       GoKind: 22
-      Pointee: 912 StructureType internal/poll.errNetClosing
+      Pointee: 923 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 611
+      ID: 622
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 831968
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 623 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1029
+      ID: 1040
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1109952
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1041 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1027
+      ID: 1038
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1109568
       GoKind: 22
-      Pointee: 1028 StructureType io.discard
+      Pointee: 1039 StructureType io.discard
     - __kind: PointerType
-      ID: 1001
+      ID: 1012
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 985760
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType io.multiWriter
+      Pointee: 1013 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 909
+      ID: 920
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1132608
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType io/fs.PathError
+      Pointee: 921 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1078
+      ID: 1089
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1687232
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1090 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 338
+      ID: 342
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 339 StructureType main.Pair[go.shape.int,go.shape.bool]
+      Pointee: 343 StructureType main.Pair[go.shape.int,go.shape.bool]
     - __kind: PointerType
-      ID: 341
+      ID: 345
       Name: '*main.Pair[go.shape.string,go.shape.int]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 342 StructureType main.Pair[go.shape.string,go.shape.int]
+      Pointee: 346 StructureType main.Pair[go.shape.string,go.shape.int]
     - __kind: PointerType
       ID: 318
       Name: '*main.anotherStruct'
@@ -13498,19 +13621,19 @@ Types:
       GoKind: 22
       Pointee: 319 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 427
+      ID: 428
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 358048
       GoKind: 22
-      Pointee: 428 StructureType main.deepMap2
+      Pointee: 429 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1217
+      ID: 1218
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 357984
       GoKind: 22
-      Pointee: 1218 UnresolvedPointeeType main.deepMap3
+      Pointee: 1219 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 146
       Name: '*main.deepMap7'
@@ -13519,19 +13642,19 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1255
+      ID: 1256
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 357664
       GoKind: 22
-      Pointee: 1256 StructureType main.deepMap8
+      Pointee: 1257 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1264
+      ID: 1265
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 357600
       GoKind: 22
-      Pointee: 1265 StructureType main.deepMap9
+      Pointee: 1266 StructureType main.deepMap9
     - __kind: PointerType
       ID: 128
       Name: '*main.deepPtr2'
@@ -13540,12 +13663,12 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1169
+      ID: 1180
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 358560
       GoKind: 22
-      Pointee: 1170 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1181 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 130
       Name: '*main.deepPtr7'
@@ -13554,33 +13677,33 @@ Types:
       GoKind: 22
       Pointee: 131 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1230
+      ID: 1231
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 358240
       GoKind: 22
-      Pointee: 1231 StructureType main.deepPtr8
+      Pointee: 1232 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1232
+      ID: 1233
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 358176
       GoKind: 22
-      Pointee: 1233 StructureType main.deepPtr9
+      Pointee: 1234 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 135
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 359200
       GoKind: 22
-      Pointee: 421 StructureType main.deepSlice2
+      Pointee: 422 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1207
+      ID: 1208
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 359136
       GoKind: 22
-      Pointee: 1208 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1209 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 136
       Name: '*main.deepSlice7'
@@ -13589,19 +13712,19 @@ Types:
       GoKind: 22
       Pointee: 137 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1236
+      ID: 1237
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 358816
       GoKind: 22
-      Pointee: 1237 StructureType main.deepSlice8
+      Pointee: 1238 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1242
+      ID: 1243
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 358752
       GoKind: 22
-      Pointee: 1243 StructureType main.deepSlice9
+      Pointee: 1244 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 322
       Name: '*main.emptyStruct'
@@ -13616,14 +13739,14 @@ Types:
       GoKind: 22
       Pointee: 162 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1183
+      ID: 1194
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 827552
       GoKind: 22
-      Pointee: 355 StructureType main.firstBehavior
+      Pointee: 359 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1273
+      ID: 1274
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 359584
@@ -13649,19 +13772,19 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1184
+      ID: 1195
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 827648
       GoKind: 22
-      Pointee: 1185 StructureType main.secondBehavior
+      Pointee: 1196 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1175
+      ID: 1186
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 827744
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1187 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 148
       Name: '*main.stringType1'
@@ -13669,28 +13792,28 @@ Types:
       GoKind: 22
       Pointee: 149 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1172
+      ID: 1183
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1171 GoStringDataType main.stringType1.str
+      Pointee: 1182 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1173 GoStringHeaderType main.stringType2
+      Pointee: 1184 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1275
+      ID: 1276
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1274 GoStringDataType main.stringType2.str
+      Pointee: 1275 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 275
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 273 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 446
+      ID: 447
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 357536
@@ -13714,10 +13837,10 @@ Types:
       GoKind: 22
       Pointee: 251 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1188
+      ID: 1199
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1187 GoSliceDataType main.t.array
+      Pointee: 1198 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 270
       Name: '*main.threeStringStruct'
@@ -13731,561 +13854,561 @@ Types:
       GoKind: 22
       Pointee: 178 GoMapType map[string]int
     - __kind: PointerType
-      ID: 703
+      ID: 714
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 851936
       GoKind: 22
-      Pointee: 704 StructureType math/big.ErrNaN
+      Pointee: 715 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 991
+      ID: 1002
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 846560
       GoKind: 22
-      Pointee: 992 StructureType mime/multipart.writerOnly·1
+      Pointee: 1003 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 901
+      ID: 912
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1126080
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType net.AddrError
+      Pointee: 913 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 932
+      ID: 943
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1245888
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType net.DNSError
+      Pointee: 944 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1129
+      ID: 1140
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2096288
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType net.IPConn
+      Pointee: 1141 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 930
+      ID: 941
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1245568
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType net.OpError
+      Pointee: 942 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 903
+      ID: 914
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1126208
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType net.ParseError
+      Pointee: 915 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1139
+      ID: 1150
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2126144
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType net.TCPConn
+      Pointee: 1151 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1149
+      ID: 1160
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2171104
       GoKind: 22
-      Pointee: 1150 UnresolvedPointeeType net.UDPConn
+      Pointee: 1161 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1137
+      ID: 1148
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2125632
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType net.UnixConn
+      Pointee: 1149 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 900
+      ID: 911
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1125312
       GoKind: 22
-      Pointee: 869 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 880 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 871
+      ID: 882
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 870 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 881 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 837
+      ID: 848
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 999968
       GoKind: 22
-      Pointee: 838 StructureType net.canceledError
+      Pointee: 849 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1107
+      ID: 1118
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1882432
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType net.conn
+      Pointee: 1119 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 972
+      ID: 983
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1725760
       GoKind: 22
-      Pointee: 973 StructureType net.dialResult·1
+      Pointee: 984 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1151
+      ID: 1162
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2175360
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType net.netFD
+      Pointee: 1163 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 640
+      ID: 651
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 838208
       GoKind: 22
-      Pointee: 641 UnresolvedPointeeType net.notFoundError
+      Pointee: 652 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1226
+      ID: 1227
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1245728
       GoKind: 22
-      Pointee: 1227 StructureType net.onlyValuesCtx
+      Pointee: 1228 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 642
+      ID: 653
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 838880
       GoKind: 22
-      Pointee: 643 StructureType net.result·2
+      Pointee: 654 StructureType net.result·2
     - __kind: PointerType
-      ID: 1133
+      ID: 1144
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2110176
       GoKind: 22
-      Pointee: 1134 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1145 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1131
+      ID: 1142
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2109696
       GoKind: 22
-      Pointee: 1132 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1143 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 905
+      ID: 916
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1126848
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType net.temporaryError
+      Pointee: 917 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 934
+      ID: 945
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1246048
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType net.timeoutError
+      Pointee: 946 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 827
+      ID: 838
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 996000
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 839 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 983
+      ID: 994
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 834080
       GoKind: 22
-      Pointee: 984 StructureType net/http.bufioFlushWriter
+      Pointee: 995 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 617
+      ID: 628
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 834752
       GoKind: 22
-      Pointee: 538 BaseType net/http.http2ConnectionError
+      Pointee: 549 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 618
+      ID: 629
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 834848
       GoKind: 22
-      Pointee: 619 StructureType net/http.http2GoAwayError
+      Pointee: 630 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 926
+      ID: 937
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1242048
       GoKind: 22
-      Pointee: 927 StructureType net/http.http2StreamError
+      Pointee: 938 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 622
+      ID: 633
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 835328
       GoKind: 22
-      Pointee: 623 StructureType net/http.http2connError
+      Pointee: 634 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1047
+      ID: 1058
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1374080
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1059 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 621
+      ID: 632
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 835232
       GoKind: 22
-      Pointee: 542 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 553 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 544
+      ID: 555
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 543 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 625
+      ID: 636
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 835520
       GoKind: 22
-      Pointee: 548 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 559 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 550
+      ID: 561
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 549 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 560 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 624
+      ID: 635
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 22
-      Pointee: 545 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 556 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 547
+      ID: 558
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 546 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 557 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 898
+      ID: 909
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1121984
       GoKind: 22
-      Pointee: 899 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 910 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 833
+      ID: 844
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 996640
       GoKind: 22
-      Pointee: 834 StructureType net/http.http2noCachedConnError
+      Pointee: 845 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1098
+      ID: 1109
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1826176
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1110 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 620
+      ID: 631
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 835136
       GoKind: 22
-      Pointee: 539 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 550 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 541
+      ID: 552
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 540 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 551 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 985
+      ID: 996
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 835616
       GoKind: 22
-      Pointee: 986 StructureType net/http.http2stickyErrWriter
+      Pointee: 997 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 829
+      ID: 840
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 996256
       GoKind: 22
-      Pointee: 830 StructureType net/http.nothingWrittenError
+      Pointee: 841 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1049
+      ID: 1060
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2041088
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1061 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1005
+      ID: 1016
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 996128
       GoKind: 22
-      Pointee: 1006 StructureType net/http.persistConnWriter
+      Pointee: 1017 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1031
+      ID: 1042
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1120960
       GoKind: 22
-      Pointee: 1032 StructureType net/http.readWriteCloserBody
+      Pointee: 1043 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 626
+      ID: 637
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 835712
       GoKind: 22
-      Pointee: 627 StructureType net/http.requestBodyReadError
+      Pointee: 638 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 928
+      ID: 939
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1243168
       GoKind: 22
-      Pointee: 929 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 940 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 896
+      ID: 907
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1121856
       GoKind: 22
-      Pointee: 897 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 908 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 831
+      ID: 842
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 996384
       GoKind: 22
-      Pointee: 832 StructureType net/http.transportReadFromServerError
+      Pointee: 843 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 615
+      ID: 626
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 833984
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 627 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1100
+      ID: 1111
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1827968
       GoKind: 22
-      Pointee: 1101 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1112 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1015
+      ID: 1026
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1010080
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1027 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 695
+      ID: 706
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 850880
       GoKind: 22
-      Pointee: 696 StructureType net/netip.parseAddrError
+      Pointee: 707 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 693
+      ID: 704
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 850784
       GoKind: 22
-      Pointee: 694 StructureType net/netip.parsePrefixError
+      Pointee: 705 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1057
+      ID: 1068
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1990752
       GoKind: 22
-      Pointee: 1058 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1069 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1017
+      ID: 1028
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1015200
       GoKind: 22
-      Pointee: 1018 StructureType net/smtp.dataCloser
+      Pointee: 1029 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 679
+      ID: 690
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 846752
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType net/textproto.Error
+      Pointee: 691 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 678
+      ID: 689
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 846656
       GoKind: 22
-      Pointee: 573 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 584 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 575
+      ID: 586
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 574 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 585 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1013
+      ID: 1024
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1009440
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1025 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 936
+      ID: 947
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1246368
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net/url.Error
+      Pointee: 948 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 644
+      ID: 655
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 838976
       GoKind: 22
-      Pointee: 551 GoStringHeaderType net/url.EscapeError
+      Pointee: 562 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 553
+      ID: 564
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 552 GoStringDataType net/url.EscapeError.str
+      Pointee: 563 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 645
+      ID: 656
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 839072
       GoKind: 22
-      Pointee: 554 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 565 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 556
+      ID: 567
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 555 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 566 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 1157
+      ID: 1168
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2212608
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType os.File
+      Pointee: 1169 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 810
+      ID: 821
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 989600
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType os.LinkError
+      Pointee: 822 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 874
+      ID: 885
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1114560
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType os.SyscallError
+      Pointee: 886 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1155
+      ID: 1166
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2209664
       GoKind: 22
-      Pointee: 1156 StructureType os.fileWithoutReadFrom
+      Pointee: 1167 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1153
+      ID: 1164
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2208928
       GoKind: 22
-      Pointee: 1154 StructureType os.fileWithoutWriteTo
+      Pointee: 1165 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 839
+      ID: 850
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1006112
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType os/exec.Error
+      Pointee: 851 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 975
+      ID: 986
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1962016
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 987 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1035
+      ID: 1046
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1133632
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1047 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 841
+      ID: 852
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1006240
       GoKind: 22
-      Pointee: 842 StructureType os/exec.wrappedError
+      Pointee: 853 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 775
+      ID: 786
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 867968
       GoKind: 22
-      Pointee: 586 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 597 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 588
+      ID: 599
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 587 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 598 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 774
+      ID: 785
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 867872
       GoKind: 22
-      Pointee: 585 BaseType os/user.UnknownUserIdError
+      Pointee: 596 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 613
+      ID: 624
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 832736
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType reflect.ValueError
+      Pointee: 625 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 701
+      ID: 712
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 851552
       GoKind: 22
-      Pointee: 702 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 713 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 813
+      ID: 824
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 990496
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 825 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 818
+      ID: 829
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 992416
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 830 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14301,12 +14424,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 815
+      ID: 826
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 990624
       GoKind: 22
-      Pointee: 816 StructureType runtime.boundsError
+      Pointee: 827 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -14322,24 +14445,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 876
+      ID: 887
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1116864
       GoKind: 22
-      Pointee: 877 StructureType runtime.errorAddressString
+      Pointee: 888 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 812
+      ID: 823
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 990240
       GoKind: 22
-      Pointee: 793 GoStringHeaderType runtime.errorString
+      Pointee: 804 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 795
+      ID: 806
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 794 GoStringDataType runtime.errorString.str
+      Pointee: 805 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -14362,17 +14485,17 @@ Types:
       GoKind: 22
       Pointee: 145 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 817
+      ID: 828
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 992160
       GoKind: 22
-      Pointee: 796 GoStringHeaderType runtime.plainError
+      Pointee: 807 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 798
+      ID: 809
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 797 GoStringDataType runtime.plainError.str
+      Pointee: 808 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14395,12 +14518,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 808
+      ID: 819
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 988448
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType strconv.NumError
+      Pointee: 820 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -14409,104 +14532,104 @@ Types:
       GoKind: 22
       Pointee: 13 GoStringHeaderType string
     - __kind: PointerType
-      ID: 414
+      ID: 415
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 413 GoStringDataType string.str
+      Pointee: 414 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1094
+      ID: 1105
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1824640
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType strings.Builder
+      Pointee: 1106 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1003
+      ID: 1014
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 988576
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1015 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 999
+      ID: 1010
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 924832
       GoKind: 22
-      Pointee: 1000 StructureType struct { io.Writer }
+      Pointee: 1011 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 268
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 120 StructureType struct {}
     - __kind: PointerType
-      ID: 938
+      ID: 949
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1248608
       GoKind: 22
-      Pointee: 925 BaseType syscall.Errno
+      Pointee: 936 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 1127
+      ID: 1138
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2028704
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1139 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 867
+      ID: 878
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1052192
       GoKind: 22
-      Pointee: 868 StructureType text/template.ExecError
+      Pointee: 879 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 379
+      ID: 324
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1433984
       GoKind: 22
-      Pointee: 380 StructureType time.Location
+      Pointee: 325 StructureType time.Location
     - __kind: PointerType
-      ID: 609
+      ID: 620
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 830240
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType time.ParseError
+      Pointee: 621 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 376
+      ID: 380
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 989984
       GoKind: 22
-      Pointee: 377 StructureType time.Timer
+      Pointee: 381 StructureType time.Timer
     - __kind: PointerType
-      ID: 608
+      ID: 619
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 830144
       GoKind: 22
-      Pointee: 535 GoStringHeaderType time.fileSizeError
+      Pointee: 546 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 537
+      ID: 548
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType time.fileSizeError.str
+      Pointee: 547 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 1191
+      ID: 504
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 364896
       GoKind: 22
-      Pointee: 1192 StructureType time.zone
+      Pointee: 505 StructureType time.zone
     - __kind: PointerType
-      ID: 1194
+      ID: 507
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 364960
       GoKind: 22
-      Pointee: 1195 StructureType time.zoneTrans
+      Pointee: 508 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -14550,56 +14673,56 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 1090
+      ID: 1101
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1781408
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 1102 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 697
+      ID: 708
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 850976
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 709 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1119
+      ID: 1130
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2005280
       GoKind: 22
-      Pointee: 1120 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1131 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 681
+      ID: 692
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 847136
       GoKind: 22
-      Pointee: 682 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 693 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 683
+      ID: 694
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 847232
       GoKind: 22
-      Pointee: 576 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 587 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 846
+      ID: 857
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1009824
       GoKind: 22
-      Pointee: 847 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 858 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 848
+      ID: 859
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1009952
       GoKind: 22
-      Pointee: 801 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 812 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1189
+      ID: 1200
       Name: <-chan time.Time
       GoRuntimeType: 547008
       GoKind: 18
@@ -14612,7 +14735,7 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 1548
+      ID: 1552
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14628,10 +14751,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 351 GoSliceHeaderType []go.shape.float64
+            Type: 355 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14641,10 +14764,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 351 GoSliceHeaderType []go.shape.float64
+            Type: 355 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14654,17 +14777,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 354 GoSubroutineType func(go.shape.float64) bool
+            Type: 358 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 1, name: pred}
+                  Variable: {subprogram: 191, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1553
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14674,17 +14797,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 351 GoSliceHeaderType []go.shape.float64
+            Type: 355 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 2, name: ~r0}
+                  Variable: {subprogram: 191, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1546
+      ID: 1550
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14700,10 +14823,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14713,10 +14836,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14726,17 +14849,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 329 GoSubroutineType func(go.shape.int) bool
+            Type: 333 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: pred}
+                  Variable: {subprogram: 172, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1551
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14746,20 +14869,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 2, name: ~r0}
+                  Variable: {subprogram: 172, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1604
+      ID: 1608
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1550
+      ID: 1554
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14775,10 +14898,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14788,10 +14911,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14801,17 +14924,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 330 GoSubroutineType func(go.shape.int) go.shape.string
+            Type: 334 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: f}
+                  Variable: {subprogram: 173, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1555
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14821,17 +14944,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 2, name: ~r0}
+                  Variable: {subprogram: 173, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1562
+      ID: 1566
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14850,10 +14973,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14863,10 +14986,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 338 PointerType *main.Pair[go.shape.int,go.shape.bool]
+            Type: 342 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: x}
+                  Variable: {subprogram: 179, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14876,10 +14999,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14889,20 +15012,20 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 340 BaseType go.shape.bool
+            Type: 344 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 2, name: v}
+                  Variable: {subprogram: 179, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1563
+      ID: 1567
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1564
+      ID: 1568
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14921,10 +15044,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -14934,10 +15057,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 341 PointerType *main.Pair[go.shape.string,go.shape.int]
+            Type: 345 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: x}
+                  Variable: {subprogram: 180, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -14947,10 +15070,10 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -14960,20 +15083,20 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 2, name: v}
+                  Variable: {subprogram: 180, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1565
+      ID: 1569
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1602
+      ID: 1606
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14982,17 +15105,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 355 StructureType main.firstBehavior
+            Type: 359 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 0, name: b}
+                  Variable: {subprogram: 198, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1607
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15004,14 +15127,14 @@ Types:
             Type: 13 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 1, name: ~r0}
+                  Variable: {subprogram: 198, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1582
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15027,10 +15150,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15040,10 +15163,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15053,17 +15176,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1586
       Name: Probe[main.genericContains[go.shape.int]]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15079,10 +15202,10 @@ Types:
           Offset: 17
           Kind: local
           Expression:
-            Type: 327 GoSliceHeaderType []go.shape.int
+            Type: 331 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15092,17 +15215,17 @@ Types:
           Offset: 41
           Kind: local
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1583
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15114,14 +15237,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 187, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1584
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15137,10 +15260,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15150,10 +15273,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 348 GoSliceHeaderType []go.shape.string
+            Type: 352 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: haystack}
+                  Variable: {subprogram: 188, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15163,17 +15286,17 @@ Types:
           Offset: 57
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1587
       Name: Probe[main.genericContains[go.shape.string]]Line
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15183,17 +15306,17 @@ Types:
           Offset: 9
           Kind: local
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1585
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15205,14 +15328,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 2, name: ~r0}
+                  Variable: {subprogram: 188, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1578
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15222,10 +15345,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 345 PointerType *go.shape.string
+            Type: 349 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15235,17 +15358,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 345 PointerType *go.shape.string
+            Type: 349 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1575
+      ID: 1579
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15255,17 +15378,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: ~r0}
+                  Variable: {subprogram: 185, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1580
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15275,10 +15398,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 346 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 350 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15288,17 +15411,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 346 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 350 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1577
+      ID: 1581
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15308,17 +15431,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 347 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 351 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: ~r0}
+                  Variable: {subprogram: 186, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1574
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15328,10 +15451,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 343 StructureType go.shape.struct { main.i int }
+            Type: 347 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15341,17 +15464,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 343 StructureType go.shape.struct { main.i int }
+            Type: 347 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1575
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15363,14 +15486,14 @@ Types:
             Type: 13 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: ~r0}
+                  Variable: {subprogram: 183, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1576
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15380,10 +15503,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 344 StructureType go.shape.struct { main.s string }
+            Type: 348 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15393,17 +15516,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 344 StructureType go.shape.struct { main.s string }
+            Type: 348 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1577
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15415,14 +15538,14 @@ Types:
             Type: 13 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: ~r0}
+                  Variable: {subprogram: 184, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1552
+      ID: 1556
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15432,10 +15555,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 328 PointerType *go.shape.int
+            Type: 332 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15445,17 +15568,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 328 PointerType *go.shape.int
+            Type: 332 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1553
+      ID: 1557
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15465,17 +15588,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 PointerType *go.shape.int
+            Type: 332 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 174, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1554
+      ID: 1558
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15485,10 +15608,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 331 PointerType *go.shape.struct { Name string }
+            Type: 335 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15498,17 +15621,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 331 PointerType *go.shape.struct { Name string }
+            Type: 335 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1555
+      ID: 1559
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15518,17 +15641,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 331 PointerType *go.shape.struct { Name string }
+            Type: 335 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: ~r0}
+                  Variable: {subprogram: 175, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1556
+      ID: 1560
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15538,10 +15661,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 333 PointerType *go.shape.struct { X int; Y int }
+            Type: 337 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15551,17 +15674,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 333 PointerType *go.shape.struct { X int; Y int }
+            Type: 337 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1557
+      ID: 1561
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15571,17 +15694,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 333 PointerType *go.shape.struct { X int; Y int }
+            Type: 337 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: ~r0}
+                  Variable: {subprogram: 176, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1572
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15597,10 +15720,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15610,10 +15733,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15623,17 +15746,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: b}
+                  Variable: {subprogram: 182, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1573
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15649,10 +15772,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15662,17 +15785,17 @@ Types:
           Offset: 33
           Kind: return
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 3, name: ~r1}
+                  Variable: {subprogram: 182, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1566
+      ID: 1570
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15688,10 +15811,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15701,10 +15824,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15714,17 +15837,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 340 BaseType go.shape.bool
+            Type: 344 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: b}
+                  Variable: {subprogram: 181, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1571
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15740,10 +15863,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 340 BaseType go.shape.bool
+            Type: 344 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
@@ -15753,17 +15876,17 @@ Types:
           Offset: 18
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 3, name: ~r1}
+                  Variable: {subprogram: 181, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1560
+      ID: 1564
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15773,10 +15896,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 337 StructureType main.largeGenericType[go.shape.int]
+            Type: 341 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
@@ -15786,17 +15909,17 @@ Types:
           Offset: 145
           Kind: argument
           Expression:
-            Type: 337 StructureType main.largeGenericType[go.shape.int]
+            Type: 341 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1561
+      ID: 1565
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15806,17 +15929,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: ~r0}
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1562
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15826,10 +15949,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 335 StructureType main.largeGenericType[go.shape.string]
+            Type: 339 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
@@ -15839,17 +15962,17 @@ Types:
           Offset: 153
           Kind: argument
           Expression:
-            Type: 335 StructureType main.largeGenericType[go.shape.string]
+            Type: 339 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1559
+      ID: 1563
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15859,17 +15982,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: ~r0}
+                  Variable: {subprogram: 177, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1546
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15879,10 +16002,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15892,17 +16015,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1543
+      ID: 1547
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15912,17 +16035,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1548
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15932,10 +16055,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15945,17 +16068,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1545
+      ID: 1549
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15965,20 +16088,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15997,7 +16120,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1350
+      ID: 1351
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16029,7 +16152,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1351
+      ID: 1352
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16048,7 +16171,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1347
+      ID: 1348
       Name: Probe[main.testAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16080,7 +16203,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1348
+      ID: 1349
       Name: Probe[main.testAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16099,7 +16222,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1479
+      ID: 1480
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16131,7 +16254,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1480
+      ID: 1481
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16150,7 +16273,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1294
+      ID: 1295
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16182,7 +16305,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1292
+      ID: 1293
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -16214,7 +16337,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1290
+      ID: 1291
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16246,7 +16369,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1359
+      ID: 1360
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16278,7 +16401,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1291
+      ID: 1292
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16310,7 +16433,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1293
+      ID: 1294
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16342,7 +16465,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16374,7 +16497,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -16393,7 +16516,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1312
+      ID: 1313
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16425,10 +16548,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1313
+      ID: 1314
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1279
+      ID: 1280
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16460,7 +16583,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1276
+      ID: 1277
       Name: Probe[main.testByteArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16492,7 +16615,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1383
+      ID: 1384
       Name: Probe[main.testChannel]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16524,7 +16647,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testCombinedByte]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16582,7 +16705,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1378
+      ID: 1379
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       ExprStatusArraySize: 1
@@ -16614,7 +16737,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1379
+      ID: 1380
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -16659,7 +16782,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.testConflictingReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16691,7 +16814,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.testConflictingReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16723,7 +16846,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1391
+      ID: 1392
       Name: Probe[main.testCycle]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16755,7 +16878,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1319
+      ID: 1320
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16787,7 +16910,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1320
+      ID: 1321
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16819,7 +16942,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1315
+      ID: 1316
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16851,7 +16974,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1316
+      ID: 1317
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16883,7 +17006,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1317
+      ID: 1318
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16915,7 +17038,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1318
+      ID: 1319
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16947,7 +17070,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -17005,7 +17128,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17037,7 +17160,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17069,7 +17192,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17101,7 +17224,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -17133,7 +17256,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1314
+      ID: 1315
       Name: Probe[main.testErrorAtLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17191,7 +17314,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1349
+      ID: 1350
       Name: Probe[main.testError]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17223,7 +17346,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1331
+      ID: 1332
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17255,10 +17378,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1332
+      ID: 1333
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1329
+      ID: 1330
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -17290,10 +17413,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1330
+      ID: 1331
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1343
+      ID: 1344
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17325,7 +17448,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1345
+      ID: 1346
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17357,7 +17480,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1344
+      ID: 1345
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17376,7 +17499,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1341
+      ID: 1342
       Name: Probe[main.testFrameless]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17408,7 +17531,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1342
+      ID: 1343
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17427,7 +17550,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1333
+      ID: 1334
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17459,10 +17582,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1334
+      ID: 1335
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1337
+      ID: 1338
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17494,13 +17617,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1338
+      ID: 1339
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1594
+      ID: 1598
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1335
+      ID: 1336
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17558,28 +17681,28 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1336
+      ID: 1337
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1595
+      ID: 1599
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1596
+      ID: 1600
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1597
+      ID: 1601
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1598
+      ID: 1602
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1339
+      ID: 1340
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1340
+      ID: 1341
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1591
+      ID: 1595
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17591,7 +17714,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17604,14 +17727,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
+      ID: 1592
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17623,14 +17746,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1589
+      ID: 1593
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17642,14 +17765,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1594
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17661,7 +17784,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17674,14 +17797,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1597
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17693,7 +17816,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17706,17 +17829,17 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1596
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1599
+      ID: 1603
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17728,7 +17851,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17741,14 +17864,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1604
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17760,7 +17883,7 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17773,14 +17896,14 @@ Types:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1605
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17792,7 +17915,7 @@ Types:
             Type: 163 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
@@ -17805,14 +17928,14 @@ Types:
             Type: 163 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1282
+      ID: 1283
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17844,7 +17967,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1283
+      ID: 1284
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17876,7 +17999,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1284
+      ID: 1285
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17908,7 +18031,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1281
+      ID: 1282
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -17940,7 +18063,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1280
+      ID: 1281
       Name: Probe[main.testIntArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17972,7 +18095,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1346
+      ID: 1347
       Name: Probe[main.testInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18004,7 +18127,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -18036,7 +18159,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1478
+      ID: 1479
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18055,7 +18178,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18087,40 +18210,8 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1323
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1324
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
     - __kind: EventRootType
       ID: 1325
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -18154,7 +18245,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1483
+      ID: 1326
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -18394,7 +18517,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18413,7 +18536,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1327
+      ID: 1328
       Name: Probe[main.testManyPointers]
       ByteSize: 1121
       ExprStatusArraySize: 1
@@ -18445,7 +18568,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1328
+      ID: 1329
       Name: Probe[main.testManyStrings]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -18477,7 +18600,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1357
+      ID: 1358
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18509,7 +18632,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18541,7 +18664,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18573,7 +18696,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18605,7 +18728,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1375
+      ID: 1376
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18637,7 +18760,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1361
+      ID: 1362
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18669,7 +18792,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18701,7 +18824,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18727,38 +18850,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1362
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 195 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 195 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18797,7 +18888,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1371
+      ID: 1364
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 195 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 195 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1372
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18829,7 +18952,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1370
+      ID: 1371
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18861,7 +18984,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1355
+      ID: 1356
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18893,7 +19016,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1356
+      ID: 1357
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18925,7 +19048,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1354
+      ID: 1355
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18957,7 +19080,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18989,7 +19112,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1369
+      ID: 1370
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19021,7 +19144,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19053,7 +19176,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19085,7 +19208,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19113,38 +19236,6 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1519
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 13 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 13 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -19181,7 +19272,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1485
+      ID: 1521
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 13 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 13 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -19421,7 +19544,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19440,7 +19563,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19498,7 +19621,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19530,7 +19653,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -19588,7 +19711,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19607,7 +19730,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19627,6 +19750,143 @@ Types:
           DictIndex: -1
         - Name: i
           Offset: 9
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1425
+      Name: Probe[main.testMultipleNamedReturn]
+    - __kind: EventRootType
+      ID: 1427
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1429
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1431
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
           Kind: argument
           Expression:
             Type: 11 BaseType int
@@ -19640,21 +19900,63 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1424
-      Name: Probe[main.testMultipleNamedReturn]
-    - __kind: EventRootType
-      ID: 1426
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
-          Kind: argument
+          Kind: return
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: return
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1426
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19662,57 +19964,57 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1428
-      Name: Probe[main.testMultipleNamedReturn]
+      Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result
           Offset: 17
-          Kind: template_segment
+          Kind: return
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 25
-          Kind: argument
+          Kind: return
           Expression:
             Type: 11 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19720,185 +20022,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1430
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1432
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1423
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: return
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1425
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: capture_expression
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1427
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result
-          Offset: 17
-          Kind: return
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 25
-          Kind: return
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1429
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -19982,7 +20105,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1431
+      ID: 1432
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20014,7 +20137,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20046,7 +20169,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20091,7 +20214,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1380
+      ID: 1381
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 63
       ExprStatusArraySize: 3
@@ -20227,7 +20350,42 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1419
+      Name: Probe[main.testNamedReturn]
+    - __kind: EventRootType
+      ID: 1421
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20260,41 +20418,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1418
-      Name: Probe[main.testNamedReturn]
-    - __kind: EventRootType
-      ID: 1420
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: i
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1417
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20313,7 +20436,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20332,7 +20455,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20364,7 +20487,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20396,7 +20519,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20423,10 +20546,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20453,7 +20576,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20511,7 +20634,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -20569,7 +20692,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -20653,7 +20776,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1503
+      ID: 1504
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -20685,7 +20808,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20717,7 +20840,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1386
+      ID: 1387
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20749,7 +20872,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1360
+      ID: 1361
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20781,7 +20904,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20813,7 +20936,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1410
+      ID: 1411
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       ExprStatusArraySize: 1
@@ -20871,7 +20994,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1411
+      ID: 1412
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20903,7 +21026,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1412
+      ID: 1413
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20935,7 +21058,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20954,10 +21077,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20976,10 +21099,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -20998,10 +21121,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21020,10 +21143,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1463
+      ID: 1464
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -21146,10 +21269,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -21181,10 +21304,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1451
+      ID: 1452
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21216,7 +21339,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1408
+      ID: 1409
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -21248,7 +21371,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1409
+      ID: 1410
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21267,7 +21390,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21286,7 +21409,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21305,7 +21428,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1406
+      ID: 1407
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21337,7 +21460,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21382,7 +21505,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1405
+      ID: 1406
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21427,7 +21550,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21459,7 +21582,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21491,7 +21614,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21510,29 +21633,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1392
+      ID: 1393
       Name: Probe[main.testReturnsInt]
     - __kind: EventRootType
-      ID: 1394
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1396
+      ID: 1395
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21551,7 +21655,26 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1398
+      ID: 1397
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 11 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1399
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21583,7 +21706,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1393
+      ID: 1394
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21602,7 +21725,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1395
+      ID: 1396
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21634,7 +21757,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1397
+      ID: 1398
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21666,7 +21789,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1399
+      ID: 1400
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21685,7 +21808,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1414
+      ID: 1415
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21717,7 +21840,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21736,10 +21859,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21758,10 +21881,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1450
+      ID: 1451
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -21988,10 +22111,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1461
+      ID: 1462
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1462
+      ID: 1463
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22010,10 +22133,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -22084,10 +22207,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -22119,7 +22242,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.testReturnsNamedDeferLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22177,10 +22300,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22199,10 +22322,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -22312,10 +22435,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22334,10 +22457,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -22356,7 +22479,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1277
+      ID: 1278
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22388,7 +22511,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1298
+      ID: 1299
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22420,7 +22543,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1296
+      ID: 1297
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22452,13 +22575,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1309
+      ID: 1310
       Name: Probe[main.testSingleFloat32]
     - __kind: EventRootType
-      ID: 1310
+      ID: 1311
       Name: Probe[main.testSingleFloat64]
     - __kind: EventRootType
-      ID: 1301
+      ID: 1302
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22490,7 +22613,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1302
+      ID: 1303
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22522,7 +22645,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1303
+      ID: 1304
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22554,7 +22677,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1300
+      ID: 1301
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22612,7 +22735,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1299
+      ID: 1300
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22644,7 +22767,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1297
+      ID: 1298
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22676,7 +22799,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22708,7 +22831,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1306
+      ID: 1307
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22740,7 +22863,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1307
+      ID: 1308
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22772,7 +22895,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1308
+      ID: 1309
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22804,7 +22927,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1305
+      ID: 1306
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22836,7 +22959,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1304
+      ID: 1305
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22868,7 +22991,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22900,7 +23023,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22932,7 +23055,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1358
+      ID: 1359
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22964,7 +23087,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22983,10 +23106,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[main.testSomeNamedReturn]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23005,7 +23128,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1443
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23037,7 +23160,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23095,7 +23218,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23114,7 +23237,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23172,7 +23295,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23217,7 +23340,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -23249,7 +23372,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23294,7 +23417,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1278
+      ID: 1279
       Name: Probe[main.testStringArray]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23326,7 +23449,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1389
+      ID: 1390
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23358,7 +23481,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1501
+      ID: 1502
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23390,7 +23513,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1321
+      ID: 1322
       Name: Probe[main.testStringType1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23422,7 +23545,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1322
+      ID: 1323
       Name: Probe[main.testStringType2]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23454,7 +23577,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23512,7 +23635,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1352
+      ID: 1353
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23544,7 +23667,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23576,7 +23699,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23608,7 +23731,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -23640,10 +23763,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -23675,7 +23798,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1353
+      ID: 1354
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23707,7 +23830,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23726,7 +23849,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -23758,13 +23881,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -23848,7 +23971,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -23932,7 +24055,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1326
+      ID: 1327
       Name: Probe[main.testTakeContext]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23951,7 +24074,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -23970,7 +24093,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24002,7 +24125,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24059,7 +24182,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24091,7 +24214,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24136,13 +24259,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24226,7 +24349,103 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1311
+      ID: 1540
+      Name: Probe[main.testTimeFixedZone]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 323 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 323 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1541
+      Name: Probe[main.testTimeMonotonic]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 326 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: c
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 326 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1539
+      Name: Probe[main.testTimeUTC]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 323 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 323 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1312
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24258,7 +24477,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1287
+      ID: 1288
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24290,7 +24509,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1288
+      ID: 1289
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24322,7 +24541,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1289
+      ID: 1290
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24354,7 +24573,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1286
+      ID: 1287
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24386,7 +24605,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1285
+      ID: 1286
       Name: Probe[main.testUintArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24418,7 +24637,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24450,7 +24669,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24482,7 +24701,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24514,7 +24733,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1387
+      ID: 1388
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24546,7 +24765,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1295
+      ID: 1296
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       ExprStatusArraySize: 1
@@ -24574,38 +24793,6 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1504
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 259 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 259 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -24642,7 +24829,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1493
+      ID: 1506
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 259 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 259 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1494
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24700,7 +24919,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24732,7 +24951,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1588
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -24748,10 +24967,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24761,10 +24980,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 349 StructureType main.typeWithGenerics[go.shape.int]
+            Type: 353 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 0, name: x}
+                  Variable: {subprogram: 189, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24774,17 +24993,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1589
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24796,14 +25015,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 2, name: ~r0}
+                  Variable: {subprogram: 189, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1590
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -24819,10 +25038,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24832,10 +25051,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 350 StructureType main.typeWithGenerics[go.shape.string]
+            Type: 354 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24845,17 +25064,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1591
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -24867,14 +25086,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 2, name: ~r0}
+                  Variable: {subprogram: 190, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1538
+      ID: 1542
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -24884,10 +25103,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -24897,17 +25116,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 323 BaseType go.shape.int
+            Type: 327 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1539
+      ID: 1543
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24917,17 +25136,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 324 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 328 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1544
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -24937,10 +25156,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -24950,17 +25169,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 325 GoStringHeaderType go.shape.string
+            Type: 329 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1541
+      ID: 1545
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -24970,10 +25189,10 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 326 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 330 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25003,7 +25222,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 336
+      ID: 340
       Name: '[16]uint8'
       ByteSize: 16
       GoRuntimeType: 623200
@@ -25215,7 +25434,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 456
+      ID: 457
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 626080
@@ -25224,7 +25443,7 @@ Types:
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 441
+      ID: 442
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 626368
@@ -25250,7 +25469,7 @@ Types:
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 967
+      ID: 978
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 627424
@@ -25259,7 +25478,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1174
+      ID: 1185
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25285,7 +25504,7 @@ Types:
       HasCount: true
       Element: 81 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 424
+      ID: 425
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 623296
@@ -25294,7 +25513,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 1200
+      ID: 1201
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 452384
@@ -25302,20 +25521,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1201 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1202 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1203 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1204 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1203
+      ID: 1204
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 382 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 133
       Name: '[]*main.deepSlice2'
@@ -25332,15 +25551,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 422 GoSliceDataType []*main.deepSlice2.array
+      Data: 423 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 422
+      ID: 423
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 135 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1205
+      ID: 1206
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 448864
@@ -25348,22 +25567,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1206 PointerType **main.deepSlice3
+          Type: 1207 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1209 GoSliceDataType []*main.deepSlice3.array
+      Data: 1210 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1209
+      ID: 1210
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1207 PointerType *main.deepSlice3
+      Element: 1208 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1234
+      ID: 1235
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 448544
@@ -25371,22 +25590,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1235 PointerType **main.deepSlice8
+          Type: 1236 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1238 GoSliceDataType []*main.deepSlice8.array
+      Data: 1239 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1238
+      ID: 1239
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1236 PointerType *main.deepSlice8
+      Element: 1237 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1240
+      ID: 1241
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 448480
@@ -25394,20 +25613,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1241 PointerType **main.deepSlice9
+          Type: 1242 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1244 GoSliceDataType []*main.deepSlice9.array
+      Data: 1245 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1244
+      ID: 1245
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1242 PointerType *main.deepSlice9
+      Element: 1243 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 124
       Name: '[]*string'
@@ -25424,9 +25643,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 419 GoSliceDataType []*string.array
+      Data: 420 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 419
+      ID: 420
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25446,9 +25665,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 488 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 489
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25468,9 +25687,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 486 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 487
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25490,9 +25709,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 484 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 484
+      ID: 485
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25512,9 +25731,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 482 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 483
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25534,9 +25753,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 480 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 481
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25556,9 +25775,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 468 GoSliceDataType [][]uint.array
+      Data: 469 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 468
+      ID: 469
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25579,207 +25798,207 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 472 GoSliceDataType []bool.array
+      Data: 473 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 473
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 461
       Name: '[]bucket<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 528
       Element: 229 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 460
       Name: '[]bucket<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 224 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 444
       Name: '[]bucket<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 656
       Element: 192 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 450
+      ID: 451
       Name: '[]bucket<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 152
       Element: 204 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 512
+      ID: 519
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 374 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 378 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 429
+      ID: 430
       Name: '[]bucket<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 143 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1219
+      ID: 1220
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1215 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1257
+      ID: 1258
       Name: '[]bucket<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1253 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1254 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1266
+      ID: 1267
       Name: '[]bucket<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1262 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1263 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 433
+      ID: 434
       Name: '[]bucket<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 172 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 1272
+      ID: 1273
       Name: '[]bucket<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 1271 GoHMapBucketType bucket<int,interface {}>
+      Element: 1272 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 465
       Name: '[]bucket<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 239 GoHMapBucketType bucket<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 452
+      ID: 453
       Name: '[]bucket<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
       Element: 209 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 534
+      ID: 545
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 525 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 447
+      ID: 448
       Name: '[]bucket<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 199 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 440
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 187 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 518
+      ID: 525
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 401 GoHMapBucketType bucket<string,float64>
+      Element: 402 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 978
+      ID: 989
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 950 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 438
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 182 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 516
+      ID: 523
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 396 GoHMapBucketType bucket<string,interface {}>
+      Element: 397 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 436
+      ID: 437
       Name: '[]bucket<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 177 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 521
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 391 GoHMapBucketType bucket<string,string>
+      Element: 392 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 462
+      ID: 463
       Name: '[]bucket<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 234 GoHMapBucketType bucket<struct {},int>
     - __kind: GoSliceDataType
-      ID: 491
+      ID: 492
       Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 400
       Element: 291 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 493
+      ID: 494
       Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 296 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 496
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 301 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 498
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 306 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 499
+      ID: 500
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 311 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 501
+      ID: 502
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 316 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 466
       Name: '[]bucket<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
       Element: 244 GoHMapBucketType bucket<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 457
+      ID: 458
       Name: '[]bucket<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 219 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 455
       Name: '[]bucket<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
       Element: 214 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 962
+      ID: 973
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 456864
@@ -25794,15 +26013,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 979 GoSliceDataType []float64.array
+      Data: 990 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 979
+      ID: 990
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 19 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 402
+      ID: 403
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 451936
@@ -25810,22 +26029,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 403 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 404 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 519 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 526 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 526
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 404 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 405 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 405
+      ID: 406
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 452128
@@ -25833,22 +26052,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 406 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 407 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 527 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 534 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 527
+      ID: 534
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 407 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 408 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 351
+      ID: 355
       Name: '[]go.shape.float64'
       ByteSize: 24
       GoRuntimeType: 454368
@@ -25856,44 +26075,44 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 352 PointerType *go.shape.float64
+          Type: 356 PointerType *go.shape.float64
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 508 GoSliceDataType []go.shape.float64.array
+      Data: 515 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 508
+      ID: 515
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 353 BaseType go.shape.float64
+      Element: 357 BaseType go.shape.float64
     - __kind: GoSliceHeaderType
-      ID: 327
+      ID: 331
       Name: '[]go.shape.int'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 328 PointerType *go.shape.int
+          Type: 332 PointerType *go.shape.int
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 504 GoSliceDataType []go.shape.int.array
+      Data: 511 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 504
+      ID: 511
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 323 BaseType go.shape.int
+      Element: 327 BaseType go.shape.int
     - __kind: GoSliceHeaderType
-      ID: 348
+      ID: 352
       Name: '[]go.shape.string'
       ByteSize: 24
       GoRuntimeType: 450272
@@ -25901,22 +26120,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 345 PointerType *go.shape.string
+          Type: 349 PointerType *go.shape.string
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 506 GoSliceDataType []go.shape.string.array
+      Data: 513 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 513
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 325 GoStringHeaderType go.shape.string
+      Element: 329 GoStringHeaderType go.shape.string
     - __kind: GoSliceHeaderType
-      ID: 1246
+      ID: 1247
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 457312
@@ -25931,63 +26150,63 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1247 GoSliceDataType []interface {}.array
+      Data: 1248 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1247
+      ID: 1248
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 159 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 458
+      ID: 459
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 456 ArrayType [4]int
+      Element: 457 ArrayType [4]int
     - __kind: ArrayType
-      ID: 440
+      ID: 441
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 441 ArrayType [4]string
+      Element: 442 ArrayType [4]string
     - __kind: ArrayType
-      ID: 448
+      ID: 449
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 510
+      ID: 517
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 511 GoInterfaceType context.canceler
+      Element: 518 GoInterfaceType context.canceler
     - __kind: ArrayType
-      ID: 425
+      ID: 426
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 434
+      ID: 435
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 461
+      ID: 462
       Name: '[]key<struct {}>'
       Count: 8
       HasCount: true
       Element: 120 StructureType struct {}
     - __kind: ArrayType
-      ID: 453
+      ID: 454
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -26008,15 +26227,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 478 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 479 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 479
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 273 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 445
+      ID: 446
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 449504
@@ -26024,16 +26243,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 446 PointerType *main.structWithMap
+          Type: 447 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 529 GoSliceDataType []main.structWithMap.array
+      Data: 536 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 536
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26053,9 +26272,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 470 GoSliceDataType []main.structWithNoStrings.array
+      Data: 471 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 471
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26080,9 +26299,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 430 GoSliceDataType []string.array
+      Data: 431 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 430
+      ID: 431
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26103,14 +26322,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 476 GoSliceDataType []struct {}.array
+      Data: 477 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 477
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 120 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 1190
+      ID: 503
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 455584
@@ -26118,22 +26337,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1191 PointerType *time.zone
+          Type: 504 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1196 GoSliceDataType []time.zone.array
+      Data: 538 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 1196
+      ID: 538
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 1192 StructureType time.zone
+      Element: 505 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 1193
+      ID: 506
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 455648
@@ -26141,20 +26360,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1194 PointerType *time.zoneTrans
+          Type: 507 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1198 GoSliceDataType []time.zoneTrans.array
+      Data: 540 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 1198
+      ID: 540
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 1195 StructureType time.zoneTrans
+      Element: 508 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 259
       Name: '[]uint'
@@ -26171,9 +26390,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 466 GoSliceDataType []uint.array
+      Data: 467 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 466
+      ID: 467
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26194,9 +26413,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 474 GoSliceDataType []uint16.array
+      Data: 475 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 474
+      ID: 475
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26217,9 +26436,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 415 GoSliceDataType []uint8.array
+      Data: 416 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 415
+      ID: 416
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26240,186 +26459,186 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 417 GoSliceDataType []uintptr.array
+      Data: 418 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 417
+      ID: 418
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 531
+      ID: 542
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 532 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 543 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 426
+      ID: 427
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 427 PointerType *main.deepMap2
+      Element: 428 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1216
+      ID: 1217
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1217 PointerType *main.deepMap3
+      Element: 1218 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 1254
+      ID: 1255
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1255 PointerType *main.deepMap8
+      Element: 1256 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 1263
+      ID: 1264
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1264 PointerType *main.deepMap9
+      Element: 1265 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 442
+      ID: 443
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 108 ArrayType [2]int
     - __kind: ArrayType
-      ID: 455
+      ID: 456
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 456 ArrayType [4]int
+      Element: 457 ArrayType [4]int
     - __kind: ArrayType
-      ID: 444
+      ID: 445
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 445 GoSliceHeaderType []main.structWithMap
+      Element: 446 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 438
+      ID: 439
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 156 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 517
+      ID: 524
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 977
+      ID: 988
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 969 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 432
+      ID: 433
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 515
+      ID: 522
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 159 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 435
+      ID: 436
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 118 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 449
+      ID: 450
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 248 StructureType main.node
     - __kind: ArrayType
-      ID: 490
+      ID: 491
       Name: '[]val<main.structWithCyclicMaps>'
       ByteSize: 384
       Count: 8
       HasCount: true
       Element: 286 StructureType main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 492
+      ID: 493
       Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 287 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 494
+      ID: 495
       Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 292 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 496
+      ID: 497
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 297 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 498
+      ID: 499
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 500
+      ID: 501
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 513
+      ID: 520
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 463
+      ID: 464
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
       Element: 120 StructureType struct {}
     - __kind: ArrayType
-      ID: 451
+      ID: 452
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1117
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 761
+      ID: 772
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 862016
@@ -26434,33 +26653,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 762 GoSliceDataType archive/tar.headerError.array
+      Data: 773 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 762
+      ID: 773
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1057
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 1005
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 996
+      ID: 1007
       Name: archive/zip.dirWriter
       GoRuntimeType: 1084192
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1093
+      ID: 1104
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1033
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1384000
@@ -26470,7 +26689,7 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1035
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26486,18 +26705,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 458 ArrayType []key<[4]int>
+          Type: 459 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 455 ArrayType []val<[4]int>
+          Type: 456 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 228 PointerType *bucket<[4]int,[4]int>
-      KeyType: 456 ArrayType [4]int
-      ValueType: 456 ArrayType [4]int
+      KeyType: 457 ArrayType [4]int
+      ValueType: 457 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 224
       Name: bucket<[4]int,uint8>
@@ -26505,17 +26724,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 458 ArrayType []key<[4]int>
+          Type: 459 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 451 ArrayType []val<uint8>
+          Type: 452 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 223 PointerType *bucket<[4]int,uint8>
-      KeyType: 456 ArrayType [4]int
+      KeyType: 457 ArrayType [4]int
       ValueType: 5 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 192
@@ -26524,17 +26743,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 440 ArrayType []key<[4]string>
+          Type: 441 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 442 ArrayType []val<[2]int>
+          Type: 443 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 191 PointerType *bucket<[4]string,[2]int>
-      KeyType: 441 ArrayType [4]string
+      KeyType: 442 ArrayType [4]string
       ValueType: 108 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 204
@@ -26543,36 +26762,36 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 448 ArrayType []key<bool>
+          Type: 449 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 449 ArrayType []val<main.node>
+          Type: 450 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 203 PointerType *bucket<bool,main.node>
       KeyType: 6 BaseType bool
       ValueType: 248 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 374
+      ID: 378
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 510 ArrayType []key<context.canceler>
+          Type: 517 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 463 ArrayType []val<struct {}>
+          Type: 464 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 373 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 511 GoInterfaceType context.canceler
+          Type: 377 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 518 GoInterfaceType context.canceler
       ValueType: 120 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 143
@@ -26581,75 +26800,75 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 426 ArrayType []val<*main.deepMap2>
+          Type: 427 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 142 PointerType *bucket<int,*main.deepMap2>
       KeyType: 11 BaseType int
-      ValueType: 427 PointerType *main.deepMap2
+      ValueType: 428 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1215
+      ID: 1216
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1216 ArrayType []val<*main.deepMap3>
+          Type: 1217 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1214 PointerType *bucket<int,*main.deepMap3>
+          Type: 1215 PointerType *bucket<int,*main.deepMap3>
       KeyType: 11 BaseType int
-      ValueType: 1217 PointerType *main.deepMap3
+      ValueType: 1218 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 1253
+      ID: 1254
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1254 ArrayType []val<*main.deepMap8>
+          Type: 1255 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 1252 PointerType *bucket<int,*main.deepMap8>
+          Type: 1253 PointerType *bucket<int,*main.deepMap8>
       KeyType: 11 BaseType int
-      ValueType: 1255 PointerType *main.deepMap8
+      ValueType: 1256 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 1262
+      ID: 1263
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1263 ArrayType []val<*main.deepMap9>
+          Type: 1264 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 1261 PointerType *bucket<int,*main.deepMap9>
+          Type: 1262 PointerType *bucket<int,*main.deepMap9>
       KeyType: 11 BaseType int
-      ValueType: 1264 PointerType *main.deepMap9
+      ValueType: 1265 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 172
       Name: bucket<int,int>
@@ -26657,35 +26876,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 432 ArrayType []val<int>
+          Type: 433 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 171 PointerType *bucket<int,int>
       KeyType: 11 BaseType int
       ValueType: 11 BaseType int
     - __kind: GoHMapBucketType
-      ID: 1271
+      ID: 1272
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 515 ArrayType []val<interface {}>
+          Type: 522 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 1270 PointerType *bucket<int,interface {}>
+          Type: 1271 PointerType *bucket<int,interface {}>
       KeyType: 11 BaseType int
       ValueType: 159 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -26695,13 +26914,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 463 ArrayType []val<struct {}>
+          Type: 464 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 238 PointerType *bucket<int,struct {}>
@@ -26714,37 +26933,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 425 ArrayType []key<int>
+          Type: 426 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 451 ArrayType []val<uint8>
+          Type: 452 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 208 PointerType *bucket<int,uint8>
       KeyType: 11 BaseType int
       ValueType: 5 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 525
+      ID: 532
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 531 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 542 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 524 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 532 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 543 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 199
       Name: bucket<string,[]main.structWithMap>
@@ -26752,18 +26971,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 444 ArrayType []val<[]main.structWithMap>
+          Type: 445 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 198 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 445 GoSliceHeaderType []main.structWithMap
+      ValueType: 446 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 187
       Name: bucket<string,[]string>
@@ -26771,56 +26990,56 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 438 ArrayType []val<[]string>
+          Type: 439 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 186 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 156 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 401
+      ID: 402
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 517 ArrayType []val<float64>
+          Type: 524 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 400 PointerType *bucket<string,float64>
+          Type: 401 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 950
+      ID: 961
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 977 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 988 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 949 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 969 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 182
       Name: bucket<string,int>
@@ -26828,35 +27047,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 432 ArrayType []val<int>
+          Type: 433 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 181 PointerType *bucket<string,int>
       KeyType: 13 GoStringHeaderType string
       ValueType: 11 BaseType int
     - __kind: GoHMapBucketType
-      ID: 396
+      ID: 397
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 515 ArrayType []val<interface {}>
+          Type: 522 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 395 PointerType *bucket<string,interface {}>
+          Type: 396 PointerType *bucket<string,interface {}>
       KeyType: 13 GoStringHeaderType string
       ValueType: 159 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -26866,35 +27085,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 435 ArrayType []val<main.nestedStruct>
+          Type: 436 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 176 PointerType *bucket<string,main.nestedStruct>
       KeyType: 13 GoStringHeaderType string
       ValueType: 118 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 391
+      ID: 392
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 434 ArrayType []key<string>
+          Type: 435 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 513 ArrayType []val<string>
+          Type: 520 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 390 PointerType *bucket<string,string>
+          Type: 391 PointerType *bucket<string,string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 13 GoStringHeaderType string
     - __kind: GoHMapBucketType
@@ -26904,13 +27123,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 432 ArrayType []val<int>
+          Type: 433 ArrayType []val<int>
         - Name: overflow
           Offset: 72
           Type: 233 PointerType *bucket<struct {},int>
@@ -26923,13 +27142,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 490 ArrayType []val<main.structWithCyclicMaps>
+          Type: 491 ArrayType []val<main.structWithCyclicMaps>
         - Name: overflow
           Offset: 392
           Type: 290 PointerType *bucket<struct {},main.structWithCyclicMaps>
@@ -26942,13 +27161,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 492 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+          Type: 493 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 295 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -26961,13 +27180,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 494 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 495 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 300 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -26980,13 +27199,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 496 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 497 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 305 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -26999,13 +27218,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 498 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 499 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 310 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27018,13 +27237,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 500 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 501 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 315 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27037,13 +27256,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 461 ArrayType []key<struct {}>
+          Type: 462 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 463 ArrayType []val<struct {}>
+          Type: 464 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 8
           Type: 243 PointerType *bucket<struct {},struct {}>
@@ -27056,18 +27275,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 453 ArrayType []key<uint8>
+          Type: 454 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 455 ArrayType []val<[4]int>
+          Type: 456 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 218 PointerType *bucket<uint8,[4]int>
       KeyType: 5 BaseType uint8
-      ValueType: 456 ArrayType [4]int
+      ValueType: 457 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 214
       Name: bucket<uint8,uint8>
@@ -27075,28 +27294,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 424 ArrayType [8]uint8
+          Type: 425 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 453 ArrayType []key<uint8>
+          Type: 454 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 451 ArrayType []val<uint8>
+          Type: 452 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 213 PointerType *bucket<uint8,uint8>
       KeyType: 5 BaseType uint8
       ValueType: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1081
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1108
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1142
+      ID: 1153
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27122,13 +27341,13 @@ Types:
       GoRuntimeType: 534784
       GoKind: 15
     - __kind: BaseType
-      ID: 568
+      ID: 579
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 767840
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 580
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 767936
@@ -27136,26 +27355,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *compress/flate.InternalError.str
+          Type: 582 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 570 GoStringDataType compress/flate.InternalError.str
+      Data: 581 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 581
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1055
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 1001
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1066
+      ID: 1077
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27172,19 +27391,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 370
       Name: context.backgroundCtx
       GoRuntimeType: 1681632
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 367 StructureType context.emptyCtx
+          Type: 371 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 357
+      ID: 361
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1838464
@@ -27195,13 +27414,13 @@ Types:
           Type: 152 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 368 StructureType sync.Mutex
+          Type: 372 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 369 StructureType sync/atomic.Value
+          Type: 373 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 370 GoMapType map[context.canceler]struct {}
+          Type: 374 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -27211,7 +27430,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 511
+      ID: 518
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1074848
@@ -27224,13 +27443,13 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 873
+      ID: 884
       Name: context.deadlineExceededError
       GoRuntimeType: 1288576
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 367
+      ID: 371
       Name: context.emptyCtx
       GoRuntimeType: 1412512
       GoKind: 25
@@ -27239,7 +27458,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 359
+      ID: 363
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1704192
@@ -27250,11 +27469,11 @@ Types:
           Type: 152 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 375 GoSubroutineType func() bool
+          Type: 379 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 361
+      ID: 365
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1430144
@@ -27262,29 +27481,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 357 StructureType context.cancelCtx
+          Type: 361 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 376 PointerType *time.Timer
+          Type: 380 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 378 StructureType time.Time
+          Type: 323 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 381
+      ID: 382
       Name: context.todoCtx
       GoRuntimeType: 1681856
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 367 StructureType context.emptyCtx
+          Type: 371 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 363
+      ID: 367
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1715680
@@ -27302,7 +27521,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 365
+      ID: 369
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1681408
@@ -27314,63 +27533,63 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 582
+      ID: 593
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770432
       GoKind: 2
     - __kind: BaseType
-      ID: 583
+      ID: 594
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770528
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1056
+      ID: 1067
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1092
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 584
+      ID: 595
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770624
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1089
+      ID: 1100
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1094
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1096
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 572
+      ID: 583
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 768416
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 856
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1168
+      ID: 1179
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 687
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 674
+      ID: 685
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1614752
@@ -27381,34 +27600,34 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 967 ArrayType [5]uint8
+          Type: 978 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 968 GoInterfaceType net.Conn
+          Type: 979 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 800
+      ID: 811
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 956320
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1065
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1072
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 951
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 963
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 748
+      ID: 759
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1617824
@@ -27416,21 +27635,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 951 PointerType *crypto/x509.Certificate
+          Type: 962 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 970 BaseType crypto/x509.InvalidReason
+          Type: 981 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 742
+      ID: 753
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1081504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 744
+      ID: 755
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1416352
@@ -27438,24 +27657,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 951 PointerType *crypto/x509.Certificate
+          Type: 962 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 581
+      ID: 592
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 770048
       GoKind: 2
     - __kind: BaseType
-      ID: 970
+      ID: 981
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 540288
       GoKind: 2
     - __kind: StructureType
-      ID: 850
+      ID: 861
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1380320
@@ -27465,13 +27684,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 750
+      ID: 761
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1081760
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 746
+      ID: 757
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1617632
@@ -27479,15 +27698,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 951 PointerType *crypto/x509.Certificate
+          Type: 962 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 951 PointerType *crypto/x509.Certificate
+          Type: 962 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 765
+      ID: 776
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1260128
@@ -27497,7 +27716,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 769
+      ID: 780
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1260288
@@ -27507,55 +27726,55 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 767
+      ID: 778
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 566
+      ID: 577
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 767456
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1023
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 567
+      ID: 578
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 767648
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 648
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 847
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 640
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 646
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 644
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 642
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1148
+      ID: 1159
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 639
+      ID: 650
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1244608
@@ -27565,19 +27784,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1020
+      ID: 1031
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 747
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 734
+      ID: 745
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 578
+      ID: 589
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 769952
@@ -27585,22 +27804,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 580 PointerType *encoding/xml.UnmarshalError.str
+          Type: 591 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 579 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 590 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 579
+      ID: 590
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 739
+      ID: 750
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1137
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27617,11 +27836,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 607
+      ID: 618
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 814
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27637,15 +27856,15 @@ Types:
       GoRuntimeType: 534976
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1147
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 816
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 818
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27655,7 +27874,7 @@ Types:
       GoRuntimeType: 447200
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 375
+      ID: 379
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 545856
@@ -27667,44 +27886,44 @@ Types:
       GoRuntimeType: 782048
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 354
+      ID: 358
       Name: func(go.shape.float64) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 329
+      ID: 333
       Name: func(go.shape.int) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 330
+      ID: 334
       Name: func(go.shape.int) go.shape.string
       ByteSize: 8
       GoKind: 19
     - __kind: StructureType
-      ID: 324
+      ID: 328
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
     - __kind: StructureType
-      ID: 326
+      ID: 330
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 678
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 648
+      ID: 659
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1613024
@@ -27712,7 +27931,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 960 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 971 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -27720,25 +27939,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 661
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 975
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 654
+      ID: 665
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1077664
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 977
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 560
+      ID: 571
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 766880
@@ -27746,18 +27965,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 562 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 573 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 561 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 561
+      ID: 572
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 960
+      ID: 971
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2084544
@@ -27765,7 +27984,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 961 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 972 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -27780,7 +27999,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 962 GoSliceHeaderType []float64
+          Type: 973 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 16 BaseType int64
@@ -27789,10 +28008,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 963 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 974 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 965 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 976 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 156 GoSliceHeaderType []string
@@ -27806,13 +28025,13 @@ Types:
           Offset: 184
           Type: 16 BaseType int64
     - __kind: BaseType
-      ID: 961
+      ID: 972
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 536640
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 568
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 766784
@@ -27820,18 +28039,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 570 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 558 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 569
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 563
+      ID: 574
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 766976
@@ -27839,30 +28058,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 565 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 576 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 564
+      ID: 575
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1045
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1125
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 759
+      ID: 770
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 383
+      ID: 384
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2204704
@@ -27870,7 +28089,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 384 StructureType sync.RWMutex
+          Type: 385 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -27891,13 +28110,13 @@ Types:
           Type: 16 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 392 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 393 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 397 GoMapType map[string]float64
+          Type: 398 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 12 BaseType uint64
@@ -27912,10 +28131,10 @@ Types:
           Type: 15 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 402 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 403 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 405 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 406 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27927,7 +28146,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 408 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 13 GoStringHeaderType string
@@ -27950,7 +28169,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 409
+      ID: 410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2081856
@@ -27961,13 +28180,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 410 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 382 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 385 StructureType sync/atomic.Int32
+          Type: 386 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -27976,16 +28195,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 412 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 413 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 12 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 384 StructureType sync.RWMutex
+          Type: 385 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -27994,12 +28213,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 402 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 403 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 404
+      ID: 405
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1788800
@@ -28016,7 +28235,7 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -28024,20 +28243,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 392
+      ID: 393
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 987552
       GoKind: 21
-      HeaderType: 394 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 395 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 1202
+      ID: 1203
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 533760
       GoKind: 10
     - __kind: StructureType
-      ID: 407
+      ID: 408
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1633152
@@ -28051,16 +28270,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 521 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 528 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 526 GoMapType map[string]interface {}
+          Type: 533 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1222
+      ID: 1223
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 533
+      ID: 544
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1789056
@@ -28068,7 +28287,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1220 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1221 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -28083,15 +28302,15 @@ Types:
           Type: 19 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1221 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1220
+      ID: 1221
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 951616
       GoKind: 5
     - __kind: StructureType
-      ID: 411
+      ID: 412
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 1976704
@@ -28099,16 +28318,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 384 StructureType sync.RWMutex
+          Type: 385 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1200 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1201 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 387 GoMapType map[string]string
+          Type: 388 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 11 BaseType int
@@ -28123,12 +28342,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1203 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 382 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 412
+      ID: 413
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 828800
@@ -28137,15 +28356,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 919
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1144
+      ID: 1155
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1225
+      ID: 1226
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1444352
@@ -28155,29 +28374,29 @@ Types:
           Offset: 0
           Type: 152 GoInterfaceType context.Context
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 696
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 692
+      ID: 703
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1080736
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 577
+      ID: 588
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 769088
       GoKind: 2
     - __kind: StructureType
-      ID: 690
+      ID: 701
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1080608
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 688
+      ID: 699
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1414432
@@ -28190,7 +28409,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 708
+      ID: 719
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1415232
@@ -28203,7 +28422,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 712
+      ID: 723
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1617056
@@ -28219,7 +28438,7 @@ Types:
           Offset: 24
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 710
+      ID: 721
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1254528
@@ -28229,7 +28448,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 706
+      ID: 717
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1254208
@@ -28239,14 +28458,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 946
+      ID: 957
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1141056
       GoKind: 21
-      HeaderType: 948 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 959 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 969
+      ID: 980
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1013536
@@ -28261,15 +28480,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 981 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 992 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 981
+      ID: 992
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 720
+      ID: 731
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1415552
@@ -28277,12 +28496,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 946 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 957 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 946 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 957 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 714
+      ID: 725
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1254688
@@ -28292,7 +28511,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 718
+      ID: 729
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1617248
@@ -28303,12 +28522,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 969 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 969 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 716
+      ID: 727
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1415392
@@ -28321,7 +28540,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 722
+      ID: 733
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1254848
@@ -28329,9 +28548,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 378 StructureType time.Time
+          Type: 323 GoTimeType time.Time
     - __kind: StructureType
-      ID: 728
+      ID: 739
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1415872
@@ -28344,7 +28563,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 730
+      ID: 741
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1255168
@@ -28354,7 +28573,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 726
+      ID: 737
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1415712
@@ -28367,7 +28586,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 724
+      ID: 735
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1255008
@@ -28377,7 +28596,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 732
+      ID: 743
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1416032
@@ -28390,7 +28609,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 656
+      ID: 667
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1246848
@@ -28400,11 +28619,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1084
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 658
+      ID: 669
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1247008
@@ -28412,21 +28631,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 656 StructureType github.com/cihub/seelog.baseError
+          Type: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1063
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1019
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1053
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 662
+      ID: 673
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1247328
@@ -28434,13 +28653,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 656 StructureType github.com/cihub/seelog.baseError
+          Type: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1115
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1115
+      ID: 1126
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1978816
@@ -28448,12 +28667,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1103 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1114 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 1116
+      ID: 1127
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2002208
@@ -28461,7 +28680,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1103 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1114 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -28469,11 +28688,11 @@ Types:
           Offset: 24
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1021
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 660
+      ID: 671
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1247168
@@ -28481,9 +28700,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 656 StructureType github.com/cihub/seelog.baseError
+          Type: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 664
+      ID: 675
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1247488
@@ -28491,64 +28710,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 656 StructureType github.com/cihub/seelog.baseError
+          Type: 667 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1088
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1121
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1123
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 953
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 858
+      ID: 869
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 867
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 871
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 873
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1074
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 863
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 670
+      ID: 681
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1248448
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1171
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 927
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 896
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1721056
@@ -28564,11 +28783,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 890
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 822
+      ID: 833
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1518560
@@ -28581,7 +28800,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 891
+      ID: 902
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1721504
@@ -28597,13 +28816,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 799
+      ID: 810
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 953440
       GoKind: 8
     - __kind: StructureType
-      ID: 883
+      ID: 894
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1720832
@@ -28619,13 +28838,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 971
+      ID: 982
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 765152
       GoKind: 8
     - __kind: StructureType
-      ID: 881
+      ID: 892
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1720608
@@ -28633,15 +28852,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 971 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 982 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 971 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 982 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 889
+      ID: 900
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1638912
@@ -28654,7 +28873,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 887
+      ID: 898
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1721280
@@ -28670,11 +28889,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1164
+      ID: 1175
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 906
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1440128
@@ -28684,19 +28903,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 826
+      ID: 837
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1200896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 824
+      ID: 835
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1200768
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 893
+      ID: 904
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1639104
@@ -28709,7 +28928,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 589
+      ID: 600
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 772448
@@ -28717,36 +28936,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 591 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 602 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 590 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 601 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 590
+      ID: 601
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 340
+      ID: 344
       Name: go.shape.bool
       ByteSize: 1
       GoRuntimeType: 546816
       GoKind: 1
     - __kind: BaseType
-      ID: 353
+      ID: 357
       Name: go.shape.float64
       ByteSize: 8
       GoRuntimeType: 546880
       GoKind: 14
     - __kind: BaseType
-      ID: 323
+      ID: 327
       Name: go.shape.int
       ByteSize: 8
       GoRuntimeType: 546688
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 329
       Name: go.shape.string
       ByteSize: 16
       GoRuntimeType: 546752
@@ -28754,18 +28973,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 503 PointerType *go.shape.string.str
+          Type: 510 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 502 GoStringDataType go.shape.string.str
+      Data: 509 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 502
+      ID: 509
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 332
+      ID: 336
       Name: go.shape.struct { Name string }
       ByteSize: 16
       GoKind: 25
@@ -28774,7 +28993,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 334
+      ID: 338
       Name: go.shape.struct { X int; Y int }
       ByteSize: 16
       GoKind: 25
@@ -28786,13 +29005,13 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 343
+      ID: 347
       Name: go.shape.struct { main.i int }
       ByteSize: 8
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 11 BaseType int}]
     - __kind: StructureType
-      ID: 344
+      ID: 348
       Name: go.shape.struct { main.s string }
       ByteSize: 16
       GoKind: 25
@@ -28801,7 +29020,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 347
+      ID: 351
       Name: go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
       ByteSize: 48
       GoKind: 25
@@ -28816,11 +29035,11 @@ Types:
           Offset: 32
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 966
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 877
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1271968
@@ -28830,7 +29049,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 1040
+      ID: 1051
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1495424
@@ -28838,13 +29057,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1064 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1075 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1135
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1064
+      ID: 1075
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1091616
@@ -28857,7 +29076,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1026
+      ID: 1037
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1388800
@@ -28867,19 +29086,19 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 592
+      ID: 603
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 773024
       GoKind: 10
     - __kind: BaseType
-      ID: 953
+      ID: 964
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 966976
       GoKind: 10
     - __kind: StructureType
-      ID: 924
+      ID: 935
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1760256
@@ -28890,12 +29109,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 953 BaseType golang.org/x/net/http2.ErrCode
+          Type: 964 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 785
+      ID: 796
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1423232
@@ -28903,12 +29122,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 953 BaseType golang.org/x/net/http2.ErrCode
+          Type: 964 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 596
+      ID: 607
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 773216
@@ -28916,18 +29135,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 598 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 609 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 597 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 608 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 597
+      ID: 608
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 602
+      ID: 613
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 773408
@@ -28935,18 +29154,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 604 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 615 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 603 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 614 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 603
+      ID: 614
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 599
+      ID: 610
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 773312
@@ -28954,18 +29173,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 601 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 612 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 600 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 611 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 600
+      ID: 611
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 593
+      ID: 604
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 773120
@@ -28973,22 +29192,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 595 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 606 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 594 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 605 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 594
+      ID: 605
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1133
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 789
+      ID: 800
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1272608
@@ -28998,13 +29217,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 605
+      ID: 616
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 773504
       GoKind: 2
     - __kind: StructureType
-      ID: 777
+      ID: 788
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1267648
@@ -29014,11 +29233,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 933
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 944
+      ID: 955
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1786016
@@ -29034,7 +29253,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 779
+      ID: 790
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1422752
@@ -29047,7 +29266,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1087
+      ID: 1098
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1839488
@@ -29055,16 +29274,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 968 GoInterfaceType net.Conn
+          Type: 979 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1102 GoInterfaceType io.Reader
+          Type: 1113 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1049
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 875
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1386400
@@ -29074,29 +29293,29 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1009
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 757
+      ID: 768
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 865
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 931
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 918
+      ID: 929
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1333216
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 771
+      ID: 782
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1260928
@@ -29106,7 +29325,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 773
+      ID: 784
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1261088
@@ -29116,11 +29335,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 700
+      ID: 711
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1086
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -29156,7 +29375,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 229 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 460 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 461 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 222
       Name: hash<[4]int,uint8>
@@ -29190,7 +29409,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 224 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 459 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 460 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 190
       Name: hash<[4]string,[2]int>
@@ -29224,7 +29443,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 192 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 443 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 444 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 202
       Name: hash<bool,main.node>
@@ -29258,9 +29477,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 204 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 450 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 451 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 372
+      ID: 376
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -29281,18 +29500,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 373 PointerType *bucket<context.canceler,struct {}>
+          Type: 377 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 373 PointerType *bucket<context.canceler,struct {}>
+          Type: 377 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 374 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 512 GoSliceDataType []bucket<context.canceler,struct {}>.array
+      BucketType: 378 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 519 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 141
       Name: hash<int,*main.deepMap2>
@@ -29326,9 +29545,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 143 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 429 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 430 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1213
+      ID: 1214
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -29349,20 +29568,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1214 PointerType *bucket<int,*main.deepMap3>
+          Type: 1215 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1214 PointerType *bucket<int,*main.deepMap3>
+          Type: 1215 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1215 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1219 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1220 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 1251
+      ID: 1252
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -29383,20 +29602,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1252 PointerType *bucket<int,*main.deepMap8>
+          Type: 1253 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 1252 PointerType *bucket<int,*main.deepMap8>
+          Type: 1253 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1253 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 1257 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1254 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1258 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 1260
+      ID: 1261
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -29417,18 +29636,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1261 PointerType *bucket<int,*main.deepMap9>
+          Type: 1262 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 1261 PointerType *bucket<int,*main.deepMap9>
+          Type: 1262 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1262 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 1266 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1263 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1267 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 170
       Name: hash<int,int>
@@ -29462,9 +29681,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 172 GoHMapBucketType bucket<int,int>
-      BucketsType: 433 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 434 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 1269
+      ID: 1270
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -29485,18 +29704,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1270 PointerType *bucket<int,interface {}>
+          Type: 1271 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 1270 PointerType *bucket<int,interface {}>
+          Type: 1271 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1271 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 1272 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1272 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1273 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 237
       Name: hash<int,struct {}>
@@ -29530,7 +29749,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 239 GoHMapBucketType bucket<int,struct {}>
-      BucketsType: 464 GoSliceDataType []bucket<int,struct {}>.array
+      BucketsType: 465 GoSliceDataType []bucket<int,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 207
       Name: hash<int,uint8>
@@ -29564,9 +29783,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 209 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 452 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 453 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 523
+      ID: 530
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -29587,18 +29806,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 524 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 524 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 525 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 534 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 545 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
       ID: 197
       Name: hash<string,[]main.structWithMap>
@@ -29632,7 +29851,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 199 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 447 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 448 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 185
       Name: hash<string,[]string>
@@ -29666,9 +29885,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 187 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 439 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 440 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 399
+      ID: 400
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -29689,20 +29908,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 400 PointerType *bucket<string,float64>
+          Type: 401 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 400 PointerType *bucket<string,float64>
+          Type: 401 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 401 GoHMapBucketType bucket<string,float64>
-      BucketsType: 518 GoSliceDataType []bucket<string,float64>.array
+      BucketType: 402 GoHMapBucketType bucket<string,float64>
+      BucketsType: 525 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 948
+      ID: 959
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -29723,18 +29942,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 949 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 949 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 950 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 978 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 989 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 180
       Name: hash<string,int>
@@ -29768,9 +29987,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 182 GoHMapBucketType bucket<string,int>
-      BucketsType: 437 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 438 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 394
+      ID: 395
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -29791,18 +30010,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 395 PointerType *bucket<string,interface {}>
+          Type: 396 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 395 PointerType *bucket<string,interface {}>
+          Type: 396 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 396 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 516 GoSliceDataType []bucket<string,interface {}>.array
+      BucketType: 397 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 523 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 175
       Name: hash<string,main.nestedStruct>
@@ -29836,9 +30055,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 177 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 436 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 437 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 389
+      ID: 390
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -29859,18 +30078,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 390 PointerType *bucket<string,string>
+          Type: 391 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 390 PointerType *bucket<string,string>
+          Type: 391 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 391 GoHMapBucketType bucket<string,string>
-      BucketsType: 514 GoSliceDataType []bucket<string,string>.array
+      BucketType: 392 GoHMapBucketType bucket<string,string>
+      BucketsType: 521 GoSliceDataType []bucket<string,string>.array
     - __kind: GoHMapHeaderType
       ID: 232
       Name: hash<struct {},int>
@@ -29904,7 +30123,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 234 GoHMapBucketType bucket<struct {},int>
-      BucketsType: 462 GoSliceDataType []bucket<struct {},int>.array
+      BucketsType: 463 GoSliceDataType []bucket<struct {},int>.array
     - __kind: GoHMapHeaderType
       ID: 289
       Name: hash<struct {},main.structWithCyclicMaps>
@@ -29938,7 +30157,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 291 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
-      BucketsType: 491 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+      BucketsType: 492 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 294
       Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -29972,7 +30191,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 296 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 493 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 494 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 299
       Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30006,7 +30225,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 301 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 495 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 496 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 304
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30040,7 +30259,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 306 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 497 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 498 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 309
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30074,7 +30293,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 311 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 499 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 500 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 314
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30108,7 +30327,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 316 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 501 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 502 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 242
       Name: hash<struct {},struct {}>
@@ -30142,7 +30361,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 244 GoHMapBucketType bucket<struct {},struct {}>
-      BucketsType: 465 GoSliceDataType []bucket<struct {},struct {}>.array
+      BucketsType: 466 GoSliceDataType []bucket<struct {},struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 217
       Name: hash<uint8,[4]int>
@@ -30176,7 +30395,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 219 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 457 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 458 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 212
       Name: hash<uint8,uint8>
@@ -30210,9 +30429,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 214 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 454 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 455 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 803
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -30259,7 +30478,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 752
+      ID: 763
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -30285,25 +30504,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 999
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 925
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1166
+      ID: 1177
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 912
+      ID: 923
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1313536
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 623
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -30384,11 +30603,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1041
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1071
+      ID: 1082
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1109696
@@ -30401,7 +30620,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1102
+      ID: 1113
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 985888
@@ -30414,7 +30633,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1059
+      ID: 1070
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1074336
@@ -30440,47 +30659,47 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1028
+      ID: 1039
       Name: io.discard
       GoRuntimeType: 1288256
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1013
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 921
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1090
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 339
+      ID: 343
       Name: main.Pair[go.shape.int,go.shape.bool]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
         - Name: Value
           Offset: 8
-          Type: 340 BaseType go.shape.bool
+          Type: 344 BaseType go.shape.bool
     - __kind: StructureType
-      ID: 342
+      ID: 346
       Name: main.Pair[go.shape.string,go.shape.int]
       ByteSize: 24
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
         - Name: Value
           Offset: 16
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
     - __kind: StructureType
       ID: 317
       Name: main.aStruct
@@ -30507,7 +30726,7 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1273 PointerType *main.nestedStruct
+          Type: 1274 PointerType *main.nestedStruct
     - __kind: GoInterfaceType
       ID: 164
       Name: main.behavior
@@ -30548,7 +30767,7 @@ Types:
           Offset: 0
           Type: 139 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 428
+      ID: 429
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1105856
@@ -30556,9 +30775,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1211 GoMapType map[int]*main.deepMap3
+          Type: 1212 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1218
+      ID: 1219
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30570,9 +30789,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1249 GoMapType map[int]*main.deepMap8
+          Type: 1250 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1256
+      ID: 1257
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1105088
@@ -30580,9 +30799,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1258 GoMapType map[int]*main.deepMap9
+          Type: 1259 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1265
+      ID: 1266
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1104960
@@ -30590,7 +30809,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1267 GoMapType map[int]interface {}
+          Type: 1268 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 127
       Name: main.deepPtr1
@@ -30610,9 +30829,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1169 PointerType *main.deepPtr3
+          Type: 1180 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1170
+      ID: 1181
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30624,9 +30843,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1230 PointerType *main.deepPtr8
+          Type: 1231 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1231
+      ID: 1232
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1106240
@@ -30634,9 +30853,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1232 PointerType *main.deepPtr9
+          Type: 1233 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1233
+      ID: 1234
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1106112
@@ -30656,7 +30875,7 @@ Types:
           Offset: 0
           Type: 133 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 421
+      ID: 422
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1108160
@@ -30664,9 +30883,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1205 GoSliceHeaderType []*main.deepSlice3
+          Type: 1206 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1208
+      ID: 1209
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -30678,9 +30897,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1234 GoSliceHeaderType []*main.deepSlice8
+          Type: 1235 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1237
+      ID: 1238
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1107392
@@ -30688,9 +30907,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1240 GoSliceHeaderType []*main.deepSlice9
+          Type: 1241 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1243
+      ID: 1244
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1107264
@@ -30698,7 +30917,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1246 GoSliceHeaderType []interface {}
+          Type: 1247 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 321
       Name: main.emptyStruct
@@ -30716,16 +30935,16 @@ Types:
           Type: 157 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 368 StructureType sync.Mutex
+          Type: 372 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1177 StructureType sync.Once
+          Type: 1188 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1179 StructureType sync.WaitGroup
+          Type: 1190 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 385 StructureType sync/atomic.Int32
+          Type: 386 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 157
       Name: main.esotericStack
@@ -30755,7 +30974,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 355
+      ID: 359
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1238048
@@ -30765,71 +30984,71 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 337
+      ID: 341
       Name: main.largeGenericType[go.shape.int]
       ByteSize: 136
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
     - __kind: StructureType
-      ID: 335
+      ID: 339
       Name: main.largeGenericType[go.shape.string]
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 336 ArrayType [16]uint8
+          Type: 340 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 252
       Name: main.largeStruct
@@ -31143,9 +31362,9 @@ Types:
           Type: 11 BaseType int
         - Name: data
           Offset: 8
-          Type: 1174 ArrayType [63]uint64
+          Type: 1185 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1185
+      ID: 1196
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1238208
@@ -31165,7 +31384,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1187
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -31176,31 +31395,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1172 PointerType *main.stringType1.str
+          Type: 1183 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 1171 GoStringDataType main.stringType1.str
+      Data: 1182 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1171
+      ID: 1182
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1173
+      ID: 1184
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1275 PointerType *main.stringType2.str
+          Type: 1276 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 1274 GoStringDataType main.stringType2.str
+      Data: 1275 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1274
+      ID: 1275
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -31316,16 +31535,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1186 PointerType **main.t
+          Type: 1197 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1187 GoSliceDataType main.t.array
+      Data: 1198 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1187
+      ID: 1198
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -31381,29 +31600,38 @@ Types:
         - Name: c
           Offset: 32
           Type: 13 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 326
+      Name: main.timeCapture
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: monotonicNow
+          Offset: 0
+          Type: 323 GoTimeType time.Time
     - __kind: BaseType
       ID: 122
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 349
+      ID: 353
       Name: main.typeWithGenerics[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 323 BaseType go.shape.int
+          Type: 327 BaseType go.shape.int
     - __kind: StructureType
-      ID: 350
+      ID: 354
       Name: main.typeWithGenerics[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 325 GoStringHeaderType go.shape.string
+          Type: 329 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 257
       Name: main.wideStruct
@@ -31472,12 +31700,12 @@ Types:
       GoKind: 21
       HeaderType: 202 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 370
+      ID: 374
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 886688
       GoKind: 21
-      HeaderType: 372 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 376 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 139
       Name: map[int]*main.deepMap2
@@ -31486,26 +31714,26 @@ Types:
       GoKind: 21
       HeaderType: 141 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1211
+      ID: 1212
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 884192
       GoKind: 21
-      HeaderType: 1213 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1214 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1249
+      ID: 1250
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 883712
       GoKind: 21
-      HeaderType: 1251 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1252 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1258
+      ID: 1259
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 883616
       GoKind: 21
-      HeaderType: 1260 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1261 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 168
       Name: map[int]int
@@ -31514,12 +31742,12 @@ Types:
       GoKind: 21
       HeaderType: 170 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 1267
+      ID: 1268
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 883520
       GoKind: 21
-      HeaderType: 1269 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1270 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 235
       Name: map[int]struct {}
@@ -31535,12 +31763,12 @@ Types:
       GoKind: 21
       HeaderType: 207 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 521
+      ID: 528
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 886880
       GoKind: 21
-      HeaderType: 523 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 530 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 195
       Name: map[string][]main.structWithMap
@@ -31556,12 +31784,12 @@ Types:
       GoKind: 21
       HeaderType: 185 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 397
+      ID: 398
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 886784
       GoKind: 21
-      HeaderType: 399 GoHMapHeaderType hash<string,float64>
+      HeaderType: 400 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
       ID: 178
       Name: map[string]int
@@ -31570,12 +31798,12 @@ Types:
       GoKind: 21
       HeaderType: 180 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 526
+      ID: 533
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 882944
       GoKind: 21
-      HeaderType: 394 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 395 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
       ID: 173
       Name: map[string]main.nestedStruct
@@ -31584,12 +31812,12 @@ Types:
       GoKind: 21
       HeaderType: 175 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 387
+      ID: 388
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 885920
       GoKind: 21
-      HeaderType: 389 GoHMapHeaderType hash<string,string>
+      HeaderType: 390 GoHMapHeaderType hash<string,string>
     - __kind: GoMapType
       ID: 230
       Name: map[struct {}]int
@@ -31655,7 +31883,7 @@ Types:
       GoKind: 21
       HeaderType: 212 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 704
+      ID: 715
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1253888
@@ -31665,7 +31893,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 992
+      ID: 1003
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1250688
@@ -31675,11 +31903,11 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 913
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 968
+      ID: 979
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1413152
@@ -31692,35 +31920,35 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 944
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1141
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 942
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 915
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1151
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1150
+      ID: 1161
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1149
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 869
+      ID: 880
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1077280
@@ -31728,28 +31956,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 871 PointerType *net.UnknownNetworkError.str
+          Type: 882 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 870 GoStringDataType net.UnknownNetworkError.str
+      Data: 881 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 870
+      ID: 881
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 838
+      ID: 849
       Name: net.canceledError
       GoRuntimeType: 1201664
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1119
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 973
+      ID: 984
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1978112
@@ -31757,7 +31985,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 968 GoInterfaceType net.Conn
+          Type: 979 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -31768,27 +31996,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1163
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1146
+      ID: 1157
       Name: net.noReadFrom
       GoRuntimeType: 1077536
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1145
+      ID: 1156
       Name: net.noWriteTo
       GoRuntimeType: 1077408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 641
+      ID: 652
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1227
+      ID: 1228
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1643904
@@ -31801,7 +32029,7 @@ Types:
           Offset: 16
           Type: 152 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 643
+      ID: 654
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1612832
@@ -31809,7 +32037,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 956 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 967 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -31817,7 +32045,7 @@ Types:
           Offset: 96
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 1134
+      ID: 1145
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2154432
@@ -31825,12 +32053,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1146 StructureType net.noReadFrom
+          Type: 1157 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1139 PointerType *net.TCPConn
+          Type: 1150 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1132
+      ID: 1143
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2153888
@@ -31838,24 +32066,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1145 StructureType net.noWriteTo
+          Type: 1156 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1139 PointerType *net.TCPConn
+          Type: 1150 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 917
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 946
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 839
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 984
+      ID: 995
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1242368
@@ -31865,19 +32093,19 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 538
+      ID: 549
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 765632
       GoKind: 10
     - __kind: BaseType
-      ID: 945
+      ID: 956
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 953536
       GoKind: 10
     - __kind: StructureType
-      ID: 619
+      ID: 630
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1611296
@@ -31888,12 +32116,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 945 BaseType net/http.http2ErrCode
+          Type: 956 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 927
+      ID: 938
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1776288
@@ -31904,12 +32132,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 945 BaseType net/http.http2ErrCode
+          Type: 956 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 623
+      ID: 634
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1412832
@@ -31917,16 +32145,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 945 BaseType net/http.http2ErrCode
+          Type: 956 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1059
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 542
+      ID: 553
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 765824
@@ -31934,18 +32162,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 544 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 555 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 543 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 543
+      ID: 554
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 548
+      ID: 559
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 766016
@@ -31953,18 +32181,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 550 PointerType *net/http.http2headerFieldNameError.str
+          Type: 561 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 549 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 560 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 549
+      ID: 560
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 545
+      ID: 556
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 765920
@@ -31972,32 +32200,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 547 PointerType *net/http.http2headerFieldValueError.str
+          Type: 558 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 546 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 557 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 546
+      ID: 557
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 899
+      ID: 910
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 845
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1201152
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1110
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 539
+      ID: 550
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 765728
@@ -32005,18 +32233,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 541 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 552 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 540 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 551 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 540
+      ID: 551
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 986
+      ID: 997
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1612064
@@ -32024,22 +32252,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 968 GoInterfaceType net.Conn
+          Type: 979 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1067 BaseType time.Duration
+          Type: 1078 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 101 PointerType *error
     - __kind: ArrayType
-      ID: 1068
+      ID: 1079
       Name: net/http.incomparable
       GoRuntimeType: 833792
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 830
+      ID: 841
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1374720
@@ -32049,11 +32277,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1061
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1006
+      ID: 1017
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1374560
@@ -32061,9 +32289,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1049 PointerType *net/http.persistConn
+          Type: 1060 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1032
+      ID: 1043
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1683424
@@ -32071,15 +32299,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1068 ArrayType net/http.incomparable
+          Type: 1079 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1069 PointerType *bufio.Reader
+          Type: 1080 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1071 GoInterfaceType io.ReadWriteCloser
+          Type: 1082 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 627
+      ID: 638
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1243328
@@ -32089,17 +32317,17 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 929
+      ID: 940
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 897
+      ID: 908
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1300576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 832
+      ID: 843
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1374880
@@ -32109,11 +32337,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 627
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1101
+      ID: 1112
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1914528
@@ -32121,13 +32349,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1096 PointerType *bufio.Writer
+          Type: 1107 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1027
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 696
+      ID: 707
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1616672
@@ -32143,7 +32371,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 694
+      ID: 705
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1414592
@@ -32156,11 +32384,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1058
+      ID: 1069
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1018
+      ID: 1029
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1416512
@@ -32168,16 +32396,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1057 PointerType *net/smtp.Client
+          Type: 1068 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1059 GoInterfaceType io.WriteCloser
+          Type: 1070 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 691
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 573
+      ID: 584
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 768512
@@ -32185,26 +32413,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 575 PointerType *net/textproto.ProtocolError.str
+          Type: 586 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 574 GoStringDataType net/textproto.ProtocolError.str
+      Data: 585 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 574
+      ID: 585
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1025
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 948
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 551
+      ID: 562
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 766496
@@ -32212,18 +32440,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 553 PointerType *net/url.EscapeError.str
+          Type: 564 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 552 GoStringDataType net/url.EscapeError.str
+      Data: 563 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 552
+      ID: 563
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 554
+      ID: 565
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 766592
@@ -32231,30 +32459,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 556 PointerType *net/url.InvalidHostError.str
+          Type: 567 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 555 GoStringDataType net/url.InvalidHostError.str
+      Data: 566 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 555
+      ID: 566
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1169
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 822
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 886
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1156
+      ID: 1167
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2222624
@@ -32262,12 +32490,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1162 StructureType os.noReadFrom
+          Type: 1173 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1157 PointerType *os.File
+          Type: 1168 PointerType *os.File
     - __kind: StructureType
-      ID: 1154
+      ID: 1165
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2221824
@@ -32275,36 +32503,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1161 StructureType os.noWriteTo
+          Type: 1172 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1157 PointerType *os.File
+          Type: 1168 PointerType *os.File
     - __kind: StructureType
-      ID: 1162
+      ID: 1173
       Name: os.noReadFrom
       GoRuntimeType: 1075616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1161
+      ID: 1172
       Name: os.noWriteTo
       GoRuntimeType: 1075488
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 851
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 987
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1047
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 853
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1519136
@@ -32317,7 +32545,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 586
+      ID: 597
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 771680
@@ -32325,36 +32553,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 588 PointerType *os/user.UnknownGroupIdError.str
+          Type: 599 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 587 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 598 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 587
+      ID: 598
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 585
+      ID: 596
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 771584
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 625
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 702
+      ID: 713
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 825
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 830
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -32366,7 +32594,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 816
+      ID: 827
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1765856
@@ -32383,9 +32611,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 974 BaseType runtime.boundsErrorCode
+          Type: 985 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 974
+      ID: 985
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 535168
@@ -32405,7 +32633,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 877
+      ID: 888
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1636992
@@ -32418,7 +32646,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 793
+      ID: 804
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 952672
@@ -32426,13 +32654,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 795 PointerType *runtime.errorString.str
+          Type: 806 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 794 GoStringDataType runtime.errorString.str
+      Data: 805 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 794
+      ID: 805
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -33058,7 +33286,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 796
+      ID: 807
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 953248
@@ -33066,13 +33294,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 798 PointerType *runtime.plainError.str
+          Type: 809 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 797 GoStringDataType runtime.plainError.str
+      Data: 808 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 797
+      ID: 808
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -33154,7 +33382,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 820
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -33166,26 +33394,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 414 PointerType *string.str
+          Type: 415 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 413 GoStringDataType string.str
+      Data: 414 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 413
+      ID: 414
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1106
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1015
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1000
+      ID: 1011
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1279776
@@ -33201,7 +33429,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 368
+      ID: 372
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1291296
@@ -33214,7 +33442,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1177
+      ID: 1188
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1292416
@@ -33222,12 +33450,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1178 StructureType sync/atomic.Uint32
+          Type: 1189 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 368 StructureType sync.Mutex
+          Type: 372 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 384
+      ID: 385
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1718368
@@ -33235,7 +33463,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 368 StructureType sync.Mutex
+          Type: 372 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -33244,12 +33472,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 385 StructureType sync/atomic.Int32
+          Type: 386 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 385 StructureType sync/atomic.Int32
+          Type: 386 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1179
+      ID: 1190
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1432448
@@ -33257,21 +33485,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1180 StructureType sync.noCopy
+          Type: 1191 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1181 StructureType sync/atomic.Uint64
+          Type: 1192 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1180
+      ID: 1191
       Name: sync.noCopy
       GoRuntimeType: 952288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 385
+      ID: 386
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1292736
@@ -33279,12 +33507,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 386 StructureType sync/atomic.noCopy
+          Type: 387 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 15 BaseType int32
     - __kind: StructureType
-      ID: 1178
+      ID: 1189
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1292896
@@ -33292,12 +33520,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 386 StructureType sync/atomic.noCopy
+          Type: 387 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1181
+      ID: 1192
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1432832
@@ -33305,15 +33533,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 386 StructureType sync/atomic.noCopy
+          Type: 387 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1182 StructureType sync/atomic.align64
+          Type: 1193 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 12 BaseType uint64
     - __kind: StructureType
-      ID: 369
+      ID: 373
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1114048
@@ -33323,29 +33551,29 @@ Types:
           Offset: 0
           Type: 159 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1182
+      ID: 1193
       Name: sync/atomic.align64
       GoRuntimeType: 952480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 386
+      ID: 387
       Name: sync/atomic.noCopy
       GoRuntimeType: 952384
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 925
+      ID: 936
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1202432
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1139
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 868
+      ID: 879
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1523552
@@ -33358,13 +33586,13 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 1067
+      ID: 1078
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1790592
       GoKind: 6
     - __kind: StructureType
-      ID: 380
+      ID: 325
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1842816
@@ -33375,10 +33603,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 1190 GoSliceHeaderType []time.zone
+          Type: 503 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 1193 GoSliceHeaderType []time.zoneTrans
+          Type: 506 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -33390,13 +33618,13 @@ Types:
           Type: 16 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 1191 PointerType *time.zone
+          Type: 504 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 621
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 378
+    - __kind: GoTimeType
+      ID: 323
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2234848
@@ -33410,9 +33638,17 @@ Types:
           Type: 16 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 379 PointerType *time.Location
+          Type: 324 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 377
+      ID: 381
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1293536
@@ -33420,12 +33656,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1189 GoChannelType <-chan time.Time
+          Type: 1200 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 546
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 764096
@@ -33433,18 +33669,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *time.fileSizeError.str
+          Type: 548 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 536 GoStringDataType time.fileSizeError.str
+      Data: 547 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 547
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1192
+      ID: 505
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1433792
@@ -33460,7 +33696,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1195
+      ID: 508
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1635840
@@ -33521,11 +33757,11 @@ Types:
       GoRuntimeType: 535104
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1102
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 956
+      ID: 967
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1936256
@@ -33536,10 +33772,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 957 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 968 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 958 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 969 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -33554,18 +33790,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 959 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 970 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 959
+      ID: 970
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 957952
       GoKind: 9
     - __kind: StructureType
-      ID: 957
+      ID: 968
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1802624
@@ -33590,21 +33826,21 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 709
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 958
+      ID: 969
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 538752
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1120
+      ID: 1131
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 682
+      ID: 693
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1251008
@@ -33614,13 +33850,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 576
+      ID: 587
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 768608
       GoKind: 2
     - __kind: StructureType
-      ID: 847
+      ID: 858
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1519328
@@ -33633,12 +33869,12 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 801
+      ID: 812
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 956800
       GoKind: 5
-MaxTypeID: 1604
+MaxTypeID: 1608
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,11 +12,11 @@ Probes:
         - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1714 EventRootType Probe[main.stackC]
+              Type: 1715 EventRootType Probe[main.stackC]
               InjectionPoints: [{PC: "0x854c58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1715 EventRootType Probe[main.stackC]Return
+              Type: 1716 EventRootType Probe[main.stackC]Return
               InjectionPoints: [{PC: "0x854c8c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -32,11 +32,11 @@ Probes:
         - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testAny]
+              Type: 1554 EventRootType Probe[main.testAny]
               InjectionPoints: [{PC: "0x84fa28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1554 EventRootType Probe[main.testAny]Return
+              Type: 1555 EventRootType Probe[main.testAny]Return
               InjectionPoints: [{PC: "0x84fa54", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -58,11 +58,11 @@ Probes:
         - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.testAnyPtr]
+              Type: 1557 EventRootType Probe[main.testAnyPtr]
               InjectionPoints: [{PC: "0x84faa8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.testAnyPtr]Return
+              Type: 1558 EventRootType Probe[main.testAnyPtr]Return
               InjectionPoints: [{PC: "0x84fad4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -83,11 +83,11 @@ Probes:
         - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1685 EventRootType Probe[main.testArrayArgAndReturn]
+              Type: 1686 EventRootType Probe[main.testArrayArgAndReturn]
               InjectionPoints: [{PC: "0x85377c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1686 EventRootType Probe[main.testArrayArgAndReturn]Return
+              Type: 1687 EventRootType Probe[main.testArrayArgAndReturn]Return
               InjectionPoints: [{PC: "0x853814", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -109,7 +109,7 @@ Probes:
         - subprogram: {subprogram: 19}
           events:
             - Kind: Entry
-              Type: 1500 EventRootType Probe[main.testArrayEmptyStructs]
+              Type: 1501 EventRootType Probe[main.testArrayEmptyStructs]
               InjectionPoints: [{PC: "0x84b470", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -131,7 +131,7 @@ Probes:
         - subprogram: {subprogram: 15}
           events:
             - Kind: Entry
-              Type: 1496 EventRootType Probe[main.testArrayOfArrays]
+              Type: 1497 EventRootType Probe[main.testArrayOfArrays]
               InjectionPoints: [{PC: "0x84b430", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -153,7 +153,7 @@ Probes:
         - subprogram: {subprogram: 17}
           events:
             - Kind: Entry
-              Type: 1498 EventRootType Probe[main.testArrayOfArraysOfArrays]
+              Type: 1499 EventRootType Probe[main.testArrayOfArraysOfArrays]
               InjectionPoints: [{PC: "0x84b450", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -175,7 +175,7 @@ Probes:
         - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 1565 EventRootType Probe[main.testArrayOfMaps]
+              Type: 1566 EventRootType Probe[main.testArrayOfMaps]
               InjectionPoints: [{PC: "0x850230", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -197,7 +197,7 @@ Probes:
         - subprogram: {subprogram: 16}
           events:
             - Kind: Entry
-              Type: 1497 EventRootType Probe[main.testArrayOfStrings]
+              Type: 1498 EventRootType Probe[main.testArrayOfStrings]
               InjectionPoints: [{PC: "0x84b440", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -218,7 +218,7 @@ Probes:
         - subprogram: {subprogram: 18}
           events:
             - Kind: Entry
-              Type: 1499 EventRootType Probe[main.testArrayOfStructs]
+              Type: 1500 EventRootType Probe[main.testArrayOfStructs]
               InjectionPoints: [{PC: "0x84b460", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -240,11 +240,11 @@ Probes:
         - subprogram: {subprogram: 90}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testAtomicAdd]
+              Type: 1588 EventRootType Probe[main.testAtomicAdd]
               InjectionPoints: [{PC: "0x8519d0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1588 EventRootType Probe[main.testAtomicAdd]Return
+              Type: 1589 EventRootType Probe[main.testAtomicAdd]Return
               InjectionPoints: [{PC: "0x851a0c", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -266,11 +266,11 @@ Probes:
         - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testBigStruct]
+              Type: 1519 EventRootType Probe[main.testBigStruct]
               InjectionPoints: [{PC: "0x84b9c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1519 EventRootType Probe[main.testBigStruct]Return
+              Type: 1520 EventRootType Probe[main.testBigStruct]Return
               InjectionPoints: [{PC: "0x84b9d8", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -292,7 +292,7 @@ Probes:
         - subprogram: {subprogram: 4}
           events:
             - Kind: Entry
-              Type: 1485 EventRootType Probe[main.testBoolArray]
+              Type: 1486 EventRootType Probe[main.testBoolArray]
               InjectionPoints: [{PC: "0x84b380", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -314,7 +314,7 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 1482 EventRootType Probe[main.testByteArray]
+              Type: 1483 EventRootType Probe[main.testByteArray]
               InjectionPoints: [{PC: "0x84b350", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -341,11 +341,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1733 EventRootType Probe[main.testStruct]
+              Type: 1734 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0x854fb0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1734 EventRootType Probe[main.testStruct]Return
+              Type: 1735 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0x854fcc", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1794 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1798 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x84f2e8"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1795 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1799 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x84f2e8"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 6 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 189, index: 0, name: x}
+                      Variable: {subprogram: 192, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -437,10 +437,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1796 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1800 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x84f2e8"
                   Frameless: false
@@ -477,7 +477,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testCombinedString]
+              Type: 1585 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0x851770", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
@@ -496,7 +496,7 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testCombinedString]
+              Type: 1586 EventRootType Probe[main.testCombinedString]
               InjectionPoints: [{PC: "0x851770", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -522,7 +522,7 @@ Probes:
         - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1741 EventRootType Probe[main.testTenStrings]
+              Type: 1742 EventRootType Probe[main.testTenStrings]
               InjectionPoints: [{PC: "0x855060", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
@@ -560,7 +560,7 @@ Probes:
         - subprogram: {subprogram: 91}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testChannel]
+              Type: 1590 EventRootType Probe[main.testChannel]
               InjectionPoints: [{PC: "0x851a10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -590,7 +590,7 @@ Probes:
         - subprogram: {subprogram: 87}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testCombinedByte]
+              Type: 1584 EventRootType Probe[main.testCombinedByte]
               InjectionPoints: [{PC: "0x851750", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -619,11 +619,11 @@ Probes:
         - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1650 EventRootType Probe[main.testConflictingReturn]
+              Type: 1651 EventRootType Probe[main.testConflictingReturn]
               InjectionPoints: [{PC: "0x852998", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1651 EventRootType Probe[main.testConflictingReturn]Return
+              Type: 1652 EventRootType Probe[main.testConflictingReturn]Return
               InjectionPoints: [{PC: "0x852a44", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -645,7 +645,7 @@ Probes:
         - subprogram: {subprogram: 99}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testCycle]
+              Type: 1598 EventRootType Probe[main.testCycle]
               InjectionPoints: [{PC: "0x851cc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -667,7 +667,7 @@ Probes:
         - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 1525 EventRootType Probe[main.testDeepMap1]
+              Type: 1526 EventRootType Probe[main.testDeepMap1]
               InjectionPoints: [{PC: "0x84bec0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -689,7 +689,7 @@ Probes:
         - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 1526 EventRootType Probe[main.testDeepMap7]
+              Type: 1527 EventRootType Probe[main.testDeepMap7]
               InjectionPoints: [{PC: "0x84bed0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -711,7 +711,7 @@ Probes:
         - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 1521 EventRootType Probe[main.testDeepPtr1]
+              Type: 1522 EventRootType Probe[main.testDeepPtr1]
               InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -733,7 +733,7 @@ Probes:
         - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testDeepPtr7]
+              Type: 1523 EventRootType Probe[main.testDeepPtr7]
               InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -755,7 +755,7 @@ Probes:
         - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 1523 EventRootType Probe[main.testDeepSlice1]
+              Type: 1524 EventRootType Probe[main.testDeepSlice1]
               InjectionPoints: [{PC: "0x84bd60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -777,7 +777,7 @@ Probes:
         - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testDeepSlice7]
+              Type: 1525 EventRootType Probe[main.testDeepSlice7]
               InjectionPoints: [{PC: "0x84bd70", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -799,7 +799,7 @@ Probes:
         - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1702 EventRootType Probe[main.testEmptySlice]
+              Type: 1703 EventRootType Probe[main.testEmptySlice]
               InjectionPoints: [{PC: "0x8545b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -826,7 +826,7 @@ Probes:
         - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1705 EventRootType Probe[main.testEmptySliceOfStructs]
+              Type: 1706 EventRootType Probe[main.testEmptySliceOfStructs]
               InjectionPoints: [{PC: "0x8545e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -854,7 +854,7 @@ Probes:
         - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1728 EventRootType Probe[main.testEmptyString]
+              Type: 1729 EventRootType Probe[main.testEmptyString]
               InjectionPoints: [{PC: "0x854d30", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -876,7 +876,7 @@ Probes:
         - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1742 EventRootType Probe[main.testEmptyStruct]
+              Type: 1743 EventRootType Probe[main.testEmptyStruct]
               InjectionPoints: [{PC: "0x8550b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -897,7 +897,7 @@ Probes:
         - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1743 EventRootType Probe[main.testEmptyStructPointer]
+              Type: 1744 EventRootType Probe[main.testEmptyStructPointer]
               InjectionPoints: [{PC: "0x8550c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -919,7 +919,7 @@ Probes:
         - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 1555 EventRootType Probe[main.testError]
+              Type: 1556 EventRootType Probe[main.testError]
               InjectionPoints: [{PC: "0x84fa80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -953,7 +953,7 @@ Probes:
         - subprogram: {subprogram: 38}
           events:
             - Kind: Line
-              Type: 1520 EventRootType Probe[main.testErrorAtLine]Line
+              Type: 1521 EventRootType Probe[main.testErrorAtLine]Line
               InjectionPoints: [{PC: "0x84ba4c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -981,11 +981,11 @@ Probes:
         - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testEsotericHeap]
+              Type: 1538 EventRootType Probe[main.testEsotericHeap]
               InjectionPoints: [{PC: "0x84e2f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1538 EventRootType Probe[main.testEsotericHeap]Return
+              Type: 1539 EventRootType Probe[main.testEsotericHeap]Return
               InjectionPoints: [{PC: "0x84e334", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1007,11 +1007,11 @@ Probes:
         - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testEsotericStack]
+              Type: 1536 EventRootType Probe[main.testEsotericStack]
               InjectionPoints: [{PC: "0x84e22c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1536 EventRootType Probe[main.testEsotericStack]Return
+              Type: 1537 EventRootType Probe[main.testEsotericStack]Return
               InjectionPoints: [{PC: "0x84e29c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1033,11 +1033,11 @@ Probes:
         - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testFrameless]
+              Type: 1548 EventRootType Probe[main.testFrameless]
               InjectionPoints: [{PC: "0x84f760", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1548 EventRootType Probe[main.testFrameless]Return
+              Type: 1549 EventRootType Probe[main.testFrameless]Return
               InjectionPoints: [{PC: "0x84f768", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -1059,11 +1059,11 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 1549 EventRootType Probe[main.testFramelessArray]
+              Type: 1550 EventRootType Probe[main.testFramelessArray]
               InjectionPoints: [{PC: "0x84f77c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1550 EventRootType Probe[main.testFramelessArray]Return
+              Type: 1551 EventRootType Probe[main.testFramelessArray]Return
               InjectionPoints: [{PC: "0x84f7b8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1088,7 +1088,7 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Line
-              Type: 1551 EventRootType Probe[main.testFramelessArray]Line
+              Type: 1552 EventRootType Probe[main.testFramelessArray]Line
               InjectionPoints: [{PC: "0x84f77c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1107,15 +1107,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1780 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x857220", Frameless: true}]
+              Type: 1784 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0x857370", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1781 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x857228", Frameless: true}]
+              Type: 1785 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x857378", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,15 +1125,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1782 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x857240", Frameless: false}]
+              Type: 1786 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0x857390", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1783 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x85727c", Frameless: false}]
+              Type: 1787 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0x8573cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,15 +1152,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1776 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x857188", Frameless: false}]
+              Type: 1780 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0x8572d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1777 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x857198", Frameless: false}]
+              Type: 1781 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0x8572e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,15 +1170,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1778 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x8571d8", Frameless: false}]
+              Type: 1782 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0x857328", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1779 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x8571f0", Frameless: false}]
+              Type: 1783 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0x857340", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,18 +1197,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1784 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x857290", Frameless: true}]
+              Type: 1788 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0x8573e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1785 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1789 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x8572b8"
+                - PC: "0x857408"
                   Frameless: true
-                - PC: "0x8572c0"
+                - PC: "0x857410"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,18 +1219,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1786 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x8572e8", Frameless: false}]
+              Type: 1790 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0x857438", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1787 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1791 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x857348"
+                - PC: "0x857498"
                   Frameless: false
-                - PC: "0x857358"
+                - PC: "0x8574a8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,11 +1253,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Line
-              Type: 1788 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x857294", Frameless: true}]
+              Type: 1792 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0x8573e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,11 +1265,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1789 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x8572f8", Frameless: false}]
+              Type: 1793 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0x857448", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,15 +1286,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1764 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x856e80", Frameless: true}]
+              Type: 1768 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0x856fd0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1765 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x856e88", Frameless: true}]
+              Type: 1769 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0x856fd8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,15 +1304,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1766 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x856f10", Frameless: true}]
+              Type: 1770 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0x857060", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1767 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x856f14", Frameless: true}]
+              Type: 1771 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0x857064", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,15 +1332,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 169}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1752 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x856a88", Frameless: false}]
+              Type: 1756 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0x856bd8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1753 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x856b5c", Frameless: false}]
+              Type: 1757 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x856cac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1350,14 +1350,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1754 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1758 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x84a518", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1755 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1759 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x84a5ec", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1378,15 +1378,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1756 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x856ba8", Frameless: false}]
+              Type: 1760 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x856cf8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1757 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x856bb8", Frameless: false}]
+              Type: 1761 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x856d08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,15 +1405,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1790 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x857390", Frameless: true}]
+              Type: 1794 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0x8574e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1791 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x857398", Frameless: true}]
+              Type: 1795 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0x8574e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,15 +1423,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1792 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x857428", Frameless: false}]
+              Type: 1796 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0x857578", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1793 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x85744c", Frameless: false}]
+              Type: 1797 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0x85759c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,15 +1450,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
+        - subprogram: {subprogram: 170}
           events:
             - Kind: Entry
-              Type: 1748 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x8569f0", Frameless: true}]
+              Type: 1752 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0x856b40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1749 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8569f4", Frameless: true}]
+              Type: 1753 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x856b44", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,15 +1468,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 168}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1750 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x856a00", Frameless: true}]
+              Type: 1754 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0x856b50", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1751 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x856a0c", Frameless: true}]
+              Type: 1755 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x856b5c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,15 +1495,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1768 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x856fb0", Frameless: true}]
+              Type: 1772 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0x857100", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1769 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x856fb8", Frameless: true}]
+              Type: 1773 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0x857108", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,15 +1513,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1770 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x857058", Frameless: false}]
+              Type: 1774 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0x8571a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1771 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x857084", Frameless: false}]
+              Type: 1775 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0x8571d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,15 +1540,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1758 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x856e50", Frameless: true}]
+              Type: 1762 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x856fa0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1759 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x856e54", Frameless: true}]
+              Type: 1763 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x856fa4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,15 +1558,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1760 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x856e60", Frameless: true}]
+              Type: 1764 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0x856fb0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1761 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x856e64", Frameless: true}]
+              Type: 1765 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0x856fb4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,15 +1576,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1762 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x856e70", Frameless: true}]
+              Type: 1766 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0x856fc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1763 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x856e74", Frameless: true}]
+              Type: 1767 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0x856fc4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,15 +1603,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1772 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x857140", Frameless: true}]
+              Type: 1776 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0x857290", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1773 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x857148", Frameless: true}]
+              Type: 1777 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0x857298", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,15 +1621,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1774 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x857150", Frameless: true}]
+              Type: 1778 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x8572a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1775 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x857160", Frameless: true}]
+              Type: 1779 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x8572b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,15 +1648,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1744 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x8569d0", Frameless: true}]
+              Type: 1748 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0x856b20", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1745 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8569d4", Frameless: true}]
+              Type: 1749 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x856b24", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,15 +1666,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1746 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x8569e0", Frameless: true}]
+              Type: 1750 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0x856b30", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1747 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8569ec", Frameless: true}]
+              Type: 1751 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x856b3c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1696,11 +1696,11 @@ Probes:
         - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 1539 EventRootType Probe[main.testInlinedBA]
+              Type: 1540 EventRootType Probe[main.testInlinedBA]
               InjectionPoints: [{PC: "0x84f488", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1540 EventRootType Probe[main.testInlinedBA]Return
+              Type: 1541 EventRootType Probe[main.testInlinedBA]Return
               InjectionPoints: [{PC: "0x84f4e0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1727,11 +1727,11 @@ Probes:
         - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 1541 EventRootType Probe[main.testInlinedBB]
+              Type: 1542 EventRootType Probe[main.testInlinedBB]
               InjectionPoints: [{PC: "0x84f518", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1542 EventRootType Probe[main.testInlinedBB]Return
+              Type: 1543 EventRootType Probe[main.testInlinedBB]Return
               InjectionPoints: [{PC: "0x84f5a0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1758,11 +1758,11 @@ Probes:
         - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testInlinedBBA]
+              Type: 1544 EventRootType Probe[main.testInlinedBBA]
               InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1544 EventRootType Probe[main.testInlinedBBA]Return
+              Type: 1545 EventRootType Probe[main.testInlinedBBA]Return
               InjectionPoints: [{PC: "0x84f614", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1781,10 +1781,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1800 EventRootType Probe[main.testInlinedBBB]
+              Type: 1804 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0x84f568", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1802,11 +1802,11 @@ Probes:
         - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testInlinedBC]
+              Type: 1546 EventRootType Probe[main.testInlinedBC]
               InjectionPoints: [{PC: "0x84f658", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1546 EventRootType Probe[main.testInlinedBC]Return
+              Type: 1547 EventRootType Probe[main.testInlinedBC]Return
               InjectionPoints: [{PC: "0x84f748", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1821,10 +1821,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Entry
-              Type: 1801 EventRootType Probe[main.testInlinedBCA]
+              Type: 1805 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0x84f65c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1842,10 +1842,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Line
-              Type: 1802 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1806 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0x84f65c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1860,10 +1860,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Entry
-              Type: 1803 EventRootType Probe[main.testInlinedBCB]
+              Type: 1807 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0x84f710", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1881,10 +1881,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Line
-              Type: 1804 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1808 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0x84f710", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1899,10 +1899,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 196}
+        - subprogram: {subprogram: 199}
           events:
             - Kind: Entry
-              Type: 1810 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1814 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x84a068"
                   Frameless: true
@@ -1922,10 +1922,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1797 EventRootType Probe[main.testInlinedPrint]
+              Type: 1801 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0x84f2e8"
                   Frameless: false
@@ -1939,7 +1939,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1798 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1802 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0x84f320", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1961,10 +1961,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1799 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1803 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x84f2e8"
                   Frameless: false
@@ -1993,10 +1993,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Entry
-              Type: 1805 EventRootType Probe[main.testInlinedSq]
+              Type: 1809 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0x84f764", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2018,10 +2018,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Line
-              Type: 1806 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1810 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0x84f764", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2041,10 +2041,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 194}
+        - subprogram: {subprogram: 197}
           events:
             - Kind: Entry
-              Type: 1807 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1811 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0x84f794"
                   Frameless: false
@@ -2070,7 +2070,7 @@ Probes:
         - subprogram: {subprogram: 7}
           events:
             - Kind: Entry
-              Type: 1488 EventRootType Probe[main.testInt16Array]
+              Type: 1489 EventRootType Probe[main.testInt16Array]
               InjectionPoints: [{PC: "0x84b3b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2092,7 +2092,7 @@ Probes:
         - subprogram: {subprogram: 8}
           events:
             - Kind: Entry
-              Type: 1489 EventRootType Probe[main.testInt32Array]
+              Type: 1490 EventRootType Probe[main.testInt32Array]
               InjectionPoints: [{PC: "0x84b3c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2114,7 +2114,7 @@ Probes:
         - subprogram: {subprogram: 9}
           events:
             - Kind: Entry
-              Type: 1490 EventRootType Probe[main.testInt64Array]
+              Type: 1491 EventRootType Probe[main.testInt64Array]
               InjectionPoints: [{PC: "0x84b3d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2136,7 +2136,7 @@ Probes:
         - subprogram: {subprogram: 6}
           events:
             - Kind: Entry
-              Type: 1487 EventRootType Probe[main.testInt8Array]
+              Type: 1488 EventRootType Probe[main.testInt8Array]
               InjectionPoints: [{PC: "0x84b3a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2158,7 +2158,7 @@ Probes:
         - subprogram: {subprogram: 5}
           events:
             - Kind: Entry
-              Type: 1486 EventRootType Probe[main.testIntArray]
+              Type: 1487 EventRootType Probe[main.testIntArray]
               InjectionPoints: [{PC: "0x84b390", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2180,7 +2180,7 @@ Probes:
         - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 1552 EventRootType Probe[main.testInterface]
+              Type: 1553 EventRootType Probe[main.testInterface]
               InjectionPoints: [{PC: "0x84fa00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2201,11 +2201,11 @@ Probes:
         - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1683 EventRootType Probe[main.testLargeArgAndReturn]
+              Type: 1684 EventRootType Probe[main.testLargeArgAndReturn]
               InjectionPoints: [{PC: "0x8535c0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1684 EventRootType Probe[main.testLargeArgAndReturn]Return
+              Type: 1685 EventRootType Probe[main.testLargeArgAndReturn]Return
               InjectionPoints: [{PC: "0x853718", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2227,7 +2227,7 @@ Probes:
         - subprogram: {subprogram: 93}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testLinkedList]
+              Type: 1592 EventRootType Probe[main.testLinkedList]
               InjectionPoints: [{PC: "0x851bd0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2252,7 +2252,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1529 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1530 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x84bf1c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2274,7 +2274,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1530 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1531 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x84bfac", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2296,7 +2296,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1531 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1532 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x84c054", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2339,11 +2339,11 @@ Probes:
         - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1689 EventRootType Probe[main.testManyArgsArrayReturn]
+              Type: 1690 EventRootType Probe[main.testManyArgsArrayReturn]
               InjectionPoints: [{PC: "0x853a7c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1690 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              Type: 1691 EventRootType Probe[main.testManyArgsArrayReturn]Return
               InjectionPoints: [{PC: "0x853be8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2406,7 +2406,7 @@ Probes:
         - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testManyPointers]
+              Type: 1534 EventRootType Probe[main.testManyPointers]
               InjectionPoints: [{PC: "0x84c600", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2430,7 +2430,7 @@ Probes:
         - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testManyStrings]
+              Type: 1535 EventRootType Probe[main.testManyStrings]
               InjectionPoints: [{PC: "0x84df70", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2452,7 +2452,7 @@ Probes:
         - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 1563 EventRootType Probe[main.testMapArrayToArray]
+              Type: 1564 EventRootType Probe[main.testMapArrayToArray]
               InjectionPoints: [{PC: "0x850210", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2474,7 +2474,7 @@ Probes:
         - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 1570 EventRootType Probe[main.testMapEmbeddedMaps]
+              Type: 1571 EventRootType Probe[main.testMapEmbeddedMaps]
               InjectionPoints: [{PC: "0x850270", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2496,7 +2496,7 @@ Probes:
         - subprogram: {subprogram: 84}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testMapEmptyKey]
+              Type: 1581 EventRootType Probe[main.testMapEmptyKey]
               InjectionPoints: [{PC: "0x850310", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2518,7 +2518,7 @@ Probes:
         - subprogram: {subprogram: 86}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testMapEmptyKeyAndValue]
+              Type: 1583 EventRootType Probe[main.testMapEmptyKeyAndValue]
               InjectionPoints: [{PC: "0x850330", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2540,7 +2540,7 @@ Probes:
         - subprogram: {subprogram: 85}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testMapEmptyValue]
+              Type: 1582 EventRootType Probe[main.testMapEmptyValue]
               InjectionPoints: [{PC: "0x850320", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2562,7 +2562,7 @@ Probes:
         - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 1567 EventRootType Probe[main.testMapIntToInt]
+              Type: 1568 EventRootType Probe[main.testMapIntToInt]
               InjectionPoints: [{PC: "0x850250", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2584,7 +2584,7 @@ Probes:
         - subprogram: {subprogram: 83}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testMapLargeKeyLargeValue]
+              Type: 1580 EventRootType Probe[main.testMapLargeKeyLargeValue]
               InjectionPoints: [{PC: "0x850300", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2606,7 +2606,7 @@ Probes:
         - subprogram: {subprogram: 82}
           events:
             - Kind: Entry
-              Type: 1578 EventRootType Probe[main.testMapLargeKeySmallValue]
+              Type: 1579 EventRootType Probe[main.testMapLargeKeySmallValue]
               InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2630,7 +2630,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.testMapMassive]
+              Type: 1569 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0x850260", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2654,7 +2654,7 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1569 EventRootType Probe[main.testMapMassive]
+              Type: 1570 EventRootType Probe[main.testMapMassive]
               InjectionPoints: [{PC: "0x850260", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2676,7 +2676,7 @@ Probes:
         - subprogram: {subprogram: 81}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testMapSmallKeyLargeValue]
+              Type: 1578 EventRootType Probe[main.testMapSmallKeyLargeValue]
               InjectionPoints: [{PC: "0x8502e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2698,7 +2698,7 @@ Probes:
         - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 1576 EventRootType Probe[main.testMapSmallKeySmallValue]
+              Type: 1577 EventRootType Probe[main.testMapSmallKeySmallValue]
               InjectionPoints: [{PC: "0x8502d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2720,7 +2720,7 @@ Probes:
         - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 1561 EventRootType Probe[main.testMapStringToInt]
+              Type: 1562 EventRootType Probe[main.testMapStringToInt]
               InjectionPoints: [{PC: "0x8501f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2742,7 +2742,7 @@ Probes:
         - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.testMapStringToSlice]
+              Type: 1563 EventRootType Probe[main.testMapStringToSlice]
               InjectionPoints: [{PC: "0x850200", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2764,7 +2764,7 @@ Probes:
         - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.testMapStringToStruct]
+              Type: 1561 EventRootType Probe[main.testMapStringToStruct]
               InjectionPoints: [{PC: "0x8501e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2786,7 +2786,7 @@ Probes:
         - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testMapWithLinkedList]
+              Type: 1572 EventRootType Probe[main.testMapWithLinkedList]
               InjectionPoints: [{PC: "0x850280", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2808,7 +2808,7 @@ Probes:
         - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 1574 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+              Type: 1575 EventRootType Probe[main.testMapWithSmallKeyAndValue]
               InjectionPoints: [{PC: "0x8502b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2830,7 +2830,7 @@ Probes:
         - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+              Type: 1576 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
               InjectionPoints: [{PC: "0x8502c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2852,7 +2852,7 @@ Probes:
         - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 1572 EventRootType Probe[main.testMapWithSmallValue]
+              Type: 1573 EventRootType Probe[main.testMapWithSmallValue]
               InjectionPoints: [{PC: "0x850290", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2876,7 +2876,7 @@ Probes:
         - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.testMapWithSmallValueMassive]
+              Type: 1574 EventRootType Probe[main.testMapWithSmallValueMassive]
               InjectionPoints: [{PC: "0x8502a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2898,7 +2898,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1725 EventRootType Probe[main.testMassiveString]
+              Type: 1726 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0x854d10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2921,7 +2921,7 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1726 EventRootType Probe[main.testMassiveString]
+              Type: 1727 EventRootType Probe[main.testMassiveString]
               InjectionPoints: [{PC: "0x854d10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2968,11 +2968,11 @@ Probes:
         - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1691 EventRootType Probe[main.testMixedArgsStackReturn]
+              Type: 1692 EventRootType Probe[main.testMixedArgsStackReturn]
               InjectionPoints: [{PC: "0x853c50", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1692 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              Type: 1693 EventRootType Probe[main.testMixedArgsStackReturn]Return
               InjectionPoints: [{PC: "0x853dfc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3038,11 +3038,11 @@ Probes:
         - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1695 EventRootType Probe[main.testMultipleArrayArgs]
+              Type: 1696 EventRootType Probe[main.testMultipleArrayArgs]
               InjectionPoints: [{PC: "0x853efc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1696 EventRootType Probe[main.testMultipleArrayArgs]Return
+              Type: 1697 EventRootType Probe[main.testMultipleArrayArgs]Return
               InjectionPoints: [{PC: "0x853fa4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3073,11 +3073,11 @@ Probes:
         - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1687 EventRootType Probe[main.testMultipleLargeArgs]
+              Type: 1688 EventRootType Probe[main.testMultipleLargeArgs]
               InjectionPoints: [{PC: "0x853850", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1688 EventRootType Probe[main.testMultipleLargeArgs]Return
+              Type: 1689 EventRootType Probe[main.testMultipleLargeArgs]Return
               InjectionPoints: [{PC: "0x853a20", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3103,11 +3103,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1628 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1629 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x852808", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1629 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1630 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x852894", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3143,7 +3143,7 @@ Probes:
         - subprogram: {subprogram: 89}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testMultipleSimpleParams]
+              Type: 1587 EventRootType Probe[main.testMultipleSimpleParams]
               InjectionPoints: [{PC: "0x851830", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3184,11 +3184,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1622 EventRootType Probe[main.testNamedReturn]
+              Type: 1623 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0x852768", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1623 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1624 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0x8527c8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3212,11 +3212,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1624 EventRootType Probe[main.testNamedReturn]
+              Type: 1625 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0x852768", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1625 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1626 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0x8527c8", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
@@ -3235,11 +3235,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1630 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1631 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x852808", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1631 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1632 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x852894", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
@@ -3259,11 +3259,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1632 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1633 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x852808", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1633 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1634 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x852894", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3296,11 +3296,11 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1626 EventRootType Probe[main.testNamedReturn]
+              Type: 1627 EventRootType Probe[main.testNamedReturn]
               InjectionPoints: [{PC: "0x852768", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1627 EventRootType Probe[main.testNamedReturn]Return
+              Type: 1628 EventRootType Probe[main.testNamedReturn]Return
               InjectionPoints: [{PC: "0x8527c8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3328,7 +3328,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1737 EventRootType Probe[main.testNestedPointer]
+              Type: 1738 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0x855050", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3353,7 +3353,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1738 EventRootType Probe[main.testNestedPointer]
+              Type: 1739 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0x855050", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3384,7 +3384,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1739 EventRootType Probe[main.testNestedPointer]
+              Type: 1740 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0x855050", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3409,7 +3409,7 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1740 EventRootType Probe[main.testNestedPointer]
+              Type: 1741 EventRootType Probe[main.testNestedPointer]
               InjectionPoints: [{PC: "0x855050", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3436,7 +3436,7 @@ Probes:
         - subprogram: {subprogram: 98}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testNilPointer]
+              Type: 1597 EventRootType Probe[main.testNilPointer]
               InjectionPoints: [{PC: "0x851ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3463,7 +3463,7 @@ Probes:
         - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1709 EventRootType Probe[main.testNilSlice]
+              Type: 1710 EventRootType Probe[main.testNilSlice]
               InjectionPoints: [{PC: "0x854620", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3490,7 +3490,7 @@ Probes:
         - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1706 EventRootType Probe[main.testNilSliceOfStructs]
+              Type: 1707 EventRootType Probe[main.testNilSliceOfStructs]
               InjectionPoints: [{PC: "0x8545f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3525,7 +3525,7 @@ Probes:
         - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1708 EventRootType Probe[main.testNilSliceWithOtherParams]
+              Type: 1709 EventRootType Probe[main.testNilSliceWithOtherParams]
               InjectionPoints: [{PC: "0x854610", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3557,7 +3557,7 @@ Probes:
         - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1724 EventRootType Probe[main.testOneStringInStructPointer]
+              Type: 1725 EventRootType Probe[main.testOneStringInStructPointer]
               InjectionPoints: [{PC: "0x854d00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3579,7 +3579,7 @@ Probes:
         - subprogram: {subprogram: 94}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.testPointerLoop]
+              Type: 1593 EventRootType Probe[main.testPointerLoop]
               InjectionPoints: [{PC: "0x851be0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3601,7 +3601,7 @@ Probes:
         - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.testPointerToMap]
+              Type: 1567 EventRootType Probe[main.testPointerToMap]
               InjectionPoints: [{PC: "0x850240", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3623,7 +3623,7 @@ Probes:
         - subprogram: {subprogram: 92}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testPointerToSimpleStruct]
+              Type: 1591 EventRootType Probe[main.testPointerToSimpleStruct]
               InjectionPoints: [{PC: "0x851bc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -3647,11 +3647,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testReturnsInt]
+              Type: 1599 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0x852018", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1599 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1600 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0x85205c", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
@@ -3671,11 +3671,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1642 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1643 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0x8528d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1643 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1644 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0x852960", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3720,11 +3720,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1609 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0x852138", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1609 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1610 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0x8521d0", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3766,11 +3766,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testReturnsInt]
+              Type: 1601 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0x852018", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1601 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1602 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0x85205c", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3815,11 +3815,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1610 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1611 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0x852138", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1611 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1612 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0x8521d0", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
@@ -3863,11 +3863,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1644 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1645 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0x8528d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1645 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1646 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0x852960", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
@@ -3884,11 +3884,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1646 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1647 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0x8528d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1647 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1648 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0x852960", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3910,11 +3910,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testReturnsInt]
+              Type: 1603 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0x852018", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1603 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1604 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0x85205c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -3937,11 +3937,11 @@ Probes:
         - subprogram: {subprogram: 105}
           events:
             - Kind: Entry
-              Type: 1618 EventRootType Probe[main.testReturnsAny]
+              Type: 1619 EventRootType Probe[main.testReturnsAny]
               InjectionPoints: [{PC: "0x852408", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1619 EventRootType Probe[main.testReturnsAny]Return
+              Type: 1620 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
                 - PC: "0x8524a4"
                   Frameless: false
@@ -3976,11 +3976,11 @@ Probes:
         - subprogram: {subprogram: 104}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testReturnsAnyAndError]
+              Type: 1617 EventRootType Probe[main.testReturnsAnyAndError]
               InjectionPoints: [{PC: "0x852288", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1617 EventRootType Probe[main.testReturnsAnyAndError]Return
+              Type: 1618 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
                 - PC: "0x8522dc"
                   Frameless: false
@@ -4014,11 +4014,11 @@ Probes:
         - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1661 EventRootType Probe[main.testReturnsArray]
+              Type: 1662 EventRootType Probe[main.testReturnsArray]
               InjectionPoints: [{PC: "0x852fcc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1662 EventRootType Probe[main.testReturnsArray]Return
+              Type: 1663 EventRootType Probe[main.testReturnsArray]Return
               InjectionPoints: [{PC: "0x853020", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4035,11 +4035,11 @@ Probes:
         - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1663 EventRootType Probe[main.testReturnsArrayOne]
+              Type: 1664 EventRootType Probe[main.testReturnsArrayOne]
               InjectionPoints: [{PC: "0x853058", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1664 EventRootType Probe[main.testReturnsArrayOne]Return
+              Type: 1665 EventRootType Probe[main.testReturnsArrayOne]Return
               InjectionPoints: [{PC: "0x853094", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4056,11 +4056,11 @@ Probes:
         - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1665 EventRootType Probe[main.testReturnsArrayZero]
+              Type: 1666 EventRootType Probe[main.testReturnsArrayZero]
               InjectionPoints: [{PC: "0x8530c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1666 EventRootType Probe[main.testReturnsArrayZero]Return
+              Type: 1667 EventRootType Probe[main.testReturnsArrayZero]Return
               InjectionPoints: [{PC: "0x853100", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4077,11 +4077,11 @@ Probes:
         - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1669 EventRootType Probe[main.testReturnsBacktrackInt]
+              Type: 1670 EventRootType Probe[main.testReturnsBacktrackInt]
               InjectionPoints: [{PC: "0x8531b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1670 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              Type: 1671 EventRootType Probe[main.testReturnsBacktrackInt]Return
               InjectionPoints: [{PC: "0x85321c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4098,11 +4098,11 @@ Probes:
         - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1681 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              Type: 1682 EventRootType Probe[main.testReturnsBoolAndUintptr]
               InjectionPoints: [{PC: "0x853548", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1682 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              Type: 1683 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
               InjectionPoints: [{PC: "0x853588", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4119,11 +4119,11 @@ Probes:
         - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1657 EventRootType Probe[main.testReturnsComplex]
+              Type: 1658 EventRootType Probe[main.testReturnsComplex]
               InjectionPoints: [{PC: "0x852e78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1658 EventRootType Probe[main.testReturnsComplex]Return
+              Type: 1659 EventRootType Probe[main.testReturnsComplex]Return
               InjectionPoints: [{PC: "0x852ec4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4141,11 +4141,11 @@ Probes:
         - subprogram: {subprogram: 103}
           events:
             - Kind: Entry
-              Type: 1614 EventRootType Probe[main.testReturnsError]
+              Type: 1615 EventRootType Probe[main.testReturnsError]
               InjectionPoints: [{PC: "0x852208", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1615 EventRootType Probe[main.testReturnsError]Return
+              Type: 1616 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
                 - PC: "0x852238"
                   Frameless: false
@@ -4170,11 +4170,11 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testReturnsInt]
+              Type: 1605 EventRootType Probe[main.testReturnsInt]
               InjectionPoints: [{PC: "0x852018", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1605 EventRootType Probe[main.testReturnsInt]Return
+              Type: 1606 EventRootType Probe[main.testReturnsInt]Return
               InjectionPoints: [{PC: "0x85205c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4195,11 +4195,11 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1612 EventRootType Probe[main.testReturnsIntAndFloat]
+              Type: 1613 EventRootType Probe[main.testReturnsIntAndFloat]
               InjectionPoints: [{PC: "0x852138", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1613 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              Type: 1614 EventRootType Probe[main.testReturnsIntAndFloat]Return
               InjectionPoints: [{PC: "0x8521d0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4220,11 +4220,11 @@ Probes:
         - subprogram: {subprogram: 101}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testReturnsIntPointer]
+              Type: 1607 EventRootType Probe[main.testReturnsIntPointer]
               InjectionPoints: [{PC: "0x852098", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1607 EventRootType Probe[main.testReturnsIntPointer]Return
+              Type: 1608 EventRootType Probe[main.testReturnsIntPointer]Return
               InjectionPoints: [{PC: "0x8520f8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4246,11 +4246,11 @@ Probes:
         - subprogram: {subprogram: 106}
           events:
             - Kind: Entry
-              Type: 1620 EventRootType Probe[main.testReturnsInterface]
+              Type: 1621 EventRootType Probe[main.testReturnsInterface]
               InjectionPoints: [{PC: "0x852608", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1621 EventRootType Probe[main.testReturnsInterface]Return
+              Type: 1622 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
                 - PC: "0x8526d4"
                   Frameless: false
@@ -4275,11 +4275,11 @@ Probes:
         - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.testReturnsLargeStruct]
+              Type: 1660 EventRootType Probe[main.testReturnsLargeStruct]
               InjectionPoints: [{PC: "0x852f00", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1660 EventRootType Probe[main.testReturnsLargeStruct]Return
+              Type: 1661 EventRootType Probe[main.testReturnsLargeStruct]Return
               InjectionPoints: [{PC: "0x852f94", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4296,11 +4296,11 @@ Probes:
         - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1655 EventRootType Probe[main.testReturnsManyFloats]
+              Type: 1656 EventRootType Probe[main.testReturnsManyFloats]
               InjectionPoints: [{PC: "0x852db8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1656 EventRootType Probe[main.testReturnsManyFloats]Return
+              Type: 1657 EventRootType Probe[main.testReturnsManyFloats]Return
               InjectionPoints: [{PC: "0x852e3c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4317,11 +4317,11 @@ Probes:
         - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1673 EventRootType Probe[main.testReturnsMixed]
+              Type: 1674 EventRootType Probe[main.testReturnsMixed]
               InjectionPoints: [{PC: "0x853338", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1674 EventRootType Probe[main.testReturnsMixed]Return
+              Type: 1675 EventRootType Probe[main.testReturnsMixed]Return
               InjectionPoints: [{PC: "0x853390", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4338,11 +4338,11 @@ Probes:
         - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1667 EventRootType Probe[main.testReturnsMixedStruct]
+              Type: 1668 EventRootType Probe[main.testReturnsMixedStruct]
               InjectionPoints: [{PC: "0x853138", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1668 EventRootType Probe[main.testReturnsMixedStruct]Return
+              Type: 1669 EventRootType Probe[main.testReturnsMixedStruct]Return
               InjectionPoints: [{PC: "0x853180", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4359,11 +4359,11 @@ Probes:
         - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1679 EventRootType Probe[main.testReturnsMultipleFloats]
+              Type: 1680 EventRootType Probe[main.testReturnsMultipleFloats]
               InjectionPoints: [{PC: "0x8534c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1680 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              Type: 1681 EventRootType Probe[main.testReturnsMultipleFloats]Return
               InjectionPoints: [{PC: "0x85350c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4383,7 +4383,7 @@ Probes:
         - subprogram: {subprogram: 111}
           events:
             - Kind: Line
-              Type: 1652 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              Type: 1653 EventRootType Probe[main.testReturnsNamedDeferLine]Line
               InjectionPoints: [{PC: "0x852b48", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4404,11 +4404,11 @@ Probes:
         - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1677 EventRootType Probe[main.testReturnsOnlyFloat]
+              Type: 1678 EventRootType Probe[main.testReturnsOnlyFloat]
               InjectionPoints: [{PC: "0x853458", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1678 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              Type: 1679 EventRootType Probe[main.testReturnsOnlyFloat]Return
               InjectionPoints: [{PC: "0x853498", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4425,11 +4425,11 @@ Probes:
         - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1653 EventRootType Probe[main.testReturnsPrimitives]
+              Type: 1654 EventRootType Probe[main.testReturnsPrimitives]
               InjectionPoints: [{PC: "0x852d28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1654 EventRootType Probe[main.testReturnsPrimitives]Return
+              Type: 1655 EventRootType Probe[main.testReturnsPrimitives]Return
               InjectionPoints: [{PC: "0x852d80", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4446,11 +4446,11 @@ Probes:
         - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1675 EventRootType Probe[main.testReturnsStructWithArray]
+              Type: 1676 EventRootType Probe[main.testReturnsStructWithArray]
               InjectionPoints: [{PC: "0x8533cc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1676 EventRootType Probe[main.testReturnsStructWithArray]Return
+              Type: 1677 EventRootType Probe[main.testReturnsStructWithArray]Return
               InjectionPoints: [{PC: "0x853420", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4467,11 +4467,11 @@ Probes:
         - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1671 EventRootType Probe[main.testReturnsWideStruct]
+              Type: 1672 EventRootType Probe[main.testReturnsWideStruct]
               InjectionPoints: [{PC: "0x853260", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1672 EventRootType Probe[main.testReturnsWideStruct]Return
+              Type: 1673 EventRootType Probe[main.testReturnsWideStruct]Return
               InjectionPoints: [{PC: "0x853304", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4489,7 +4489,7 @@ Probes:
         - subprogram: {subprogram: 2}
           events:
             - Kind: Entry
-              Type: 1483 EventRootType Probe[main.testRuneArray]
+              Type: 1484 EventRootType Probe[main.testRuneArray]
               InjectionPoints: [{PC: "0x84b360", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4524,11 +4524,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1634 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1635 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x852808", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1635 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1636 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x852894", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -4574,7 +4574,7 @@ Probes:
         - subprogram: {subprogram: 23}
           events:
             - Kind: Entry
-              Type: 1504 EventRootType Probe[main.testSingleBool]
+              Type: 1505 EventRootType Probe[main.testSingleBool]
               InjectionPoints: [{PC: "0x84b7e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4596,7 +4596,7 @@ Probes:
         - subprogram: {subprogram: 21}
           events:
             - Kind: Entry
-              Type: 1502 EventRootType Probe[main.testSingleByte]
+              Type: 1503 EventRootType Probe[main.testSingleByte]
               InjectionPoints: [{PC: "0x84b7c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4618,7 +4618,7 @@ Probes:
         - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 1515 EventRootType Probe[main.testSingleFloat32]
+              Type: 1516 EventRootType Probe[main.testSingleFloat32]
               InjectionPoints: [{PC: "0x84b890", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4636,7 +4636,7 @@ Probes:
         - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testSingleFloat64]
+              Type: 1517 EventRootType Probe[main.testSingleFloat64]
               InjectionPoints: [{PC: "0x84b8a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4654,7 +4654,7 @@ Probes:
         - subprogram: {subprogram: 24}
           events:
             - Kind: Entry
-              Type: 1505 EventRootType Probe[main.testSingleInt]
+              Type: 1506 EventRootType Probe[main.testSingleInt]
               InjectionPoints: [{PC: "0x84b7f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4676,7 +4676,7 @@ Probes:
         - subprogram: {subprogram: 26}
           events:
             - Kind: Entry
-              Type: 1507 EventRootType Probe[main.testSingleInt16]
+              Type: 1508 EventRootType Probe[main.testSingleInt16]
               InjectionPoints: [{PC: "0x84b810", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4699,7 +4699,7 @@ Probes:
         - subprogram: {subprogram: 27}
           events:
             - Kind: Entry
-              Type: 1508 EventRootType Probe[main.testSingleInt32]
+              Type: 1509 EventRootType Probe[main.testSingleInt32]
               InjectionPoints: [{PC: "0x84b820", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4721,7 +4721,7 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Entry
-              Type: 1509 EventRootType Probe[main.testSingleInt64]
+              Type: 1510 EventRootType Probe[main.testSingleInt64]
               InjectionPoints: [{PC: "0x84b830", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4750,7 +4750,7 @@ Probes:
         - subprogram: {subprogram: 25}
           events:
             - Kind: Entry
-              Type: 1506 EventRootType Probe[main.testSingleInt8]
+              Type: 1507 EventRootType Probe[main.testSingleInt8]
               InjectionPoints: [{PC: "0x84b800", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4781,7 +4781,7 @@ Probes:
         - subprogram: {subprogram: 22}
           events:
             - Kind: Entry
-              Type: 1503 EventRootType Probe[main.testSingleRune]
+              Type: 1504 EventRootType Probe[main.testSingleRune]
               InjectionPoints: [{PC: "0x84b7d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4803,7 +4803,7 @@ Probes:
         - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1716 EventRootType Probe[main.testSingleString]
+              Type: 1717 EventRootType Probe[main.testSingleString]
               InjectionPoints: [{PC: "0x854cb0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4825,7 +4825,7 @@ Probes:
         - subprogram: {subprogram: 29}
           events:
             - Kind: Entry
-              Type: 1510 EventRootType Probe[main.testSingleUint]
+              Type: 1511 EventRootType Probe[main.testSingleUint]
               InjectionPoints: [{PC: "0x84b840", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4847,7 +4847,7 @@ Probes:
         - subprogram: {subprogram: 31}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testSingleUint16]
+              Type: 1513 EventRootType Probe[main.testSingleUint16]
               InjectionPoints: [{PC: "0x84b860", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4869,7 +4869,7 @@ Probes:
         - subprogram: {subprogram: 32}
           events:
             - Kind: Entry
-              Type: 1513 EventRootType Probe[main.testSingleUint32]
+              Type: 1514 EventRootType Probe[main.testSingleUint32]
               InjectionPoints: [{PC: "0x84b870", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4891,7 +4891,7 @@ Probes:
         - subprogram: {subprogram: 33}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testSingleUint64]
+              Type: 1515 EventRootType Probe[main.testSingleUint64]
               InjectionPoints: [{PC: "0x84b880", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4913,7 +4913,7 @@ Probes:
         - subprogram: {subprogram: 30}
           events:
             - Kind: Entry
-              Type: 1511 EventRootType Probe[main.testSingleUint8]
+              Type: 1512 EventRootType Probe[main.testSingleUint8]
               InjectionPoints: [{PC: "0x84b850", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4935,7 +4935,7 @@ Probes:
         - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1712 EventRootType Probe[main.testSliceEmptyStructs]
+              Type: 1713 EventRootType Probe[main.testSliceEmptyStructs]
               InjectionPoints: [{PC: "0x854640", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4957,7 +4957,7 @@ Probes:
         - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1703 EventRootType Probe[main.testSliceOfSlices]
+              Type: 1704 EventRootType Probe[main.testSliceOfSlices]
               InjectionPoints: [{PC: "0x8545c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4979,7 +4979,7 @@ Probes:
         - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.testSmallMap]
+              Type: 1565 EventRootType Probe[main.testSmallMap]
               InjectionPoints: [{PC: "0x850220", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5000,11 +5000,11 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1648 EventRootType Probe[main.testSomeNamedReturn]
+              Type: 1649 EventRootType Probe[main.testSomeNamedReturn]
               InjectionPoints: [{PC: "0x8528d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1649 EventRootType Probe[main.testSomeNamedReturn]Return
+              Type: 1650 EventRootType Probe[main.testSomeNamedReturn]Return
               InjectionPoints: [{PC: "0x852960", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5025,11 +5025,11 @@ Probes:
         - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1693 EventRootType Probe[main.testStackArgRegReturns]
+              Type: 1694 EventRootType Probe[main.testStackArgRegReturns]
               InjectionPoints: [{PC: "0x853e58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1694 EventRootType Probe[main.testStackArgRegReturns]Return
+              Type: 1695 EventRootType Probe[main.testStackArgRegReturns]Return
               InjectionPoints: [{PC: "0x853ebc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5051,7 +5051,7 @@ Probes:
         - subprogram: {subprogram: 3}
           events:
             - Kind: Entry
-              Type: 1484 EventRootType Probe[main.testStringArray]
+              Type: 1485 EventRootType Probe[main.testStringArray]
               InjectionPoints: [{PC: "0x84b370", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5073,7 +5073,7 @@ Probes:
         - subprogram: {subprogram: 97}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testStringPointer]
+              Type: 1596 EventRootType Probe[main.testStringPointer]
               InjectionPoints: [{PC: "0x851c80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5095,7 +5095,7 @@ Probes:
         - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1707 EventRootType Probe[main.testStringSlice]
+              Type: 1708 EventRootType Probe[main.testStringSlice]
               InjectionPoints: [{PC: "0x854600", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5117,7 +5117,7 @@ Probes:
         - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 1527 EventRootType Probe[main.testStringType1]
+              Type: 1528 EventRootType Probe[main.testStringType1]
               InjectionPoints: [{PC: "0x84bee0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5139,7 +5139,7 @@ Probes:
         - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 1528 EventRootType Probe[main.testStringType2]
+              Type: 1529 EventRootType Probe[main.testStringType2]
               InjectionPoints: [{PC: "0x84bef0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5161,11 +5161,11 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1735 EventRootType Probe[main.testStruct]
+              Type: 1736 EventRootType Probe[main.testStruct]
               InjectionPoints: [{PC: "0x854fb0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1736 EventRootType Probe[main.testStruct]Return
+              Type: 1737 EventRootType Probe[main.testStruct]Return
               InjectionPoints: [{PC: "0x854fcc", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5192,7 +5192,7 @@ Probes:
         - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1704 EventRootType Probe[main.testStructSlice]
+              Type: 1705 EventRootType Probe[main.testStructSlice]
               InjectionPoints: [{PC: "0x8545d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5219,7 +5219,7 @@ Probes:
         - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.testStructWithAny]
+              Type: 1559 EventRootType Probe[main.testStructWithAny]
               InjectionPoints: [{PC: "0x84fb00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5240,11 +5240,11 @@ Probes:
         - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1697 EventRootType Probe[main.testStructWithArrayArg]
+              Type: 1698 EventRootType Probe[main.testStructWithArrayArg]
               InjectionPoints: [{PC: "0x853fdc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1698 EventRootType Probe[main.testStructWithArrayArg]Return
+              Type: 1699 EventRootType Probe[main.testStructWithArrayArg]Return
               InjectionPoints: [{PC: "0x85406c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5266,11 +5266,11 @@ Probes:
         - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1731 EventRootType Probe[main.testStructWithCyclicMaps]
+              Type: 1732 EventRootType Probe[main.testStructWithCyclicMaps]
               InjectionPoints: [{PC: "0x854ec0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1732 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              Type: 1733 EventRootType Probe[main.testStructWithCyclicMaps]Return
               InjectionPoints: [{PC: "0x854ed8", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5291,7 +5291,7 @@ Probes:
         - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1730 EventRootType Probe[main.testStructWithCyclicSlices]
+              Type: 1731 EventRootType Probe[main.testStructWithCyclicSlices]
               InjectionPoints: [{PC: "0x854eb0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5318,7 +5318,7 @@ Probes:
         - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 1559 EventRootType Probe[main.testStructWithMap]
+              Type: 1560 EventRootType Probe[main.testStructWithMap]
               InjectionPoints: [{PC: "0x8501d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5351,7 +5351,7 @@ Probes:
         - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1713 EventRootType Probe[main.testSubslices]
+              Type: 1714 EventRootType Probe[main.testSubslices]
               InjectionPoints: [{PC: "0x854650", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5391,7 +5391,7 @@ Probes:
         - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1729 EventRootType Probe[main.testSubstrings]
+              Type: 1730 EventRootType Probe[main.testSubstrings]
               InjectionPoints: [{PC: "0x854d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5423,7 +5423,7 @@ Probes:
         - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testTakeContext]
+              Type: 1533 EventRootType Probe[main.testTakeContext]
               InjectionPoints: [{PC: "0x84c480", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
@@ -5439,11 +5439,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1636 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1637 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x852808", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1637 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1638 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x852894", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5464,11 +5464,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1638 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1639 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x852808", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1639 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1640 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x852894", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5491,11 +5491,11 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1640 EventRootType Probe[main.testMultipleNamedReturn]
+              Type: 1641 EventRootType Probe[main.testMultipleNamedReturn]
               InjectionPoints: [{PC: "0x852808", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1641 EventRootType Probe[main.testMultipleNamedReturn]Return
+              Type: 1642 EventRootType Probe[main.testMultipleNamedReturn]Return
               InjectionPoints: [{PC: "0x852894", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5527,7 +5527,7 @@ Probes:
         - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1717 EventRootType Probe[main.testThreeStrings]
+              Type: 1718 EventRootType Probe[main.testThreeStrings]
               InjectionPoints: [{PC: "0x854cc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5559,11 +5559,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1718 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1719 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0x854cd0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1719 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1720 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0x854ce8", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5593,11 +5593,11 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1720 EventRootType Probe[main.testThreeStringsInStruct]
+              Type: 1721 EventRootType Probe[main.testThreeStringsInStruct]
               InjectionPoints: [{PC: "0x854cd0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1721 EventRootType Probe[main.testThreeStringsInStruct]Return
+              Type: 1722 EventRootType Probe[main.testThreeStringsInStruct]Return
               InjectionPoints: [{PC: "0x854ce8", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5629,7 +5629,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1722 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1723 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0x854cf0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5659,7 +5659,7 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1723 EventRootType Probe[main.testThreeStringsInStructPointer]
+              Type: 1724 EventRootType Probe[main.testThreeStringsInStructPointer]
               InjectionPoints: [{PC: "0x854cf0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5679,6 +5679,72 @@ Probes:
                   DSL: a.c
                   EventKind: Entry
                   EventExpressionIndex: 2
+    - id: testTimeFixedZone
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeFixedZone}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 166}
+          events:
+            - Kind: Entry
+              Type: 1746 EventRootType Probe[main.testTimeFixedZone]
+              InjectionPoints: [{PC: "0x855be0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeMonotonic
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeMonotonic}
+      tags: ['foo:bar']
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 167}
+          events:
+            - Kind: Entry
+              Type: 1747 EventRootType Probe[main.testTimeMonotonic]
+              InjectionPoints: [{PC: "0x855bf0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{c}'
+            Segments:
+                - JSON: {Ref: c}
+                  DSL: c
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeUTC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeUTC}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 165}
+          events:
+            - Kind: Entry
+              Type: 1745 EventRootType Probe[main.testTimeUTC]
+              InjectionPoints: [{PC: "0x855bd0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -5691,7 +5757,7 @@ Probes:
         - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 1517 EventRootType Probe[main.testTypeAlias]
+              Type: 1518 EventRootType Probe[main.testTypeAlias]
               InjectionPoints: [{PC: "0x84b8b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5713,7 +5779,7 @@ Probes:
         - subprogram: {subprogram: 12}
           events:
             - Kind: Entry
-              Type: 1493 EventRootType Probe[main.testUint16Array]
+              Type: 1494 EventRootType Probe[main.testUint16Array]
               InjectionPoints: [{PC: "0x84b400", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5735,7 +5801,7 @@ Probes:
         - subprogram: {subprogram: 13}
           events:
             - Kind: Entry
-              Type: 1494 EventRootType Probe[main.testUint32Array]
+              Type: 1495 EventRootType Probe[main.testUint32Array]
               InjectionPoints: [{PC: "0x84b410", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5757,7 +5823,7 @@ Probes:
         - subprogram: {subprogram: 14}
           events:
             - Kind: Entry
-              Type: 1495 EventRootType Probe[main.testUint64Array]
+              Type: 1496 EventRootType Probe[main.testUint64Array]
               InjectionPoints: [{PC: "0x84b420", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5779,7 +5845,7 @@ Probes:
         - subprogram: {subprogram: 11}
           events:
             - Kind: Entry
-              Type: 1492 EventRootType Probe[main.testUint8Array]
+              Type: 1493 EventRootType Probe[main.testUint8Array]
               InjectionPoints: [{PC: "0x84b3f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5801,7 +5867,7 @@ Probes:
         - subprogram: {subprogram: 10}
           events:
             - Kind: Entry
-              Type: 1491 EventRootType Probe[main.testUintArray]
+              Type: 1492 EventRootType Probe[main.testUintArray]
               InjectionPoints: [{PC: "0x84b3e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5823,7 +5889,7 @@ Probes:
         - subprogram: {subprogram: 96}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testUintPointer]
+              Type: 1595 EventRootType Probe[main.testUintPointer]
               InjectionPoints: [{PC: "0x851c10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5845,7 +5911,7 @@ Probes:
         - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1701 EventRootType Probe[main.testUintSlice]
+              Type: 1702 EventRootType Probe[main.testUintSlice]
               InjectionPoints: [{PC: "0x8545a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5867,7 +5933,7 @@ Probes:
         - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1727 EventRootType Probe[main.testUnitializedString]
+              Type: 1728 EventRootType Probe[main.testUnitializedString]
               InjectionPoints: [{PC: "0x854d20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5889,7 +5955,7 @@ Probes:
         - subprogram: {subprogram: 95}
           events:
             - Kind: Entry
-              Type: 1593 EventRootType Probe[main.testUnsafePointer]
+              Type: 1594 EventRootType Probe[main.testUnsafePointer]
               InjectionPoints: [{PC: "0x851bf0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5911,7 +5977,7 @@ Probes:
         - subprogram: {subprogram: 20}
           events:
             - Kind: Entry
-              Type: 1501 EventRootType Probe[main.testVeryLargeArray]
+              Type: 1502 EventRootType Probe[main.testVeryLargeArray]
               InjectionPoints: [{PC: "0x84b490", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5933,7 +5999,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1710 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1711 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0x854630", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5955,7 +6021,7 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1711 EventRootType Probe[main.testVeryLargeSlice]
+              Type: 1712 EventRootType Probe[main.testVeryLargeSlice]
               InjectionPoints: [{PC: "0x854630", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5974,18 +6040,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 195}
+        - subprogram: {subprogram: 198}
           events:
             - Kind: Entry
-              Type: 1808 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1812 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0x84f938"
                   Frameless: false
-                - PC: "0x85752c"
+                - PC: "0x85767c"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1809 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1813 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0x84f970", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -6007,11 +6073,11 @@ Probes:
         - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1699 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              Type: 1700 EventRootType Probe[main.testZeroSizeArgAndReturn]
               InjectionPoints: [{PC: "0x8540a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1700 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              Type: 1701 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
               InjectionPoints: [{PC: "0x854110", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -10157,138 +10223,195 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 165
-      Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x8569d0..0x8569e0]
+      Name: main.testTimeUTC
+      OutOfLinePCRanges: [0x855bd0..0x855be0]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 326 BaseType go.shape.int
+        - Name: x
+          Type: 326 GoTimeType time.Time
           Locations:
-            - Range: 0x8569d0..0x8569e0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x855bd0..0x855be0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0x8569d0..0x8569d4
-              Pieces: []
-            - Range: 0x8569d4..0x8569d5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8569d5..0x8569e0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+          DictIndex: -1
+      DictRegister: null
     - ID: 166
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x8569e0..0x8569f0]
+      Name: main.testTimeFixedZone
+      OutOfLinePCRanges: [0x855be0..0x855bf0]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 328 GoStringHeaderType go.shape.string
+        - Name: x
+          Type: 326 GoTimeType time.Time
           Locations:
-            - Range: 0x8569e0..0x8569ec
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8569ec..0x8569f0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x8569e0..0x8569ec
-              Pieces: []
-            - Range: 0x8569ec..0x8569ed
+            - Range: 0x855be0..0x855bf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8569ed..0x8569f0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 167
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x8569f0..0x856a00]
+      Name: main.testTimeMonotonic
+      OutOfLinePCRanges: [0x855bf0..0x855c00]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+        - Name: c
+          Type: 329 StructureType main.timeCapture
           Locations:
-            - Range: 0x8569f0..0x856a00
+            - Range: 0x855bf0..0x855c00
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 168
+      Name: main.wrapBox[go.shape.int]
+      OutOfLinePCRanges: [0x856b20..0x856b30]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 330 BaseType go.shape.int
+          Locations:
+            - Range: 0x856b20..0x856b30
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 326 BaseType go.shape.int
+          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8569f0..0x8569f4
+            - Range: 0x856b20..0x856b24
               Pieces: []
-            - Range: 0x8569f4..0x8569f5
+            - Range: 0x856b24..0x856b25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8569f5..0x856a00
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 168
-      Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x856a00..0x856a10]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x856a00..0x856a0c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x856a0c..0x856a10
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x856a00..0x856a0c
-              Pieces: []
-            - Range: 0x856a0c..0x856a0d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856a0d..0x856a10
+            - Range: 0x856b25..0x856b30
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0x856b30..0x856b40]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 332 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x856b30..0x856b3c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x856b3c..0x856b40
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x856b30..0x856b3c
+              Pieces: []
+            - Range: 0x856b3c..0x856b3d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x856b3d..0x856b40
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0x856b40..0x856b50]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0x856b40..0x856b50
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 BaseType go.shape.int
+          Locations:
+            - Range: 0x856b40..0x856b44
+              Pieces: []
+            - Range: 0x856b44..0x856b45
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x856b45..0x856b50
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 171
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0x856b50..0x856b60]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x856b50..0x856b5c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x856b5c..0x856b60
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x856b50..0x856b5c
+              Pieces: []
+            - Range: 0x856b5c..0x856b5d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x856b5d..0x856b60
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x856a70..0x856b90]
+      OutOfLinePCRanges: [0x856bc0..0x856ce0]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 330 GoSliceHeaderType []go.shape.int
+          Type: 334 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x856a70..0x856a9c
+            - Range: 0x856bc0..0x856bec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10296,7 +10419,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x856a9c..0x856aac
+            - Range: 0x856bec..0x856bfc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10304,7 +10427,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x856aac..0x856b90
+            - Range: 0x856bfc..0x856ce0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10315,20 +10438,20 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 332 GoSubroutineType func(go.shape.int) bool
+          Type: 336 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x856a70..0x856aac
+            - Range: 0x856bc0..0x856bfc
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x856aac..0x856b90
+            - Range: 0x856bfc..0x856ce0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 330 GoSliceHeaderType []go.shape.int
+          Type: 334 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x856a70..0x856b5c
+            - Range: 0x856bc0..0x856cac
               Pieces: []
-            - Range: 0x856b5c..0x856b5d
+            - Range: 0x856cac..0x856cad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10336,14 +10459,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x856b5d..0x856b90
+            - Range: 0x856cad..0x856ce0
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 330 GoSliceHeaderType []go.shape.int
+          Type: 334 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x856aac..0x856ac8
+            - Range: 0x856bfc..0x856c18
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10351,7 +10474,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x856ac8..0x856acc
+            - Range: 0x856c18..0x856c1c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10359,7 +10482,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x856acc..0x856ad0
+            - Range: 0x856c1c..0x856c20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10367,7 +10490,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x856ad0..0x856ad0
+            - Range: 0x856c20..0x856c20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10375,7 +10498,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x856ad0..0x856afc
+            - Range: 0x856c20..0x856c4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10383,7 +10506,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x856afc..0x856b50
+            - Range: 0x856c4c..0x856ca0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10391,7 +10514,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x856b50..0x856b90
+            - Range: 0x856ca0..0x856ce0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10402,217 +10525,217 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0x856aec..0x856afc
+            - Range: 0x856c3c..0x856c4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856afc..0x856b50
+            - Range: 0x856c4c..0x856ca0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 170
+    - ID: 173
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x856b90..0x856be0]
+      OutOfLinePCRanges: [0x856ce0..0x856d30]
       InlinePCRanges: []
       Variables:
         - Name: box
-          Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x856b90..0x856bb8
+            - Range: 0x856ce0..0x856d08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
-          Type: 333 GoSubroutineType func(go.shape.int) go.shape.string
+          Type: 337 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x856b90..0x856bb8
+            - Range: 0x856ce0..0x856d08
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x856b90..0x856bb8
+            - Range: 0x856ce0..0x856d08
               Pieces: []
-            - Range: 0x856bb8..0x856bb9
+            - Range: 0x856d08..0x856d09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856bb9..0x856be0
+            - Range: 0x856d09..0x856d30
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x856e50..0x856e60]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 331 PointerType *go.shape.int
-          Locations:
-            - Range: 0x856e50..0x856e60
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 PointerType *go.shape.int
-          Locations:
-            - Range: 0x856e50..0x856e54
-              Pieces: []
-            - Range: 0x856e54..0x856e55
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856e55..0x856e60
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x856e60..0x856e70]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 334 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x856e60..0x856e70
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 334 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x856e60..0x856e64
-              Pieces: []
-            - Range: 0x856e64..0x856e65
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856e65..0x856e70
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 173
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x856e70..0x856e80]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 336 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0x856e70..0x856e80
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0x856e70..0x856e74
-              Pieces: []
-            - Range: 0x856e74..0x856e75
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856e75..0x856e80
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 174
-      Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x856e80..0x856e90]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0x856fa0..0x856fb0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 338 StructureType main.largeGenericType[go.shape.string]
+        - Name: p
+          Type: 335 PointerType *go.shape.int
           Locations:
-            - Range: 0x856e80..0x856e90
-              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+            - Range: 0x856fa0..0x856fb0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 335 PointerType *go.shape.int
           Locations:
-            - Range: 0x856e80..0x856e88
+            - Range: 0x856fa0..0x856fa4
               Pieces: []
-            - Range: 0x856e88..0x856e89
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856e89..0x856e90
+            - Range: 0x856fa4..0x856fa5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x856fa5..0x856fb0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
-      Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x856f10..0x856f20]
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x856fb0..0x856fc0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 340 StructureType main.largeGenericType[go.shape.int]
+        - Name: p
+          Type: 338 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x856f10..0x856f20
-              Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
+            - Range: 0x856fb0..0x856fc0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 326 BaseType go.shape.int
+          Type: 338 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x856f10..0x856f14
+            - Range: 0x856fb0..0x856fb4
               Pieces: []
-            - Range: 0x856f14..0x856f15
+            - Range: 0x856fb4..0x856fb5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856f15..0x856f20
+            - Range: 0x856fb5..0x856fc0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 176
-      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x856fb0..0x856fc0]
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x856fc0..0x856fd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 340 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x856fc0..0x856fd0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 340 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x856fc0..0x856fc4
+              Pieces: []
+            - Range: 0x856fc4..0x856fc5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x856fc5..0x856fd0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 177
+      Name: main.largeGenericType[go.shape.string].LargeGet
+      OutOfLinePCRanges: [0x856fd0..0x856fe0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 341 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Type: 342 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x856fb0..0x856fc0
+            - Range: 0x856fd0..0x856fe0
+              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x856fd0..0x856fd8
+              Pieces: []
+            - Range: 0x856fd8..0x856fd9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x856fd9..0x856fe0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 178
+      Name: main.largeGenericType[go.shape.int].LargeGet
+      OutOfLinePCRanges: [0x857060..0x857070]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 344 StructureType main.largeGenericType[go.shape.int]
+          Locations:
+            - Range: 0x857060..0x857070
+              Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 BaseType go.shape.int
+          Locations:
+            - Range: 0x857060..0x857064
+              Pieces: []
+            - Range: 0x857064..0x857065
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x857065..0x857070
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 179
+      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
+      OutOfLinePCRanges: [0x857100..0x857110]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 345 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Locations:
+            - Range: 0x857100..0x857110
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0x856fb0..0x856fc0
+            - Range: 0x857100..0x857110
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 343 BaseType go.shape.bool
+          Type: 347 BaseType go.shape.bool
           Locations:
-            - Range: 0x856fb0..0x856fc0
+            - Range: 0x857100..0x857110
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 177
+    - ID: 180
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x857040..0x8570c0]
+      OutOfLinePCRanges: [0x857190..0x857210]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 344 PointerType *main.Pair[go.shape.string,go.shape.int]
+          Type: 348 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x857040..0x8570c0
+            - Range: 0x857190..0x857210
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x857040..0x8570c0
+            - Range: 0x857190..0x857210
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10621,22 +10744,22 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0x857040..0x8570c0
+            - Range: 0x857190..0x857210
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 178
+    - ID: 181
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x857140..0x857150]
+      OutOfLinePCRanges: [0x857290..0x8572a0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x857140..0x857150
+            - Range: 0x857290..0x8572a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10645,61 +10768,61 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 343 BaseType go.shape.bool
+          Type: 347 BaseType go.shape.bool
           Locations:
-            - Range: 0x857140..0x857150
+            - Range: 0x857290..0x8572a0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 343 BaseType go.shape.bool
+          Type: 347 BaseType go.shape.bool
           Locations:
-            - Range: 0x857140..0x857148
+            - Range: 0x857290..0x857298
               Pieces: []
-            - Range: 0x857148..0x857149
+            - Range: 0x857298..0x857299
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x857149..0x857150
+            - Range: 0x857299..0x8572a0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x857140..0x857148
+            - Range: 0x857290..0x857298
               Pieces: []
-            - Range: 0x857148..0x857149
+            - Range: 0x857298..0x857299
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x857149..0x857150
+            - Range: 0x857299..0x8572a0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 179
+    - ID: 182
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x857150..0x857170]
+      OutOfLinePCRanges: [0x8572a0..0x8572c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0x857150..0x857160
+            - Range: 0x8572a0..0x8572b0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x857150..0x85715c
+            - Range: 0x8572a0..0x8572ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85715c..0x857170
+            - Range: 0x8572ac..0x8572c0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10708,75 +10831,75 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x857150..0x857160
+            - Range: 0x8572a0..0x8572b0
               Pieces: []
-            - Range: 0x857160..0x857161
+            - Range: 0x8572b0..0x8572b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x857161..0x857170
+            - Range: 0x8572b1..0x8572c0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0x857150..0x857160
+            - Range: 0x8572a0..0x8572b0
               Pieces: []
-            - Range: 0x857160..0x857161
+            - Range: 0x8572b0..0x8572b1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x857161..0x857170
+            - Range: 0x8572b1..0x8572c0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 180
+    - ID: 183
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x857170..0x8571c0]
+      OutOfLinePCRanges: [0x8572c0..0x857310]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 346 StructureType go.shape.struct { main.i int }
+          Type: 350 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x857170..0x857198
+            - Range: 0x8572c0..0x8572e8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x857170..0x857198
+            - Range: 0x8572c0..0x8572e8
               Pieces: []
-            - Range: 0x857198..0x857199
+            - Range: 0x8572e8..0x8572e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x857199..0x8571c0
+            - Range: 0x8572e9..0x857310
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 184
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x8571c0..0x857220]
+      OutOfLinePCRanges: [0x857310..0x857370]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 347 StructureType go.shape.struct { main.s string }
+          Type: 351 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x8571c0..0x8571ec
+            - Range: 0x857310..0x85733c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8571ec..0x8571f0
+            - Range: 0x85733c..0x857340
               Pieces:
                 - Size: 8
                   Op: null
@@ -10787,65 +10910,65 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8571c0..0x8571f0
+            - Range: 0x857310..0x857340
               Pieces: []
-            - Range: 0x8571f0..0x8571f1
+            - Range: 0x857340..0x857341
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8571f1..0x857220
+            - Range: 0x857341..0x857370
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 182
+    - ID: 185
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x857220..0x857230]
+      OutOfLinePCRanges: [0x857370..0x857380]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 348 PointerType *go.shape.string
+          Type: 352 PointerType *go.shape.string
           Locations:
-            - Range: 0x857220..0x857228
+            - Range: 0x857370..0x857378
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x857220..0x857228
+            - Range: 0x857370..0x857378
               Pieces: []
-            - Range: 0x857228..0x857229
+            - Range: 0x857378..0x857379
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x857229..0x857230
+            - Range: 0x857379..0x857380
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 183
+    - ID: 186
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x857230..0x857290]
+      OutOfLinePCRanges: [0x857380..0x8573e0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 353 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x857230..0x85726c
+            - Range: 0x857380..0x8573bc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 354 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x857230..0x85727c
+            - Range: 0x857380..0x8573cc
               Pieces: []
-            - Range: 0x85727c..0x85727d
+            - Range: 0x8573cc..0x8573cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10859,20 +10982,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85727d..0x857290
+            - Range: 0x8573cd..0x8573e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 184
+    - ID: 187
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x857290..0x8572d0]
+      OutOfLinePCRanges: [0x8573e0..0x857420]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 330 GoSliceHeaderType []go.shape.int
+          Type: 334 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x857290..0x85729c
+            - Range: 0x8573e0..0x8573ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10880,7 +11003,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85729c..0x8572d0
+            - Range: 0x8573ec..0x857420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10891,44 +11014,44 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0x857290..0x8572d0
+            - Range: 0x8573e0..0x857420
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x857290..0x8572b8
+            - Range: 0x8573e0..0x857408
               Pieces: []
-            - Range: 0x8572b8..0x8572b9
+            - Range: 0x857408..0x857409
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8572b9..0x8572c0
+            - Range: 0x857409..0x857410
               Pieces: []
-            - Range: 0x8572c0..0x8572c1
+            - Range: 0x857410..0x857411
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8572c1..0x8572d0
+            - Range: 0x857411..0x857420
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0x8572ac..0x8572bc
+            - Range: 0x8573fc..0x85740c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 185
+    - ID: 188
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x8572d0..0x857390]
+      OutOfLinePCRanges: [0x857420..0x8574e0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 351 GoSliceHeaderType []go.shape.string
+          Type: 355 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x8572d0..0x8572f4
+            - Range: 0x857420..0x857444
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10936,7 +11059,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8572f4..0x8572f8
+            - Range: 0x857444..0x857448
               Pieces:
                 - Size: 8
                   Op: null
@@ -10947,15 +11070,15 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8572d0..0x85732c
+            - Range: 0x857420..0x85747c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85732c..0x857390
+            - Range: 0x85747c..0x8574e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10966,28 +11089,28 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8572d0..0x857348
+            - Range: 0x857420..0x857498
               Pieces: []
-            - Range: 0x857348..0x857349
+            - Range: 0x857498..0x857499
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x857349..0x857358
+            - Range: 0x857499..0x8574a8
               Pieces: []
-            - Range: 0x857358..0x857359
+            - Range: 0x8574a8..0x8574a9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x857359..0x857390
+            - Range: 0x8574a9..0x8574e0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x85730c..0x857320
+            - Range: 0x85745c..0x857470
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x857320..0x85732c
+            - Range: 0x857470..0x85747c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10996,58 +11119,58 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 186
+    - ID: 189
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x857390..0x8573a0]
+      OutOfLinePCRanges: [0x8574e0..0x8574f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 352 StructureType main.typeWithGenerics[go.shape.int]
+          Type: 356 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x857390..0x857398
+            - Range: 0x8574e0..0x8574e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
           Locations:
-            - Range: 0x857390..0x8573a0
+            - Range: 0x8574e0..0x8574f0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x857390..0x857398
+            - Range: 0x8574e0..0x8574e8
               Pieces: []
-            - Range: 0x857398..0x857399
+            - Range: 0x8574e8..0x8574e9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x857399..0x8573a0
+            - Range: 0x8574e9..0x8574f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
-    - ID: 187
+    - ID: 190
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x857410..0x857480]
+      OutOfLinePCRanges: [0x857560..0x8575d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 353 StructureType main.typeWithGenerics[go.shape.string]
+          Type: 357 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x857410..0x85743c
+            - Range: 0x857560..0x85758c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85743c..0x857448
+            - Range: 0x85758c..0x857598
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x857448..0x85744c
+            - Range: 0x857598..0x85759c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11056,9 +11179,9 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x857410..0x85744c
+            - Range: 0x857560..0x85759c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11069,22 +11192,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x857410..0x85744c
+            - Range: 0x857560..0x85759c
               Pieces: []
-            - Range: 0x85744c..0x85744d
+            - Range: 0x85759c..0x85759d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85744d..0x857480
+            - Range: 0x85759d..0x8575d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 188
+    - ID: 191
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x84a500..0x84a620]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 354 GoSliceHeaderType []go.shape.float64
+          Type: 358 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x84a500..0x84a52c
               Pieces:
@@ -11113,7 +11236,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 357 GoSubroutineType func(go.shape.float64) bool
+          Type: 361 GoSubroutineType func(go.shape.float64) bool
           Locations:
             - Range: 0x84a500..0x84a53c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
@@ -11122,7 +11245,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 354 GoSliceHeaderType []go.shape.float64
+          Type: 358 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x84a500..0x84a5ec
               Pieces: []
@@ -11139,7 +11262,7 @@ Subprograms:
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 354 GoSliceHeaderType []go.shape.float64
+          Type: 358 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x84a53c..0x84a558
               Pieces:
@@ -11200,7 +11323,7 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 356 BaseType go.shape.float64
+          Type: 360 BaseType go.shape.float64
           Locations:
             - Range: 0x84a57c..0x84a58c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
@@ -11209,7 +11332,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 189
+    - ID: 192
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84f2d0..0x84f340]
       InlinePCRanges:
@@ -11240,7 +11363,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 193
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11248,7 +11371,7 @@ Subprograms:
           RootRanges: [0x84f500..0x84f5c0]
       Variables: []
       DictRegister: null
-    - ID: 191
+    - ID: 194
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11256,7 +11379,7 @@ Subprograms:
           RootRanges: [0x84f640..0x84f760]
       Variables: []
       DictRegister: null
-    - ID: 192
+    - ID: 195
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11264,7 +11387,7 @@ Subprograms:
           RootRanges: [0x84f640..0x84f760]
       Variables: []
       DictRegister: null
-    - ID: 193
+    - ID: 196
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11279,7 +11402,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 194
+    - ID: 197
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11298,15 +11421,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 195
+    - ID: 198
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x84f920..0x84f990]
       InlinePCRanges:
-        - Ranges: [0x85752c..0x857560]
-          RootRanges: [0x857500..0x8575b0]
+        - Ranges: [0x85767c..0x8576b0]
+          RootRanges: [0x857650..0x857700]
       Variables:
         - Name: b
-          Type: 358 StructureType main.firstBehavior
+          Type: 362 StructureType main.firstBehavior
           Locations:
             - Range: 0x84f920..0x84f94c
               Pieces:
@@ -11338,7 +11461,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 196
+    - ID: 199
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11350,31 +11473,31 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1382
+      ID: 1383
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 387 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 139
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 140 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1387
+      ID: 1388
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1388 PointerType *main.deepSlice3
+      Pointee: 1389 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1422
+      ID: 1423
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1423 PointerType *main.deepSlice8
+      Pointee: 1424 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1428
+      ID: 1429
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1429 PointerType *main.deepSlice9
+      Pointee: 1430 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 153
       Name: '**main.stringType2'
@@ -11382,7 +11505,7 @@ Types:
       GoKind: 22
       Pointee: 154 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1367
+      ID: 1378
       Name: '**main.t'
       ByteSize: 8
       Pointee: 253 PointerType *main.t
@@ -11414,40 +11537,40 @@ Types:
       ByteSize: 8
       Pointee: 207 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 378
+      ID: 382
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 379 PointerType *table<context.canceler,struct {}>
+      Pointee: 383 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 147
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 148 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1395
+      ID: 1396
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1396 PointerType *table<int,*main.deepMap3>
+      Pointee: 1397 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1439
+      ID: 1440
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1440 PointerType *table<int,*main.deepMap8>
+      Pointee: 1441 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1454
+      ID: 1455
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1455 PointerType *table<int,*main.deepMap9>
+      Pointee: 1456 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 174
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 175 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1469
+      ID: 1470
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1470 PointerType *table<int,interface {}>
+      Pointee: 1471 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 241
       Name: '**table<int,struct {}>'
@@ -11459,10 +11582,10 @@ Types:
       ByteSize: 8
       Pointee: 212 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 684 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 691 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 201
       Name: '**table<string,[]main.structWithMap>'
@@ -11474,35 +11597,35 @@ Types:
       ByteSize: 8
       Pointee: 190 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 405
+      ID: 406
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 406 PointerType *table<string,float64>
+      Pointee: 407 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1118
+      ID: 1129
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1119 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1130 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 184
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 185 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 400
+      ID: 401
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 401 PointerType *table<string,interface {}>
+      Pointee: 402 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 179
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 180 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 395
+      ID: 396
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 396 PointerType *table<string,string>
+      Pointee: 397 PointerType *table<string,string>
     - __kind: PointerType
       ID: 236
       Name: '**table<struct {},int>'
@@ -11554,145 +11677,145 @@ Types:
       ByteSize: 8
       Pointee: 217 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1385
+      ID: 1386
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1384 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1385 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 428
+      ID: 429
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 427 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 428 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1391
+      ID: 1392
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1390 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1391 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1426
+      ID: 1427
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1425 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1426 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1432
+      ID: 1433
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1431 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1432 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 425
+      ID: 426
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 424 GoSliceDataType []*string.array
+      Pointee: 425 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 588
+      ID: 589
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 587 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 588 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 586
+      ID: 587
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 585 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 586 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 584
+      ID: 585
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 583 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 584 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 582
+      ID: 583
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 581 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 582 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 282
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 580
+      ID: 581
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 579 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 580 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 568
+      ID: 569
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 567 GoSliceDataType [][]uint.array
+      Pointee: 568 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 572
+      ID: 573
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 571 GoSliceDataType []bool.array
+      Pointee: 572 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1155
+      ID: 1166
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1154 GoSliceDataType []float64.array
+      Pointee: 1165 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 678 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 685 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 686 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 644
+      ID: 651
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 643 GoSliceDataType []go.shape.float64.array
+      Pointee: 650 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 640
+      ID: 647
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 639 GoSliceDataType []go.shape.int.array
+      Pointee: 646 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 642
+      ID: 649
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 641 GoSliceDataType []go.shape.string.array
+      Pointee: 648 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
-      ID: 1435
+      ID: 1436
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1434 GoSliceDataType []interface {}.array
+      Pointee: 1435 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 280
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 277 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 578
+      ID: 579
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 577 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 578 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 688 GoSliceDataType []main.structWithMap.array
+      Pointee: 695 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 570
+      ID: 571
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 569 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 570 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11701,111 +11824,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 440
+      ID: 441
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 439 GoSliceDataType []string.array
+      Pointee: 440 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 576
+      ID: 577
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 575 GoSliceDataType []struct {}.array
+      Pointee: 576 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 1378
+      ID: 698
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 1377 GoSliceDataType []time.zone.array
+      Pointee: 697 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 1380
+      ID: 700
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 1379 GoSliceDataType []time.zoneTrans.array
+      Pointee: 699 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 264
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 262 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 566
+      ID: 567
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 565 GoSliceDataType []uint.array
+      Pointee: 566 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 574
+      ID: 575
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 573 GoSliceDataType []uint16.array
+      Pointee: 574 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 421
+      ID: 422
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 420 GoSliceDataType []uint8.array
+      Pointee: 421 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 423
+      ID: 424
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 422 GoSliceDataType []uintptr.array
+      Pointee: 423 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1285
+      ID: 1296
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1987168
       GoKind: 22
-      Pointee: 1286 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1297 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 929
+      ID: 940
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 930336
       GoKind: 22
-      Pointee: 930 GoSliceHeaderType archive/tar.headerError
+      Pointee: 941 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 932
+      ID: 943
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 931 GoSliceDataType archive/tar.headerError.array
+      Pointee: 942 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1220
+      ID: 1231
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1438464
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1232 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1168
+      ID: 1179
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 930528
       GoKind: 22
-      Pointee: 1169 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1180 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1170
+      ID: 1181
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 930624
       GoKind: 22
-      Pointee: 1171 StructureType archive/zip.dirWriter
+      Pointee: 1182 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1268
+      ID: 1279
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1906848
       GoKind: 22
-      Pointee: 1269 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1280 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1196
+      ID: 1207
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1057920
       GoKind: 22
-      Pointee: 1197 StructureType archive/zip.nopCloser
+      Pointee: 1208 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1198
+      ID: 1209
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1058176
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1210 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -11814,477 +11937,477 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1243
+      ID: 1254
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2176000
       GoKind: 22
-      Pointee: 1244 UnresolvedPointeeType bufio.Reader
+      Pointee: 1255 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1274
+      ID: 1285
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1952128
       GoKind: 22
-      Pointee: 1275 UnresolvedPointeeType bufio.Writer
+      Pointee: 1286 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1323
+      ID: 1334
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2273280
       GoKind: 22
-      Pointee: 1324 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1335 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 839
+      ID: 850
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 912864
       GoKind: 22
-      Pointee: 733 BaseType compress/flate.CorruptInputError
+      Pointee: 744 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 840
+      ID: 851
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 912960
       GoKind: 22
-      Pointee: 734 GoStringHeaderType compress/flate.InternalError
+      Pointee: 745 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 736
+      ID: 747
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 735 GoStringDataType compress/flate.InternalError.str
+      Pointee: 746 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1218
+      ID: 1229
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1427904
       GoKind: 22
-      Pointee: 1219 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1230 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1164
+      ID: 1175
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 913056
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1176 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1240
+      ID: 1251
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1729216
       GoKind: 22
-      Pointee: 1241 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1252 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1415
+      ID: 1416
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1554304
       GoKind: 22
-      Pointee: 369 StructureType context.backgroundCtx
+      Pointee: 373 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 359
+      ID: 363
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1726912
       GoKind: 22
-      Pointee: 360 StructureType context.cancelCtx
+      Pointee: 364 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1041
+      ID: 1052
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1192736
       GoKind: 22
-      Pointee: 1042 StructureType context.deadlineExceededError
+      Pointee: 1053 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1410
+      ID: 1411
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1416544
       GoKind: 22
-      Pointee: 370 StructureType context.emptyCtx
+      Pointee: 374 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 361
+      ID: 365
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1416704
       GoKind: 22
-      Pointee: 362 StructureType context.stopCtx
+      Pointee: 366 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 363
+      ID: 367
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1727104
       GoKind: 22
-      Pointee: 364 StructureType context.timerCtx
+      Pointee: 368 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1416
+      ID: 1417
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1554464
       GoKind: 22
-      Pointee: 386 StructureType context.todoCtx
+      Pointee: 387 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 365
+      ID: 369
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1553984
       GoKind: 22
-      Pointee: 366 StructureType context.valueCtx
+      Pointee: 370 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 367
+      ID: 371
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1554144
       GoKind: 22
-      Pointee: 368 StructureType context.withoutCancelCtx
+      Pointee: 372 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 921
+      ID: 932
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 747 BaseType crypto/aes.KeySizeError
+      Pointee: 758 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 922
+      ID: 933
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925152
       GoKind: 22
-      Pointee: 748 BaseType crypto/des.KeySizeError
+      Pointee: 759 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 923
+      ID: 934
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 749 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 760 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1230
+      ID: 1241
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1569664
       GoKind: 22
-      Pointee: 1231 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1242 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1264
+      ID: 1275
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1865504
       GoKind: 22
-      Pointee: 1265 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1276 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1296
+      ID: 1307
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2123328
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1270
+      ID: 1281
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1907360
       GoKind: 22
-      Pointee: 1271 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1282 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1266
+      ID: 1277
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1865952
       GoKind: 22
-      Pointee: 1267 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1278 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1262
+      ID: 1273
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1858112
       GoKind: 22
-      Pointee: 1263 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1274 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 924
+      ID: 935
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925728
       GoKind: 22
-      Pointee: 750 BaseType crypto/rc4.KeySizeError
+      Pointee: 761 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1280
+      ID: 1291
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1956736
       GoKind: 22
-      Pointee: 1281 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1292 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1252
+      ID: 1263
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1812320
       GoKind: 22
-      Pointee: 1253 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1264 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 845
+      ID: 856
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 914496
       GoKind: 22
-      Pointee: 737 BaseType crypto/tls.AlertError
+      Pointee: 748 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1013
+      ID: 1024
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1046272
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1025 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1349
+      ID: 1360
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2385152
       GoKind: 22
-      Pointee: 1350 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1361 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 843
+      ID: 854
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 855 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 841
+      ID: 852
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 914208
       GoKind: 22
-      Pointee: 842 StructureType crypto/tls.RecordHeaderError
+      Pointee: 853 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1012
+      ID: 1023
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1044608
       GoKind: 22
-      Pointee: 969 BaseType crypto/tls.alert
+      Pointee: 980 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1228
+      ID: 1239
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1562624
       GoKind: 22
-      Pointee: 1229 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1240 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1235
+      ID: 1246
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1646144
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1247 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1108
+      ID: 1119
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1428224
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1120 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1120
+      ID: 1131
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2045216
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1132 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 915
+      ID: 926
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 923904
       GoKind: 22
-      Pointee: 916 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 927 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 909
+      ID: 920
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 910 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 921 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 911
+      ID: 922
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 912 StructureType crypto/x509.HostnameError
+      Pointee: 923 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 908
+      ID: 919
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 923328
       GoKind: 22
-      Pointee: 746 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 757 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1018
+      ID: 1029
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1052032
       GoKind: 22
-      Pointee: 1019 StructureType crypto/x509.SystemRootsError
+      Pointee: 1030 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 917
+      ID: 928
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 918 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 929 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 913
+      ID: 924
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 923808
       GoKind: 22
-      Pointee: 914 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 925 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 933
+      ID: 944
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 930816
       GoKind: 22
-      Pointee: 934 StructureType encoding/asn1.StructuralError
+      Pointee: 945 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 937
+      ID: 948
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931008
       GoKind: 22
-      Pointee: 938 StructureType encoding/asn1.SyntaxError
+      Pointee: 949 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 935
+      ID: 946
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 930912
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 947 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 831
+      ID: 842
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 910368
       GoKind: 22
-      Pointee: 731 BaseType encoding/base64.CorruptInputError
+      Pointee: 742 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1186
+      ID: 1197
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1041152
       GoKind: 22
-      Pointee: 1187 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1198 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 834
+      ID: 845
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 911232
       GoKind: 22
-      Pointee: 732 BaseType encoding/hex.InvalidByteError
+      Pointee: 743 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 802
+      ID: 813
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 814 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1004
+      ID: 1015
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1037440
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1016 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 794
+      ID: 805
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 904704
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 806 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 800
+      ID: 811
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 812 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 798
+      ID: 809
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 810 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 796
+      ID: 807
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 808 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1329
+      ID: 1340
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2298304
       GoKind: 22
-      Pointee: 1330 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1341 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 804
+      ID: 815
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 805 StructureType encoding/json.jsonError
+      Pointee: 816 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1194
+      ID: 1205
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1054848
       GoKind: 22
-      Pointee: 1195 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1206 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 903
+      ID: 914
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 915 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 901
+      ID: 912
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 913 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 905
+      ID: 916
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 743 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 754 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 745
+      ID: 756
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 744 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 755 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 906
+      ID: 917
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 907 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 918 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1307
+      ID: 1318
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2161760
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1319 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -12293,19 +12416,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 772
+      ID: 783
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896064
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType errors.errorString
+      Pointee: 784 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 971
+      ID: 982
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1023232
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType errors.joinError
+      Pointee: 983 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -12321,913 +12444,913 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 1317
+      ID: 1328
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2265600
       GoKind: 22
-      Pointee: 1318 UnresolvedPointeeType fmt.pp
+      Pointee: 1329 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 973
+      ID: 984
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1023360
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType fmt.wrapError
+      Pointee: 985 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 975
+      ID: 986
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1023488
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 987 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 832
+      ID: 843
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 910752
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 844 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 813
+      ID: 824
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 907872
       GoKind: 22
-      Pointee: 814 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 825 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 815
+      ID: 826
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 907968
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 827 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1132
+      ID: 1143
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 907680
       GoKind: 22
-      Pointee: 1133 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1144 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 819
+      ID: 830
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 820 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 831 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1134
+      ID: 1145
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 907776
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1146 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 817
+      ID: 828
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 908064
       GoKind: 22
-      Pointee: 725 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 736 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 727
+      ID: 738
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 726 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 737 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 812
+      ID: 823
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 907584
       GoKind: 22
-      Pointee: 722 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 733 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 724
+      ID: 735
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 723 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 818
+      ID: 829
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 728 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 739 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 730
+      ID: 741
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 729 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 740 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1208
+      ID: 1219
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1210272
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1220 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1293
+      ID: 1304
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2059904
       GoKind: 22
-      Pointee: 1294 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1305 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 927
+      ID: 938
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 929280
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 939 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 387
+      ID: 388
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2283520
       GoKind: 22
-      Pointee: 388 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 389 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 413
+      ID: 414
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2009216
       GoKind: 22
-      Pointee: 414 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 408
+      ID: 409
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1192992
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 411
+      ID: 412
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1193120
       GoKind: 22
-      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 413 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1408
+      ID: 1409
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1193760
       GoKind: 22
-      Pointee: 1409 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1410 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 696
+      ID: 707
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1193888
       GoKind: 22
-      Pointee: 697 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 708 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 415
+      ID: 416
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2228192
       GoKind: 22
-      Pointee: 416 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 417 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1076
+      ID: 1087
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1213856
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1088 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1325
+      ID: 1336
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2275328
       GoKind: 22
-      Pointee: 1326 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1337 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1411
+      ID: 1412
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1422144
       GoKind: 22
-      Pointee: 1412 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 1413 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 852
+      ID: 863
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 917856
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 864 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 859
+      ID: 870
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 918912
       GoKind: 22
-      Pointee: 860 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 871 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 854
+      ID: 865
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 918624
       GoKind: 22
-      Pointee: 742 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 753 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 857
+      ID: 868
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 918816
       GoKind: 22
-      Pointee: 858 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 869 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 855
+      ID: 866
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 918720
       GoKind: 22
-      Pointee: 856 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 867 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 875
+      ID: 886
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 920832
       GoKind: 22
-      Pointee: 876 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 887 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 879
+      ID: 890
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 921024
       GoKind: 22
-      Pointee: 880 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 891 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 877
+      ID: 888
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 920928
       GoKind: 22
-      Pointee: 878 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 889 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 873
+      ID: 884
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 874 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 885 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1157
+      ID: 1168
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1156 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1167 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 887
+      ID: 898
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 921408
       GoKind: 22
-      Pointee: 888 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 899 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 881
+      ID: 892
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 921120
       GoKind: 22
-      Pointee: 882 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 893 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 885
+      ID: 896
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 921312
       GoKind: 22
-      Pointee: 886 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 897 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 883
+      ID: 894
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 921216
       GoKind: 22
-      Pointee: 884 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 895 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 889
+      ID: 900
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 921504
       GoKind: 22
-      Pointee: 890 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 901 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 895
+      ID: 906
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 921792
       GoKind: 22
-      Pointee: 896 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 907 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 897
+      ID: 908
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 921888
       GoKind: 22
-      Pointee: 898 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 909 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 893
+      ID: 904
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 921696
       GoKind: 22
-      Pointee: 894 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 905 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 891
+      ID: 902
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 921600
       GoKind: 22
-      Pointee: 892 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 903 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 899
+      ID: 910
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 900 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 911 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 821
+      ID: 832
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 822 StructureType github.com/cihub/seelog.baseError
+      Pointee: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1246
+      ID: 1257
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1804704
       GoKind: 22
-      Pointee: 1247 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1258 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 823
+      ID: 834
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 824 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 835 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1226
+      ID: 1237
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1560864
       GoKind: 22
-      Pointee: 1227 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1238 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1182
+      ID: 1193
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1040128
       GoKind: 22
-      Pointee: 1183 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1194 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1216
+      ID: 1227
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1425824
       GoKind: 22
-      Pointee: 1217 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1228 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 827
+      ID: 838
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 828 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 839 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1283
+      ID: 1294
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1976512
       GoKind: 22
-      Pointee: 1284 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1295 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1300
+      ID: 1311
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2134912
       GoKind: 22
-      Pointee: 1295 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1306 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1299
+      ID: 1310
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2134528
       GoKind: 22
-      Pointee: 1298 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1309 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1184
+      ID: 1195
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1040256
       GoKind: 22
-      Pointee: 1185 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1196 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 825
+      ID: 836
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 826 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 837 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 829
+      ID: 840
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 909792
       GoKind: 22
-      Pointee: 830 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 841 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1248
+      ID: 1259
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1806496
       GoKind: 22
-      Pointee: 1249 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1260 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1289
+      ID: 1300
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2013824
       GoKind: 22
-      Pointee: 1290 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1301 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1291
+      ID: 1302
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2044896
       GoKind: 22
-      Pointee: 1292 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1303 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1110
+      ID: 1121
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1440864
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1122 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1026
+      ID: 1037
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1066368
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1038 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1024
+      ID: 1035
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1066240
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1036 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1028
+      ID: 1039
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1070336
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1040 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1030
+      ID: 1041
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1070464
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1042 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1237
+      ID: 1248
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1673600
       GoKind: 22
-      Pointee: 1238 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1249 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1020
+      ID: 1031
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1052672
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1032 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 835
+      ID: 846
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 911424
       GoKind: 22
-      Pointee: 836 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 847 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1341
+      ID: 1352
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2361376
       GoKind: 22
-      Pointee: 1342 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1353 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1084
+      ID: 1095
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1223072
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1096 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1053
+      ID: 1064
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1201184
       GoKind: 22
-      Pointee: 1054 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1065 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1047
+      ID: 1058
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1200800
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1059 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 990
+      ID: 1001
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1031680
       GoKind: 22
-      Pointee: 991 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1002 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1059
+      ID: 1070
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1201568
       GoKind: 22
-      Pointee: 1060 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1071 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 989
+      ID: 1000
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1031552
       GoKind: 22
-      Pointee: 968 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 979 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1051
+      ID: 1062
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1201056
       GoKind: 22
-      Pointee: 1052 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1063 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1049
+      ID: 1060
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1200928
       GoKind: 22
-      Pointee: 1050 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1061 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1057
+      ID: 1068
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1201440
       GoKind: 22
-      Pointee: 1058 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1069 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1055
+      ID: 1066
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1201312
       GoKind: 22
-      Pointee: 1056 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1067 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1345
+      ID: 1356
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2373184
       GoKind: 22
-      Pointee: 1346 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1357 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1063
+      ID: 1074
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1201952
       GoKind: 22
-      Pointee: 1064 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1075 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 994
+      ID: 1005
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1031936
       GoKind: 22
-      Pointee: 995 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1006 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 992
+      ID: 1003
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1031808
       GoKind: 22
-      Pointee: 993 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1004 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1061
+      ID: 1072
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1201824
       GoKind: 22
-      Pointee: 1062 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1073 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 949
+      ID: 960
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 943776
       GoKind: 22
-      Pointee: 755 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 766 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 757
+      ID: 768
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 756 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 767 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 355
+      ID: 359
       Name: '*go.shape.float64'
       ByteSize: 8
       GoRuntimeType: 479232
       GoKind: 22
-      Pointee: 356 BaseType go.shape.float64
+      Pointee: 360 BaseType go.shape.float64
     - __kind: PointerType
-      ID: 331
+      ID: 335
       Name: '*go.shape.int'
       ByteSize: 8
       GoRuntimeType: 478784
       GoKind: 22
-      Pointee: 326 BaseType go.shape.int
+      Pointee: 330 BaseType go.shape.int
     - __kind: PointerType
-      ID: 348
+      ID: 352
       Name: '*go.shape.string'
       ByteSize: 8
       GoRuntimeType: 478848
       GoKind: 22
-      Pointee: 328 GoStringHeaderType go.shape.string
+      Pointee: 332 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 638
+      ID: 645
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 637 GoStringDataType go.shape.string.str
+      Pointee: 644 GoStringDataType go.shape.string.str
     - __kind: PointerType
-      ID: 334
+      ID: 338
       Name: '*go.shape.struct { Name string }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 335 StructureType go.shape.struct { Name string }
+      Pointee: 339 StructureType go.shape.struct { Name string }
     - __kind: PointerType
-      ID: 336
+      ID: 340
       Name: '*go.shape.struct { X int; Y int }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 337 StructureType go.shape.struct { X int; Y int }
+      Pointee: 341 StructureType go.shape.struct { X int; Y int }
     - __kind: PointerType
-      ID: 349
+      ID: 353
       Name: '*go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+      Pointee: 354 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1123
+      ID: 1134
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1672064
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1135 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1034
+      ID: 1045
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1085184
       GoKind: 22
-      Pointee: 1035 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1046 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1214
+      ID: 1225
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1262752
       GoKind: 22
-      Pointee: 1215 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1226 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1305
+      ID: 1316
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2149888
       GoKind: 22
-      Pointee: 1306 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1317 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1200
+      ID: 1211
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1087488
       GoKind: 22
-      Pointee: 1201 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1212 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 950
+      ID: 961
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 945024
       GoKind: 22
-      Pointee: 758 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 769 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1092
+      ID: 1103
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1264416
       GoKind: 22
-      Pointee: 1093 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1104 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 953
+      ID: 964
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 945312
       GoKind: 22
-      Pointee: 954 StructureType golang.org/x/net/http2.connError
+      Pointee: 965 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 952
+      ID: 963
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945216
       GoKind: 22
-      Pointee: 762 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 773 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 764
+      ID: 775
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 763 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 774 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 956
+      ID: 967
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 945504
       GoKind: 22
-      Pointee: 768 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 779 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 770
+      ID: 781
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 769 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 780 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 955
+      ID: 966
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 945408
       GoKind: 22
-      Pointee: 765 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 776 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 767
+      ID: 778
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 766 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 777 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 951
+      ID: 962
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945120
       GoKind: 22
-      Pointee: 759 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 770 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 761
+      ID: 772
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 760 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 771 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1303
+      ID: 1314
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2147968
       GoKind: 22
-      Pointee: 1304 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1315 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 957
+      ID: 968
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 945600
       GoKind: 22
-      Pointee: 958 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 969 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 959
+      ID: 970
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 945696
       GoKind: 22
-      Pointee: 771 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 782 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 945
+      ID: 956
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 938976
       GoKind: 22
-      Pointee: 946 StructureType google.golang.org/grpc.dropError
+      Pointee: 957 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1090
+      ID: 1101
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1261472
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1102 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1112
+      ID: 1123
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1448224
       GoKind: 22
-      Pointee: 1113 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1124 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 947
+      ID: 958
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942048
       GoKind: 22
-      Pointee: 948 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 959 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1254
+      ID: 1265
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1812768
       GoKind: 22
-      Pointee: 1255 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1266 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1212
+      ID: 1223
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1258016
       GoKind: 22
-      Pointee: 1213 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1224 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1032
+      ID: 1043
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1079424
       GoKind: 22
-      Pointee: 1033 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1044 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1172
+      ID: 1183
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 942144
       GoKind: 22
-      Pointee: 1173 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1184 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 925
+      ID: 936
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 927168
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 937 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1022
+      ID: 1033
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1056256
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1034 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1088
+      ID: 1099
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1229472
       GoKind: 22
-      Pointee: 1089 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1100 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1086
+      ID: 1097
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1229216
       GoKind: 22
-      Pointee: 1087 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1098 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 939
+      ID: 950
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 940 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 951 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 941
+      ID: 952
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 931968
       GoKind: 22
-      Pointee: 942 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 953 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 867
+      ID: 878
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 919296
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 879 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1260
+      ID: 1271
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1853184
       GoKind: 22
-      Pointee: 1261 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1272 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 960
+      ID: 971
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 946464
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType html/template.Error
+      Pointee: 972 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -13271,101 +13394,101 @@ Types:
       GoKind: 22
       Pointee: 162 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 919
+      ID: 930
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 924576
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 931 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 837
+      ID: 848
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 849 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1162
+      ID: 1173
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1174 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1082
+      ID: 1093
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1215008
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1094 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1347
+      ID: 1358
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2378816
       GoKind: 22
-      Pointee: 1348 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1359 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1080
+      ID: 1091
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1214880
       GoKind: 22
-      Pointee: 1081 StructureType internal/poll.errNetClosing
+      Pointee: 1092 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 777
+      ID: 788
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 778 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 789 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1204
+      ID: 1215
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1192480
       GoKind: 22
-      Pointee: 1205 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1216 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1202
+      ID: 1213
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1192096
       GoKind: 22
-      Pointee: 1203 StructureType io.discard
+      Pointee: 1214 StructureType io.discard
     - __kind: PointerType
-      ID: 1176
+      ID: 1187
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1024256
       GoKind: 22
-      Pointee: 1177 UnresolvedPointeeType io.multiWriter
+      Pointee: 1188 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1078
+      ID: 1089
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1214624
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1090 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1250
+      ID: 1261
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1806720
       GoKind: 22
-      Pointee: 1251 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1262 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 341
+      ID: 345
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 342 StructureType main.Pair[go.shape.int,go.shape.bool]
+      Pointee: 346 StructureType main.Pair[go.shape.int,go.shape.bool]
     - __kind: PointerType
-      ID: 344
+      ID: 348
       Name: '*main.Pair[go.shape.string,go.shape.int]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 345 StructureType main.Pair[go.shape.string,go.shape.int]
+      Pointee: 349 StructureType main.Pair[go.shape.string,go.shape.int]
     - __kind: PointerType
       ID: 321
       Name: '*main.anotherStruct'
@@ -13373,19 +13496,19 @@ Types:
       GoKind: 22
       Pointee: 322 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 435
+      ID: 436
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 385280
       GoKind: 22
-      Pointee: 436 StructureType main.deepMap2
+      Pointee: 437 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1403
+      ID: 1404
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385216
       GoKind: 22
-      Pointee: 1404 UnresolvedPointeeType main.deepMap3
+      Pointee: 1405 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
@@ -13394,19 +13517,19 @@ Types:
       GoKind: 22
       Pointee: 150 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1447
+      ID: 1448
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 384896
       GoKind: 22
-      Pointee: 1448 StructureType main.deepMap8
+      Pointee: 1449 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1462
+      ID: 1463
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 384832
       GoKind: 22
-      Pointee: 1463 StructureType main.deepMap9
+      Pointee: 1464 StructureType main.deepMap9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr2'
@@ -13415,12 +13538,12 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1351
+      ID: 1362
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 385792
       GoKind: 22
-      Pointee: 1352 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1363 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
@@ -13429,33 +13552,33 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1417
+      ID: 1418
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 385472
       GoKind: 22
-      Pointee: 1418 StructureType main.deepPtr8
+      Pointee: 1419 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1419
+      ID: 1420
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 385408
       GoKind: 22
-      Pointee: 1420 StructureType main.deepPtr9
+      Pointee: 1421 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 140
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 386432
       GoKind: 22
-      Pointee: 426 StructureType main.deepSlice2
+      Pointee: 427 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1388
+      ID: 1389
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 386368
       GoKind: 22
-      Pointee: 1389 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1390 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
@@ -13464,19 +13587,19 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1423
+      ID: 1424
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 386048
       GoKind: 22
-      Pointee: 1424 StructureType main.deepSlice8
+      Pointee: 1425 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1429
+      ID: 1430
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 385984
       GoKind: 22
-      Pointee: 1430 StructureType main.deepSlice9
+      Pointee: 1431 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 325
       Name: '*main.emptyStruct'
@@ -13491,14 +13614,14 @@ Types:
       GoKind: 22
       Pointee: 165 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1364
+      ID: 1375
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 895776
       GoKind: 22
-      Pointee: 358 StructureType main.firstBehavior
+      Pointee: 362 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1479
+      ID: 1480
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 386816
@@ -13524,19 +13647,19 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1365
+      ID: 1376
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 895872
       GoKind: 22
-      Pointee: 1366 StructureType main.secondBehavior
+      Pointee: 1377 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1357
+      ID: 1368
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 895968
       GoKind: 22
-      Pointee: 1358 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1369 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType1'
@@ -13544,28 +13667,28 @@ Types:
       GoKind: 22
       Pointee: 152 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1354
+      ID: 1365
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1353 GoStringDataType main.stringType1.str
+      Pointee: 1364 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 154
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1355 GoStringHeaderType main.stringType2
+      Pointee: 1366 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1481
+      ID: 1482
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1480 GoStringDataType main.stringType2.str
+      Pointee: 1481 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 278
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 276 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 489
+      ID: 490
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 384768
@@ -13589,10 +13712,10 @@ Types:
       GoKind: 22
       Pointee: 254 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1369
+      ID: 1380
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1368 GoSliceDataType main.t.array
+      Pointee: 1379 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 273
       Name: '*main.threeStringStruct'
@@ -13620,40 +13743,40 @@ Types:
       ByteSize: 8
       Pointee: 205 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 376
+      ID: 380
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 377 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 381 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 145
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1393
+      ID: 1394
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1394 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1395 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1437
+      ID: 1438
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1438 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1439 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1452
+      ID: 1453
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1453 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1454 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 172
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 173 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1467
+      ID: 1468
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1468 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1469 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 239
       Name: '*map<int,struct {}>'
@@ -13665,10 +13788,10 @@ Types:
       ByteSize: 8
       Pointee: 210 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 681
+      ID: 688
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 682 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 689 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 199
       Name: '*map<string,[]main.structWithMap>'
@@ -13680,35 +13803,35 @@ Types:
       ByteSize: 8
       Pointee: 188 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 403
+      ID: 404
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 404 GoSwissMapHeaderType map<string,float64>
+      Pointee: 405 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1116
+      ID: 1127
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1117 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1128 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 182
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 183 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 399 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 400 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 177
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 178 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 393
+      ID: 394
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 394 GoSwissMapHeaderType map<string,string>
+      Pointee: 395 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 234
       Name: '*map<struct {},int>'
@@ -13766,728 +13889,728 @@ Types:
       GoKind: 22
       Pointee: 181 GoMapType map[string]int
     - __kind: PointerType
-      ID: 871
+      ID: 882
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 872 StructureType math/big.ErrNaN
+      Pointee: 883 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1166
+      ID: 1177
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 914976
       GoKind: 22
-      Pointee: 1167 StructureType mime/multipart.writerOnly·1
+      Pointee: 1178 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1070
+      ID: 1081
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1208096
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType net.AddrError
+      Pointee: 1082 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1101
+      ID: 1112
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1424064
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType net.DNSError
+      Pointee: 1113 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1311
+      ID: 1322
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2235936
       GoKind: 22
-      Pointee: 1312 UnresolvedPointeeType net.IPConn
+      Pointee: 1323 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1099
+      ID: 1110
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1423744
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType net.OpError
+      Pointee: 1111 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1072
+      ID: 1083
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1208224
       GoKind: 22
-      Pointee: 1073 UnresolvedPointeeType net.ParseError
+      Pointee: 1084 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1321
+      ID: 1332
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2266624
       GoKind: 22
-      Pointee: 1322 UnresolvedPointeeType net.TCPConn
+      Pointee: 1333 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1331
+      ID: 1342
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2311616
       GoKind: 22
-      Pointee: 1332 UnresolvedPointeeType net.UDPConn
+      Pointee: 1343 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1319
+      ID: 1330
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2266112
       GoKind: 22
-      Pointee: 1320 UnresolvedPointeeType net.UnixConn
+      Pointee: 1331 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1069
+      ID: 1080
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1207328
       GoKind: 22
-      Pointee: 1038 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1049 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1040
+      ID: 1051
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1039 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1050 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1006
+      ID: 1017
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1038336
       GoKind: 22
-      Pointee: 1007 StructureType net.canceledError
+      Pointee: 1018 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1287
+      ID: 1298
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2010944
       GoKind: 22
-      Pointee: 1288 UnresolvedPointeeType net.conn
+      Pointee: 1299 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1141
+      ID: 1152
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1847808
       GoKind: 22
-      Pointee: 1142 StructureType net.dialResult·1
+      Pointee: 1153 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1333
+      ID: 1344
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2315872
       GoKind: 22
-      Pointee: 1334 UnresolvedPointeeType net.netFD
+      Pointee: 1345 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 806
+      ID: 817
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 906432
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType net.notFoundError
+      Pointee: 818 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1413
+      ID: 1414
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1423904
       GoKind: 22
-      Pointee: 1414 StructureType net.onlyValuesCtx
+      Pointee: 1415 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 808
+      ID: 819
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 907104
       GoKind: 22
-      Pointee: 809 StructureType net.result·2
+      Pointee: 820 StructureType net.result·2
     - __kind: PointerType
-      ID: 1315
+      ID: 1326
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2252160
       GoKind: 22
-      Pointee: 1316 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1327 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1313
+      ID: 1324
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2251680
       GoKind: 22
-      Pointee: 1314 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1325 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1074
+      ID: 1085
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1208864
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType net.temporaryError
+      Pointee: 1086 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1103
+      ID: 1114
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1424224
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType net.timeoutError
+      Pointee: 1115 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 996
+      ID: 1007
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1034368
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1008 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1158
+      ID: 1169
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 902208
       GoKind: 22
-      Pointee: 1159 StructureType net/http.bufioFlushWriter
+      Pointee: 1170 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 783
+      ID: 794
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 902880
       GoKind: 22
-      Pointee: 703 BaseType net/http.http2ConnectionError
+      Pointee: 714 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 784
+      ID: 795
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 902976
       GoKind: 22
-      Pointee: 785 StructureType net/http.http2GoAwayError
+      Pointee: 796 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1095
+      ID: 1106
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1420224
       GoKind: 22
-      Pointee: 1096 StructureType net/http.http2StreamError
+      Pointee: 1107 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 788
+      ID: 799
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 903552
       GoKind: 22
-      Pointee: 789 StructureType net/http.http2connError
+      Pointee: 800 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1222
+      ID: 1233
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1557984
       GoKind: 22
-      Pointee: 1223 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1234 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 787
+      ID: 798
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 903456
       GoKind: 22
-      Pointee: 707 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 718 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 709
+      ID: 720
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 708 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 719 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 791
+      ID: 802
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 903744
       GoKind: 22
-      Pointee: 713 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 724 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 715
+      ID: 726
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 714 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 725 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 790
+      ID: 801
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 903648
       GoKind: 22
-      Pointee: 710 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 721 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 712
+      ID: 723
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 711 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 722 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1067
+      ID: 1078
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1204000
       GoKind: 22
-      Pointee: 1068 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1079 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1002
+      ID: 1013
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1035008
       GoKind: 22
-      Pointee: 1003 StructureType net/http.http2noCachedConnError
+      Pointee: 1014 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1276
+      ID: 1287
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1953152
       GoKind: 22
-      Pointee: 1277 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1288 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 786
+      ID: 797
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 903360
       GoKind: 22
-      Pointee: 704 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 715 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 706
+      ID: 717
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 705 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 716 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1160
+      ID: 1171
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 903840
       GoKind: 22
-      Pointee: 1161 StructureType net/http.http2stickyErrWriter
+      Pointee: 1172 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 998
+      ID: 1009
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1034624
       GoKind: 22
-      Pointee: 999 StructureType net/http.nothingWrittenError
+      Pointee: 1010 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1224
+      ID: 1235
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2177248
       GoKind: 22
-      Pointee: 1225 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1236 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1180
+      ID: 1191
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1034496
       GoKind: 22
-      Pointee: 1181 StructureType net/http.persistConnWriter
+      Pointee: 1192 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1206
+      ID: 1217
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1203104
       GoKind: 22
-      Pointee: 1207 StructureType net/http.readWriteCloserBody
+      Pointee: 1218 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 792
+      ID: 803
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 793 StructureType net/http.requestBodyReadError
+      Pointee: 804 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1097
+      ID: 1108
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1421344
       GoKind: 22
-      Pointee: 1098 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1109 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1065
+      ID: 1076
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1203872
       GoKind: 22
-      Pointee: 1066 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1077 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1000
+      ID: 1011
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1034752
       GoKind: 22
-      Pointee: 1001 StructureType net/http.transportReadFromServerError
+      Pointee: 1012 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1258
+      ID: 1269
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1844672
       GoKind: 22
-      Pointee: 1259 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1270 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 781
+      ID: 792
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 902112
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 793 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1278
+      ID: 1289
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1954944
       GoKind: 22
-      Pointee: 1279 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1290 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1190
+      ID: 1201
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1047424
       GoKind: 22
-      Pointee: 1191 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1202 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 863
+      ID: 874
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 919104
       GoKind: 22
-      Pointee: 864 StructureType net/netip.parseAddrError
+      Pointee: 875 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 861
+      ID: 872
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 862 StructureType net/netip.parsePrefixError
+      Pointee: 873 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1232
+      ID: 1243
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2121920
       GoKind: 22
-      Pointee: 1233 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1244 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1192
+      ID: 1203
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1052288
       GoKind: 22
-      Pointee: 1193 StructureType net/smtp.dataCloser
+      Pointee: 1204 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 847
+      ID: 858
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 915168
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType net/textproto.Error
+      Pointee: 859 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 846
+      ID: 857
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 915072
       GoKind: 22
-      Pointee: 738 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 749 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 740
+      ID: 751
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 739 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 750 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1188
+      ID: 1199
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1046656
       GoKind: 22
-      Pointee: 1189 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1200 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1105
+      ID: 1116
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1424544
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType net/url.Error
+      Pointee: 1117 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 810
+      ID: 821
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 907200
       GoKind: 22
-      Pointee: 716 GoStringHeaderType net/url.EscapeError
+      Pointee: 727 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 718
+      ID: 729
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 717 GoStringDataType net/url.EscapeError.str
+      Pointee: 728 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 811
+      ID: 822
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 907296
       GoKind: 22
-      Pointee: 719 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 730 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 721
+      ID: 732
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 720 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 731 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 535
+      ID: 536
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 536 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 537 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 527
+      ID: 528
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 528 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 529 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 475
+      ID: 476
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 476 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 477 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 494
+      ID: 495
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 495 StructureType noalg.map.group[bool]main.node
+      Pointee: 496 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 648 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 655 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 431
+      ID: 432
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 432 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 433 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1399
+      ID: 1400
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1400 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1401 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1443
+      ID: 1444
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1444 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1445 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1458
+      ID: 1459
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1459 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 443
+      ID: 444
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 444 StructureType noalg.map.group[int]int
+      Pointee: 445 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1473
+      ID: 1474
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1474 StructureType noalg.map.group[int]interface {}
+      Pointee: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 551
+      ID: 552
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 552 StructureType noalg.map.group[int]struct {}
+      Pointee: 553 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 502
+      ID: 503
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 503 StructureType noalg.map.group[int]uint8
+      Pointee: 504 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 692
+      ID: 703
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 693 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 484
+      ID: 485
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 485 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 486 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 467
+      ID: 468
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 468 StructureType noalg.map.group[string][]string
+      Pointee: 469 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 672
+      ID: 679
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 673 StructureType noalg.map.group[string]float64
+      Pointee: 680 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1148
+      ID: 1159
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1149 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 459
+      ID: 460
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 460 StructureType noalg.map.group[string]int
+      Pointee: 461 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 664
+      ID: 671
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 665 StructureType noalg.map.group[string]interface {}
+      Pointee: 672 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 451
+      ID: 452
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 452 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 453 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 657 StructureType noalg.map.group[string]string
+      Pointee: 664 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 543
+      ID: 544
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 544 StructureType noalg.map.group[struct {}]int
+      Pointee: 545 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 591
+      ID: 592
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 592 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 599
+      ID: 600
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 600 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 607
+      ID: 608
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 608 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 615
+      ID: 616
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 623
+      ID: 624
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 631
+      ID: 632
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 559
+      ID: 560
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 560 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 561 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 518
+      ID: 519
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 519 StructureType noalg.map.group[uint8][4]int
+      Pointee: 520 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 510
+      ID: 511
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 511 StructureType noalg.map.group[uint8]uint8
+      Pointee: 512 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1339
+      ID: 1350
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2354528
       GoKind: 22
-      Pointee: 1340 UnresolvedPointeeType os.File
+      Pointee: 1351 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 979
+      ID: 990
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1027968
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType os.LinkError
+      Pointee: 991 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1043
+      ID: 1054
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1197088
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType os.SyscallError
+      Pointee: 1055 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1337
+      ID: 1348
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2350848
       GoKind: 22
-      Pointee: 1338 StructureType os.fileWithoutReadFrom
+      Pointee: 1349 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1335
+      ID: 1346
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2350112
       GoKind: 22
-      Pointee: 1336 StructureType os.fileWithoutWriteTo
+      Pointee: 1347 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1008
+      ID: 1019
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1043328
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType os/exec.Error
+      Pointee: 1020 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1144
+      ID: 1155
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2091072
       GoKind: 22
-      Pointee: 1145 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1156 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1210
+      ID: 1221
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1215904
       GoKind: 22
-      Pointee: 1211 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1222 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1010
+      ID: 1021
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1043456
       GoKind: 22
-      Pointee: 1011 StructureType os/exec.wrappedError
+      Pointee: 1022 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 944
+      ID: 955
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 937056
       GoKind: 22
-      Pointee: 752 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 763 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 754
+      ID: 765
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 753 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 764 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 943
+      ID: 954
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 936960
       GoKind: 22
-      Pointee: 751 BaseType os/user.UnknownUserIdError
+      Pointee: 762 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 779
+      ID: 790
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 780 UnresolvedPointeeType reflect.ValueError
+      Pointee: 791 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 869
+      ID: 880
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 881 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 983
+      ID: 994
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1028992
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 995 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 987
+      ID: 998
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1030784
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 999 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14503,12 +14626,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 985
+      ID: 996
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1029120
       GoKind: 22
-      Pointee: 986 StructureType runtime.boundsError
+      Pointee: 997 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -14524,24 +14647,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1045
+      ID: 1056
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1199392
       GoKind: 22
-      Pointee: 1046 StructureType runtime.errorAddressString
+      Pointee: 1057 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 981
+      ID: 992
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1028608
       GoKind: 22
-      Pointee: 962 GoStringHeaderType runtime.errorString
+      Pointee: 973 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 964
+      ID: 975
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 963 GoStringDataType runtime.errorString.str
+      Pointee: 974 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -14557,17 +14680,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 982
+      ID: 993
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1028736
       GoKind: 22
-      Pointee: 965 GoStringHeaderType runtime.plainError
+      Pointee: 976 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 967
+      ID: 978
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 966 GoStringDataType runtime.plainError.str
+      Pointee: 977 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14597,12 +14720,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 977
+      ID: 988
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1026816
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType strconv.NumError
+      Pointee: 989 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -14611,264 +14734,264 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 419
+      ID: 420
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 418 GoStringDataType string.str
+      Pointee: 419 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1272
+      ID: 1283
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1951616
       GoKind: 22
-      Pointee: 1273 UnresolvedPointeeType strings.Builder
+      Pointee: 1284 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1178
+      ID: 1189
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1026944
       GoKind: 22
-      Pointee: 1179 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1190 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1174
+      ID: 1185
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 970816
       GoKind: 22
-      Pointee: 1175 StructureType struct { io.Writer }
+      Pointee: 1186 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 271
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
-      ID: 1107
+      ID: 1118
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1426784
       GoKind: 22
-      Pointee: 1094 BaseType syscall.Errno
+      Pointee: 1105 BaseType syscall.Errno
     - __kind: PointerType
       ID: 232
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 533 StructureType table<[4]int,[4]int>
+      Pointee: 534 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 227
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 525 StructureType table<[4]int,uint8>
+      Pointee: 526 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 195
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 473 StructureType table<[4]string,[2]int>
+      Pointee: 474 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 207
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 492 StructureType table<bool,main.node>
+      Pointee: 493 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 379
+      ID: 383
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 645 StructureType table<context.canceler,struct {}>
+      Pointee: 652 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 148
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 429 StructureType table<int,*main.deepMap2>
+      Pointee: 430 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1396
+      ID: 1397
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1397 StructureType table<int,*main.deepMap3>
+      Pointee: 1398 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1440
+      ID: 1441
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1441 StructureType table<int,*main.deepMap8>
+      Pointee: 1442 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1455
+      ID: 1456
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1456 StructureType table<int,*main.deepMap9>
+      Pointee: 1457 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 175
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 441 StructureType table<int,int>
+      Pointee: 442 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1470
+      ID: 1471
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1471 StructureType table<int,interface {}>
+      Pointee: 1472 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 242
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 549 StructureType table<int,struct {}>
+      Pointee: 550 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 212
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 500 StructureType table<int,uint8>
+      Pointee: 501 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 690 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 701 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 202
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 482 StructureType table<string,[]main.structWithMap>
+      Pointee: 483 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 190
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 465 StructureType table<string,[]string>
+      Pointee: 466 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 406
+      ID: 407
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 670 StructureType table<string,float64>
+      Pointee: 677 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1119
+      ID: 1130
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1146 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1157 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 185
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 457 StructureType table<string,int>
+      Pointee: 458 StructureType table<string,int>
     - __kind: PointerType
-      ID: 401
+      ID: 402
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 662 StructureType table<string,interface {}>
+      Pointee: 669 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 180
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 449 StructureType table<string,main.nestedStruct>
+      Pointee: 450 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 396
+      ID: 397
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 654 StructureType table<string,string>
+      Pointee: 661 StructureType table<string,string>
     - __kind: PointerType
       ID: 237
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 541 StructureType table<struct {},int>
+      Pointee: 542 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 294
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 589 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 590 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 299
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 597 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 598 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 304
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 605 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 606 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 309
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 613 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 614 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 314
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 621 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 622 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 319
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 629 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 630 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 247
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 557 StructureType table<struct {},struct {}>
+      Pointee: 558 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 222
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 516 StructureType table<uint8,[4]int>
+      Pointee: 517 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 217
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 508 StructureType table<uint8,uint8>
+      Pointee: 509 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1309
+      ID: 1320
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2162144
       GoKind: 22
-      Pointee: 1310 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1321 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1036
+      ID: 1047
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1089024
       GoKind: 22
-      Pointee: 1037 StructureType text/template.ExecError
+      Pointee: 1048 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 384
+      ID: 327
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1621568
       GoKind: 22
-      Pointee: 385 StructureType time.Location
+      Pointee: 328 StructureType time.Location
     - __kind: PointerType
-      ID: 775
+      ID: 786
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 898464
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType time.ParseError
+      Pointee: 787 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 381
+      ID: 385
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1028352
       GoKind: 22
-      Pointee: 382 StructureType time.Timer
+      Pointee: 386 StructureType time.Timer
     - __kind: PointerType
-      ID: 774
+      ID: 785
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 898368
       GoKind: 22
-      Pointee: 700 GoStringHeaderType time.fileSizeError
+      Pointee: 711 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 702
+      ID: 713
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 701 GoStringDataType time.fileSizeError.str
+      Pointee: 712 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 1372
+      ID: 639
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 392064
       GoKind: 22
-      Pointee: 1373 StructureType time.zone
+      Pointee: 640 StructureType time.zone
     - __kind: PointerType
-      ID: 1375
+      ID: 642
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 392128
       GoKind: 22
-      Pointee: 1376 StructureType time.zoneTrans
+      Pointee: 643 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -14912,49 +15035,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 865
+      ID: 876
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 919200
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 877 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1301
+      ID: 1312
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2137600
       GoKind: 22
-      Pointee: 1302 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1313 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 849
+      ID: 860
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 915360
       GoKind: 22
-      Pointee: 850 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 861 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 851
+      ID: 862
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 741 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 752 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1015
+      ID: 1026
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1047168
       GoKind: 22
-      Pointee: 1016 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1027 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1017
+      ID: 1028
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1047296
       GoKind: 22
-      Pointee: 970 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 981 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1370
+      ID: 1381
       Name: <-chan time.Time
       GoRuntimeType: 596384
       GoKind: 18
@@ -14967,7 +15090,7 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 1754
+      ID: 1758
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14983,10 +15106,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 354 GoSliceHeaderType []go.shape.float64
+            Type: 358 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -14996,10 +15119,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 354 GoSliceHeaderType []go.shape.float64
+            Type: 358 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15009,17 +15132,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 357 GoSubroutineType func(go.shape.float64) bool
+            Type: 361 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 1, name: pred}
+                  Variable: {subprogram: 191, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1755
+      ID: 1759
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -15029,17 +15152,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 354 GoSliceHeaderType []go.shape.float64
+            Type: 358 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 2, name: ~r0}
+                  Variable: {subprogram: 191, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1752
+      ID: 1756
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15055,10 +15178,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15068,10 +15191,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15081,17 +15204,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 332 GoSubroutineType func(go.shape.int) bool
+            Type: 336 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: pred}
+                  Variable: {subprogram: 172, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1753
+      ID: 1757
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -15101,20 +15224,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 2, name: ~r0}
+                  Variable: {subprogram: 172, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1810
+      ID: 1814
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1756
+      ID: 1760
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15130,10 +15253,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15143,10 +15266,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15156,17 +15279,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 333 GoSubroutineType func(go.shape.int) go.shape.string
+            Type: 337 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: f}
+                  Variable: {subprogram: 173, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1757
+      ID: 1761
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15176,17 +15299,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 2, name: ~r0}
+                  Variable: {subprogram: 173, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1768
+      ID: 1772
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15205,10 +15328,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15218,10 +15341,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 341 PointerType *main.Pair[go.shape.int,go.shape.bool]
+            Type: 345 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: x}
+                  Variable: {subprogram: 179, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15231,10 +15354,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15244,20 +15367,20 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 343 BaseType go.shape.bool
+            Type: 347 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 2, name: v}
+                  Variable: {subprogram: 179, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1769
+      ID: 1773
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1770
+      ID: 1774
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15276,10 +15399,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15289,10 +15412,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 344 PointerType *main.Pair[go.shape.string,go.shape.int]
+            Type: 348 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: x}
+                  Variable: {subprogram: 180, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15302,10 +15425,10 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15315,20 +15438,20 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 2, name: v}
+                  Variable: {subprogram: 180, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1771
+      ID: 1775
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1808
+      ID: 1812
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15337,17 +15460,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 358 StructureType main.firstBehavior
+            Type: 362 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 0, name: b}
+                  Variable: {subprogram: 198, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1809
+      ID: 1813
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15359,14 +15482,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 1, name: ~r0}
+                  Variable: {subprogram: 198, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1784
+      ID: 1788
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15382,10 +15505,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15395,10 +15518,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15408,17 +15531,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1788
+      ID: 1792
       Name: Probe[main.genericContains[go.shape.int]]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15434,10 +15557,10 @@ Types:
           Offset: 17
           Kind: local
           Expression:
-            Type: 330 GoSliceHeaderType []go.shape.int
+            Type: 334 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15447,17 +15570,17 @@ Types:
           Offset: 41
           Kind: local
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1785
+      ID: 1789
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15469,14 +15592,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 187, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1786
+      ID: 1790
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15492,10 +15615,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15505,10 +15628,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 351 GoSliceHeaderType []go.shape.string
+            Type: 355 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: haystack}
+                  Variable: {subprogram: 188, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15518,17 +15641,17 @@ Types:
           Offset: 57
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1789
+      ID: 1793
       Name: Probe[main.genericContains[go.shape.string]]Line
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15538,17 +15661,17 @@ Types:
           Offset: 9
           Kind: local
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1787
+      ID: 1791
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15560,14 +15683,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 2, name: ~r0}
+                  Variable: {subprogram: 188, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1780
+      ID: 1784
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15577,10 +15700,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 348 PointerType *go.shape.string
+            Type: 352 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15590,17 +15713,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 348 PointerType *go.shape.string
+            Type: 352 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1781
+      ID: 1785
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15610,17 +15733,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: ~r0}
+                  Variable: {subprogram: 185, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1782
+      ID: 1786
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15630,10 +15753,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 353 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15643,17 +15766,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 349 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 353 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1783
+      ID: 1787
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15663,17 +15786,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 350 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 354 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: ~r0}
+                  Variable: {subprogram: 186, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1776
+      ID: 1780
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15683,10 +15806,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 346 StructureType go.shape.struct { main.i int }
+            Type: 350 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15696,17 +15819,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 346 StructureType go.shape.struct { main.i int }
+            Type: 350 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1777
+      ID: 1781
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15718,14 +15841,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: ~r0}
+                  Variable: {subprogram: 183, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1778
+      ID: 1782
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15735,10 +15858,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 347 StructureType go.shape.struct { main.s string }
+            Type: 351 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15748,17 +15871,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 347 StructureType go.shape.struct { main.s string }
+            Type: 351 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1779
+      ID: 1783
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15770,14 +15893,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: ~r0}
+                  Variable: {subprogram: 184, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1758
+      ID: 1762
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15787,10 +15910,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 331 PointerType *go.shape.int
+            Type: 335 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15800,17 +15923,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 331 PointerType *go.shape.int
+            Type: 335 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1759
+      ID: 1763
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15820,17 +15943,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 331 PointerType *go.shape.int
+            Type: 335 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 174, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1760
+      ID: 1764
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15840,10 +15963,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 334 PointerType *go.shape.struct { Name string }
+            Type: 338 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15853,17 +15976,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 334 PointerType *go.shape.struct { Name string }
+            Type: 338 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1761
+      ID: 1765
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15873,17 +15996,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 334 PointerType *go.shape.struct { Name string }
+            Type: 338 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: ~r0}
+                  Variable: {subprogram: 175, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1762
+      ID: 1766
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15893,10 +16016,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 336 PointerType *go.shape.struct { X int; Y int }
+            Type: 340 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15906,17 +16029,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 336 PointerType *go.shape.struct { X int; Y int }
+            Type: 340 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1763
+      ID: 1767
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15926,17 +16049,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 PointerType *go.shape.struct { X int; Y int }
+            Type: 340 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: ~r0}
+                  Variable: {subprogram: 176, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1774
+      ID: 1778
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15952,10 +16075,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15965,10 +16088,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15978,17 +16101,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: b}
+                  Variable: {subprogram: 182, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1775
+      ID: 1779
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16004,10 +16127,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16017,17 +16140,17 @@ Types:
           Offset: 33
           Kind: return
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 3, name: ~r1}
+                  Variable: {subprogram: 182, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1772
+      ID: 1776
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -16043,10 +16166,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16056,10 +16179,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16069,17 +16192,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 343 BaseType go.shape.bool
+            Type: 347 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: b}
+                  Variable: {subprogram: 181, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1773
+      ID: 1777
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -16095,10 +16218,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 343 BaseType go.shape.bool
+            Type: 347 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
@@ -16108,17 +16231,17 @@ Types:
           Offset: 18
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 3, name: ~r1}
+                  Variable: {subprogram: 181, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1766
+      ID: 1770
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -16128,10 +16251,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 340 StructureType main.largeGenericType[go.shape.int]
+            Type: 344 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
@@ -16141,17 +16264,17 @@ Types:
           Offset: 145
           Kind: argument
           Expression:
-            Type: 340 StructureType main.largeGenericType[go.shape.int]
+            Type: 344 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1767
+      ID: 1771
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16161,17 +16284,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: ~r0}
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1764
+      ID: 1768
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -16181,10 +16304,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 338 StructureType main.largeGenericType[go.shape.string]
+            Type: 342 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
@@ -16194,17 +16317,17 @@ Types:
           Offset: 153
           Kind: argument
           Expression:
-            Type: 338 StructureType main.largeGenericType[go.shape.string]
+            Type: 342 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1765
+      ID: 1769
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16214,17 +16337,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: ~r0}
+                  Variable: {subprogram: 177, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1748
+      ID: 1752
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16234,10 +16357,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16247,17 +16370,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1749
+      ID: 1753
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16267,17 +16390,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1750
+      ID: 1754
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16287,10 +16410,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16300,17 +16423,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1751
+      ID: 1755
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16320,20 +16443,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1714
+      ID: 1715
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1715
+      ID: 1716
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16352,7 +16475,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16384,7 +16507,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16403,7 +16526,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16435,7 +16558,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16454,7 +16577,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1685
+      ID: 1686
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16486,7 +16609,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1686
+      ID: 1687
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16505,7 +16628,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1500
+      ID: 1501
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16537,7 +16660,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1498
+      ID: 1499
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -16569,7 +16692,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1496
+      ID: 1497
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16601,7 +16724,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16633,7 +16756,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1497
+      ID: 1498
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16665,7 +16788,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1499
+      ID: 1500
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16697,7 +16820,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16729,7 +16852,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
+      ID: 1589
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -16748,7 +16871,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16780,10 +16903,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16815,7 +16938,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testByteArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16847,7 +16970,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1589
+      ID: 1590
       Name: Probe[main.testChannel]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16879,7 +17002,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testCombinedByte]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16937,7 +17060,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       ExprStatusArraySize: 1
@@ -16969,7 +17092,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -17014,7 +17137,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1650
+      ID: 1651
       Name: Probe[main.testConflictingReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17046,7 +17169,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1651
+      ID: 1652
       Name: Probe[main.testConflictingReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -17078,7 +17201,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testCycle]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17110,7 +17233,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17142,7 +17265,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17174,7 +17297,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17206,7 +17329,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17238,7 +17361,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17270,7 +17393,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17302,7 +17425,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1705
+      ID: 1706
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -17360,7 +17483,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1702
+      ID: 1703
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17392,7 +17515,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1728
+      ID: 1729
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17424,7 +17547,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1743
+      ID: 1744
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17456,7 +17579,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1742
+      ID: 1743
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -17488,7 +17611,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testErrorAtLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17546,7 +17669,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testError]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17578,7 +17701,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17610,10 +17733,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -17645,10 +17768,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17680,7 +17803,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17712,7 +17835,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17731,7 +17854,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testFrameless]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17763,7 +17886,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17782,7 +17905,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17814,10 +17937,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17849,13 +17972,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1800
+      ID: 1804
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17913,28 +18036,28 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1801
+      ID: 1805
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1802
+      ID: 1806
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1803
+      ID: 1807
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1804
+      ID: 1808
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1797
+      ID: 1801
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17946,7 +18069,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -17959,14 +18082,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1794
+      ID: 1798
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17978,14 +18101,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1795
+      ID: 1799
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17997,14 +18120,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1796
+      ID: 1800
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18016,7 +18139,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18029,14 +18152,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1799
+      ID: 1803
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18048,7 +18171,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18061,17 +18184,17 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1798
+      ID: 1802
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1805
+      ID: 1809
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18083,7 +18206,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18096,14 +18219,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1806
+      ID: 1810
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18115,7 +18238,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18128,14 +18251,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1807
+      ID: 1811
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18147,7 +18270,7 @@ Types:
             Type: 166 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
@@ -18160,14 +18283,14 @@ Types:
             Type: 166 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -18199,7 +18322,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18231,7 +18354,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18263,7 +18386,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -18295,7 +18418,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testIntArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18327,7 +18450,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18359,7 +18482,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -18391,7 +18514,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1684
+      ID: 1685
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18410,7 +18533,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18442,40 +18565,8 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1529
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1530
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -18509,7 +18600,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1689
+      ID: 1532
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1690
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -18749,7 +18872,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1690
+      ID: 1691
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18768,7 +18891,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testManyPointers]
       ByteSize: 1121
       ExprStatusArraySize: 1
@@ -18800,7 +18923,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testManyStrings]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -18832,7 +18955,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18864,7 +18987,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18896,7 +19019,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18928,7 +19051,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18960,7 +19083,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18992,7 +19115,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19024,7 +19147,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19056,7 +19179,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19082,38 +19205,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1568
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 198 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 198 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19152,7 +19243,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1570
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 198 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1578
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19184,7 +19307,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19216,7 +19339,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19248,7 +19371,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19280,7 +19403,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19312,7 +19435,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19344,7 +19467,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19376,7 +19499,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19408,7 +19531,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19440,7 +19563,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19468,38 +19591,6 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1725
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -19536,7 +19627,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1691
+      ID: 1727
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1692
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -19776,7 +19899,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1692
+      ID: 1693
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19795,7 +19918,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1695
+      ID: 1696
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19853,7 +19976,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1696
+      ID: 1697
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19885,7 +20008,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1687
+      ID: 1688
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -19943,7 +20066,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1688
+      ID: 1689
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19962,7 +20085,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19982,6 +20105,143 @@ Types:
           DictIndex: -1
         - Name: i
           Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1631
+      Name: Probe[main.testMultipleNamedReturn]
+    - __kind: EventRootType
+      ID: 1633
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1635
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1637
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1639
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1641
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -19995,21 +20255,63 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1630
-      Name: Probe[main.testMultipleNamedReturn]
-    - __kind: EventRootType
-      ID: 1632
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: return
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1632
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -20017,57 +20319,57 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1634
-      Name: Probe[main.testMultipleNamedReturn]
+      Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result
           Offset: 17
-          Kind: template_segment
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 25
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -20075,185 +20377,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1636
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1638
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1640
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1629
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1631
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1633
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result
-          Offset: 17
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 25
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1635
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20337,7 +20460,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20369,7 +20492,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20401,7 +20524,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20446,7 +20569,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 63
       ExprStatusArraySize: 3
@@ -20582,7 +20705,42 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1625
+      Name: Probe[main.testNamedReturn]
+    - __kind: EventRootType
+      ID: 1627
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20615,41 +20773,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1624
-      Name: Probe[main.testNamedReturn]
-    - __kind: EventRootType
-      ID: 1626
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: i
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1623
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20668,7 +20791,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20687,7 +20810,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20719,7 +20842,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1737
+      ID: 1738
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20751,7 +20874,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1738
+      ID: 1739
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20778,10 +20901,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1739
+      ID: 1740
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1740
+      ID: 1741
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20808,7 +20931,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20866,7 +20989,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1706
+      ID: 1707
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -20924,7 +21047,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1708
+      ID: 1709
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -21008,7 +21131,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1709
+      ID: 1710
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21040,7 +21163,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1724
+      ID: 1725
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21072,7 +21195,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21104,7 +21227,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21136,7 +21259,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21168,7 +21291,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       ExprStatusArraySize: 1
@@ -21226,7 +21349,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21258,7 +21381,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21290,7 +21413,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21309,10 +21432,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21331,10 +21454,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -21353,10 +21476,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21375,10 +21498,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -21501,10 +21624,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -21536,10 +21659,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1657
+      ID: 1658
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21571,7 +21694,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -21603,7 +21726,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21622,7 +21745,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21641,7 +21764,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21660,7 +21783,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21692,7 +21815,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21737,7 +21860,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21782,7 +21905,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21814,7 +21937,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21846,7 +21969,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21865,29 +21988,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testReturnsInt]
     - __kind: EventRootType
-      ID: 1600
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1602
+      ID: 1601
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21906,7 +22010,26 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1604
+      ID: 1603
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1605
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21938,7 +22061,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21957,7 +22080,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21989,7 +22112,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22021,7 +22144,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22040,7 +22163,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22072,7 +22195,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1621
+      ID: 1622
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22091,10 +22214,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1659
+      ID: 1660
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -22113,10 +22236,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1655
+      ID: 1656
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1656
+      ID: 1657
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -22343,10 +22466,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22365,10 +22488,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1673
+      ID: 1674
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1674
+      ID: 1675
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -22439,10 +22562,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -22474,7 +22597,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1652
+      ID: 1653
       Name: Probe[main.testReturnsNamedDeferLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22532,10 +22655,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22554,10 +22677,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1653
+      ID: 1654
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1654
+      ID: 1655
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -22667,10 +22790,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22689,10 +22812,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1672
+      ID: 1673
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -22711,7 +22834,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22743,7 +22866,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22775,7 +22898,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22807,13 +22930,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testSingleFloat32]
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testSingleFloat64]
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22845,7 +22968,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22877,7 +23000,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22909,7 +23032,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22967,7 +23090,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22999,7 +23122,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1503
+      ID: 1504
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23031,7 +23154,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1716
+      ID: 1717
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23063,7 +23186,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -23095,7 +23218,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23127,7 +23250,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23159,7 +23282,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -23191,7 +23314,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23223,7 +23346,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1712
+      ID: 1713
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23255,7 +23378,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1703
+      ID: 1704
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23287,7 +23410,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23319,7 +23442,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23338,10 +23461,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.testSomeNamedReturn]
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23360,7 +23483,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23392,7 +23515,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23450,7 +23573,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1645
+      ID: 1646
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23469,7 +23592,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23527,7 +23650,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23572,7 +23695,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1693
+      ID: 1694
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -23604,7 +23727,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1694
+      ID: 1695
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23649,7 +23772,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testStringArray]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23681,7 +23804,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23713,7 +23836,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1707
+      ID: 1708
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23745,7 +23868,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testStringType1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23777,7 +23900,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testStringType2]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23809,7 +23932,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1704
+      ID: 1705
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23867,7 +23990,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23899,7 +24022,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1697
+      ID: 1698
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23931,7 +24054,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1698
+      ID: 1699
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23963,7 +24086,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1731
+      ID: 1732
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -23995,10 +24118,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1732
+      ID: 1733
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1730
+      ID: 1731
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -24030,7 +24153,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24062,7 +24185,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1733
+      ID: 1734
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24081,7 +24204,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1735
+      ID: 1736
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -24113,13 +24236,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1734
+      ID: 1735
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1736
+      ID: 1737
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1713
+      ID: 1714
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -24203,7 +24326,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1729
+      ID: 1730
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24287,7 +24410,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testTakeContext]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24306,7 +24429,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1741
+      ID: 1742
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -24325,7 +24448,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1722
+      ID: 1723
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24357,7 +24480,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1723
+      ID: 1724
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24414,7 +24537,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1718
+      ID: 1719
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24446,7 +24569,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1720
+      ID: 1721
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24491,13 +24614,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1719
+      ID: 1720
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1721
+      ID: 1722
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1717
+      ID: 1718
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24581,7 +24704,103 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1517
+      ID: 1746
+      Name: Probe[main.testTimeFixedZone]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 326 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 326 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1747
+      Name: Probe[main.testTimeMonotonic]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 329 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: c
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 329 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1745
+      Name: Probe[main.testTimeUTC]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 326 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 326 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1518
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24613,7 +24832,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24645,7 +24864,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24677,7 +24896,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1495
+      ID: 1496
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24709,7 +24928,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24741,7 +24960,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testUintArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24773,7 +24992,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24805,7 +25024,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1701
+      ID: 1702
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24837,7 +25056,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1727
+      ID: 1728
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24869,7 +25088,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24901,7 +25120,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1501
+      ID: 1502
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       ExprStatusArraySize: 1
@@ -24929,38 +25148,6 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1710
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 262 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 262 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -24997,7 +25184,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1699
+      ID: 1712
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 262 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 262 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1700
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25055,7 +25274,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1700
+      ID: 1701
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -25087,7 +25306,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1790
+      ID: 1794
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25103,10 +25322,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25116,10 +25335,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 352 StructureType main.typeWithGenerics[go.shape.int]
+            Type: 356 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 0, name: x}
+                  Variable: {subprogram: 189, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25129,17 +25348,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1791
+      ID: 1795
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -25151,14 +25370,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 2, name: ~r0}
+                  Variable: {subprogram: 189, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1792
+      ID: 1796
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -25174,10 +25393,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25187,10 +25406,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 353 StructureType main.typeWithGenerics[go.shape.string]
+            Type: 357 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25200,17 +25419,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1793
+      ID: 1797
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -25222,14 +25441,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 2, name: ~r0}
+                  Variable: {subprogram: 190, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1744
+      ID: 1748
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25239,10 +25458,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25252,17 +25471,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 326 BaseType go.shape.int
+            Type: 330 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1745
+      ID: 1749
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25272,17 +25491,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 327 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1746
+      ID: 1750
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25292,10 +25511,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25305,17 +25524,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 328 GoStringHeaderType go.shape.string
+            Type: 332 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1747
+      ID: 1751
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25325,10 +25544,10 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25365,7 +25584,7 @@ Types:
       HasCount: true
       Element: 92 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 339
+      ID: 343
       Name: '[16]uint8'
       ByteSize: 16
       GoRuntimeType: 680192
@@ -25586,7 +25805,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 522
+      ID: 523
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 682880
@@ -25595,7 +25814,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 479
+      ID: 480
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683168
@@ -25621,7 +25840,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1136
+      ID: 1147
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684704
@@ -25630,7 +25849,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1356
+      ID: 1367
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25656,7 +25875,7 @@ Types:
       HasCount: true
       Element: 85 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1381
+      ID: 1382
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 481280
@@ -25664,20 +25883,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1382 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1383 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1384 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1385 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1384
+      ID: 1385
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 387 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 138
       Name: '[]*main.deepSlice2'
@@ -25694,15 +25913,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 427 GoSliceDataType []*main.deepSlice2.array
+      Data: 428 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 427
+      ID: 428
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 140 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1386
+      ID: 1387
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477184
@@ -25710,22 +25929,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1387 PointerType **main.deepSlice3
+          Type: 1388 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1390 GoSliceDataType []*main.deepSlice3.array
+      Data: 1391 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1390
+      ID: 1391
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1388 PointerType *main.deepSlice3
+      Element: 1389 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1421
+      ID: 1422
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 476864
@@ -25733,22 +25952,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1422 PointerType **main.deepSlice8
+          Type: 1423 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1425 GoSliceDataType []*main.deepSlice8.array
+      Data: 1426 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1425
+      ID: 1426
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1423 PointerType *main.deepSlice8
+      Element: 1424 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1427
+      ID: 1428
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 476800
@@ -25756,20 +25975,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1428 PointerType **main.deepSlice9
+          Type: 1429 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1431 GoSliceDataType []*main.deepSlice9.array
+      Data: 1432 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1431
+      ID: 1432
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1429 PointerType *main.deepSlice9
+      Element: 1430 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 129
       Name: '[]*string'
@@ -25786,201 +26005,201 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 424 GoSliceDataType []*string.array
+      Data: 425 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 424
+      ID: 425
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 95 PointerType *string
     - __kind: GoSliceDataType
-      ID: 539
+      ID: 540
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 232 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 531
+      ID: 532
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 227 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 481
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 195 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 498
+      ID: 499
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 207 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 652
+      ID: 659
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 379 PointerType *table<context.canceler,struct {}>
+      Element: 383 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 438
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 148 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1405
+      ID: 1406
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1396 PointerType *table<int,*main.deepMap3>
+      Element: 1397 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1449
+      ID: 1450
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1440 PointerType *table<int,*main.deepMap8>
+      Element: 1441 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1464
+      ID: 1465
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1455 PointerType *table<int,*main.deepMap9>
+      Element: 1456 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 447
+      ID: 448
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 175 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1477
+      ID: 1478
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1470 PointerType *table<int,interface {}>
+      Element: 1471 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 555
+      ID: 556
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 242 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 507
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 212 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 698
+      ID: 709
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 684 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 691 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 490
+      ID: 491
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 202 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 472
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 190 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 676
+      ID: 683
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 406 PointerType *table<string,float64>
+      Element: 407 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1152
+      ID: 1163
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1119 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1130 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 464
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 185 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 668
+      ID: 675
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 401 PointerType *table<string,interface {}>
+      Element: 402 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 456
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 180 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 660
+      ID: 667
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 396 PointerType *table<string,string>
+      Element: 397 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 547
+      ID: 548
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 237 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 595
+      ID: 596
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 294 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 603
+      ID: 604
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 299 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 611
+      ID: 612
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 304 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 619
+      ID: 620
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 309 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 627
+      ID: 628
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 314 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 635
+      ID: 636
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 319 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 563
+      ID: 564
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 247 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 523
+      ID: 524
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 222 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 515
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26000,9 +26219,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 587 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 588 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 587
+      ID: 588
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26022,9 +26241,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 585 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 586 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 585
+      ID: 586
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26044,9 +26263,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 583 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 584 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 583
+      ID: 584
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26066,9 +26285,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 581 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 582 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 581
+      ID: 582
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26088,9 +26307,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 579 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 580 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 579
+      ID: 580
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26110,9 +26329,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 567 GoSliceDataType [][]uint.array
+      Data: 568 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 567
+      ID: 568
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26133,15 +26352,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 571 GoSliceDataType []bool.array
+      Data: 572 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 571
+      ID: 572
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1131
+      ID: 1142
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487168
@@ -26156,15 +26375,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1154 GoSliceDataType []float64.array
+      Data: 1165 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1154
+      ID: 1165
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 20 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 407
+      ID: 408
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 480832
@@ -26172,22 +26391,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 408 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 678 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 685 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 678
+      ID: 685
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 409 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 410
+      ID: 411
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 481024
@@ -26195,22 +26414,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 412 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 686 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 686
+      ID: 693
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 413 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 354
+      ID: 358
       Name: '[]go.shape.float64'
       ByteSize: 24
       GoRuntimeType: 483392
@@ -26218,66 +26437,66 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 355 PointerType *go.shape.float64
+          Type: 359 PointerType *go.shape.float64
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 643 GoSliceDataType []go.shape.float64.array
+      Data: 650 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 643
+      ID: 650
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 356 BaseType go.shape.float64
+      Element: 360 BaseType go.shape.float64
     - __kind: GoSliceHeaderType
-      ID: 330
+      ID: 334
       Name: '[]go.shape.int'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 331 PointerType *go.shape.int
+          Type: 335 PointerType *go.shape.int
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 639 GoSliceDataType []go.shape.int.array
+      Data: 646 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 639
+      ID: 646
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 326 BaseType go.shape.int
+      Element: 330 BaseType go.shape.int
     - __kind: GoSliceHeaderType
-      ID: 351
+      ID: 355
       Name: '[]go.shape.string'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 348 PointerType *go.shape.string
+          Type: 352 PointerType *go.shape.string
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 641 GoSliceDataType []go.shape.string.array
+      Data: 648 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 641
+      ID: 648
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 328 GoStringHeaderType go.shape.string
+      Element: 332 GoStringHeaderType go.shape.string
     - __kind: GoSliceHeaderType
-      ID: 1433
+      ID: 1434
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 487616
@@ -26292,9 +26511,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1434 GoSliceDataType []interface {}.array
+      Data: 1435 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1434
+      ID: 1435
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26314,15 +26533,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 577 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 578 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 577
+      ID: 578
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 276 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 488
+      ID: 489
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 477824
@@ -26330,16 +26549,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 489 PointerType *main.structWithMap
+          Type: 490 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 688 GoSliceDataType []main.structWithMap.array
+      Data: 695 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 688
+      ID: 695
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26359,205 +26578,205 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 569 GoSliceDataType []main.structWithNoStrings.array
+      Data: 570 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 569
+      ID: 570
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 267 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 541
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 536 StructureType noalg.map.group[[4]int][4]int
+      Element: 537 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 532
+      ID: 533
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 528 StructureType noalg.map.group[[4]int]uint8
+      Element: 529 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 481
+      ID: 482
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 476 StructureType noalg.map.group[[4]string][2]int
+      Element: 477 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 499
+      ID: 500
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 495 StructureType noalg.map.group[bool]main.node
+      Element: 496 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 653
+      ID: 660
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 648 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 655 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 439
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 432 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 433 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1406
+      ID: 1407
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1400 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1401 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1450
+      ID: 1451
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1444 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1445 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1465
+      ID: 1466
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1459 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 448
+      ID: 449
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 444 StructureType noalg.map.group[int]int
+      Element: 445 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1478
+      ID: 1479
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1474 StructureType noalg.map.group[int]interface {}
+      Element: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 556
+      ID: 557
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 552 StructureType noalg.map.group[int]struct {}
+      Element: 553 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 507
+      ID: 508
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 503 StructureType noalg.map.group[int]uint8
+      Element: 504 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 699
+      ID: 710
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 693 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 491
+      ID: 492
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 485 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 486 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 473
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 468 StructureType noalg.map.group[string][]string
+      Element: 469 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 677
+      ID: 684
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 673 StructureType noalg.map.group[string]float64
+      Element: 680 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1153
+      ID: 1164
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1149 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 465
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 460 StructureType noalg.map.group[string]int
+      Element: 461 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 669
+      ID: 676
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 665 StructureType noalg.map.group[string]interface {}
+      Element: 672 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 456
+      ID: 457
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 452 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 453 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 661
+      ID: 668
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 657 StructureType noalg.map.group[string]string
+      Element: 664 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 548
+      ID: 549
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 544 StructureType noalg.map.group[struct {}]int
+      Element: 545 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 596
+      ID: 597
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 592 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 604
+      ID: 605
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 600 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 612
+      ID: 613
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 608 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 620
+      ID: 621
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 628
+      ID: 629
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 636
+      ID: 637
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 564
+      ID: 565
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 560 StructureType noalg.map.group[struct {}]struct {}
+      Element: 561 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 524
+      ID: 525
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 519 StructureType noalg.map.group[uint8][4]int
+      Element: 520 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 515
+      ID: 516
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 511 StructureType noalg.map.group[uint8]uint8
+      Element: 512 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -26578,9 +26797,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 439 GoSliceDataType []string.array
+      Data: 440 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 440
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26600,14 +26819,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 575 GoSliceDataType []struct {}.array
+      Data: 576 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 575
+      ID: 576
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 125 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 1371
+      ID: 638
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485824
@@ -26615,22 +26834,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1372 PointerType *time.zone
+          Type: 639 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1377 GoSliceDataType []time.zone.array
+      Data: 697 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 1377
+      ID: 697
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 1373 StructureType time.zone
+      Element: 640 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 1374
+      ID: 641
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485888
@@ -26638,20 +26857,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1375 PointerType *time.zoneTrans
+          Type: 642 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1379 GoSliceDataType []time.zoneTrans.array
+      Data: 699 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 1379
+      ID: 699
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 1376 StructureType time.zoneTrans
+      Element: 643 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 262
       Name: '[]uint'
@@ -26668,9 +26887,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 565 GoSliceDataType []uint.array
+      Data: 566 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 565
+      ID: 566
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26691,9 +26910,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 573 GoSliceDataType []uint16.array
+      Data: 574 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 573
+      ID: 574
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26714,9 +26933,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 420 GoSliceDataType []uint8.array
+      Data: 421 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 420
+      ID: 421
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26737,19 +26956,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 422 GoSliceDataType []uintptr.array
+      Data: 423 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 422
+      ID: 423
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1286
+      ID: 1297
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 930
+      ID: 941
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 930432
@@ -26764,33 +26983,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 931 GoSliceDataType archive/tar.headerError.array
+      Data: 942 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 931
+      ID: 942
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1232
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1169
+      ID: 1180
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1171
+      ID: 1182
       Name: archive/zip.dirWriter
       GoRuntimeType: 1121056
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1269
+      ID: 1280
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1197
+      ID: 1208
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1568544
@@ -26800,7 +27019,7 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1210
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26810,15 +27029,15 @@ Types:
       GoRuntimeType: 584352
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1244
+      ID: 1255
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1275
+      ID: 1286
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1324
+      ID: 1335
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -26844,13 +27063,13 @@ Types:
       GoRuntimeType: 584096
       GoKind: 15
     - __kind: BaseType
-      ID: 733
+      ID: 744
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834656
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 734
+      ID: 745
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 834752
@@ -26858,26 +27077,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 736 PointerType *compress/flate.InternalError.str
+          Type: 747 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 735 GoStringDataType compress/flate.InternalError.str
+      Data: 746 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 735
+      ID: 746
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1219
+      ID: 1230
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1176
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1241
+      ID: 1252
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -26894,19 +27113,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 369
+      ID: 373
       Name: context.backgroundCtx
       GoRuntimeType: 1800896
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 370 StructureType context.emptyCtx
+          Type: 374 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 360
+      ID: 364
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1966976
@@ -26917,13 +27136,13 @@ Types:
           Type: 155 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 371 StructureType sync.Mutex
+          Type: 375 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 374 StructureType sync/atomic.Value
+          Type: 378 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 375 GoMapType map[context.canceler]struct {}
+          Type: 379 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 16 GoInterfaceType error
@@ -26933,7 +27152,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 651
+      ID: 658
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1111712
@@ -26946,13 +27165,13 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1042
+      ID: 1053
       Name: context.deadlineExceededError
       GoRuntimeType: 1467424
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 374
       Name: context.emptyCtx
       GoRuntimeType: 1599424
       GoKind: 25
@@ -26961,7 +27180,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 362
+      ID: 366
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1825120
@@ -26972,11 +27191,11 @@ Types:
           Type: 155 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 380 GoSubroutineType func() bool
+          Type: 384 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 364
+      ID: 368
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1617536
@@ -26984,29 +27203,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 360 StructureType context.cancelCtx
+          Type: 364 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 381 PointerType *time.Timer
+          Type: 385 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 383 StructureType time.Time
+          Type: 326 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 386
+      ID: 387
       Name: context.todoCtx
       GoRuntimeType: 1801120
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 370 StructureType context.emptyCtx
+          Type: 374 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 370
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1837056
@@ -27024,7 +27243,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 372
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1800672
@@ -27036,81 +27255,81 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 747
+      ID: 758
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 2
     - __kind: BaseType
-      ID: 748
+      ID: 759
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837344
       GoKind: 2
     - __kind: BaseType
-      ID: 749
+      ID: 760
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837440
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1231
+      ID: 1242
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1265
+      ID: 1276
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1308
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1271
+      ID: 1282
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1267
+      ID: 1278
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1263
+      ID: 1274
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 750
+      ID: 761
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837536
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1281
+      ID: 1292
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1253
+      ID: 1264
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 737
+      ID: 748
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835232
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1025
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1350
+      ID: 1361
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 855
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 853
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1733440
@@ -27121,34 +27340,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1136 ArrayType [5]uint8
+          Type: 1147 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 969
+      ID: 980
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 993632
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1229
+      ID: 1240
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1247
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1120
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1132
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 927
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1736320
@@ -27156,21 +27375,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1120 PointerType *crypto/x509.Certificate
+          Type: 1131 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1139 BaseType crypto/x509.InvalidReason
+          Type: 1150 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 910
+      ID: 921
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1118624
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 912
+      ID: 923
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1603264
@@ -27178,24 +27397,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1120 PointerType *crypto/x509.Certificate
+          Type: 1131 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 746
+      ID: 757
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836864
       GoKind: 2
     - __kind: BaseType
-      ID: 1139
+      ID: 1150
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 589536
       GoKind: 2
     - __kind: StructureType
-      ID: 1019
+      ID: 1030
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1564544
@@ -27205,13 +27424,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 918
+      ID: 929
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1118880
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 914
+      ID: 925
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1736128
@@ -27219,15 +27438,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1120 PointerType *crypto/x509.Certificate
+          Type: 1131 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1120 PointerType *crypto/x509.Certificate
+          Type: 1131 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 934
+      ID: 945
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1439104
@@ -27237,7 +27456,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 938
+      ID: 949
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1439264
@@ -27247,55 +27466,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 947
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 731
+      ID: 742
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834272
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1187
+      ID: 1198
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 732
+      ID: 743
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 834464
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 814
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1016
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 806
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 812
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 810
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 808
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1330
+      ID: 1341
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 805
+      ID: 816
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1422784
@@ -27305,19 +27524,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1195
+      ID: 1206
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 915
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 913
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 743
+      ID: 754
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -27325,22 +27544,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 745 PointerType *encoding/xml.UnmarshalError.str
+          Type: 756 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 744 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 755 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 744
+      ID: 755
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 907
+      ID: 918
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1319
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27357,11 +27576,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 784
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 983
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27377,15 +27596,15 @@ Types:
       GoRuntimeType: 584288
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1318
+      ID: 1329
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 985
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 987
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27395,7 +27614,7 @@ Types:
       GoRuntimeType: 475328
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 380
+      ID: 384
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 595232
@@ -27407,44 +27626,44 @@ Types:
       GoRuntimeType: 849344
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 357
+      ID: 361
       Name: func(go.shape.float64) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 332
+      ID: 336
       Name: func(go.shape.int) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 333
+      ID: 337
       Name: func(go.shape.int) go.shape.string
       ByteSize: 8
       GoKind: 19
     - __kind: StructureType
-      ID: 327
+      ID: 331
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
     - __kind: StructureType
-      ID: 329
+      ID: 333
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 844
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 814
+      ID: 825
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1732288
@@ -27452,7 +27671,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1129 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1140 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27460,25 +27679,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 827
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1133
+      ID: 1144
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 820
+      ID: 831
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1114400
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1146
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 725
+      ID: 736
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 833696
@@ -27486,18 +27705,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 727 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 738 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 726 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 737 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 726
+      ID: 737
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1129
+      ID: 1140
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2221952
@@ -27505,7 +27724,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1130 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1141 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27520,7 +27739,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1131 GoSliceHeaderType []float64
+          Type: 1142 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -27529,10 +27748,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1132 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1143 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1134 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1145 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 159 GoSliceHeaderType []string
@@ -27546,13 +27765,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 1130
+      ID: 1141
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 585952
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 722
+      ID: 733
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 833600
@@ -27560,18 +27779,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 724 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 723 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 723
+      ID: 734
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 728
+      ID: 739
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 833792
@@ -27579,30 +27798,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 730 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 741 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 729 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 740 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 729
+      ID: 740
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1220
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1294
+      ID: 1305
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 939
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 388
+      ID: 389
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2345184
@@ -27610,7 +27829,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 389 StructureType sync.RWMutex
+          Type: 390 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -27631,13 +27850,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 397 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 398 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 402 GoMapType map[string]float64
+          Type: 403 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -27652,10 +27871,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 407 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 408 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 411 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27667,7 +27886,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 413 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 414 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -27690,7 +27909,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 414
+      ID: 415
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2218816
@@ -27701,13 +27920,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 415 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 387 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 390 StructureType sync/atomic.Int32
+          Type: 391 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27716,16 +27935,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 417 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 418 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 389 StructureType sync.RWMutex
+          Type: 390 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -27734,12 +27953,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 407 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 408 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 409
+      ID: 410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1913216
@@ -27756,7 +27975,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27764,20 +27983,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 397
+      ID: 398
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1284448
       GoKind: 21
-      HeaderType: 399 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 400 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1383
+      ID: 1384
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 583072
       GoKind: 10
     - __kind: StructureType
-      ID: 412
+      ID: 413
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1751264
@@ -27791,16 +28010,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 680 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 687 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 685 GoMapType map[string]interface {}
+          Type: 692 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1409
+      ID: 1410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 697
+      ID: 708
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1913472
@@ -27808,7 +28027,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1407 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1408 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27823,15 +28042,15 @@ Types:
           Type: 20 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1408 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1407
+      ID: 1408
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 988640
       GoKind: 5
     - __kind: StructureType
-      ID: 416
+      ID: 417
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2107872
@@ -27839,16 +28058,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 389 StructureType sync.RWMutex
+          Type: 390 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1381 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1382 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 392 GoMapType map[string]string
+          Type: 393 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -27863,12 +28082,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1383 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1384 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 387 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 417
+      ID: 418
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 897024
@@ -27877,15 +28096,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1088
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1326
+      ID: 1337
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1412
+      ID: 1413
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1631360
@@ -27895,29 +28114,29 @@ Types:
           Offset: 0
           Type: 155 GoInterfaceType context.Context
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 864
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 860
+      ID: 871
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1117856
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 742
+      ID: 753
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 835904
       GoKind: 2
     - __kind: StructureType
-      ID: 858
+      ID: 869
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1117728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 856
+      ID: 867
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1601344
@@ -27930,7 +28149,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 876
+      ID: 887
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1602144
@@ -27943,7 +28162,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 880
+      ID: 891
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1735552
@@ -27959,7 +28178,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 878
+      ID: 889
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1432704
@@ -27969,7 +28188,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 874
+      ID: 885
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1432384
@@ -27979,14 +28198,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1115
+      ID: 1126
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1503584
       GoKind: 21
-      HeaderType: 1117 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1128 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1138
+      ID: 1149
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1050752
@@ -28001,15 +28220,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1156 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1167 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1156
+      ID: 1167
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 888
+      ID: 899
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1602464
@@ -28017,12 +28236,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1115 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1126 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1115 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1126 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 882
+      ID: 893
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1432864
@@ -28032,7 +28251,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 886
+      ID: 897
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1735744
@@ -28043,12 +28262,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1138 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1138 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 884
+      ID: 895
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1602304
@@ -28061,7 +28280,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 890
+      ID: 901
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1433024
@@ -28069,9 +28288,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 383 StructureType time.Time
+          Type: 326 GoTimeType time.Time
     - __kind: StructureType
-      ID: 896
+      ID: 907
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1602784
@@ -28084,7 +28303,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 898
+      ID: 909
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1433344
@@ -28094,7 +28313,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 894
+      ID: 905
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1602624
@@ -28107,7 +28326,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 892
+      ID: 903
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1433184
@@ -28117,7 +28336,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 911
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1602944
@@ -28130,7 +28349,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 822
+      ID: 833
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1425024
@@ -28140,11 +28359,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1247
+      ID: 1258
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 824
+      ID: 835
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1425184
@@ -28152,21 +28371,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 822 StructureType github.com/cihub/seelog.baseError
+          Type: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1227
+      ID: 1238
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1183
+      ID: 1194
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1217
+      ID: 1228
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 828
+      ID: 839
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1425504
@@ -28174,13 +28393,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 822 StructureType github.com/cihub/seelog.baseError
+          Type: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1284
+      ID: 1295
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1295
+      ID: 1306
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2110336
@@ -28188,12 +28407,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1283 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1294 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 1298
+      ID: 1309
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2134144
@@ -28201,7 +28420,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1283 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1294 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28209,11 +28428,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1185
+      ID: 1196
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 826
+      ID: 837
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1425344
@@ -28221,9 +28440,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 822 StructureType github.com/cihub/seelog.baseError
+          Type: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 830
+      ID: 841
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1425664
@@ -28231,64 +28450,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 822 StructureType github.com/cihub/seelog.baseError
+          Type: 833 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1249
+      ID: 1260
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1290
+      ID: 1301
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1292
+      ID: 1303
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1122
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1038
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1036
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1040
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1042
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1238
+      ID: 1249
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1032
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 836
+      ID: 847
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1426624
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1342
+      ID: 1353
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1096
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1054
+      ID: 1065
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1842880
@@ -28304,11 +28523,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1059
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 991
+      ID: 1002
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1706336
@@ -28321,7 +28540,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 1060
+      ID: 1071
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1843328
@@ -28337,13 +28556,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 968
+      ID: 979
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 990464
       GoKind: 8
     - __kind: StructureType
-      ID: 1052
+      ID: 1063
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1842656
@@ -28359,13 +28578,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1140
+      ID: 1151
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 831968
       GoKind: 8
     - __kind: StructureType
-      ID: 1050
+      ID: 1061
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1842432
@@ -28373,15 +28592,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1140 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1151 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1140 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1151 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1058
+      ID: 1069
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1756832
@@ -28394,7 +28613,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1056
+      ID: 1067
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1843104
@@ -28410,11 +28629,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1346
+      ID: 1357
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1064
+      ID: 1075
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1627136
@@ -28424,19 +28643,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 995
+      ID: 1006
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1284960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 993
+      ID: 1004
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1284832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1062
+      ID: 1073
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1757024
@@ -28449,7 +28668,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 755
+      ID: 766
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839360
@@ -28457,36 +28676,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 757 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 768 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 756 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 767 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 756
+      ID: 767
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 343
+      ID: 347
       Name: go.shape.bool
       ByteSize: 1
       GoRuntimeType: 596192
       GoKind: 1
     - __kind: BaseType
-      ID: 356
+      ID: 360
       Name: go.shape.float64
       ByteSize: 8
       GoRuntimeType: 596256
       GoKind: 14
     - __kind: BaseType
-      ID: 326
+      ID: 330
       Name: go.shape.int
       ByteSize: 8
       GoRuntimeType: 596064
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 332
       Name: go.shape.string
       ByteSize: 16
       GoRuntimeType: 596128
@@ -28494,18 +28713,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 638 PointerType *go.shape.string.str
+          Type: 645 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 637 GoStringDataType go.shape.string.str
+      Data: 644 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 637
+      ID: 644
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 335
+      ID: 339
       Name: go.shape.struct { Name string }
       ByteSize: 16
       GoKind: 25
@@ -28514,7 +28733,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 337
+      ID: 341
       Name: go.shape.struct { X int; Y int }
       ByteSize: 16
       GoKind: 25
@@ -28526,13 +28745,13 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 346
+      ID: 350
       Name: go.shape.struct { main.i int }
       ByteSize: 8
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 347
+      ID: 351
       Name: go.shape.struct { main.s string }
       ByteSize: 16
       GoKind: 25
@@ -28541,7 +28760,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 350
+      ID: 354
       Name: go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
       ByteSize: 48
       GoKind: 25
@@ -28556,11 +28775,11 @@ Types:
           Offset: 32
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1135
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1035
+      ID: 1046
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1450944
@@ -28570,7 +28789,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1215
+      ID: 1226
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1682432
@@ -28578,13 +28797,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1239 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1250 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1306
+      ID: 1317
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1239
+      ID: 1250
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1128608
@@ -28597,7 +28816,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1201
+      ID: 1212
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1573504
@@ -28607,19 +28826,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 758
+      ID: 769
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 839936
       GoKind: 10
     - __kind: BaseType
-      ID: 1122
+      ID: 1133
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1004096
       GoKind: 10
     - __kind: StructureType
-      ID: 1093
+      ID: 1104
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1882528
@@ -28630,12 +28849,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1122 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1133 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 954
+      ID: 965
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1609984
@@ -28643,12 +28862,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1122 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1133 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 762
+      ID: 773
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840128
@@ -28656,18 +28875,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 764 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 775 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 763 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 774 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 763
+      ID: 774
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 768
+      ID: 779
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840320
@@ -28675,18 +28894,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 770 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 781 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 769 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 780 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 769
+      ID: 780
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 765
+      ID: 776
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -28694,18 +28913,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 767 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 778 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 766 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 777 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 766
+      ID: 777
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 759
+      ID: 770
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840032
@@ -28713,22 +28932,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 761 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 772 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 760 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 771 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 760
+      ID: 771
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1304
+      ID: 1315
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 958
+      ID: 969
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1451584
@@ -28738,13 +28957,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 771
+      ID: 782
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840416
       GoKind: 2
     - __kind: StructureType
-      ID: 946
+      ID: 957
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1446624
@@ -28754,11 +28973,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1102
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1113
+      ID: 1124
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1910432
@@ -28774,7 +28993,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 948
+      ID: 959
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1609504
@@ -28787,7 +29006,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1255
+      ID: 1266
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1968000
@@ -28795,16 +29014,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1282 GoInterfaceType io.Reader
+          Type: 1293 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1213
+      ID: 1224
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1033
+      ID: 1044
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1571104
@@ -28814,29 +29033,29 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1173
+      ID: 1184
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 937
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1034
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1089
+      ID: 1100
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1087
+      ID: 1098
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1514144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 940
+      ID: 951
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1439904
@@ -28846,7 +29065,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 942
+      ID: 953
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1440064
@@ -28856,463 +29075,463 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 879
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 534
+      ID: 535
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 535 PointerType *noalg.map.group[[4]int][4]int
+          Type: 536 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 536 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 540 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 537 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 541 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 526
+      ID: 527
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 527 PointerType *noalg.map.group[[4]int]uint8
+          Type: 528 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 528 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 532 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 529 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 533 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 474
+      ID: 475
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 475 PointerType *noalg.map.group[[4]string][2]int
+          Type: 476 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 476 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 481 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 477 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 482 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 493
+      ID: 494
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 494 PointerType *noalg.map.group[bool]main.node
+          Type: 495 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 495 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 499 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 496 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 500 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 646
+      ID: 653
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 647 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 654 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 648 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 653 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 655 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 660 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 430
+      ID: 431
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 431 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 432 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 432 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 438 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 433 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 439 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1398
+      ID: 1399
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1399 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1400 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1400 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1406 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1401 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1407 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1442
+      ID: 1443
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1443 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1444 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1444 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1450 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1445 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1451 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1457
+      ID: 1458
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1458 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1459 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1459 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1465 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1460 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1466 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 442
+      ID: 443
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 443 PointerType *noalg.map.group[int]int
+          Type: 444 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 444 StructureType noalg.map.group[int]int
-      GroupSliceType: 448 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 445 StructureType noalg.map.group[int]int
+      GroupSliceType: 449 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1472
+      ID: 1473
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1473 PointerType *noalg.map.group[int]interface {}
+          Type: 1474 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1474 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1478 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1475 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1479 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 550
+      ID: 551
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 551 PointerType *noalg.map.group[int]struct {}
+          Type: 552 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 552 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 556 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 553 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 557 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 501
+      ID: 502
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 502 PointerType *noalg.map.group[int]uint8
+          Type: 503 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 503 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 507 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 504 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 508 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 691
+      ID: 702
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 692 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 703 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 693 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 699 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 710 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 483
+      ID: 484
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 484 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 485 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 485 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 491 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 486 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 492 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 466
+      ID: 467
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 467 PointerType *noalg.map.group[string][]string
+          Type: 468 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 468 StructureType noalg.map.group[string][]string
-      GroupSliceType: 472 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 469 StructureType noalg.map.group[string][]string
+      GroupSliceType: 473 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 671
+      ID: 678
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 672 PointerType *noalg.map.group[string]float64
+          Type: 679 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 673 StructureType noalg.map.group[string]float64
-      GroupSliceType: 677 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 680 StructureType noalg.map.group[string]float64
+      GroupSliceType: 684 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1147
+      ID: 1158
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1148 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1159 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1149 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1153 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1164 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 458
+      ID: 459
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 459 PointerType *noalg.map.group[string]int
+          Type: 460 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 460 StructureType noalg.map.group[string]int
-      GroupSliceType: 464 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 461 StructureType noalg.map.group[string]int
+      GroupSliceType: 465 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 663
+      ID: 670
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 664 PointerType *noalg.map.group[string]interface {}
+          Type: 671 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 665 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 669 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 672 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 676 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 450
+      ID: 451
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 451 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 452 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 452 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 456 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 453 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 457 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 655
+      ID: 662
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 656 PointerType *noalg.map.group[string]string
+          Type: 663 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 657 StructureType noalg.map.group[string]string
-      GroupSliceType: 661 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 664 StructureType noalg.map.group[string]string
+      GroupSliceType: 668 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 542
+      ID: 543
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 543 PointerType *noalg.map.group[struct {}]int
+          Type: 544 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 544 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 548 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 545 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 549 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 590
+      ID: 591
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 591 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 592 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 592 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 596 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 597 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 598
+      ID: 599
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 599 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 600 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 600 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 604 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 605 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 606
+      ID: 607
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 607 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 608 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 608 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 612 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 613 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 614
+      ID: 615
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 615 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 616 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 620 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 621 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 622
+      ID: 623
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 623 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 624 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 628 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 629 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 630
+      ID: 631
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 631 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 632 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 636 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 637 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 558
+      ID: 559
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 559 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 560 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 560 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 564 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 561 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 565 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 517
+      ID: 518
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 518 PointerType *noalg.map.group[uint8][4]int
+          Type: 519 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 519 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 524 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 520 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 525 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 509
+      ID: 510
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 510 PointerType *noalg.map.group[uint8]uint8
+          Type: 511 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 511 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 515 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 512 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 516 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1261
+      ID: 1272
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 972
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29359,7 +29578,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 931
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29385,29 +29604,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 849
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1174
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1094
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1348
+      ID: 1359
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1081
+      ID: 1092
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1492864
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 778
+      ID: 789
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29488,7 +29707,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 373
+      ID: 377
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1490304
@@ -29501,11 +29720,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1205
+      ID: 1216
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1245
+      ID: 1256
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1192224
@@ -29518,7 +29737,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1282
+      ID: 1293
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1024384
@@ -29531,7 +29750,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1234
+      ID: 1245
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1111200
@@ -29557,47 +29776,47 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1203
+      ID: 1214
       Name: io.discard
       GoRuntimeType: 1467104
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1177
+      ID: 1188
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1090
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1251
+      ID: 1262
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 342
+      ID: 346
       Name: main.Pair[go.shape.int,go.shape.bool]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
         - Name: Value
           Offset: 8
-          Type: 343 BaseType go.shape.bool
+          Type: 347 BaseType go.shape.bool
     - __kind: StructureType
-      ID: 345
+      ID: 349
       Name: main.Pair[go.shape.string,go.shape.int]
       ByteSize: 24
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
         - Name: Value
           Offset: 16
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
     - __kind: StructureType
       ID: 320
       Name: main.aStruct
@@ -29624,7 +29843,7 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1479 PointerType *main.nestedStruct
+          Type: 1480 PointerType *main.nestedStruct
     - __kind: GoInterfaceType
       ID: 167
       Name: main.behavior
@@ -29665,7 +29884,7 @@ Types:
           Offset: 0
           Type: 144 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 436
+      ID: 437
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1188384
@@ -29673,9 +29892,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1392 GoMapType map[int]*main.deepMap3
+          Type: 1393 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1404
+      ID: 1405
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -29687,9 +29906,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1436 GoMapType map[int]*main.deepMap8
+          Type: 1437 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1448
+      ID: 1449
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1187616
@@ -29697,9 +29916,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1451 GoMapType map[int]*main.deepMap9
+          Type: 1452 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1463
+      ID: 1464
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1187488
@@ -29707,7 +29926,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1466 GoMapType map[int]interface {}
+          Type: 1467 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 132
       Name: main.deepPtr1
@@ -29727,9 +29946,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1351 PointerType *main.deepPtr3
+          Type: 1362 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1352
+      ID: 1363
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -29741,9 +29960,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1417 PointerType *main.deepPtr8
+          Type: 1418 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1418
+      ID: 1419
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1188768
@@ -29751,9 +29970,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1419 PointerType *main.deepPtr9
+          Type: 1420 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1420
+      ID: 1421
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1188640
@@ -29773,7 +29992,7 @@ Types:
           Offset: 0
           Type: 138 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 426
+      ID: 427
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1190688
@@ -29781,9 +30000,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1386 GoSliceHeaderType []*main.deepSlice3
+          Type: 1387 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1389
+      ID: 1390
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -29795,9 +30014,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1421 GoSliceHeaderType []*main.deepSlice8
+          Type: 1422 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1424
+      ID: 1425
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1189920
@@ -29805,9 +30024,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1427 GoSliceHeaderType []*main.deepSlice9
+          Type: 1428 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1430
+      ID: 1431
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1189792
@@ -29815,7 +30034,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1433 GoSliceHeaderType []interface {}
+          Type: 1434 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 324
       Name: main.emptyStruct
@@ -29833,16 +30052,16 @@ Types:
           Type: 160 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 371 StructureType sync.Mutex
+          Type: 375 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1359 StructureType sync.Once
+          Type: 1370 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1361 StructureType sync.WaitGroup
+          Type: 1372 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 390 StructureType sync/atomic.Int32
+          Type: 391 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 160
       Name: main.esotericStack
@@ -29872,7 +30091,7 @@ Types:
           Offset: 56
           Type: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 358
+      ID: 362
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1416064
@@ -29882,71 +30101,71 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 340
+      ID: 344
       Name: main.largeGenericType[go.shape.int]
       ByteSize: 136
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
     - __kind: StructureType
-      ID: 338
+      ID: 342
       Name: main.largeGenericType[go.shape.string]
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 339 ArrayType [16]uint8
+          Type: 343 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 255
       Name: main.largeStruct
@@ -30260,9 +30479,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1356 ArrayType [63]uint64
+          Type: 1367 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1366
+      ID: 1377
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1416224
@@ -30282,7 +30501,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1358
+      ID: 1369
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30293,31 +30512,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1354 PointerType *main.stringType1.str
+          Type: 1365 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1353 GoStringDataType main.stringType1.str
+      Data: 1364 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1353
+      ID: 1364
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1355
+      ID: 1366
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1481 PointerType *main.stringType2.str
+          Type: 1482 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1480 GoStringDataType main.stringType2.str
+      Data: 1481 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1480
+      ID: 1481
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -30433,16 +30652,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1367 PointerType **main.t
+          Type: 1378 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1368 GoSliceDataType main.t.array
+      Data: 1379 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1368
+      ID: 1379
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -30498,29 +30717,38 @@ Types:
         - Name: c
           Offset: 32
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 329
+      Name: main.timeCapture
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: monotonicNow
+          Offset: 0
+          Type: 326 GoTimeType time.Time
     - __kind: BaseType
       ID: 127
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 352
+      ID: 356
       Name: main.typeWithGenerics[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 326 BaseType go.shape.int
+          Type: 330 BaseType go.shape.int
     - __kind: StructureType
-      ID: 353
+      ID: 357
       Name: main.typeWithGenerics[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 328 GoStringHeaderType go.shape.string
+          Type: 332 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 260
       Name: main.wideStruct
@@ -30590,8 +30818,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 539 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 536 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 540 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 537 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 225
       Name: map<[4]int,uint8>
@@ -30622,8 +30850,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 531 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 528 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 532 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 529 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 193
       Name: map<[4]string,[2]int>
@@ -30654,8 +30882,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 480 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 476 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 481 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 477 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 205
       Name: map<bool,main.node>
@@ -30686,10 +30914,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 498 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 495 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 499 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 496 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 377
+      ID: 381
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -30702,7 +30930,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 378 PointerType **table<context.canceler,struct {}>
+          Type: 382 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30718,8 +30946,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 652 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 648 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 659 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 655 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 146
       Name: map<int,*main.deepMap2>
@@ -30750,10 +30978,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 437 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 432 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 438 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 433 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1394
+      ID: 1395
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -30766,7 +30994,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1395 PointerType **table<int,*main.deepMap3>
+          Type: 1396 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30782,10 +31010,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1405 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1400 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1406 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1401 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1438
+      ID: 1439
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -30798,7 +31026,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1439 PointerType **table<int,*main.deepMap8>
+          Type: 1440 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30814,10 +31042,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1449 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1444 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1450 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1445 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1453
+      ID: 1454
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -30830,7 +31058,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1454 PointerType **table<int,*main.deepMap9>
+          Type: 1455 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30846,8 +31074,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1464 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1459 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1465 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 173
       Name: map<int,int>
@@ -30878,10 +31106,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 447 GoSliceDataType []*table<int,int>.array
-      GroupType: 444 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 448 GoSliceDataType []*table<int,int>.array
+      GroupType: 445 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1468
+      ID: 1469
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -30894,7 +31122,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1469 PointerType **table<int,interface {}>
+          Type: 1470 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30910,8 +31138,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1477 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1474 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1478 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 240
       Name: map<int,struct {}>
@@ -30942,8 +31170,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 555 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 552 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 556 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 553 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 210
       Name: map<int,uint8>
@@ -30974,10 +31202,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 506 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 503 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 507 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 504 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 682
+      ID: 689
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -30990,7 +31218,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 683 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 690 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31006,8 +31234,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 698 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 693 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 709 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 200
       Name: map<string,[]main.structWithMap>
@@ -31038,8 +31266,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 490 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 485 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 491 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 486 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 188
       Name: map<string,[]string>
@@ -31070,10 +31298,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 471 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 468 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 472 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 469 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 404
+      ID: 405
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31086,7 +31314,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 405 PointerType **table<string,float64>
+          Type: 406 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31102,10 +31330,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 676 GoSliceDataType []*table<string,float64>.array
-      GroupType: 673 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 683 GoSliceDataType []*table<string,float64>.array
+      GroupType: 680 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1117
+      ID: 1128
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31118,7 +31346,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1118 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1129 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31134,8 +31362,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1152 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1149 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1163 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 183
       Name: map<string,int>
@@ -31166,10 +31394,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 463 GoSliceDataType []*table<string,int>.array
-      GroupType: 460 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 464 GoSliceDataType []*table<string,int>.array
+      GroupType: 461 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 399
+      ID: 400
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31182,7 +31410,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 400 PointerType **table<string,interface {}>
+          Type: 401 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31198,8 +31426,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 668 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 665 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 675 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 672 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 178
       Name: map<string,main.nestedStruct>
@@ -31230,10 +31458,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 455 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 452 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 456 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 453 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 394
+      ID: 395
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31246,7 +31474,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 395 PointerType **table<string,string>
+          Type: 396 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31262,8 +31490,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 660 GoSliceDataType []*table<string,string>.array
-      GroupType: 657 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 667 GoSliceDataType []*table<string,string>.array
+      GroupType: 664 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 235
       Name: map<struct {},int>
@@ -31294,8 +31522,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 547 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 544 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 548 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 545 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 292
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31326,8 +31554,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 595 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 592 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 596 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 297
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31358,8 +31586,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 603 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 600 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 604 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 302
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31390,8 +31618,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 611 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 608 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 612 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 307
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31422,8 +31650,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 619 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 620 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 312
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31454,8 +31682,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 627 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 628 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 317
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31486,8 +31714,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 635 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 636 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 245
       Name: map<struct {},struct {}>
@@ -31518,8 +31746,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 563 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 560 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 564 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 561 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 220
       Name: map<uint8,[4]int>
@@ -31550,8 +31778,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 523 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 519 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 524 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 520 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 215
       Name: map<uint8,uint8>
@@ -31582,8 +31810,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 514 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 511 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 515 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 512 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 228
       Name: map[[4]int][4]int
@@ -31613,12 +31841,12 @@ Types:
       GoKind: 21
       HeaderType: 205 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 375
+      ID: 379
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1132832
       GoKind: 21
-      HeaderType: 377 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 381 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 144
       Name: map[int]*main.deepMap2
@@ -31627,26 +31855,26 @@ Types:
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1392
+      ID: 1393
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1130400
       GoKind: 21
-      HeaderType: 1394 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1395 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1436
+      ID: 1437
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1129760
       GoKind: 21
-      HeaderType: 1438 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1439 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1451
+      ID: 1452
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1129632
       GoKind: 21
-      HeaderType: 1453 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1454 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 171
       Name: map[int]int
@@ -31655,12 +31883,12 @@ Types:
       GoKind: 21
       HeaderType: 173 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1466
+      ID: 1467
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1129504
       GoKind: 21
-      HeaderType: 1468 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1469 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 238
       Name: map[int]struct {}
@@ -31676,12 +31904,12 @@ Types:
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 680
+      ID: 687
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1133088
       GoKind: 21
-      HeaderType: 682 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 689 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 198
       Name: map[string][]main.structWithMap
@@ -31697,12 +31925,12 @@ Types:
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 402
+      ID: 403
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1132960
       GoKind: 21
-      HeaderType: 404 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 405 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 181
       Name: map[string]int
@@ -31711,12 +31939,12 @@ Types:
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 685
+      ID: 692
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1129376
       GoKind: 21
-      HeaderType: 399 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 400 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 176
       Name: map[string]main.nestedStruct
@@ -31725,12 +31953,12 @@ Types:
       GoKind: 21
       HeaderType: 178 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 392
+      ID: 393
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1132704
       GoKind: 21
-      HeaderType: 394 GoSwissMapHeaderType map<string,string>
+      HeaderType: 395 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 233
       Name: map[struct {}]int
@@ -31796,7 +32024,7 @@ Types:
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 872
+      ID: 883
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1432064
@@ -31806,7 +32034,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1167
+      ID: 1178
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1428864
@@ -31816,11 +32044,11 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1082
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1137
+      ID: 1148
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1600064
@@ -31833,35 +32061,35 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1113
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1312
+      ID: 1323
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1111
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1073
+      ID: 1084
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1322
+      ID: 1333
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1332
+      ID: 1343
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1320
+      ID: 1331
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1038
+      ID: 1049
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1114016
@@ -31869,28 +32097,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1040 PointerType *net.UnknownNetworkError.str
+          Type: 1051 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1039 GoStringDataType net.UnknownNetworkError.str
+      Data: 1050 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1039
+      ID: 1050
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1007
+      ID: 1018
       Name: net.canceledError
       GoRuntimeType: 1285856
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1288
+      ID: 1299
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1142
+      ID: 1153
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2109632
@@ -31898,7 +32126,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -31909,27 +32137,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1334
+      ID: 1345
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1328
+      ID: 1339
       Name: net.noReadFrom
       GoRuntimeType: 1114272
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1327
+      ID: 1338
       Name: net.noWriteTo
       GoRuntimeType: 1114144
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 818
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1414
+      ID: 1415
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1761824
@@ -31942,7 +32170,7 @@ Types:
           Offset: 16
           Type: 155 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 809
+      ID: 820
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1732096
@@ -31950,7 +32178,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1125 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1136 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -31958,7 +32186,7 @@ Types:
           Offset: 96
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1316
+      ID: 1327
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2294368
@@ -31966,12 +32194,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1328 StructureType net.noReadFrom
+          Type: 1339 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1321 PointerType *net.TCPConn
+          Type: 1332 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1314
+      ID: 1325
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2293824
@@ -31979,24 +32207,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1327 StructureType net.noWriteTo
+          Type: 1338 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1321 PointerType *net.TCPConn
+          Type: 1332 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1086
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1115
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 1008
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1159
+      ID: 1170
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1420544
@@ -32006,19 +32234,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 703
+      ID: 714
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832448
       GoKind: 10
     - __kind: BaseType
-      ID: 1114
+      ID: 1125
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 990560
       GoKind: 10
     - __kind: StructureType
-      ID: 785
+      ID: 796
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1730752
@@ -32029,12 +32257,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1114 BaseType net/http.http2ErrCode
+          Type: 1125 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1096
+      ID: 1107
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1901728
@@ -32045,12 +32273,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1114 BaseType net/http.http2ErrCode
+          Type: 1125 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 789
+      ID: 800
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1599744
@@ -32058,16 +32286,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1114 BaseType net/http.http2ErrCode
+          Type: 1125 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1223
+      ID: 1234
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 707
+      ID: 718
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -32075,18 +32303,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 709 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 720 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 708 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 719 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 708
+      ID: 719
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 713
+      ID: 724
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 832832
@@ -32094,18 +32322,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 715 PointerType *net/http.http2headerFieldNameError.str
+          Type: 726 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 714 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 725 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 714
+      ID: 725
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 710
+      ID: 721
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832736
@@ -32113,32 +32341,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 712 PointerType *net/http.http2headerFieldValueError.str
+          Type: 723 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 711 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 722 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 711
+      ID: 722
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1068
+      ID: 1079
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1003
+      ID: 1014
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1285216
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1277
+      ID: 1288
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 704
+      ID: 715
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832544
@@ -32146,18 +32374,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 706 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 717 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 705 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 716 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 705
+      ID: 716
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1161
+      ID: 1172
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1826240
@@ -32165,18 +32393,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1256 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1267 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1257 BaseType time.Duration
+          Type: 1268 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1256
+      ID: 1267
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1419904
@@ -32189,14 +32417,14 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1242
+      ID: 1253
       Name: net/http.incomparable
       GoRuntimeType: 901920
       GoKind: 17
       HasCount: true
       Element: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 999
+      ID: 1010
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1558624
@@ -32206,11 +32434,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1225
+      ID: 1236
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1181
+      ID: 1192
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1558464
@@ -32218,9 +32446,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1224 PointerType *net/http.persistConn
+          Type: 1235 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1207
+      ID: 1218
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1802688
@@ -32228,15 +32456,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1242 ArrayType net/http.incomparable
+          Type: 1253 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1243 PointerType *bufio.Reader
+          Type: 1254 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1245 GoInterfaceType io.ReadWriteCloser
+          Type: 1256 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 793
+      ID: 804
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1421504
@@ -32246,17 +32474,17 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1098
+      ID: 1109
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1066
+      ID: 1077
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1479424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1001
+      ID: 1012
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1558784
@@ -32266,7 +32494,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1259
+      ID: 1270
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2027904
@@ -32274,16 +32502,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1137 GoInterfaceType net.Conn
+          Type: 1148 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 793
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1279
+      ID: 1290
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2043936
@@ -32291,13 +32519,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1274 PointerType *bufio.Writer
+          Type: 1285 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1191
+      ID: 1202
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 875
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1735168
@@ -32313,7 +32541,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 862
+      ID: 873
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1601504
@@ -32326,11 +32554,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1233
+      ID: 1244
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1193
+      ID: 1204
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1603424
@@ -32338,16 +32566,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1232 PointerType *net/smtp.Client
+          Type: 1243 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1234 GoInterfaceType io.WriteCloser
+          Type: 1245 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 859
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 738
+      ID: 749
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835328
@@ -32355,26 +32583,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 740 PointerType *net/textproto.ProtocolError.str
+          Type: 751 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 739 GoStringDataType net/textproto.ProtocolError.str
+      Data: 750 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 739
+      ID: 750
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1189
+      ID: 1200
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1117
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 716
+      ID: 727
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833312
@@ -32382,18 +32610,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 718 PointerType *net/url.EscapeError.str
+          Type: 729 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 717 GoStringDataType net/url.EscapeError.str
+      Data: 728 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 717
+      ID: 728
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 719
+      ID: 730
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833408
@@ -32401,299 +32629,299 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 721 PointerType *net/url.InvalidHostError.str
+          Type: 732 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 720 GoStringDataType net/url.InvalidHostError.str
+      Data: 731 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 720
+      ID: 731
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 537
+      ID: 538
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 682976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 538 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 539 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 529
+      ID: 530
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 530 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 531 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 477
+      ID: 478
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 478 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 479 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 496
+      ID: 497
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 497 StructureType noalg.struct { key bool; elem main.node }
+      Element: 498 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 649
+      ID: 656
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 689024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 650 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 657 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 433
+      ID: 434
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 434 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 435 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1401
+      ID: 1402
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1402 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1403 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1445
+      ID: 1446
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 681632
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1446 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1447 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1460
+      ID: 1461
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 681536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1461 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1462 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 445
+      ID: 446
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680288
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 446 StructureType noalg.struct { key int; elem int }
+      Element: 447 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1475
+      ID: 1476
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 681440
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1476 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1477 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 553
+      ID: 554
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 554 StructureType noalg.struct { key int; elem struct {} }
+      Element: 555 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 504
+      ID: 505
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 505 StructureType noalg.struct { key int; elem uint8 }
+      Element: 506 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 694
+      ID: 705
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 689664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 695 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 706 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 486
+      ID: 487
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 683744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 487 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 488 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 469
+      ID: 470
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 470 StructureType noalg.struct { key string; elem []string }
+      Element: 471 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 674
+      ID: 681
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 689568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 675 StructureType noalg.struct { key string; elem float64 }
+      Element: 682 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1150
+      ID: 1161
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 758368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1151 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1162 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 461
+      ID: 462
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 462 StructureType noalg.struct { key string; elem int }
+      Element: 463 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 666
+      ID: 673
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 681056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 667 StructureType noalg.struct { key string; elem interface {} }
+      Element: 674 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 453
+      ID: 454
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 684032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 454 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 455 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 658
+      ID: 665
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 687200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 659 StructureType noalg.struct { key string; elem string }
+      Element: 666 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 545
+      ID: 546
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 684128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 546 StructureType noalg.struct { key struct {}; elem int }
+      Element: 547 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 593
+      ID: 594
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 594 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 595 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 601
+      ID: 602
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 602 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 603 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 609
+      ID: 610
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 610 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 611 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 617
+      ID: 618
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 618 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 619 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 625
+      ID: 626
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 626 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 627 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 633
+      ID: 634
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 634 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 635 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 561
+      ID: 562
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 684224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 562 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 563 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 520
+      ID: 521
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 684320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 521 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 522 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 512
+      ID: 513
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 684416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 513 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 514 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 536
+      ID: 537
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1297504
@@ -32704,9 +32932,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 537 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 538 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 528
+      ID: 529
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1297760
@@ -32717,9 +32945,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 529 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 530 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 476
+      ID: 477
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1298016
@@ -32730,9 +32958,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 477 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 478 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 495
+      ID: 496
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1298272
@@ -32743,9 +32971,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 496 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 497 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 648
+      ID: 655
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1302368
@@ -32756,9 +32984,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 649 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 656 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 432
+      ID: 433
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1297248
@@ -32769,9 +32997,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 433 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 434 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1400
+      ID: 1401
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1296992
@@ -32782,9 +33010,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1401 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1402 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1444
+      ID: 1445
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1295712
@@ -32795,9 +33023,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1445 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1446 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1459
+      ID: 1460
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1295456
@@ -32808,9 +33036,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1460 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1461 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 444
+      ID: 445
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1294176
@@ -32821,9 +33049,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 445 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 446 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1474
+      ID: 1475
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1295200
@@ -32834,9 +33062,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1475 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1476 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 552
+      ID: 553
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1298528
@@ -32847,9 +33075,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 553 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 554 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 503
+      ID: 504
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1298784
@@ -32860,9 +33088,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 504 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 505 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 693
+      ID: 704
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1303264
@@ -32873,9 +33101,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 694 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 705 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 485
+      ID: 486
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1299040
@@ -32886,9 +33114,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 486 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 487 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 468
+      ID: 469
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1299296
@@ -32899,9 +33127,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 469 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 470 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 673
+      ID: 680
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1303008
@@ -32912,9 +33140,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 674 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 681 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1149
+      ID: 1160
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1361248
@@ -32925,9 +33153,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1150 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1161 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 460
+      ID: 461
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1299552
@@ -32938,9 +33166,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 461 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 462 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 665
+      ID: 672
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1294944
@@ -32951,9 +33179,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 666 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 673 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 452
+      ID: 453
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1299808
@@ -32964,9 +33192,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 453 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 454 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 657
+      ID: 664
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1301600
@@ -32977,9 +33205,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 658 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 665 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 544
+      ID: 545
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1300064
@@ -32990,9 +33218,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 545 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 546 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 592
+      ID: 593
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33002,9 +33230,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 593 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 594 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 600
+      ID: 601
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33014,9 +33242,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 601 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 602 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 608
+      ID: 609
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33026,9 +33254,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 609 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 610 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 616
+      ID: 617
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33038,9 +33266,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 617 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 618 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 624
+      ID: 625
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33050,9 +33278,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 625 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 626 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 632
+      ID: 633
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33062,9 +33290,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 633 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 634 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 560
+      ID: 561
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1300320
@@ -33075,9 +33303,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 561 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 562 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 519
+      ID: 520
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1300576
@@ -33088,9 +33316,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 520 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 521 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 511
+      ID: 512
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1300832
@@ -33101,9 +33329,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 512 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 513 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 538
+      ID: 539
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1297376
@@ -33111,12 +33339,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 522 ArrayType [4]int
+          Type: 523 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 522 ArrayType [4]int
+          Type: 523 ArrayType [4]int
     - __kind: StructureType
-      ID: 530
+      ID: 531
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1297632
@@ -33124,12 +33352,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 522 ArrayType [4]int
+          Type: 523 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 478
+      ID: 479
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1297888
@@ -33137,12 +33365,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 479 ArrayType [4]string
+          Type: 480 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 113 ArrayType [2]int
     - __kind: StructureType
-      ID: 497
+      ID: 498
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1298144
@@ -33155,7 +33383,7 @@ Types:
           Offset: 8
           Type: 251 StructureType main.node
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1302240
@@ -33163,12 +33391,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 651 GoInterfaceType context.canceler
+          Type: 658 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 434
+      ID: 435
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1297120
@@ -33179,9 +33407,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 435 PointerType *main.deepMap2
+          Type: 436 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1402
+      ID: 1403
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1296864
@@ -33192,9 +33420,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1403 PointerType *main.deepMap3
+          Type: 1404 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1446
+      ID: 1447
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1295584
@@ -33205,9 +33433,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1447 PointerType *main.deepMap8
+          Type: 1448 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1461
+      ID: 1462
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1295328
@@ -33218,9 +33446,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1462 PointerType *main.deepMap9
+          Type: 1463 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 446
+      ID: 447
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1294048
@@ -33233,7 +33461,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 1476
+      ID: 1477
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1295072
@@ -33246,7 +33474,7 @@ Types:
           Offset: 8
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 554
+      ID: 555
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1298400
@@ -33259,7 +33487,7 @@ Types:
           Offset: 8
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 505
+      ID: 506
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1298656
@@ -33272,7 +33500,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 695
+      ID: 706
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1303136
@@ -33283,9 +33511,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 696 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 707 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 487
+      ID: 488
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1298912
@@ -33296,9 +33524,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 488 GoSliceHeaderType []main.structWithMap
+          Type: 489 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 470
+      ID: 471
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1299168
@@ -33311,7 +33539,7 @@ Types:
           Offset: 16
           Type: 159 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 675
+      ID: 682
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1302880
@@ -33324,7 +33552,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 1151
+      ID: 1162
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1361120
@@ -33335,9 +33563,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1138 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 462
+      ID: 463
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1299424
@@ -33350,7 +33578,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1294816
@@ -33363,7 +33591,7 @@ Types:
           Offset: 16
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 454
+      ID: 455
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1299680
@@ -33376,7 +33604,7 @@ Types:
           Offset: 16
           Type: 123 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 659
+      ID: 666
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1301472
@@ -33389,7 +33617,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 546
+      ID: 547
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1299936
@@ -33402,7 +33630,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 594
+      ID: 595
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33414,7 +33642,7 @@ Types:
           Offset: 0
           Type: 289 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 602
+      ID: 603
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33426,7 +33654,7 @@ Types:
           Offset: 0
           Type: 290 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 610
+      ID: 611
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33438,7 +33666,7 @@ Types:
           Offset: 0
           Type: 295 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 618
+      ID: 619
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33450,7 +33678,7 @@ Types:
           Offset: 0
           Type: 300 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 626
+      ID: 627
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33462,7 +33690,7 @@ Types:
           Offset: 0
           Type: 305 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 634
+      ID: 635
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33474,7 +33702,7 @@ Types:
           Offset: 0
           Type: 310 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 562
+      ID: 563
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1300192
       GoKind: 25
@@ -33486,7 +33714,7 @@ Types:
           Offset: 0
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 521
+      ID: 522
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1300448
@@ -33497,9 +33725,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 522 ArrayType [4]int
+          Type: 523 ArrayType [4]int
     - __kind: StructureType
-      ID: 513
+      ID: 514
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1300704
@@ -33512,19 +33740,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1340
+      ID: 1351
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 991
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1055
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1338
+      ID: 1349
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2362976
@@ -33532,12 +33760,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1344 StructureType os.noReadFrom
+          Type: 1355 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1339 PointerType *os.File
+          Type: 1350 PointerType *os.File
     - __kind: StructureType
-      ID: 1336
+      ID: 1347
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2362176
@@ -33545,36 +33773,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1343 StructureType os.noWriteTo
+          Type: 1354 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1339 PointerType *os.File
+          Type: 1350 PointerType *os.File
     - __kind: StructureType
-      ID: 1344
+      ID: 1355
       Name: os.noReadFrom
       GoRuntimeType: 1112480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1343
+      ID: 1354
       Name: os.noWriteTo
       GoRuntimeType: 1112352
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1020
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1145
+      ID: 1156
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1211
+      ID: 1222
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1011
+      ID: 1022
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1706912
@@ -33587,7 +33815,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 752
+      ID: 763
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 838592
@@ -33595,36 +33823,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 754 PointerType *os/user.UnknownGroupIdError.str
+          Type: 765 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 753 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 764 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 753
+      ID: 764
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 751
+      ID: 762
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 838496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 780
+      ID: 791
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 881
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 995
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 999
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33636,7 +33864,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 986
+      ID: 997
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1890144
@@ -33653,9 +33881,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1143 BaseType runtime.boundsErrorCode
+          Type: 1154 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1143
+      ID: 1154
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 584480
@@ -33675,7 +33903,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1046
+      ID: 1057
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1754912
@@ -33688,7 +33916,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 962
+      ID: 973
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 989696
@@ -33696,13 +33924,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 964 PointerType *runtime.errorString.str
+          Type: 975 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 963 GoStringDataType runtime.errorString.str
+      Data: 974 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 963
+      ID: 974
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34358,7 +34586,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 965
+      ID: 976
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 989792
@@ -34366,13 +34594,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 967 PointerType *runtime.plainError.str
+          Type: 978 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 966 GoStringDataType runtime.plainError.str
+      Data: 977 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 966
+      ID: 977
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34458,7 +34686,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 989
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -34470,26 +34698,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 419 PointerType *string.str
+          Type: 420 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 418 GoStringDataType string.str
+      Data: 419 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 418
+      ID: 419
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1273
+      ID: 1284
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1179
+      ID: 1190
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1175
+      ID: 1186
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1458784
@@ -34505,7 +34733,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 371
+      ID: 375
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1470144
@@ -34513,12 +34741,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 372 StructureType sync.noCopy
+          Type: 376 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 373 StructureType internal/sync.Mutex
+          Type: 377 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1359
+      ID: 1370
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1619840
@@ -34526,15 +34754,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 372 StructureType sync.noCopy
+          Type: 376 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1360 StructureType sync/atomic.Uint32
+          Type: 1371 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 371 StructureType sync.Mutex
+          Type: 375 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 389
+      ID: 390
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1839744
@@ -34542,7 +34770,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 371 StructureType sync.Mutex
+          Type: 375 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -34551,12 +34779,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 390 StructureType sync/atomic.Int32
+          Type: 391 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 390 StructureType sync/atomic.Int32
+          Type: 391 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1361
+      ID: 1372
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1620032
@@ -34564,21 +34792,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 372 StructureType sync.noCopy
+          Type: 376 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1362 StructureType sync/atomic.Uint64
+          Type: 1373 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 372
+      ID: 376
       Name: sync.noCopy
       GoRuntimeType: 989312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 390
+      ID: 391
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1471424
@@ -34586,12 +34814,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 391 StructureType sync/atomic.noCopy
+          Type: 392 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 1360
+      ID: 1371
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1471584
@@ -34599,12 +34827,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 391 StructureType sync/atomic.noCopy
+          Type: 392 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1362
+      ID: 1373
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1620416
@@ -34612,15 +34840,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 391 StructureType sync/atomic.noCopy
+          Type: 392 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1363 StructureType sync/atomic.align64
+          Type: 1374 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 374
+      ID: 378
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1196576
@@ -34630,25 +34858,25 @@ Types:
           Offset: 0
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1363
+      ID: 1374
       Name: sync/atomic.align64
       GoRuntimeType: 989504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 391
+      ID: 392
       Name: sync/atomic.noCopy
       GoRuntimeType: 989408
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1094
+      ID: 1105
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1287264
       GoKind: 12
     - __kind: StructureType
-      ID: 533
+      ID: 534
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -34670,9 +34898,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 534 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 535 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 525
+      ID: 526
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34694,9 +34922,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 526 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 527 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 473
+      ID: 474
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -34718,9 +34946,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 474 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 475 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 492
+      ID: 493
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -34742,9 +34970,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 493 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 494 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 645
+      ID: 652
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -34766,9 +34994,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 646 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 653 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 429
+      ID: 430
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -34790,9 +35018,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 430 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 431 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1397
+      ID: 1398
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -34814,9 +35042,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1398 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1399 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1441
+      ID: 1442
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -34838,9 +35066,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1442 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1443 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1456
+      ID: 1457
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -34862,9 +35090,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1457 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1458 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 441
+      ID: 442
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -34886,9 +35114,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 442 GoSwissMapGroupsType groupReference<int,int>
+          Type: 443 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1471
+      ID: 1472
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -34910,9 +35138,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1472 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1473 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 549
+      ID: 550
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -34934,9 +35162,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 550 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 551 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 500
+      ID: 501
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34958,9 +35186,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 501 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 502 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 690
+      ID: 701
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -34982,9 +35210,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 691 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 702 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 482
+      ID: 483
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35006,9 +35234,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 483 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 484 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 465
+      ID: 466
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35030,9 +35258,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 466 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 467 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 670
+      ID: 677
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35054,9 +35282,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 671 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 678 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1146
+      ID: 1157
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35078,9 +35306,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1147 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1158 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 457
+      ID: 458
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35102,9 +35330,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 458 GoSwissMapGroupsType groupReference<string,int>
+          Type: 459 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 662
+      ID: 669
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35126,9 +35354,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 663 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 670 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 449
+      ID: 450
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35150,9 +35378,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 450 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 451 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 654
+      ID: 661
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35174,9 +35402,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 655 GoSwissMapGroupsType groupReference<string,string>
+          Type: 662 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 541
+      ID: 542
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35198,9 +35426,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 542 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 543 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 589
+      ID: 590
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35222,9 +35450,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 590 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 591 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 597
+      ID: 598
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35246,9 +35474,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 598 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 599 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 605
+      ID: 606
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35270,9 +35498,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 606 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 607 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 613
+      ID: 614
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35294,9 +35522,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 614 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 615 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 621
+      ID: 622
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35318,9 +35546,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 622 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 623 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 629
+      ID: 630
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35342,9 +35570,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 630 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 631 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 557
+      ID: 558
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35366,9 +35594,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 558 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 559 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 516
+      ID: 517
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35390,9 +35618,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 517 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 518 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 508
+      ID: 509
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35414,13 +35642,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 509 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 510 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1310
+      ID: 1321
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1037
+      ID: 1048
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1711328
@@ -35433,13 +35661,13 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 1257
+      ID: 1268
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1915008
       GoKind: 6
     - __kind: StructureType
-      ID: 385
+      ID: 328
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1971328
@@ -35450,10 +35678,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 1371 GoSliceHeaderType []time.zone
+          Type: 638 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 1374 GoSliceHeaderType []time.zoneTrans
+          Type: 641 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -35465,13 +35693,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 1372 PointerType *time.zone
+          Type: 639 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 787
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 383
+    - __kind: GoTimeType
+      ID: 326
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2377856
@@ -35485,9 +35713,17 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 384 PointerType *time.Location
+          Type: 327 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 382
+      ID: 386
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1472224
@@ -35495,12 +35731,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1370 GoChannelType <-chan time.Time
+          Type: 1381 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 700
+      ID: 711
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 830912
@@ -35508,18 +35744,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 702 PointerType *time.fileSizeError.str
+          Type: 713 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 701 GoStringDataType time.fileSizeError.str
+      Data: 712 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 701
+      ID: 712
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1373
+      ID: 640
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1621376
@@ -35535,7 +35771,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1376
+      ID: 643
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1753760
@@ -35596,7 +35832,7 @@ Types:
       GoRuntimeType: 584416
       GoKind: 26
     - __kind: StructureType
-      ID: 1125
+      ID: 1136
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2065344
@@ -35607,10 +35843,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1126 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1137 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1127 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1138 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -35625,18 +35861,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1128 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1139 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1128
+      ID: 1139
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995264
       GoKind: 9
     - __kind: StructureType
-      ID: 1126
+      ID: 1137
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1927040
@@ -35661,21 +35897,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 877
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1127
+      ID: 1138
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588064
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1302
+      ID: 1313
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 861
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1429184
@@ -35685,13 +35921,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 741
+      ID: 752
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 2
     - __kind: StructureType
-      ID: 1016
+      ID: 1027
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1707104
@@ -35704,12 +35940,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 970
+      ID: 981
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 994112
       GoKind: 5
-MaxTypeID: 1810
+MaxTypeID: 1814
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,12 +12,12 @@ Probes:
         - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1733 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x811028", Frameless: false}]
+              Type: 1734 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0x811038", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1734 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x811058", Frameless: false}]
+              Type: 1735 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0x811068", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -32,11 +32,11 @@ Probes:
         - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 1572 EventRootType Probe[main.testAny]
+              Type: 1573 EventRootType Probe[main.testAny]
               InjectionPoints: [{PC: "0x80c188", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1573 EventRootType Probe[main.testAny]Return
+              Type: 1574 EventRootType Probe[main.testAny]Return
               InjectionPoints: [{PC: "0x80c1b0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -58,11 +58,11 @@ Probes:
         - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testAnyPtr]
+              Type: 1576 EventRootType Probe[main.testAnyPtr]
               InjectionPoints: [{PC: "0x80c1f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1576 EventRootType Probe[main.testAnyPtr]Return
+              Type: 1577 EventRootType Probe[main.testAnyPtr]Return
               InjectionPoints: [{PC: "0x80c220", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -83,12 +83,12 @@ Probes:
         - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1704 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80fc5c", Frameless: false}]
+              Type: 1705 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0x80fc6c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1705 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80fce8", Frameless: false}]
+              Type: 1706 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0x80fcf8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -109,7 +109,7 @@ Probes:
         - subprogram: {subprogram: 19}
           events:
             - Kind: Entry
-              Type: 1519 EventRootType Probe[main.testArrayEmptyStructs]
+              Type: 1520 EventRootType Probe[main.testArrayEmptyStructs]
               InjectionPoints: [{PC: "0x807dc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -131,7 +131,7 @@ Probes:
         - subprogram: {subprogram: 15}
           events:
             - Kind: Entry
-              Type: 1515 EventRootType Probe[main.testArrayOfArrays]
+              Type: 1516 EventRootType Probe[main.testArrayOfArrays]
               InjectionPoints: [{PC: "0x807d80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -153,7 +153,7 @@ Probes:
         - subprogram: {subprogram: 17}
           events:
             - Kind: Entry
-              Type: 1517 EventRootType Probe[main.testArrayOfArraysOfArrays]
+              Type: 1518 EventRootType Probe[main.testArrayOfArraysOfArrays]
               InjectionPoints: [{PC: "0x807da0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -175,8 +175,8 @@ Probes:
         - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x80c8f0", Frameless: true}]
+              Type: 1585 EventRootType Probe[main.testArrayOfMaps]
+              InjectionPoints: [{PC: "0x80c900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -197,7 +197,7 @@ Probes:
         - subprogram: {subprogram: 16}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testArrayOfStrings]
+              Type: 1517 EventRootType Probe[main.testArrayOfStrings]
               InjectionPoints: [{PC: "0x807d90", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -218,7 +218,7 @@ Probes:
         - subprogram: {subprogram: 18}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testArrayOfStructs]
+              Type: 1519 EventRootType Probe[main.testArrayOfStructs]
               InjectionPoints: [{PC: "0x807db0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -240,12 +240,12 @@ Probes:
         - subprogram: {subprogram: 90}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x80e040", Frameless: true}]
+              Type: 1607 EventRootType Probe[main.testAtomicAdd]
+              InjectionPoints: [{PC: "0x80e050", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1607 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x80e07c", Frameless: true}]
+              Type: 1608 EventRootType Probe[main.testAtomicAdd]Return
+              InjectionPoints: [{PC: "0x80e08c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -266,11 +266,11 @@ Probes:
         - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testBigStruct]
+              Type: 1538 EventRootType Probe[main.testBigStruct]
               InjectionPoints: [{PC: "0x808300", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1538 EventRootType Probe[main.testBigStruct]Return
+              Type: 1539 EventRootType Probe[main.testBigStruct]Return
               InjectionPoints: [{PC: "0x80830c", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -292,7 +292,7 @@ Probes:
         - subprogram: {subprogram: 4}
           events:
             - Kind: Entry
-              Type: 1504 EventRootType Probe[main.testBoolArray]
+              Type: 1505 EventRootType Probe[main.testBoolArray]
               InjectionPoints: [{PC: "0x807cd0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -314,7 +314,7 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 1501 EventRootType Probe[main.testByteArray]
+              Type: 1502 EventRootType Probe[main.testByteArray]
               InjectionPoints: [{PC: "0x807ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -341,12 +341,12 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1752 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x811310", Frameless: true}]
+              Type: 1753 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x811320", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1753 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x811320", Frameless: true}]
+              Type: 1754 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0x811330", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1813 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1817 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x80baa8"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1814 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1818 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x80baa8"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 6 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 189, index: 0, name: x}
+                      Variable: {subprogram: 192, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -437,10 +437,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1815 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1819 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x80baa8"
                   Frameless: false
@@ -477,8 +477,8 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80dde0", Frameless: true}]
+              Type: 1604 EventRootType Probe[main.testCombinedString]
+              InjectionPoints: [{PC: "0x80ddf0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -496,8 +496,8 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80dde0", Frameless: true}]
+              Type: 1605 EventRootType Probe[main.testCombinedString]
+              InjectionPoints: [{PC: "0x80ddf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -522,8 +522,8 @@ Probes:
         - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1760 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x8113b0", Frameless: true}]
+              Type: 1761 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0x8113c0", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -560,8 +560,8 @@ Probes:
         - subprogram: {subprogram: 91}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x80e080", Frameless: true}]
+              Type: 1609 EventRootType Probe[main.testChannel]
+              InjectionPoints: [{PC: "0x80e090", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -590,8 +590,8 @@ Probes:
         - subprogram: {subprogram: 87}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x80ddc0", Frameless: true}]
+              Type: 1603 EventRootType Probe[main.testCombinedByte]
+              InjectionPoints: [{PC: "0x80ddd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -619,12 +619,12 @@ Probes:
         - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1669 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80ef58", Frameless: false}]
+              Type: 1670 EventRootType Probe[main.testConflictingReturn]
+              InjectionPoints: [{PC: "0x80ef68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1670 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80eff8", Frameless: false}]
+              Type: 1671 EventRootType Probe[main.testConflictingReturn]Return
+              InjectionPoints: [{PC: "0x80f008", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -645,8 +645,8 @@ Probes:
         - subprogram: {subprogram: 99}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x80e310", Frameless: true}]
+              Type: 1617 EventRootType Probe[main.testCycle]
+              InjectionPoints: [{PC: "0x80e320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -667,7 +667,7 @@ Probes:
         - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 1544 EventRootType Probe[main.testDeepMap1]
+              Type: 1545 EventRootType Probe[main.testDeepMap1]
               InjectionPoints: [{PC: "0x8087a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -689,7 +689,7 @@ Probes:
         - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testDeepMap7]
+              Type: 1546 EventRootType Probe[main.testDeepMap7]
               InjectionPoints: [{PC: "0x8087b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -711,7 +711,7 @@ Probes:
         - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 1540 EventRootType Probe[main.testDeepPtr1]
+              Type: 1541 EventRootType Probe[main.testDeepPtr1]
               InjectionPoints: [{PC: "0x8084c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -733,7 +733,7 @@ Probes:
         - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 1541 EventRootType Probe[main.testDeepPtr7]
+              Type: 1542 EventRootType Probe[main.testDeepPtr7]
               InjectionPoints: [{PC: "0x8084d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -755,7 +755,7 @@ Probes:
         - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 1542 EventRootType Probe[main.testDeepSlice1]
+              Type: 1543 EventRootType Probe[main.testDeepSlice1]
               InjectionPoints: [{PC: "0x808640", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -777,7 +777,7 @@ Probes:
         - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testDeepSlice7]
+              Type: 1544 EventRootType Probe[main.testDeepSlice7]
               InjectionPoints: [{PC: "0x808650", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -799,8 +799,8 @@ Probes:
         - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1721 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x8109b0", Frameless: true}]
+              Type: 1722 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0x8109c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -826,8 +826,8 @@ Probes:
         - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1724 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x8109e0", Frameless: true}]
+              Type: 1725 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0x8109f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -854,8 +854,8 @@ Probes:
         - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1747 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x8110e0", Frameless: true}]
+              Type: 1748 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0x8110f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -876,8 +876,8 @@ Probes:
         - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1761 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x8113e0", Frameless: true}]
+              Type: 1762 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0x8113f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -897,8 +897,8 @@ Probes:
         - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1762 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x8113f0", Frameless: true}]
+              Type: 1763 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0x811400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -919,7 +919,7 @@ Probes:
         - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 1574 EventRootType Probe[main.testError]
+              Type: 1575 EventRootType Probe[main.testError]
               InjectionPoints: [{PC: "0x80c1d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -953,7 +953,7 @@ Probes:
         - subprogram: {subprogram: 38}
           events:
             - Kind: Line
-              Type: 1539 EventRootType Probe[main.testErrorAtLine]Line
+              Type: 1540 EventRootType Probe[main.testErrorAtLine]Line
               InjectionPoints: [{PC: "0x80834c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -981,11 +981,11 @@ Probes:
         - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.testEsotericHeap]
+              Type: 1557 EventRootType Probe[main.testEsotericHeap]
               InjectionPoints: [{PC: "0x80ab88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.testEsotericHeap]Return
+              Type: 1558 EventRootType Probe[main.testEsotericHeap]Return
               InjectionPoints: [{PC: "0x80abc0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1007,11 +1007,11 @@ Probes:
         - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 1554 EventRootType Probe[main.testEsotericStack]
+              Type: 1555 EventRootType Probe[main.testEsotericStack]
               InjectionPoints: [{PC: "0x80aacc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1555 EventRootType Probe[main.testEsotericStack]Return
+              Type: 1556 EventRootType Probe[main.testEsotericStack]Return
               InjectionPoints: [{PC: "0x80ab28", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1033,11 +1033,11 @@ Probes:
         - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.testFrameless]
+              Type: 1567 EventRootType Probe[main.testFrameless]
               InjectionPoints: [{PC: "0x80bef0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1567 EventRootType Probe[main.testFrameless]Return
+              Type: 1568 EventRootType Probe[main.testFrameless]Return
               InjectionPoints: [{PC: "0x80bef8", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -1059,11 +1059,11 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.testFramelessArray]
+              Type: 1569 EventRootType Probe[main.testFramelessArray]
               InjectionPoints: [{PC: "0x80bf0c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1569 EventRootType Probe[main.testFramelessArray]Return
+              Type: 1570 EventRootType Probe[main.testFramelessArray]Return
               InjectionPoints: [{PC: "0x80bf40", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1088,7 +1088,7 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Line
-              Type: 1570 EventRootType Probe[main.testFramelessArray]Line
+              Type: 1571 EventRootType Probe[main.testFramelessArray]Line
               InjectionPoints: [{PC: "0x80bf0c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1107,15 +1107,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1799 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x813400", Frameless: true}]
+              Type: 1803 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0x813550", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1800 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x813404", Frameless: true}]
+              Type: 1804 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x813554", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1125,15 +1125,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1801 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x813420", Frameless: false}]
+              Type: 1805 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0x813570", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1802 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x813450", Frameless: false}]
+              Type: 1806 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0x8135a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1152,15 +1152,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1795 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x813368", Frameless: false}]
+              Type: 1799 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0x8134b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1796 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x813378", Frameless: false}]
+              Type: 1800 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0x8134c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1170,15 +1170,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1797 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x8133b8", Frameless: false}]
+              Type: 1801 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0x813508", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1798 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x8133d0", Frameless: false}]
+              Type: 1802 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0x813520", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1197,18 +1197,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1803 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x813460", Frameless: true}]
+              Type: 1807 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0x8135b0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1804 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1808 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x813488"
+                - PC: "0x8135d8"
                   Frameless: true
-                - PC: "0x813490"
+                - PC: "0x8135e0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1219,18 +1219,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1805 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x8134b8", Frameless: false}]
+              Type: 1809 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0x813608", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1806 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1810 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x813514"
+                - PC: "0x813664"
                   Frameless: false
-                - PC: "0x813524"
+                - PC: "0x813674"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1253,11 +1253,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Line
-              Type: 1807 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x813464", Frameless: true}]
+              Type: 1811 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0x8135b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1265,11 +1265,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1808 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x8134c8", Frameless: false}]
+              Type: 1812 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0x813618", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1286,15 +1286,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1783 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x813070", Frameless: true}]
+              Type: 1787 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0x8131c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1784 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x813074", Frameless: true}]
+              Type: 1788 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0x8131c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1304,15 +1304,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1785 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x813100", Frameless: true}]
+              Type: 1789 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0x813250", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1786 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x813104", Frameless: true}]
+              Type: 1790 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0x813254", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1332,15 +1332,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 169}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1771 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x812c78", Frameless: false}]
+              Type: 1775 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0x812dc8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1772 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x812d4c", Frameless: false}]
+              Type: 1776 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x812e9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1350,14 +1350,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1773 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1777 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x806e78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1774 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1778 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x806f4c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1378,15 +1378,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1775 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x812d98", Frameless: false}]
+              Type: 1779 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x812ee8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1776 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x812da8", Frameless: false}]
+              Type: 1780 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x812ef8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1405,15 +1405,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1809 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x813560", Frameless: true}]
+              Type: 1813 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0x8136b0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1810 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x813568", Frameless: true}]
+              Type: 1814 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0x8136b8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1423,15 +1423,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1811 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x8135f8", Frameless: false}]
+              Type: 1815 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0x813748", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1812 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x81361c", Frameless: false}]
+              Type: 1816 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0x81376c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1450,15 +1450,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
+        - subprogram: {subprogram: 170}
           events:
             - Kind: Entry
-              Type: 1767 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x812be0", Frameless: true}]
+              Type: 1771 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0x812d30", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1768 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x812be4", Frameless: true}]
+              Type: 1772 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x812d34", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1468,15 +1468,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 168}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1769 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x812bf0", Frameless: true}]
+              Type: 1773 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0x812d40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1770 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x812bfc", Frameless: true}]
+              Type: 1774 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x812d4c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1495,15 +1495,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1787 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x8131a0", Frameless: true}]
+              Type: 1791 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0x8132f0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1788 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x8131a8", Frameless: true}]
+              Type: 1792 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0x8132f8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1513,15 +1513,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1789 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x813248", Frameless: false}]
+              Type: 1793 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0x813398", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1790 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x813270", Frameless: false}]
+              Type: 1794 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0x8133c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1540,15 +1540,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1777 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x813040", Frameless: true}]
+              Type: 1781 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x813190", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1778 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x813044", Frameless: true}]
+              Type: 1782 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x813194", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1558,15 +1558,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1779 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x813050", Frameless: true}]
+              Type: 1783 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0x8131a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1780 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x813054", Frameless: true}]
+              Type: 1784 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0x8131a4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1576,15 +1576,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1781 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x813060", Frameless: true}]
+              Type: 1785 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0x8131b0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1782 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x813064", Frameless: true}]
+              Type: 1786 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0x8131b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1603,15 +1603,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1791 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x813320", Frameless: true}]
+              Type: 1795 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0x813470", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1792 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x813328", Frameless: true}]
+              Type: 1796 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0x813478", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1621,15 +1621,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1793 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x813330", Frameless: true}]
+              Type: 1797 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x813480", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1794 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x813340", Frameless: true}]
+              Type: 1798 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x813490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1648,15 +1648,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1763 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x812bc0", Frameless: true}]
+              Type: 1767 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0x812d10", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1764 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x812bc4", Frameless: true}]
+              Type: 1768 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x812d14", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1666,15 +1666,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1765 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x812bd0", Frameless: true}]
+              Type: 1769 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0x812d20", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1766 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x812bdc", Frameless: true}]
+              Type: 1770 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x812d2c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1696,11 +1696,11 @@ Probes:
         - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.testInlinedBA]
+              Type: 1559 EventRootType Probe[main.testInlinedBA]
               InjectionPoints: [{PC: "0x80bc38", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1559 EventRootType Probe[main.testInlinedBA]Return
+              Type: 1560 EventRootType Probe[main.testInlinedBA]Return
               InjectionPoints: [{PC: "0x80bc8c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1727,11 +1727,11 @@ Probes:
         - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.testInlinedBB]
+              Type: 1561 EventRootType Probe[main.testInlinedBB]
               InjectionPoints: [{PC: "0x80bcc8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1561 EventRootType Probe[main.testInlinedBB]Return
+              Type: 1562 EventRootType Probe[main.testInlinedBB]Return
               InjectionPoints: [{PC: "0x80bd48", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1758,11 +1758,11 @@ Probes:
         - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.testInlinedBBA]
+              Type: 1563 EventRootType Probe[main.testInlinedBBA]
               InjectionPoints: [{PC: "0x80bd88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1563 EventRootType Probe[main.testInlinedBBA]Return
+              Type: 1564 EventRootType Probe[main.testInlinedBBA]Return
               InjectionPoints: [{PC: "0x80bdc0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1781,10 +1781,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1819 EventRootType Probe[main.testInlinedBBB]
+              Type: 1823 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0x80bd14", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1802,11 +1802,11 @@ Probes:
         - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.testInlinedBC]
+              Type: 1565 EventRootType Probe[main.testInlinedBC]
               InjectionPoints: [{PC: "0x80bdf8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1565 EventRootType Probe[main.testInlinedBC]Return
+              Type: 1566 EventRootType Probe[main.testInlinedBC]Return
               InjectionPoints: [{PC: "0x80bed4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1821,10 +1821,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Entry
-              Type: 1820 EventRootType Probe[main.testInlinedBCA]
+              Type: 1824 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0x80bdfc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1842,10 +1842,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Line
-              Type: 1821 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1825 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0x80bdfc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1860,10 +1860,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Entry
-              Type: 1822 EventRootType Probe[main.testInlinedBCB]
+              Type: 1826 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0x80bea0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1881,10 +1881,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Line
-              Type: 1823 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1827 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0x80bea0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1899,10 +1899,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 196}
+        - subprogram: {subprogram: 199}
           events:
             - Kind: Entry
-              Type: 1829 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1833 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x8069e8"
                   Frameless: true
@@ -1922,10 +1922,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1816 EventRootType Probe[main.testInlinedPrint]
+              Type: 1820 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0x80baa8"
                   Frameless: false
@@ -1939,7 +1939,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1817 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1821 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0x80badc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1961,10 +1961,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1818 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1822 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x80baa8"
                   Frameless: false
@@ -1993,10 +1993,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Entry
-              Type: 1824 EventRootType Probe[main.testInlinedSq]
+              Type: 1828 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0x80bef4", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2018,10 +2018,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Line
-              Type: 1825 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1829 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0x80bef4", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2041,10 +2041,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 194}
+        - subprogram: {subprogram: 197}
           events:
             - Kind: Entry
-              Type: 1826 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1830 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0x80bf24"
                   Frameless: false
@@ -2070,7 +2070,7 @@ Probes:
         - subprogram: {subprogram: 7}
           events:
             - Kind: Entry
-              Type: 1507 EventRootType Probe[main.testInt16Array]
+              Type: 1508 EventRootType Probe[main.testInt16Array]
               InjectionPoints: [{PC: "0x807d00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2092,7 +2092,7 @@ Probes:
         - subprogram: {subprogram: 8}
           events:
             - Kind: Entry
-              Type: 1508 EventRootType Probe[main.testInt32Array]
+              Type: 1509 EventRootType Probe[main.testInt32Array]
               InjectionPoints: [{PC: "0x807d10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2114,7 +2114,7 @@ Probes:
         - subprogram: {subprogram: 9}
           events:
             - Kind: Entry
-              Type: 1509 EventRootType Probe[main.testInt64Array]
+              Type: 1510 EventRootType Probe[main.testInt64Array]
               InjectionPoints: [{PC: "0x807d20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2136,7 +2136,7 @@ Probes:
         - subprogram: {subprogram: 6}
           events:
             - Kind: Entry
-              Type: 1506 EventRootType Probe[main.testInt8Array]
+              Type: 1507 EventRootType Probe[main.testInt8Array]
               InjectionPoints: [{PC: "0x807cf0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2158,7 +2158,7 @@ Probes:
         - subprogram: {subprogram: 5}
           events:
             - Kind: Entry
-              Type: 1505 EventRootType Probe[main.testIntArray]
+              Type: 1506 EventRootType Probe[main.testIntArray]
               InjectionPoints: [{PC: "0x807ce0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2180,7 +2180,7 @@ Probes:
         - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testInterface]
+              Type: 1572 EventRootType Probe[main.testInterface]
               InjectionPoints: [{PC: "0x80c160", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2201,12 +2201,12 @@ Probes:
         - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1702 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80fad0", Frameless: false}]
+              Type: 1703 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0x80fae0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1703 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80fbf8", Frameless: false}]
+              Type: 1704 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x80fc08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2227,8 +2227,8 @@ Probes:
         - subprogram: {subprogram: 93}
           events:
             - Kind: Entry
-              Type: 1610 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x80e220", Frameless: true}]
+              Type: 1611 EventRootType Probe[main.testLinkedList]
+              InjectionPoints: [{PC: "0x80e230", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2252,7 +2252,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1548 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1549 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x8087fc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2274,7 +2274,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1549 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1550 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x808880", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2296,7 +2296,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1550 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1551 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x80891c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2339,12 +2339,12 @@ Probes:
         - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1708 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80ff2c", Frameless: false}]
+              Type: 1709 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0x80ff3c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1709 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x81006c", Frameless: false}]
+              Type: 1710 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0x81007c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2406,7 +2406,7 @@ Probes:
         - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 1552 EventRootType Probe[main.testManyPointers]
+              Type: 1553 EventRootType Probe[main.testManyPointers]
               InjectionPoints: [{PC: "0x808e50", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2430,7 +2430,7 @@ Probes:
         - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testManyStrings]
+              Type: 1554 EventRootType Probe[main.testManyStrings]
               InjectionPoints: [{PC: "0x80a7c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2452,8 +2452,8 @@ Probes:
         - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x80c8d0", Frameless: true}]
+              Type: 1583 EventRootType Probe[main.testMapArrayToArray]
+              InjectionPoints: [{PC: "0x80c8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2474,8 +2474,8 @@ Probes:
         - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x80c930", Frameless: true}]
+              Type: 1590 EventRootType Probe[main.testMapEmbeddedMaps]
+              InjectionPoints: [{PC: "0x80c940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2496,8 +2496,8 @@ Probes:
         - subprogram: {subprogram: 84}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x80c9d0", Frameless: true}]
+              Type: 1600 EventRootType Probe[main.testMapEmptyKey]
+              InjectionPoints: [{PC: "0x80c9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2518,8 +2518,8 @@ Probes:
         - subprogram: {subprogram: 86}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x80c9f0", Frameless: true}]
+              Type: 1602 EventRootType Probe[main.testMapEmptyKeyAndValue]
+              InjectionPoints: [{PC: "0x80ca00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2540,8 +2540,8 @@ Probes:
         - subprogram: {subprogram: 85}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x80c9e0", Frameless: true}]
+              Type: 1601 EventRootType Probe[main.testMapEmptyValue]
+              InjectionPoints: [{PC: "0x80c9f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2562,8 +2562,8 @@ Probes:
         - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x80c910", Frameless: true}]
+              Type: 1587 EventRootType Probe[main.testMapIntToInt]
+              InjectionPoints: [{PC: "0x80c920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2584,8 +2584,8 @@ Probes:
         - subprogram: {subprogram: 83}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x80c9c0", Frameless: true}]
+              Type: 1599 EventRootType Probe[main.testMapLargeKeyLargeValue]
+              InjectionPoints: [{PC: "0x80c9d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2606,8 +2606,8 @@ Probes:
         - subprogram: {subprogram: 82}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x80c9b0", Frameless: true}]
+              Type: 1598 EventRootType Probe[main.testMapLargeKeySmallValue]
+              InjectionPoints: [{PC: "0x80c9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2630,8 +2630,8 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80c920", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.testMapMassive]
+              InjectionPoints: [{PC: "0x80c930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2654,8 +2654,8 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80c920", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.testMapMassive]
+              InjectionPoints: [{PC: "0x80c930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2676,8 +2676,8 @@ Probes:
         - subprogram: {subprogram: 81}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x80c9a0", Frameless: true}]
+              Type: 1597 EventRootType Probe[main.testMapSmallKeyLargeValue]
+              InjectionPoints: [{PC: "0x80c9b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2698,8 +2698,8 @@ Probes:
         - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x80c990", Frameless: true}]
+              Type: 1596 EventRootType Probe[main.testMapSmallKeySmallValue]
+              InjectionPoints: [{PC: "0x80c9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2720,8 +2720,8 @@ Probes:
         - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x80c8b0", Frameless: true}]
+              Type: 1581 EventRootType Probe[main.testMapStringToInt]
+              InjectionPoints: [{PC: "0x80c8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2742,8 +2742,8 @@ Probes:
         - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x80c8c0", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.testMapStringToSlice]
+              InjectionPoints: [{PC: "0x80c8d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2764,8 +2764,8 @@ Probes:
         - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x80c8a0", Frameless: true}]
+              Type: 1580 EventRootType Probe[main.testMapStringToStruct]
+              InjectionPoints: [{PC: "0x80c8b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2786,8 +2786,8 @@ Probes:
         - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x80c940", Frameless: true}]
+              Type: 1591 EventRootType Probe[main.testMapWithLinkedList]
+              InjectionPoints: [{PC: "0x80c950", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2808,8 +2808,8 @@ Probes:
         - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 1593 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x80c970", Frameless: true}]
+              Type: 1594 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+              InjectionPoints: [{PC: "0x80c980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2830,8 +2830,8 @@ Probes:
         - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x80c980", Frameless: true}]
+              Type: 1595 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+              InjectionPoints: [{PC: "0x80c990", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2852,8 +2852,8 @@ Probes:
         - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x80c950", Frameless: true}]
+              Type: 1592 EventRootType Probe[main.testMapWithSmallValue]
+              InjectionPoints: [{PC: "0x80c960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2876,8 +2876,8 @@ Probes:
         - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x80c960", Frameless: true}]
+              Type: 1593 EventRootType Probe[main.testMapWithSmallValueMassive]
+              InjectionPoints: [{PC: "0x80c970", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2898,8 +2898,8 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1744 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x8110c0", Frameless: true}]
+              Type: 1745 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x8110d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2921,8 +2921,8 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1745 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x8110c0", Frameless: true}]
+              Type: 1746 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x8110d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2968,12 +2968,12 @@ Probes:
         - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1710 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x8100d0", Frameless: false}]
+              Type: 1711 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0x8100e0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1711 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x810258", Frameless: false}]
+              Type: 1712 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0x810268", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3038,12 +3038,12 @@ Probes:
         - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1714 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x81034c", Frameless: false}]
+              Type: 1715 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0x81035c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1715 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x8103e4", Frameless: false}]
+              Type: 1716 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0x8103f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3073,12 +3073,12 @@ Probes:
         - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1706 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80fd20", Frameless: false}]
+              Type: 1707 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0x80fd30", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1707 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80fec4", Frameless: false}]
+              Type: 1708 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0x80fed4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3103,12 +3103,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1647 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80edd8", Frameless: false}]
+              Type: 1648 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80ede8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1648 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ee58", Frameless: false}]
+              Type: 1649 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ee68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3143,8 +3143,8 @@ Probes:
         - subprogram: {subprogram: 89}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x80dea0", Frameless: true}]
+              Type: 1606 EventRootType Probe[main.testMultipleSimpleParams]
+              InjectionPoints: [{PC: "0x80deb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3184,12 +3184,12 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1641 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80ed48", Frameless: false}]
+              Type: 1642 EventRootType Probe[main.testNamedReturn]
+              InjectionPoints: [{PC: "0x80ed58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1642 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80eda0", Frameless: false}]
+              Type: 1643 EventRootType Probe[main.testNamedReturn]Return
+              InjectionPoints: [{PC: "0x80edb0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3212,12 +3212,12 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1643 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80ed48", Frameless: false}]
+              Type: 1644 EventRootType Probe[main.testNamedReturn]
+              InjectionPoints: [{PC: "0x80ed58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1644 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80eda0", Frameless: false}]
+              Type: 1645 EventRootType Probe[main.testNamedReturn]Return
+              InjectionPoints: [{PC: "0x80edb0", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3235,12 +3235,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1649 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80edd8", Frameless: false}]
+              Type: 1650 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80ede8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1650 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ee58", Frameless: false}]
+              Type: 1651 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ee68", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3259,12 +3259,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1651 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80edd8", Frameless: false}]
+              Type: 1652 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80ede8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1652 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ee58", Frameless: false}]
+              Type: 1653 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ee68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3296,12 +3296,12 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1645 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80ed48", Frameless: false}]
+              Type: 1646 EventRootType Probe[main.testNamedReturn]
+              InjectionPoints: [{PC: "0x80ed58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1646 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80eda0", Frameless: false}]
+              Type: 1647 EventRootType Probe[main.testNamedReturn]Return
+              InjectionPoints: [{PC: "0x80edb0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3328,8 +3328,8 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1756 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8113a0", Frameless: true}]
+              Type: 1757 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x8113b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3353,8 +3353,8 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1757 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8113a0", Frameless: true}]
+              Type: 1758 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x8113b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3384,8 +3384,8 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1758 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8113a0", Frameless: true}]
+              Type: 1759 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x8113b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3409,8 +3409,8 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1759 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8113a0", Frameless: true}]
+              Type: 1760 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x8113b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3436,8 +3436,8 @@ Probes:
         - subprogram: {subprogram: 98}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x80e2f0", Frameless: true}]
+              Type: 1616 EventRootType Probe[main.testNilPointer]
+              InjectionPoints: [{PC: "0x80e300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3463,8 +3463,8 @@ Probes:
         - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1728 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x810a20", Frameless: true}]
+              Type: 1729 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0x810a30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3490,8 +3490,8 @@ Probes:
         - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1725 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x8109f0", Frameless: true}]
+              Type: 1726 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0x810a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3525,8 +3525,8 @@ Probes:
         - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1727 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x810a10", Frameless: true}]
+              Type: 1728 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0x810a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3557,8 +3557,8 @@ Probes:
         - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1743 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x8110b0", Frameless: true}]
+              Type: 1744 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0x8110c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3579,8 +3579,8 @@ Probes:
         - subprogram: {subprogram: 94}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x80e230", Frameless: true}]
+              Type: 1612 EventRootType Probe[main.testPointerLoop]
+              InjectionPoints: [{PC: "0x80e240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3601,8 +3601,8 @@ Probes:
         - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x80c900", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.testPointerToMap]
+              InjectionPoints: [{PC: "0x80c910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3623,8 +3623,8 @@ Probes:
         - subprogram: {subprogram: 92}
           events:
             - Kind: Entry
-              Type: 1609 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x80e210", Frameless: true}]
+              Type: 1610 EventRootType Probe[main.testPointerToSimpleStruct]
+              InjectionPoints: [{PC: "0x80e220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3647,12 +3647,12 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1617 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80e638", Frameless: false}]
+              Type: 1618 EventRootType Probe[main.testReturnsInt]
+              InjectionPoints: [{PC: "0x80e648", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1618 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80e678", Frameless: false}]
+              Type: 1619 EventRootType Probe[main.testReturnsInt]Return
+              InjectionPoints: [{PC: "0x80e688", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3671,12 +3671,12 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1661 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80ee98", Frameless: false}]
+              Type: 1662 EventRootType Probe[main.testSomeNamedReturn]
+              InjectionPoints: [{PC: "0x80eea8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1662 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ef1c", Frameless: false}]
+              Type: 1663 EventRootType Probe[main.testSomeNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ef2c", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3720,12 +3720,12 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1627 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80e758", Frameless: false}]
+              Type: 1628 EventRootType Probe[main.testReturnsIntAndFloat]
+              InjectionPoints: [{PC: "0x80e768", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1628 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80e7e4", Frameless: false}]
+              Type: 1629 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              InjectionPoints: [{PC: "0x80e7f4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3766,12 +3766,12 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80e638", Frameless: false}]
+              Type: 1620 EventRootType Probe[main.testReturnsInt]
+              InjectionPoints: [{PC: "0x80e648", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1620 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80e678", Frameless: false}]
+              Type: 1621 EventRootType Probe[main.testReturnsInt]Return
+              InjectionPoints: [{PC: "0x80e688", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3815,12 +3815,12 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1629 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80e758", Frameless: false}]
+              Type: 1630 EventRootType Probe[main.testReturnsIntAndFloat]
+              InjectionPoints: [{PC: "0x80e768", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1630 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80e7e4", Frameless: false}]
+              Type: 1631 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              InjectionPoints: [{PC: "0x80e7f4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3863,12 +3863,12 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1663 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80ee98", Frameless: false}]
+              Type: 1664 EventRootType Probe[main.testSomeNamedReturn]
+              InjectionPoints: [{PC: "0x80eea8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1664 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ef1c", Frameless: false}]
+              Type: 1665 EventRootType Probe[main.testSomeNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ef2c", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3884,12 +3884,12 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1665 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80ee98", Frameless: false}]
+              Type: 1666 EventRootType Probe[main.testSomeNamedReturn]
+              InjectionPoints: [{PC: "0x80eea8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1666 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ef1c", Frameless: false}]
+              Type: 1667 EventRootType Probe[main.testSomeNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ef2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3910,12 +3910,12 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80e638", Frameless: false}]
+              Type: 1622 EventRootType Probe[main.testReturnsInt]
+              InjectionPoints: [{PC: "0x80e648", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1622 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80e678", Frameless: false}]
+              Type: 1623 EventRootType Probe[main.testReturnsInt]Return
+              InjectionPoints: [{PC: "0x80e688", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3937,19 +3937,19 @@ Probes:
         - subprogram: {subprogram: 105}
           events:
             - Kind: Entry
-              Type: 1637 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80ea18", Frameless: false}]
+              Type: 1638 EventRootType Probe[main.testReturnsAny]
+              InjectionPoints: [{PC: "0x80ea28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1638 EventRootType Probe[main.testReturnsAny]Return
+              Type: 1639 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80eaa0"
+                - PC: "0x80eab0"
                   Frameless: false
-                - PC: "0x80eaf4"
+                - PC: "0x80eb04"
                   Frameless: false
-                - PC: "0x80eba4"
+                - PC: "0x80ebb4"
                   Frameless: false
-                - PC: "0x80ebb8"
+                - PC: "0x80ebc8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3976,19 +3976,19 @@ Probes:
         - subprogram: {subprogram: 104}
           events:
             - Kind: Entry
-              Type: 1635 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80e8a8", Frameless: false}]
+              Type: 1636 EventRootType Probe[main.testReturnsAnyAndError]
+              InjectionPoints: [{PC: "0x80e8b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1636 EventRootType Probe[main.testReturnsAnyAndError]Return
+              Type: 1637 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80e8fc"
+                - PC: "0x80e90c"
                   Frameless: false
-                - PC: "0x80e958"
+                - PC: "0x80e968"
                   Frameless: false
-                - PC: "0x80e998"
+                - PC: "0x80e9a8"
                   Frameless: false
-                - PC: "0x80e9d4"
+                - PC: "0x80e9e4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4014,12 +4014,12 @@ Probes:
         - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1680 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80f52c", Frameless: false}]
+              Type: 1681 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0x80f53c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1681 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80f578", Frameless: false}]
+              Type: 1682 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0x80f588", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4035,12 +4035,12 @@ Probes:
         - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1682 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80f5a8", Frameless: false}]
+              Type: 1683 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0x80f5b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1683 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80f5e0", Frameless: false}]
+              Type: 1684 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0x80f5f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4056,12 +4056,12 @@ Probes:
         - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1684 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80f618", Frameless: false}]
+              Type: 1685 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0x80f628", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1685 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80f64c", Frameless: false}]
+              Type: 1686 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0x80f65c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4077,12 +4077,12 @@ Probes:
         - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1688 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80f708", Frameless: false}]
+              Type: 1689 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0x80f718", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1689 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80f768", Frameless: false}]
+              Type: 1690 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0x80f778", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4098,12 +4098,12 @@ Probes:
         - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1700 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80fa58", Frameless: false}]
+              Type: 1701 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0x80fa68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1701 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80fa94", Frameless: false}]
+              Type: 1702 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0x80faa4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4119,12 +4119,12 @@ Probes:
         - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1676 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80f3e8", Frameless: false}]
+              Type: 1677 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0x80f3f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1677 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80f430", Frameless: false}]
+              Type: 1678 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0x80f440", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4141,15 +4141,15 @@ Probes:
         - subprogram: {subprogram: 103}
           events:
             - Kind: Entry
-              Type: 1633 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80e828", Frameless: false}]
+              Type: 1634 EventRootType Probe[main.testReturnsError]
+              InjectionPoints: [{PC: "0x80e838", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1634 EventRootType Probe[main.testReturnsError]Return
+              Type: 1635 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80e854"
+                - PC: "0x80e864"
                   Frameless: false
-                - PC: "0x80e868"
+                - PC: "0x80e878"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4170,12 +4170,12 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1623 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80e638", Frameless: false}]
+              Type: 1624 EventRootType Probe[main.testReturnsInt]
+              InjectionPoints: [{PC: "0x80e648", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1624 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80e678", Frameless: false}]
+              Type: 1625 EventRootType Probe[main.testReturnsInt]Return
+              InjectionPoints: [{PC: "0x80e688", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4195,12 +4195,12 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1631 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80e758", Frameless: false}]
+              Type: 1632 EventRootType Probe[main.testReturnsIntAndFloat]
+              InjectionPoints: [{PC: "0x80e768", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1632 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80e7e4", Frameless: false}]
+              Type: 1633 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              InjectionPoints: [{PC: "0x80e7f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4220,12 +4220,12 @@ Probes:
         - subprogram: {subprogram: 101}
           events:
             - Kind: Entry
-              Type: 1625 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80e6b8", Frameless: false}]
+              Type: 1626 EventRootType Probe[main.testReturnsIntPointer]
+              InjectionPoints: [{PC: "0x80e6c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1626 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80e714", Frameless: false}]
+              Type: 1627 EventRootType Probe[main.testReturnsIntPointer]Return
+              InjectionPoints: [{PC: "0x80e724", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4246,15 +4246,15 @@ Probes:
         - subprogram: {subprogram: 106}
           events:
             - Kind: Entry
-              Type: 1639 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80ebf8", Frameless: false}]
+              Type: 1640 EventRootType Probe[main.testReturnsInterface]
+              InjectionPoints: [{PC: "0x80ec08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1640 EventRootType Probe[main.testReturnsInterface]Return
+              Type: 1641 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80ecb0"
+                - PC: "0x80ecc0"
                   Frameless: false
-                - PC: "0x80ecc4"
+                - PC: "0x80ecd4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4275,12 +4275,12 @@ Probes:
         - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1678 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80f470", Frameless: false}]
+              Type: 1679 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0x80f480", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1679 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80f4ec", Frameless: false}]
+              Type: 1680 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0x80f4fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4296,12 +4296,12 @@ Probes:
         - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1674 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80f338", Frameless: false}]
+              Type: 1675 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0x80f348", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1675 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80f3b8", Frameless: false}]
+              Type: 1676 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0x80f3c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4317,12 +4317,12 @@ Probes:
         - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1692 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80f868", Frameless: false}]
+              Type: 1693 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0x80f878", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1693 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80f8bc", Frameless: false}]
+              Type: 1694 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0x80f8cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4338,12 +4338,12 @@ Probes:
         - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1686 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80f688", Frameless: false}]
+              Type: 1687 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0x80f698", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1687 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80f6cc", Frameless: false}]
+              Type: 1688 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0x80f6dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4359,12 +4359,12 @@ Probes:
         - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1698 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80f9e8", Frameless: false}]
+              Type: 1699 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0x80f9f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1699 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80fa28", Frameless: false}]
+              Type: 1700 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0x80fa38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4383,8 +4383,8 @@ Probes:
         - subprogram: {subprogram: 111}
           events:
             - Kind: Line
-              Type: 1671 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80f100", Frameless: false}]
+              Type: 1672 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0x80f110", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4404,12 +4404,12 @@ Probes:
         - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1696 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80f978", Frameless: false}]
+              Type: 1697 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0x80f988", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1697 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80f9b4", Frameless: false}]
+              Type: 1698 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0x80f9c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4425,12 +4425,12 @@ Probes:
         - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1672 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80f2a8", Frameless: false}]
+              Type: 1673 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0x80f2b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1673 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80f2fc", Frameless: false}]
+              Type: 1674 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0x80f30c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4446,12 +4446,12 @@ Probes:
         - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1694 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80f8fc", Frameless: false}]
+              Type: 1695 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0x80f90c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1695 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80f948", Frameless: false}]
+              Type: 1696 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0x80f958", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4467,12 +4467,12 @@ Probes:
         - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1690 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80f7a0", Frameless: false}]
+              Type: 1691 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0x80f7b0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1691 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80f82c", Frameless: false}]
+              Type: 1692 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0x80f83c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4489,7 +4489,7 @@ Probes:
         - subprogram: {subprogram: 2}
           events:
             - Kind: Entry
-              Type: 1502 EventRootType Probe[main.testRuneArray]
+              Type: 1503 EventRootType Probe[main.testRuneArray]
               InjectionPoints: [{PC: "0x807cb0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4524,12 +4524,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1653 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80edd8", Frameless: false}]
+              Type: 1654 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80ede8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1654 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ee58", Frameless: false}]
+              Type: 1655 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ee68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4574,7 +4574,7 @@ Probes:
         - subprogram: {subprogram: 23}
           events:
             - Kind: Entry
-              Type: 1523 EventRootType Probe[main.testSingleBool]
+              Type: 1524 EventRootType Probe[main.testSingleBool]
               InjectionPoints: [{PC: "0x808130", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4596,7 +4596,7 @@ Probes:
         - subprogram: {subprogram: 21}
           events:
             - Kind: Entry
-              Type: 1521 EventRootType Probe[main.testSingleByte]
+              Type: 1522 EventRootType Probe[main.testSingleByte]
               InjectionPoints: [{PC: "0x808110", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4618,7 +4618,7 @@ Probes:
         - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testSingleFloat32]
+              Type: 1535 EventRootType Probe[main.testSingleFloat32]
               InjectionPoints: [{PC: "0x8081e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4636,7 +4636,7 @@ Probes:
         - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testSingleFloat64]
+              Type: 1536 EventRootType Probe[main.testSingleFloat64]
               InjectionPoints: [{PC: "0x8081f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4654,7 +4654,7 @@ Probes:
         - subprogram: {subprogram: 24}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testSingleInt]
+              Type: 1525 EventRootType Probe[main.testSingleInt]
               InjectionPoints: [{PC: "0x808140", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4676,7 +4676,7 @@ Probes:
         - subprogram: {subprogram: 26}
           events:
             - Kind: Entry
-              Type: 1526 EventRootType Probe[main.testSingleInt16]
+              Type: 1527 EventRootType Probe[main.testSingleInt16]
               InjectionPoints: [{PC: "0x808160", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4699,7 +4699,7 @@ Probes:
         - subprogram: {subprogram: 27}
           events:
             - Kind: Entry
-              Type: 1527 EventRootType Probe[main.testSingleInt32]
+              Type: 1528 EventRootType Probe[main.testSingleInt32]
               InjectionPoints: [{PC: "0x808170", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4721,7 +4721,7 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Entry
-              Type: 1528 EventRootType Probe[main.testSingleInt64]
+              Type: 1529 EventRootType Probe[main.testSingleInt64]
               InjectionPoints: [{PC: "0x808180", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4750,7 +4750,7 @@ Probes:
         - subprogram: {subprogram: 25}
           events:
             - Kind: Entry
-              Type: 1525 EventRootType Probe[main.testSingleInt8]
+              Type: 1526 EventRootType Probe[main.testSingleInt8]
               InjectionPoints: [{PC: "0x808150", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4781,7 +4781,7 @@ Probes:
         - subprogram: {subprogram: 22}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testSingleRune]
+              Type: 1523 EventRootType Probe[main.testSingleRune]
               InjectionPoints: [{PC: "0x808120", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4803,8 +4803,8 @@ Probes:
         - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1735 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x811070", Frameless: true}]
+              Type: 1736 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0x811080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4825,7 +4825,7 @@ Probes:
         - subprogram: {subprogram: 29}
           events:
             - Kind: Entry
-              Type: 1529 EventRootType Probe[main.testSingleUint]
+              Type: 1530 EventRootType Probe[main.testSingleUint]
               InjectionPoints: [{PC: "0x808190", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4847,7 +4847,7 @@ Probes:
         - subprogram: {subprogram: 31}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testSingleUint16]
+              Type: 1532 EventRootType Probe[main.testSingleUint16]
               InjectionPoints: [{PC: "0x8081b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4869,7 +4869,7 @@ Probes:
         - subprogram: {subprogram: 32}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testSingleUint32]
+              Type: 1533 EventRootType Probe[main.testSingleUint32]
               InjectionPoints: [{PC: "0x8081c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4891,7 +4891,7 @@ Probes:
         - subprogram: {subprogram: 33}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testSingleUint64]
+              Type: 1534 EventRootType Probe[main.testSingleUint64]
               InjectionPoints: [{PC: "0x8081d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4913,7 +4913,7 @@ Probes:
         - subprogram: {subprogram: 30}
           events:
             - Kind: Entry
-              Type: 1530 EventRootType Probe[main.testSingleUint8]
+              Type: 1531 EventRootType Probe[main.testSingleUint8]
               InjectionPoints: [{PC: "0x8081a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4935,8 +4935,8 @@ Probes:
         - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1731 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x810a40", Frameless: true}]
+              Type: 1732 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0x810a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4957,8 +4957,8 @@ Probes:
         - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1722 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x8109c0", Frameless: true}]
+              Type: 1723 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0x8109d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4979,8 +4979,8 @@ Probes:
         - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x80c8e0", Frameless: true}]
+              Type: 1584 EventRootType Probe[main.testSmallMap]
+              InjectionPoints: [{PC: "0x80c8f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5000,12 +5000,12 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1667 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80ee98", Frameless: false}]
+              Type: 1668 EventRootType Probe[main.testSomeNamedReturn]
+              InjectionPoints: [{PC: "0x80eea8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1668 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ef1c", Frameless: false}]
+              Type: 1669 EventRootType Probe[main.testSomeNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ef2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5025,12 +5025,12 @@ Probes:
         - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1712 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x8102b8", Frameless: false}]
+              Type: 1713 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0x8102c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1713 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x810310", Frameless: false}]
+              Type: 1714 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0x810320", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5051,7 +5051,7 @@ Probes:
         - subprogram: {subprogram: 3}
           events:
             - Kind: Entry
-              Type: 1503 EventRootType Probe[main.testStringArray]
+              Type: 1504 EventRootType Probe[main.testStringArray]
               InjectionPoints: [{PC: "0x807cc0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5073,8 +5073,8 @@ Probes:
         - subprogram: {subprogram: 97}
           events:
             - Kind: Entry
-              Type: 1614 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x80e2d0", Frameless: true}]
+              Type: 1615 EventRootType Probe[main.testStringPointer]
+              InjectionPoints: [{PC: "0x80e2e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5095,8 +5095,8 @@ Probes:
         - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1726 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x810a00", Frameless: true}]
+              Type: 1727 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0x810a10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5117,7 +5117,7 @@ Probes:
         - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 1546 EventRootType Probe[main.testStringType1]
+              Type: 1547 EventRootType Probe[main.testStringType1]
               InjectionPoints: [{PC: "0x8087c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5139,7 +5139,7 @@ Probes:
         - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testStringType2]
+              Type: 1548 EventRootType Probe[main.testStringType2]
               InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5161,12 +5161,12 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1754 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x811310", Frameless: true}]
+              Type: 1755 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x811320", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1755 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x811320", Frameless: true}]
+              Type: 1756 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0x811330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5192,8 +5192,8 @@ Probes:
         - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1723 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x8109d0", Frameless: true}]
+              Type: 1724 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0x8109e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5219,7 +5219,7 @@ Probes:
         - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testStructWithAny]
+              Type: 1578 EventRootType Probe[main.testStructWithAny]
               InjectionPoints: [{PC: "0x80c240", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5240,12 +5240,12 @@ Probes:
         - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1716 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x81041c", Frameless: false}]
+              Type: 1717 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0x81042c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1717 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x8104a0", Frameless: false}]
+              Type: 1718 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0x8104b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5266,12 +5266,12 @@ Probes:
         - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1750 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x811260", Frameless: true}]
+              Type: 1751 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0x811270", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1751 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x81126c", Frameless: true}]
+              Type: 1752 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              InjectionPoints: [{PC: "0x81127c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5291,8 +5291,8 @@ Probes:
         - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1749 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x811250", Frameless: true}]
+              Type: 1750 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0x811260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5318,8 +5318,8 @@ Probes:
         - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 1578 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x80c890", Frameless: true}]
+              Type: 1579 EventRootType Probe[main.testStructWithMap]
+              InjectionPoints: [{PC: "0x80c8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5351,8 +5351,8 @@ Probes:
         - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1732 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x810a50", Frameless: true}]
+              Type: 1733 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0x810a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5391,8 +5391,8 @@ Probes:
         - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1748 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x8110f0", Frameless: true}]
+              Type: 1749 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0x811100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5423,7 +5423,7 @@ Probes:
         - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 1551 EventRootType Probe[main.testTakeContext]
+              Type: 1552 EventRootType Probe[main.testTakeContext]
               InjectionPoints: [{PC: "0x808ce0", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
@@ -5439,12 +5439,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1655 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80edd8", Frameless: false}]
+              Type: 1656 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80ede8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1656 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ee58", Frameless: false}]
+              Type: 1657 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ee68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5464,12 +5464,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1657 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80edd8", Frameless: false}]
+              Type: 1658 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80ede8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1658 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ee58", Frameless: false}]
+              Type: 1659 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ee68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5491,12 +5491,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80edd8", Frameless: false}]
+              Type: 1660 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80ede8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1660 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80ee58", Frameless: false}]
+              Type: 1661 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80ee68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5527,8 +5527,8 @@ Probes:
         - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1736 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x811080", Frameless: true}]
+              Type: 1737 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0x811090", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5559,12 +5559,12 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1737 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x811090", Frameless: true}]
+              Type: 1738 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x8110a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1738 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x81109c", Frameless: true}]
+              Type: 1739 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0x8110ac", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5593,12 +5593,12 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1739 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x811090", Frameless: true}]
+              Type: 1740 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x8110a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1740 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x81109c", Frameless: true}]
+              Type: 1741 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0x8110ac", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5629,8 +5629,8 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1741 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x8110a0", Frameless: true}]
+              Type: 1742 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x8110b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5659,8 +5659,8 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1742 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x8110a0", Frameless: true}]
+              Type: 1743 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x8110b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5679,6 +5679,72 @@ Probes:
                   DSL: a.c
                   EventKind: Entry
                   EventExpressionIndex: 2
+    - id: testTimeFixedZone
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeFixedZone}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 166}
+          events:
+            - Kind: Entry
+              Type: 1765 EventRootType Probe[main.testTimeFixedZone]
+              InjectionPoints: [{PC: "0x811da0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeMonotonic
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeMonotonic}
+      tags: ['foo:bar']
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 167}
+          events:
+            - Kind: Entry
+              Type: 1766 EventRootType Probe[main.testTimeMonotonic]
+              InjectionPoints: [{PC: "0x811db0", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{c}'
+            Segments:
+                - JSON: {Ref: c}
+                  DSL: c
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeUTC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeUTC}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 165}
+          events:
+            - Kind: Entry
+              Type: 1764 EventRootType Probe[main.testTimeUTC]
+              InjectionPoints: [{PC: "0x811d90", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -5691,7 +5757,7 @@ Probes:
         - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 1536 EventRootType Probe[main.testTypeAlias]
+              Type: 1537 EventRootType Probe[main.testTypeAlias]
               InjectionPoints: [{PC: "0x808200", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5713,7 +5779,7 @@ Probes:
         - subprogram: {subprogram: 12}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testUint16Array]
+              Type: 1513 EventRootType Probe[main.testUint16Array]
               InjectionPoints: [{PC: "0x807d50", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5735,7 +5801,7 @@ Probes:
         - subprogram: {subprogram: 13}
           events:
             - Kind: Entry
-              Type: 1513 EventRootType Probe[main.testUint32Array]
+              Type: 1514 EventRootType Probe[main.testUint32Array]
               InjectionPoints: [{PC: "0x807d60", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5757,7 +5823,7 @@ Probes:
         - subprogram: {subprogram: 14}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testUint64Array]
+              Type: 1515 EventRootType Probe[main.testUint64Array]
               InjectionPoints: [{PC: "0x807d70", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5779,7 +5845,7 @@ Probes:
         - subprogram: {subprogram: 11}
           events:
             - Kind: Entry
-              Type: 1511 EventRootType Probe[main.testUint8Array]
+              Type: 1512 EventRootType Probe[main.testUint8Array]
               InjectionPoints: [{PC: "0x807d40", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5801,7 +5867,7 @@ Probes:
         - subprogram: {subprogram: 10}
           events:
             - Kind: Entry
-              Type: 1510 EventRootType Probe[main.testUintArray]
+              Type: 1511 EventRootType Probe[main.testUintArray]
               InjectionPoints: [{PC: "0x807d30", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5823,8 +5889,8 @@ Probes:
         - subprogram: {subprogram: 96}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x80e260", Frameless: true}]
+              Type: 1614 EventRootType Probe[main.testUintPointer]
+              InjectionPoints: [{PC: "0x80e270", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5845,8 +5911,8 @@ Probes:
         - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1720 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x8109a0", Frameless: true}]
+              Type: 1721 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0x8109b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5867,8 +5933,8 @@ Probes:
         - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1746 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x8110d0", Frameless: true}]
+              Type: 1747 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0x8110e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5889,8 +5955,8 @@ Probes:
         - subprogram: {subprogram: 95}
           events:
             - Kind: Entry
-              Type: 1612 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x80e240", Frameless: true}]
+              Type: 1613 EventRootType Probe[main.testUnsafePointer]
+              InjectionPoints: [{PC: "0x80e250", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5911,7 +5977,7 @@ Probes:
         - subprogram: {subprogram: 20}
           events:
             - Kind: Entry
-              Type: 1520 EventRootType Probe[main.testVeryLargeArray]
+              Type: 1521 EventRootType Probe[main.testVeryLargeArray]
               InjectionPoints: [{PC: "0x807de0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5933,8 +5999,8 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1729 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x810a30", Frameless: true}]
+              Type: 1730 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x810a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5955,8 +6021,8 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1730 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x810a30", Frameless: true}]
+              Type: 1731 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x810a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5974,18 +6040,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 195}
+        - subprogram: {subprogram: 198}
           events:
             - Kind: Entry
-              Type: 1827 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1831 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0x80c0a8"
                   Frameless: false
-                - PC: "0x8136f8"
+                - PC: "0x813848"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1828 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1832 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0x80c0d0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -6007,12 +6073,12 @@ Probes:
         - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1718 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x8104d8", Frameless: false}]
+              Type: 1719 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0x8104e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1719 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x810538", Frameless: false}]
+              Type: 1720 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x810548", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7110,140 +7176,127 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x80c890..0x80c8a0]
+      OutOfLinePCRanges: [0x80c8a0..0x80c8b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 172 StructureType main.structWithMap
-          Locations:
-            - Range: 0x80c890..0x80c8a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x80c8a0..0x80c8b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 178 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x80c8a0..0x80c8b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToInt
+    - ID: 65
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x80c8b0..0x80c8c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 183 GoMapType map[string]int
+          Type: 178 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x80c8b0..0x80c8c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapStringToSlice
+    - ID: 66
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x80c8c0..0x80c8d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 188 GoMapType map[string][]string
+          Type: 183 GoMapType map[string]int
           Locations:
             - Range: 0x80c8c0..0x80c8d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testMapArrayToArray
+    - ID: 67
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x80c8d0..0x80c8e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 193 GoMapType map[[4]string][2]int
+          Type: 188 GoMapType map[string][]string
           Locations:
             - Range: 0x80c8d0..0x80c8e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 69
-      Name: main.testSmallMap
+    - ID: 68
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x80c8e0..0x80c8f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 183 GoMapType map[string]int
+          Type: 193 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x80c8e0..0x80c8f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 69
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x80c8f0..0x80c900]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 183 GoMapType map[string]int
+          Locations:
+            - Range: 0x80c8f0..0x80c900
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 70
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x80c8f0..0x80c900]
+      OutOfLinePCRanges: [0x80c900..0x80c910]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x80c8f0..0x80c900
+            - Range: 0x80c900..0x80c910
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x80c900..0x80c910]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 199 PointerType *map[string]int
-          Locations:
-            - Range: 0x80c900..0x80c910
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x80c910..0x80c920]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[int]int
+          Type: 199 PointerType *map[string]int
           Locations:
             - Range: 0x80c910..0x80c920
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapMassive
+    - ID: 72
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x80c920..0x80c930]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 200 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 173 GoMapType map[int]int
           Locations:
             - Range: 0x80c920..0x80c930
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapEmbeddedMaps
+    - ID: 73
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x80c930..0x80c940]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 200 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x80c930..0x80c940
@@ -7251,38 +7304,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithLinkedList
+    - ID: 74
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x80c940..0x80c950]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 205 GoMapType map[bool]main.node
+          Type: 200 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x80c940..0x80c950
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValue
+    - ID: 75
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x80c950..0x80c960]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 210 GoMapType map[int]uint8
+          Type: 205 GoMapType map[bool]main.node
           Locations:
             - Range: 0x80c950..0x80c960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallValueMassive
+    - ID: 76
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x80c960..0x80c970]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 210 GoMapType map[int]uint8
           Locations:
             - Range: 0x80c960..0x80c970
@@ -7290,21 +7343,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 77
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x80c970..0x80c980]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 215 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 210 GoMapType map[int]uint8
           Locations:
             - Range: 0x80c970..0x80c980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x80c980..0x80c990]
       InlinePCRanges: []
       Variables:
@@ -7316,8 +7369,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeySmallValue
+    - ID: 79
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x80c990..0x80c9a0]
       InlinePCRanges: []
       Variables:
@@ -7329,127 +7382,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 80
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x80c9a0..0x80c9b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 220 GoMapType map[uint8][4]int
+          Type: 215 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x80c9a0..0x80c9b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeySmallValue
+    - ID: 81
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x80c9b0..0x80c9c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 225 GoMapType map[[4]int]uint8
+          Type: 220 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x80c9b0..0x80c9c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 82
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x80c9c0..0x80c9d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 230 GoMapType map[[4]int][4]int
+          Type: 225 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x80c9c0..0x80c9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyKey
+    - ID: 83
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x80c9d0..0x80c9e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 235 GoMapType map[struct {}]int
+          Type: 230 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x80c9d0..0x80c9e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyValue
+    - ID: 84
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x80c9e0..0x80c9f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 240 GoMapType map[int]struct {}
+          Type: 235 GoMapType map[struct {}]int
           Locations:
             - Range: 0x80c9e0..0x80c9f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 86
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 85
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x80c9f0..0x80ca00]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 245 GoMapType map[struct {}]struct {}
+          Type: 240 GoMapType map[int]struct {}
           Locations:
             - Range: 0x80c9f0..0x80ca00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 86
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x80ca00..0x80ca10]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 245 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x80ca00..0x80ca10
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 87
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x80ddc0..0x80ddd0]
+      OutOfLinePCRanges: [0x80ddd0..0x80dde0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80ddc0..0x80ddd0
+            - Range: 0x80ddd0..0x80dde0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80ddc0..0x80ddd0
+            - Range: 0x80ddd0..0x80dde0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 20 BaseType float32
           Locations:
-            - Range: 0x80ddc0..0x80ddd0
+            - Range: 0x80ddd0..0x80dde0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x80dde0..0x80ddf0]
+      OutOfLinePCRanges: [0x80ddf0..0x80de00]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80dde0..0x80ddf0
+            - Range: 0x80ddf0..0x80de00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80dde0..0x80ddf0
+            - Range: 0x80ddf0..0x80de00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7460,48 +7526,48 @@ Subprograms:
         - Name: "y"
           Type: 20 BaseType float32
           Locations:
-            - Range: 0x80dde0..0x80ddf0
+            - Range: 0x80ddf0..0x80de00
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x80dea0..0x80deb0]
+      OutOfLinePCRanges: [0x80deb0..0x80dec0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80dea0..0x80deb0
+            - Range: 0x80deb0..0x80dec0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80dea0..0x80deb0
+            - Range: 0x80deb0..0x80dec0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x80dea0..0x80deb0
+            - Range: 0x80deb0..0x80dec0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x80dea0..0x80deb0
+            - Range: 0x80deb0..0x80dec0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80dea0..0x80deb0
+            - Range: 0x80deb0..0x80dec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7512,63 +7578,63 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x80e040..0x80e080]
+      OutOfLinePCRanges: [0x80e050..0x80e090]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80e040..0x80e07c
+            - Range: 0x80e050..0x80e08c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80e040..0x80e07c
+            - Range: 0x80e050..0x80e08c
               Pieces: []
-            - Range: 0x80e07c..0x80e07d
+            - Range: 0x80e08c..0x80e08d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e07d..0x80e080
+            - Range: 0x80e08d..0x80e090
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testChannel
-      OutOfLinePCRanges: [0x80e080..0x80e090]
+      OutOfLinePCRanges: [0x80e090..0x80e0a0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 250 GoChannelType chan bool
           Locations:
-            - Range: 0x80e080..0x80e090
+            - Range: 0x80e090..0x80e0a0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x80e210..0x80e220]
+      OutOfLinePCRanges: [0x80e220..0x80e230]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x80e210..0x80e220
+            - Range: 0x80e220..0x80e230
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 93
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x80e220..0x80e230]
+      OutOfLinePCRanges: [0x80e230..0x80e240]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 StructureType main.node
           Locations:
-            - Range: 0x80e220..0x80e230
+            - Range: 0x80e230..0x80e240
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7579,267 +7645,267 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x80e230..0x80e240]
+      OutOfLinePCRanges: [0x80e240..0x80e250]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 254 PointerType *main.node
-          Locations:
-            - Range: 0x80e230..0x80e240
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x80e240..0x80e250]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 17 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x80e240..0x80e250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 95
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0x80e250..0x80e260]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 17 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x80e250..0x80e260
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 96
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x80e260..0x80e270]
+      OutOfLinePCRanges: [0x80e270..0x80e280]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 PointerType *uint
           Locations:
-            - Range: 0x80e260..0x80e270
+            - Range: 0x80e270..0x80e280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x80e2d0..0x80e2e0]
+      OutOfLinePCRanges: [0x80e2e0..0x80e2f0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 97 PointerType *string
           Locations:
-            - Range: 0x80e2d0..0x80e2e0
+            - Range: 0x80e2e0..0x80e2f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x80e2f0..0x80e300]
+      OutOfLinePCRanges: [0x80e300..0x80e310]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 13 PointerType *bool
           Locations:
-            - Range: 0x80e2f0..0x80e300
+            - Range: 0x80e300..0x80e310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x80e2f0..0x80e300
+            - Range: 0x80e300..0x80e310
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testCycle
-      OutOfLinePCRanges: [0x80e310..0x80e320]
+      OutOfLinePCRanges: [0x80e320..0x80e330]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 255 PointerType *main.t
           Locations:
-            - Range: 0x80e310..0x80e320
+            - Range: 0x80e320..0x80e330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x80e620..0x80e6a0]
+      OutOfLinePCRanges: [0x80e630..0x80e6b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e620..0x80e63c
+            - Range: 0x80e630..0x80e64c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e620..0x80e678
+            - Range: 0x80e630..0x80e688
               Pieces: []
-            - Range: 0x80e678..0x80e679
+            - Range: 0x80e688..0x80e689
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e679..0x80e6a0
+            - Range: 0x80e689..0x80e6b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e63c..0x80e648
+            - Range: 0x80e64c..0x80e658
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e648..0x80e6a0
+            - Range: 0x80e658..0x80e6b0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80e6a0..0x80e740]
+      OutOfLinePCRanges: [0x80e6b0..0x80e750]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e6a0..0x80e6c4
+            - Range: 0x80e6b0..0x80e6d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e6c4..0x80e740
+            - Range: 0x80e6d4..0x80e750
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 102 PointerType *int
           Locations:
-            - Range: 0x80e6a0..0x80e714
+            - Range: 0x80e6b0..0x80e724
               Pieces: []
-            - Range: 0x80e714..0x80e715
+            - Range: 0x80e724..0x80e725
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e715..0x80e740
+            - Range: 0x80e725..0x80e750
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 102 PointerType *int
           Locations:
-            - Range: 0x80e6c8..0x80e6e0
+            - Range: 0x80e6d8..0x80e6f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e6e0..0x80e740
+            - Range: 0x80e6f0..0x80e750
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80e740..0x80e810]
+      OutOfLinePCRanges: [0x80e750..0x80e820]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e740..0x80e794
+            - Range: 0x80e750..0x80e7a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e740..0x80e7e4
+            - Range: 0x80e750..0x80e7f4
               Pieces: []
-            - Range: 0x80e7e4..0x80e7e5
+            - Range: 0x80e7f4..0x80e7f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e7e5..0x80e810
+            - Range: 0x80e7f5..0x80e820
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80e740..0x80e810, Pieces: []}]
+          Locations: [{Range: 0x80e750..0x80e820, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e75c..0x80e798
+            - Range: 0x80e76c..0x80e7a8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e798..0x80e810
+            - Range: 0x80e7a8..0x80e820
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x80e76c..0x80e798
+            - Range: 0x80e77c..0x80e7a8
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80e798..0x80e810
+            - Range: 0x80e7a8..0x80e820
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80e810..0x80e890]
+      OutOfLinePCRanges: [0x80e820..0x80e8a0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80e810..0x80e834
+            - Range: 0x80e820..0x80e844
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x80e810..0x80e854
+            - Range: 0x80e820..0x80e864
               Pieces: []
-            - Range: 0x80e854..0x80e855
+            - Range: 0x80e864..0x80e865
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e855..0x80e868
+            - Range: 0x80e865..0x80e878
               Pieces: []
-            - Range: 0x80e868..0x80e869
+            - Range: 0x80e878..0x80e879
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e869..0x80e890
+            - Range: 0x80e879..0x80e8a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80e890..0x80ea00]
+      OutOfLinePCRanges: [0x80e8a0..0x80ea10]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 164 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80e890..0x80e8e0
+            - Range: 0x80e8a0..0x80e8f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e8e0..0x80e8e4
+            - Range: 0x80e8f0..0x80e8f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80e96c..0x80e970
+            - Range: 0x80e97c..0x80e980
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e9ac..0x80e9b0
+            - Range: 0x80e9bc..0x80e9c0
               Pieces:
                 - Size: 8
                   Op: null
@@ -7850,117 +7916,117 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80e890..0x80e8d4
+            - Range: 0x80e8a0..0x80e8e4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 164 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80e890..0x80e8fc
+            - Range: 0x80e8a0..0x80e90c
               Pieces: []
-            - Range: 0x80e8fc..0x80e8fd
+            - Range: 0x80e90c..0x80e90d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e8fd..0x80e958
+            - Range: 0x80e90d..0x80e968
               Pieces: []
-            - Range: 0x80e958..0x80e959
+            - Range: 0x80e968..0x80e969
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e959..0x80e998
+            - Range: 0x80e969..0x80e9a8
               Pieces: []
-            - Range: 0x80e998..0x80e999
+            - Range: 0x80e9a8..0x80e9a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e999..0x80e9d4
+            - Range: 0x80e9a9..0x80e9e4
               Pieces: []
-            - Range: 0x80e9d4..0x80e9d5
+            - Range: 0x80e9e4..0x80e9e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80e9d5..0x80ea00
+            - Range: 0x80e9e5..0x80ea10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x80e890..0x80e8fc
+            - Range: 0x80e8a0..0x80e90c
               Pieces: []
-            - Range: 0x80e8fc..0x80e8fd
+            - Range: 0x80e90c..0x80e90d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e8fd..0x80e958
+            - Range: 0x80e90d..0x80e968
               Pieces: []
-            - Range: 0x80e958..0x80e959
+            - Range: 0x80e968..0x80e969
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e959..0x80e998
+            - Range: 0x80e969..0x80e9a8
               Pieces: []
-            - Range: 0x80e998..0x80e999
+            - Range: 0x80e9a8..0x80e9a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e999..0x80e9d4
+            - Range: 0x80e9a9..0x80e9e4
               Pieces: []
-            - Range: 0x80e9d4..0x80e9d5
+            - Range: 0x80e9e4..0x80e9e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e9d5..0x80ea00
+            - Range: 0x80e9e5..0x80ea10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e8e0..0x80e8e8
+            - Range: 0x80e8f0..0x80e8f8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80ea00..0x80ebe0]
+      OutOfLinePCRanges: [0x80ea10..0x80ebf0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 164 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80ea00..0x80ea40
+            - Range: 0x80ea10..0x80ea50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ea40..0x80ea48
+            - Range: 0x80ea50..0x80ea58
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80ea48..0x80ebe0
+            - Range: 0x80ea58..0x80ebf0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7971,549 +8037,549 @@ Subprograms:
         - Name: ~r0
           Type: 164 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80ea00..0x80eaa0
+            - Range: 0x80ea10..0x80eab0
               Pieces: []
-            - Range: 0x80eaa0..0x80eaa1
+            - Range: 0x80eab0..0x80eab1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80eaa1..0x80eaf4
+            - Range: 0x80eab1..0x80eb04
               Pieces: []
-            - Range: 0x80eaf4..0x80eaf5
+            - Range: 0x80eb04..0x80eb05
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80eaf5..0x80eba4
+            - Range: 0x80eb05..0x80ebb4
               Pieces: []
-            - Range: 0x80eba4..0x80eba5
+            - Range: 0x80ebb4..0x80ebb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80eba5..0x80ebb8
+            - Range: 0x80ebb5..0x80ebc8
               Pieces: []
-            - Range: 0x80ebb8..0x80ebb9
+            - Range: 0x80ebc8..0x80ebc9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ebb9..0x80ebe0
+            - Range: 0x80ebc9..0x80ebf0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ea8c..0x80ea94
+            - Range: 0x80ea9c..0x80eaa4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 102 PointerType *int
           Locations:
-            - Range: 0x80ead8..0x80eaf4
+            - Range: 0x80eae8..0x80eb04
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80ebe0..0x80ed30]
+      OutOfLinePCRanges: [0x80ebf0..0x80ed40]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 164 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80ebe0..0x80ec1c
+            - Range: 0x80ebf0..0x80ec2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ec1c..0x80ec5c
+            - Range: 0x80ec2c..0x80ec6c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80ec5c..0x80ecd0
+            - Range: 0x80ec6c..0x80ece0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80ecd0..0x80ecf8
+            - Range: 0x80ece0..0x80ed08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80ecf8..0x80ecfc
+            - Range: 0x80ed08..0x80ed0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80ecfc..0x80ed30
+            - Range: 0x80ed0c..0x80ed40
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 169 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80ebe0..0x80ecb0
+            - Range: 0x80ebf0..0x80ecc0
               Pieces: []
-            - Range: 0x80ecb0..0x80ecb1
+            - Range: 0x80ecc0..0x80ecc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ecb1..0x80ecc4
+            - Range: 0x80ecc1..0x80ecd4
               Pieces: []
-            - Range: 0x80ecc4..0x80ecc5
+            - Range: 0x80ecd4..0x80ecd5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ecc5..0x80ed30
+            - Range: 0x80ecd5..0x80ed40
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 169 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80ebe0..0x80ec1c
+            - Range: 0x80ebf0..0x80ec2c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80ec1c..0x80ec5c
+            - Range: 0x80ec2c..0x80ec6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80ec5c..0x80ec64
+            - Range: 0x80ec6c..0x80ec74
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80ec64..0x80ecbc
+            - Range: 0x80ec74..0x80eccc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80ecbc..0x80ecc0
+            - Range: 0x80eccc..0x80ecd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80ecc0..0x80ecc4
+            - Range: 0x80ecd0..0x80ecd4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80ecc4..0x80ed30
+            - Range: 0x80ecd4..0x80ed40
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80ed30..0x80edc0]
+      OutOfLinePCRanges: [0x80ed40..0x80edd0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ed30..0x80ed4c
+            - Range: 0x80ed40..0x80ed5c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ed30..0x80eda0
+            - Range: 0x80ed40..0x80edb0
               Pieces: []
-            - Range: 0x80eda0..0x80eda1
+            - Range: 0x80edb0..0x80edb1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80eda1..0x80edc0
+            - Range: 0x80edb1..0x80edd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80edc0..0x80ee80]
+      OutOfLinePCRanges: [0x80edd0..0x80ee90]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80edc0..0x80ee0c
+            - Range: 0x80edd0..0x80ee1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80edc0..0x80ee58
+            - Range: 0x80edd0..0x80ee68
               Pieces: []
-            - Range: 0x80ee58..0x80ee59
+            - Range: 0x80ee68..0x80ee69
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ee59..0x80ee80
+            - Range: 0x80ee69..0x80ee90
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80edc0..0x80ee58
+            - Range: 0x80edd0..0x80ee68
               Pieces: []
-            - Range: 0x80ee58..0x80ee59
+            - Range: 0x80ee68..0x80ee69
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ee59..0x80ee80
+            - Range: 0x80ee69..0x80ee90
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80ee80..0x80ef40]
+      OutOfLinePCRanges: [0x80ee90..0x80ef50]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ee80..0x80eebc
+            - Range: 0x80ee90..0x80eecc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80eebc..0x80ef40
+            - Range: 0x80eecc..0x80ef50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ee80..0x80ef1c
+            - Range: 0x80ee90..0x80ef2c
               Pieces: []
-            - Range: 0x80ef1c..0x80ef1d
+            - Range: 0x80ef2c..0x80ef2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ef1d..0x80ef40
+            - Range: 0x80ef2d..0x80ef50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ee80..0x80ef1c
+            - Range: 0x80ee90..0x80ef2c
               Pieces: []
-            - Range: 0x80ef1c..0x80ef1d
+            - Range: 0x80ef2c..0x80ef2d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ef1d..0x80ef40
+            - Range: 0x80ef2d..0x80ef50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ee80..0x80ef1c
+            - Range: 0x80ee90..0x80ef2c
               Pieces: []
-            - Range: 0x80ef1c..0x80ef1d
+            - Range: 0x80ef2c..0x80ef2d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80ef1d..0x80ef40
+            - Range: 0x80ef2d..0x80ef50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80ef40..0x80f020]
+      OutOfLinePCRanges: [0x80ef50..0x80f030]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ef40..0x80ef7c
+            - Range: 0x80ef50..0x80ef8c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ef7c..0x80f020
+            - Range: 0x80ef8c..0x80f030
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ef40..0x80eff8
+            - Range: 0x80ef50..0x80f008
               Pieces: []
-            - Range: 0x80eff8..0x80eff9
+            - Range: 0x80f008..0x80f009
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80eff9..0x80f020
+            - Range: 0x80f009..0x80f030
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80ef40..0x80eff8
+            - Range: 0x80ef50..0x80f008
               Pieces: []
-            - Range: 0x80eff8..0x80eff9
+            - Range: 0x80f008..0x80f009
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80eff9..0x80f020
+            - Range: 0x80f009..0x80f030
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80f020..0x80f1d0]
+      OutOfLinePCRanges: [0x80f030..0x80f1e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f020..0x80f088
+            - Range: 0x80f030..0x80f098
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f088..0x80f1d0
+            - Range: 0x80f098..0x80f1e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f04c..0x80f1d0
+            - Range: 0x80f05c..0x80f1e0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f050..0x80f1d0
+            - Range: 0x80f060..0x80f1e0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80f290..0x80f320]
+      OutOfLinePCRanges: [0x80f2a0..0x80f330]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x80f290..0x80f2fc
+            - Range: 0x80f2a0..0x80f30c
               Pieces: []
-            - Range: 0x80f2fc..0x80f2fd
+            - Range: 0x80f30c..0x80f30d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f2fd..0x80f320
+            - Range: 0x80f30d..0x80f330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 98 BaseType int16
           Locations:
-            - Range: 0x80f290..0x80f2fc
+            - Range: 0x80f2a0..0x80f30c
               Pieces: []
-            - Range: 0x80f2fc..0x80f2fd
+            - Range: 0x80f30c..0x80f30d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f2fd..0x80f320
+            - Range: 0x80f30d..0x80f330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x80f290..0x80f2fc
+            - Range: 0x80f2a0..0x80f30c
               Pieces: []
-            - Range: 0x80f2fc..0x80f2fd
+            - Range: 0x80f30c..0x80f30d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f2fd..0x80f320
+            - Range: 0x80f30d..0x80f330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x80f290..0x80f2fc
+            - Range: 0x80f2a0..0x80f30c
               Pieces: []
-            - Range: 0x80f2fc..0x80f2fd
+            - Range: 0x80f30c..0x80f30d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80f2fd..0x80f320
+            - Range: 0x80f30d..0x80f330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80f290..0x80f2fc
+            - Range: 0x80f2a0..0x80f30c
               Pieces: []
-            - Range: 0x80f2fc..0x80f2fd
+            - Range: 0x80f30c..0x80f30d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80f2fd..0x80f320
+            - Range: 0x80f30d..0x80f330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x80f290..0x80f2fc
+            - Range: 0x80f2a0..0x80f30c
               Pieces: []
-            - Range: 0x80f2fc..0x80f2fd
+            - Range: 0x80f30c..0x80f30d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80f2fd..0x80f320
+            - Range: 0x80f30d..0x80f330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x80f290..0x80f2fc
+            - Range: 0x80f2a0..0x80f30c
               Pieces: []
-            - Range: 0x80f2fc..0x80f2fd
+            - Range: 0x80f30c..0x80f30d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80f2fd..0x80f320
+            - Range: 0x80f30d..0x80f330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80f290..0x80f2fc
+            - Range: 0x80f2a0..0x80f30c
               Pieces: []
-            - Range: 0x80f2fc..0x80f2fd
+            - Range: 0x80f30c..0x80f30d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80f2fd..0x80f320
+            - Range: 0x80f30d..0x80f330
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80f320..0x80f3d0]
+      OutOfLinePCRanges: [0x80f330..0x80f3e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f320..0x80f3d0, Pieces: []}]
+          Locations: [{Range: 0x80f330..0x80f3e0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x80f320..0x80f3b8
+            - Range: 0x80f330..0x80f3c8
               Pieces: []
-            - Range: 0x80f3b8..0x80f3b9
+            - Range: 0x80f3c8..0x80f3c9
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80f3b9..0x80f3d0
+            - Range: 0x80f3c9..0x80f3e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80f3d0..0x80f450]
+      OutOfLinePCRanges: [0x80f3e0..0x80f460]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 99 BaseType complex64
-          Locations: [{Range: 0x80f3d0..0x80f450, Pieces: []}]
+          Locations: [{Range: 0x80f3e0..0x80f460, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 100 BaseType complex128
-          Locations: [{Range: 0x80f3d0..0x80f450, Pieces: []}]
+          Locations: [{Range: 0x80f3e0..0x80f460, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80f450..0x80f510]
+      OutOfLinePCRanges: [0x80f460..0x80f520]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 StructureType main.largeStruct
           Locations:
-            - Range: 0x80f450..0x80f4ec
+            - Range: 0x80f460..0x80f4fc
               Pieces: []
-            - Range: 0x80f4ec..0x80f4ed
+            - Range: 0x80f4fc..0x80f4fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8535,193 +8601,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f4ed..0x80f510
+            - Range: 0x80f4fd..0x80f520
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80f510..0x80f590]
+      OutOfLinePCRanges: [0x80f520..0x80f5a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [3]int
           Locations:
-            - Range: 0x80f510..0x80f578
+            - Range: 0x80f520..0x80f588
               Pieces: []
-            - Range: 0x80f578..0x80f579
+            - Range: 0x80f588..0x80f589
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80f579..0x80f590
+            - Range: 0x80f589..0x80f5a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80f590..0x80f600]
+      OutOfLinePCRanges: [0x80f5a0..0x80f610]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [1]int
           Locations:
-            - Range: 0x80f590..0x80f5e0
+            - Range: 0x80f5a0..0x80f5f0
               Pieces: []
-            - Range: 0x80f5e0..0x80f5e1
+            - Range: 0x80f5f0..0x80f5f1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f5e1..0x80f600
+            - Range: 0x80f5f1..0x80f610
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80f600..0x80f670]
+      OutOfLinePCRanges: [0x80f610..0x80f680]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 ArrayType [0]int
           Locations:
-            - Range: 0x80f600..0x80f64c
+            - Range: 0x80f610..0x80f65c
               Pieces: []
-            - Range: 0x80f64c..0x80f64d
+            - Range: 0x80f65c..0x80f65d
               Pieces: []
-            - Range: 0x80f64d..0x80f670
+            - Range: 0x80f65d..0x80f680
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80f670..0x80f6f0]
+      OutOfLinePCRanges: [0x80f680..0x80f700]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.mixedStruct
-          Locations: [{Range: 0x80f670..0x80f6f0, Pieces: []}]
+          Locations: [{Range: 0x80f680..0x80f700, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80f6f0..0x80f780]
+      OutOfLinePCRanges: [0x80f700..0x80f790]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f6f0..0x80f768
+            - Range: 0x80f700..0x80f778
               Pieces: []
-            - Range: 0x80f768..0x80f769
+            - Range: 0x80f778..0x80f779
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80f769..0x80f780
+            - Range: 0x80f779..0x80f790
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80f780..0x80f850]
+      OutOfLinePCRanges: [0x80f790..0x80f860]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.wideStruct
           Locations:
-            - Range: 0x80f780..0x80f82c
+            - Range: 0x80f790..0x80f83c
               Pieces: []
-            - Range: 0x80f82c..0x80f82d
+            - Range: 0x80f83c..0x80f83d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8745,145 +8811,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80f82d..0x80f850
+            - Range: 0x80f83d..0x80f860
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80f850..0x80f8e0]
+      OutOfLinePCRanges: [0x80f860..0x80f8f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f850..0x80f8bc
+            - Range: 0x80f860..0x80f8cc
               Pieces: []
-            - Range: 0x80f8bc..0x80f8bd
+            - Range: 0x80f8cc..0x80f8cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f8bd..0x80f8e0
+            - Range: 0x80f8cd..0x80f8f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f850..0x80f8e0, Pieces: []}]
+          Locations: [{Range: 0x80f860..0x80f8f0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f850..0x80f8bc
+            - Range: 0x80f860..0x80f8cc
               Pieces: []
-            - Range: 0x80f8bc..0x80f8bd
+            - Range: 0x80f8cc..0x80f8cd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80f8bd..0x80f8e0
+            - Range: 0x80f8cd..0x80f8f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f850..0x80f8e0, Pieces: []}]
+          Locations: [{Range: 0x80f860..0x80f8f0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f850..0x80f8bc
+            - Range: 0x80f860..0x80f8cc
               Pieces: []
-            - Range: 0x80f8bc..0x80f8bd
+            - Range: 0x80f8cc..0x80f8cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80f8bd..0x80f8e0
+            - Range: 0x80f8cd..0x80f8f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80f8e0..0x80f960]
+      OutOfLinePCRanges: [0x80f8f0..0x80f970]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 StructureType main.structWithArray
           Locations:
-            - Range: 0x80f8e0..0x80f948
+            - Range: 0x80f8f0..0x80f958
               Pieces: []
-            - Range: 0x80f948..0x80f949
+            - Range: 0x80f958..0x80f959
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80f949..0x80f960
+            - Range: 0x80f959..0x80f970
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80f960..0x80f9d0]
+      OutOfLinePCRanges: [0x80f970..0x80f9e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f960..0x80f9d0, Pieces: []}]
+          Locations: [{Range: 0x80f970..0x80f9e0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80f9d0..0x80fa40]
+      OutOfLinePCRanges: [0x80f9e0..0x80fa50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType float32
-          Locations: [{Range: 0x80f9d0..0x80fa40, Pieces: []}]
+          Locations: [{Range: 0x80f9e0..0x80fa50, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x80f9d0..0x80fa40, Pieces: []}]
+          Locations: [{Range: 0x80f9e0..0x80fa50, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80fa40..0x80fab0]
+      OutOfLinePCRanges: [0x80fa50..0x80fac0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80fa40..0x80fa94
+            - Range: 0x80fa50..0x80faa4
               Pieces: []
-            - Range: 0x80fa94..0x80fa95
+            - Range: 0x80faa4..0x80faa5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fa95..0x80fab0
+            - Range: 0x80faa5..0x80fac0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0x80fa40..0x80fa94
+            - Range: 0x80fa50..0x80faa4
               Pieces: []
-            - Range: 0x80fa94..0x80fa95
+            - Range: 0x80faa4..0x80faa5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80fa95..0x80fab0
+            - Range: 0x80faa5..0x80fac0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80fab0..0x80fc40]
+      OutOfLinePCRanges: [0x80fac0..0x80fc50]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 StructureType main.largeStruct
           Locations:
-            - Range: 0x80fab0..0x80fb08
+            - Range: 0x80fac0..0x80fb18
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8905,7 +8971,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80fb08..0x80fb10
+            - Range: 0x80fb18..0x80fb20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8927,7 +8993,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80fb10..0x80fb18
+            - Range: 0x80fb20..0x80fb28
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8949,7 +9015,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80fb18..0x80fb1c
+            - Range: 0x80fb28..0x80fb2c
               Pieces:
                 - Size: 8
                   Op: null
@@ -8976,9 +9042,9 @@ Subprograms:
         - Name: ~r0
           Type: 257 StructureType main.largeStruct
           Locations:
-            - Range: 0x80fab0..0x80fbf8
+            - Range: 0x80fac0..0x80fc08
               Pieces: []
-            - Range: 0x80fbf8..0x80fbf9
+            - Range: 0x80fc08..0x80fc09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9000,44 +9066,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80fbf9..0x80fc40
+            - Range: 0x80fc09..0x80fc50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80fc40..0x80fd00]
+      OutOfLinePCRanges: [0x80fc50..0x80fd10]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 258 ArrayType [3]int
           Locations:
-            - Range: 0x80fc40..0x80fd00
+            - Range: 0x80fc50..0x80fd10
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 258 ArrayType [3]int
           Locations:
-            - Range: 0x80fc40..0x80fce8
+            - Range: 0x80fc50..0x80fcf8
               Pieces: []
-            - Range: 0x80fce8..0x80fce9
+            - Range: 0x80fcf8..0x80fcf9
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80fce9..0x80fd00
+            - Range: 0x80fcf9..0x80fd10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80fd00..0x80ff10]
+      OutOfLinePCRanges: [0x80fd10..0x80ff20]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 257 StructureType main.largeStruct
           Locations:
-            - Range: 0x80fd00..0x80fd5c
+            - Range: 0x80fd10..0x80fd6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9059,7 +9125,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80fd5c..0x80fd64
+            - Range: 0x80fd6c..0x80fd74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9081,7 +9147,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80fd64..0x80fd6c
+            - Range: 0x80fd74..0x80fd7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9103,7 +9169,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80fd6c..0x80fd70
+            - Range: 0x80fd7c..0x80fd80
               Pieces:
                 - Size: 8
                   Op: null
@@ -9130,16 +9196,16 @@ Subprograms:
         - Name: s2
           Type: 257 StructureType main.largeStruct
           Locations:
-            - Range: 0x80fd00..0x80ff10
+            - Range: 0x80fd10..0x80ff20
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 257 StructureType main.largeStruct
           Locations:
-            - Range: 0x80fd00..0x80fec4
+            - Range: 0x80fd10..0x80fed4
               Pieces: []
-            - Range: 0x80fec4..0x80fec5
+            - Range: 0x80fed4..0x80fed5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9161,196 +9227,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80fec5..0x80ff10
+            - Range: 0x80fed5..0x80ff20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80ff10..0x8100b0]
+      OutOfLinePCRanges: [0x80ff20..0x8100c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff84
+            - Range: 0x80ff20..0x80ff94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ff84..0x8100b0
+            - Range: 0x80ff94..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff74
+            - Range: 0x80ff20..0x80ff84
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ff74..0x8100b0
+            - Range: 0x80ff84..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff7c
+            - Range: 0x80ff20..0x80ff8c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80ff7c..0x8100b0
+            - Range: 0x80ff8c..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff84
+            - Range: 0x80ff20..0x80ff94
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80ff84..0x8100b0
+            - Range: 0x80ff94..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff84
+            - Range: 0x80ff20..0x80ff94
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80ff84..0x8100b0
+            - Range: 0x80ff94..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff84
+            - Range: 0x80ff20..0x80ff94
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80ff84..0x8100b0
+            - Range: 0x80ff94..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff84
+            - Range: 0x80ff20..0x80ff94
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80ff84..0x8100b0
+            - Range: 0x80ff94..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff84
+            - Range: 0x80ff20..0x80ff94
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80ff84..0x8100b0
+            - Range: 0x80ff94..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ff10..0x80ff84
+            - Range: 0x80ff20..0x80ff94
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80ff84..0x8100b0
+            - Range: 0x80ff94..0x8100c0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 115 ArrayType [2]int
           Locations:
-            - Range: 0x80ff10..0x81006c
+            - Range: 0x80ff20..0x81007c
               Pieces: []
-            - Range: 0x81006c..0x81006d
+            - Range: 0x81007c..0x81007d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x81006d..0x8100b0
+            - Range: 0x81007d..0x8100c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x8100b0..0x8102a0]
+      OutOfLinePCRanges: [0x8100c0..0x8102b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8100b0..0x810134
+            - Range: 0x8100c0..0x810144
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810134..0x8102a0
+            - Range: 0x810144..0x8102b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8100b0..0x810124
+            - Range: 0x8100c0..0x810134
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x810124..0x8102a0
+            - Range: 0x810134..0x8102b0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8100b0..0x81012c
+            - Range: 0x8100c0..0x81013c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x81012c..0x8102a0
+            - Range: 0x81013c..0x8102b0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8100b0..0x810134
+            - Range: 0x8100c0..0x810144
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x810134..0x8102a0
+            - Range: 0x810144..0x8102b0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8100b0..0x810134
+            - Range: 0x8100c0..0x810144
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x810134..0x8102a0
+            - Range: 0x810144..0x8102b0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8100b0..0x810134
+            - Range: 0x8100c0..0x810144
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x810134..0x8102a0
+            - Range: 0x810144..0x8102b0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8100b0..0x810134
+            - Range: 0x8100c0..0x810144
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x810134..0x8102a0
+            - Range: 0x810144..0x8102b0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8100b0..0x810134
+            - Range: 0x8100c0..0x810144
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x810134..0x8102a0
+            - Range: 0x810144..0x8102b0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8100b0..0x810134
+            - Range: 0x8100c0..0x810144
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x810134..0x8102a0
+            - Range: 0x810144..0x8102b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9361,9 +9427,9 @@ Subprograms:
         - Name: ~r0
           Type: 257 StructureType main.largeStruct
           Locations:
-            - Range: 0x8100b0..0x810258
+            - Range: 0x8100c0..0x810268
               Pieces: []
-            - Range: 0x810258..0x810259
+            - Range: 0x810268..0x810269
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9385,208 +9451,189 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x810259..0x8102a0
+            - Range: 0x810269..0x8102b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x8102a0..0x810330]
+      OutOfLinePCRanges: [0x8102b0..0x810340]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 168 ArrayType [5]int
           Locations:
-            - Range: 0x8102a0..0x810330
+            - Range: 0x8102b0..0x810340
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8102a0..0x810310
+            - Range: 0x8102b0..0x810320
               Pieces: []
-            - Range: 0x810310..0x810311
+            - Range: 0x810320..0x810321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810311..0x810330
+            - Range: 0x810321..0x810340
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8102a0..0x810310
+            - Range: 0x8102b0..0x810320
               Pieces: []
-            - Range: 0x810310..0x810311
+            - Range: 0x810320..0x810321
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x810311..0x810330
+            - Range: 0x810321..0x810340
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8102a0..0x810310
+            - Range: 0x8102b0..0x810320
               Pieces: []
-            - Range: 0x810310..0x810311
+            - Range: 0x810320..0x810321
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x810311..0x810330
+            - Range: 0x810321..0x810340
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x810330..0x810400]
+      OutOfLinePCRanges: [0x810340..0x810410]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 115 ArrayType [2]int
           Locations:
-            - Range: 0x810330..0x810400
+            - Range: 0x810340..0x810410
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 258 ArrayType [3]int
           Locations:
-            - Range: 0x810330..0x810400
+            - Range: 0x810340..0x810410
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810330..0x8103e4
+            - Range: 0x810340..0x8103f4
               Pieces: []
-            - Range: 0x8103e4..0x8103e5
+            - Range: 0x8103f4..0x8103f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8103e5..0x810400
+            - Range: 0x8103f5..0x810410
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 115 ArrayType [2]int
           Locations:
-            - Range: 0x810330..0x8103e4
+            - Range: 0x810340..0x8103f4
               Pieces: []
-            - Range: 0x8103e4..0x8103e5
+            - Range: 0x8103f4..0x8103f5
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x8103e5..0x810400
+            - Range: 0x8103f5..0x810410
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x810400..0x8104c0]
+      OutOfLinePCRanges: [0x810410..0x8104d0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 263 StructureType main.structWithArray
           Locations:
-            - Range: 0x810400..0x8104c0
+            - Range: 0x810410..0x8104d0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810400..0x8104a0
+            - Range: 0x810410..0x8104b0
               Pieces: []
-            - Range: 0x8104a0..0x8104a1
+            - Range: 0x8104b0..0x8104b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8104a1..0x8104c0
+            - Range: 0x8104b1..0x8104d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 263 StructureType main.structWithArray
           Locations:
-            - Range: 0x810400..0x8104a0
+            - Range: 0x810410..0x8104b0
               Pieces: []
-            - Range: 0x8104a0..0x8104a1
+            - Range: 0x8104b0..0x8104b1
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8104a1..0x8104c0
+            - Range: 0x8104b1..0x8104d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810478..0x8104c0
+            - Range: 0x810488..0x8104d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x8104c0..0x810560]
+      OutOfLinePCRanges: [0x8104d0..0x810570]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 260 ArrayType [0]int
-          Locations: [{Range: 0x8104c0..0x810560, Pieces: []}]
+          Locations: [{Range: 0x8104d0..0x810570, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8104c0..0x8104fc
+            - Range: 0x8104d0..0x81050c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8104fc..0x810514
+            - Range: 0x81050c..0x810524
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x810514..0x81051c
+            - Range: 0x810524..0x81052c
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x81051c..0x810560
+            - Range: 0x81052c..0x810570
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8104c0..0x810538
+            - Range: 0x8104d0..0x810548
               Pieces: []
-            - Range: 0x810538..0x810539
+            - Range: 0x810548..0x810549
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810539..0x810560
+            - Range: 0x810549..0x810570
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 260 ArrayType [0]int
           Locations:
-            - Range: 0x8104c0..0x810538
+            - Range: 0x8104d0..0x810548
               Pieces: []
-            - Range: 0x810538..0x810539
+            - Range: 0x810548..0x810549
               Pieces: []
-            - Range: 0x810539..0x810560
+            - Range: 0x810549..0x810570
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 136
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x8109a0..0x8109b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 264 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8109a0..0x8109b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x8109b0..0x8109c0]
       InlinePCRanges: []
       Variables:
@@ -9604,13 +9651,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testSliceOfSlices
+    - ID: 137
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x8109c0..0x8109d0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 265 GoSliceHeaderType [][]uint
+          Type: 264 GoSliceHeaderType []uint
           Locations:
             - Range: 0x8109c0..0x8109d0
               Pieces:
@@ -9623,13 +9670,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testStructSlice
+    - ID: 138
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x8109d0..0x8109e0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 267 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 265 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x8109d0..0x8109e0
               Pieces:
@@ -9641,16 +9688,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x8109d0..0x8109e0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testEmptySliceOfStructs
+    - ID: 139
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x8109e0..0x8109f0]
       InlinePCRanges: []
       Variables:
@@ -9675,8 +9715,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 141
-      Name: main.testNilSliceOfStructs
+    - ID: 140
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x8109f0..0x810a00]
       InlinePCRanges: []
       Variables:
@@ -9701,15 +9741,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 141
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x810a00..0x810a10]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 267 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x810a00..0x810a10
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x810a00..0x810a10
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 142
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x810a00..0x810a10]
+      OutOfLinePCRanges: [0x810a10..0x810a20]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 161 GoSliceHeaderType []string
           Locations:
-            - Range: 0x810a00..0x810a10
+            - Range: 0x810a10..0x810a20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9722,20 +9788,20 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x810a10..0x810a20]
+      OutOfLinePCRanges: [0x810a20..0x810a30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x810a10..0x810a20
+            - Range: 0x810a20..0x810a30
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 270 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x810a10..0x810a20
+            - Range: 0x810a20..0x810a30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9748,37 +9814,18 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x810a10..0x810a20
+            - Range: 0x810a20..0x810a30
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 144
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x810a20..0x810a30]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 271 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x810a20..0x810a30
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 145
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x810a30..0x810a40]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 264 GoSliceHeaderType []uint
+          Type: 271 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x810a30..0x810a40
               Pieces:
@@ -9791,13 +9838,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
-      Name: main.testSliceEmptyStructs
+    - ID: 145
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x810a40..0x810a50]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 272 GoSliceHeaderType []struct {}
+          Type: 264 GoSliceHeaderType []uint
           Locations:
             - Range: 0x810a40..0x810a50
               Pieces:
@@ -9810,15 +9857,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 146
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x810a50..0x810a60]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 272 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x810a50..0x810a60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 147
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x810a50..0x810a60]
+      OutOfLinePCRanges: [0x810a60..0x810a70]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 264 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x810a50..0x810a60
+            - Range: 0x810a60..0x810a70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9831,7 +9897,7 @@ Subprograms:
         - Name: bs
           Type: 264 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x810a50..0x810a60
+            - Range: 0x810a60..0x810a70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9844,7 +9910,7 @@ Subprograms:
         - Name: cs
           Type: 264 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x810a50..0x810a60
+            - Range: 0x810a60..0x810a70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9857,44 +9923,27 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.stackC
-      OutOfLinePCRanges: [0x811010..0x811070]
+      OutOfLinePCRanges: [0x811020..0x811080]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x811010..0x811058
+            - Range: 0x811020..0x811068
               Pieces: []
-            - Range: 0x811058..0x811059
+            - Range: 0x811068..0x811069
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811059..0x811070
+            - Range: 0x811069..0x811080
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 149
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x811070..0x811080]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x811070..0x811080
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 150
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x811080..0x811090]
       InlinePCRanges: []
       Variables:
@@ -9909,10 +9958,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 150
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0x811090..0x8110a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x811090..0x8110a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x811080..0x811090
+            - Range: 0x811090..0x8110a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9923,7 +9989,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x811080..0x811090
+            - Range: 0x811090..0x8110a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9934,13 +10000,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x811090..0x8110a0]
+      OutOfLinePCRanges: [0x8110a0..0x8110b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x811090..0x8110a0
+            - Range: 0x8110a0..0x8110b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9959,49 +10025,32 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x8110a0..0x8110b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 275 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x8110a0..0x8110b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 153
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x8110b0..0x8110c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 276 PointerType *main.oneStringStruct
+          Type: 275 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x8110b0..0x8110c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testMassiveString
+    - ID: 153
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x8110c0..0x8110d0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
+        - Name: a
+          Type: 276 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x8110c0..0x8110d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
-      Name: main.testUnitializedString
+    - ID: 154
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0x8110d0..0x8110e0]
       InlinePCRanges: []
       Variables:
@@ -10017,8 +10066,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testEmptyString
+    - ID: 155
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x8110e0..0x8110f0]
       InlinePCRanges: []
       Variables:
@@ -10034,12 +10083,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
-      Name: main.testSubstrings
+    - ID: 156
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0x8110f0..0x811100]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x8110f0..0x811100
@@ -10050,10 +10099,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 157
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x811100..0x811110]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x811100..0x811110
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8110f0..0x811100
+            - Range: 0x811100..0x811110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10064,7 +10130,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8110f0..0x811100
+            - Range: 0x811100..0x811110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10075,26 +10141,26 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x811250..0x811260]
+      OutOfLinePCRanges: [0x811260..0x811270]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x811250..0x811260
+            - Range: 0x811260..0x811270
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x811260..0x811270]
+      OutOfLinePCRanges: [0x811270..0x811280]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x811260..0x811270
+            - Range: 0x811270..0x811280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10113,13 +10179,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testStruct
-      OutOfLinePCRanges: [0x811310..0x811330]
+      OutOfLinePCRanges: [0x811320..0x811340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0x811310..0x811330
+            - Range: 0x811320..0x811340
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10140,187 +10206,244 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x8113a0..0x8113b0]
+      OutOfLinePCRanges: [0x8113b0..0x8113c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x8113a0..0x8113b0
+            - Range: 0x8113b0..0x8113c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x8113b0..0x8113c0]
+      OutOfLinePCRanges: [0x8113c0..0x8113d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 325 StructureType main.tenStrings
           Locations:
-            - Range: 0x8113b0..0x8113c0
+            - Range: 0x8113c0..0x8113d0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8113e0..0x8113f0]
+      OutOfLinePCRanges: [0x8113f0..0x811400]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 StructureType main.emptyStruct
-          Locations: [{Range: 0x8113e0..0x8113f0, Pieces: []}]
+          Locations: [{Range: 0x8113f0..0x811400, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8113f0..0x811400]
+      OutOfLinePCRanges: [0x811400..0x811410]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 327 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8113f0..0x811400
+            - Range: 0x811400..0x811410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 165
-      Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x812bc0..0x812bd0]
+      Name: main.testTimeUTC
+      OutOfLinePCRanges: [0x811d90..0x811da0]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 328 BaseType go.shape.int
+        - Name: x
+          Type: 328 GoTimeType time.Time
           Locations:
-            - Range: 0x812bc0..0x812bd0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x811d90..0x811da0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0x812bc0..0x812bc4
-              Pieces: []
-            - Range: 0x812bc4..0x812bc5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812bc5..0x812bd0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+          DictIndex: -1
+      DictRegister: null
     - ID: 166
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x812bd0..0x812be0]
+      Name: main.testTimeFixedZone
+      OutOfLinePCRanges: [0x811da0..0x811db0]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 330 GoStringHeaderType go.shape.string
+        - Name: x
+          Type: 328 GoTimeType time.Time
           Locations:
-            - Range: 0x812bd0..0x812bdc
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x812bdc..0x812be0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x812bd0..0x812bdc
-              Pieces: []
-            - Range: 0x812bdc..0x812bdd
+            - Range: 0x811da0..0x811db0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812bdd..0x812be0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 167
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x812be0..0x812bf0]
+      Name: main.testTimeMonotonic
+      OutOfLinePCRanges: [0x811db0..0x811dc0]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+        - Name: c
+          Type: 331 StructureType main.timeCapture
           Locations:
-            - Range: 0x812be0..0x812bf0
+            - Range: 0x811db0..0x811dc0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 168
+      Name: main.wrapBox[go.shape.int]
+      OutOfLinePCRanges: [0x812d10..0x812d20]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 332 BaseType go.shape.int
+          Locations:
+            - Range: 0x812d10..0x812d20
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 BaseType go.shape.int
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x812be0..0x812be4
+            - Range: 0x812d10..0x812d14
               Pieces: []
-            - Range: 0x812be4..0x812be5
+            - Range: 0x812d14..0x812d15
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812be5..0x812bf0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 168
-      Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x812bf0..0x812c00]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x812bf0..0x812bfc
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x812bfc..0x812c00
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 330 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x812bf0..0x812bfc
-              Pieces: []
-            - Range: 0x812bfc..0x812bfd
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812bfd..0x812c00
+            - Range: 0x812d15..0x812d20
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0x812d20..0x812d30]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 334 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x812d20..0x812d2c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x812d2c..0x812d30
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x812d20..0x812d2c
+              Pieces: []
+            - Range: 0x812d2c..0x812d2d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x812d2d..0x812d30
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0x812d30..0x812d40]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0x812d30..0x812d40
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 BaseType go.shape.int
+          Locations:
+            - Range: 0x812d30..0x812d34
+              Pieces: []
+            - Range: 0x812d34..0x812d35
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x812d35..0x812d40
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 171
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0x812d40..0x812d50]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x812d40..0x812d4c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x812d4c..0x812d50
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 334 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x812d40..0x812d4c
+              Pieces: []
+            - Range: 0x812d4c..0x812d4d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x812d4d..0x812d50
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x812c60..0x812d80]
+      OutOfLinePCRanges: [0x812db0..0x812ed0]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 332 GoSliceHeaderType []go.shape.int
+          Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x812c60..0x812c8c
+            - Range: 0x812db0..0x812ddc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10328,7 +10451,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x812c8c..0x812c9c
+            - Range: 0x812ddc..0x812dec
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10336,7 +10459,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x812c9c..0x812d80
+            - Range: 0x812dec..0x812ed0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10347,20 +10470,20 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 334 GoSubroutineType func(go.shape.int) bool
+          Type: 338 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x812c60..0x812c9c
+            - Range: 0x812db0..0x812dec
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x812c9c..0x812d80
+            - Range: 0x812dec..0x812ed0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 332 GoSliceHeaderType []go.shape.int
+          Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x812c60..0x812d4c
+            - Range: 0x812db0..0x812e9c
               Pieces: []
-            - Range: 0x812d4c..0x812d4d
+            - Range: 0x812e9c..0x812e9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10368,14 +10491,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x812d4d..0x812d80
+            - Range: 0x812e9d..0x812ed0
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 332 GoSliceHeaderType []go.shape.int
+          Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x812c8c..0x812c9c
+            - Range: 0x812ddc..0x812dec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10383,7 +10506,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x812c9c..0x812cb8
+            - Range: 0x812dec..0x812e08
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10391,7 +10514,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x812cb8..0x812cbc
+            - Range: 0x812e08..0x812e0c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10399,7 +10522,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x812cbc..0x812cc0
+            - Range: 0x812e0c..0x812e10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10407,7 +10530,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x812cc0..0x812cc0
+            - Range: 0x812e10..0x812e10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10415,7 +10538,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x812cc0..0x812cec
+            - Range: 0x812e10..0x812e3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10423,7 +10546,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x812cec..0x812d40
+            - Range: 0x812e3c..0x812e90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10431,7 +10554,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x812d40..0x812d80
+            - Range: 0x812e90..0x812ed0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10442,217 +10565,217 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x812cdc..0x812cec
+            - Range: 0x812e2c..0x812e3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812cec..0x812d40
+            - Range: 0x812e3c..0x812e90
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 170
+    - ID: 173
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x812d80..0x812dd0]
+      OutOfLinePCRanges: [0x812ed0..0x812f20]
       InlinePCRanges: []
       Variables:
         - Name: box
-          Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x812d80..0x812da8
+            - Range: 0x812ed0..0x812ef8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
-          Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
+          Type: 339 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x812d80..0x812da8
+            - Range: 0x812ed0..0x812ef8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x812d80..0x812da8
+            - Range: 0x812ed0..0x812ef8
               Pieces: []
-            - Range: 0x812da8..0x812da9
+            - Range: 0x812ef8..0x812ef9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812da9..0x812dd0
+            - Range: 0x812ef9..0x812f20
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x813040..0x813050]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0x813040..0x813050
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0x813040..0x813044
-              Pieces: []
-            - Range: 0x813044..0x813045
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813045..0x813050
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x813050..0x813060]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 336 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x813050..0x813060
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x813050..0x813054
-              Pieces: []
-            - Range: 0x813054..0x813055
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813055..0x813060
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 173
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x813060..0x813070]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 338 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0x813060..0x813070
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 338 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0x813060..0x813064
-              Pieces: []
-            - Range: 0x813064..0x813065
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813065..0x813070
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 174
-      Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x813070..0x813080]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0x813190..0x8131a0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 340 StructureType main.largeGenericType[go.shape.string]
+        - Name: p
+          Type: 337 PointerType *go.shape.int
           Locations:
-            - Range: 0x813070..0x813080
-              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+            - Range: 0x813190..0x8131a0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 337 PointerType *go.shape.int
           Locations:
-            - Range: 0x813070..0x813074
+            - Range: 0x813190..0x813194
               Pieces: []
-            - Range: 0x813074..0x813075
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x813075..0x813080
+            - Range: 0x813194..0x813195
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x813195..0x8131a0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
-      Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x813100..0x813110]
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x8131a0..0x8131b0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 342 StructureType main.largeGenericType[go.shape.int]
+        - Name: p
+          Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x813100..0x813110
-              Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
+            - Range: 0x8131a0..0x8131b0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 BaseType go.shape.int
+          Type: 340 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x813100..0x813104
+            - Range: 0x8131a0..0x8131a4
               Pieces: []
-            - Range: 0x813104..0x813105
+            - Range: 0x8131a4..0x8131a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813105..0x813110
+            - Range: 0x8131a5..0x8131b0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 176
-      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x8131a0..0x8131b0]
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x8131b0..0x8131c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x8131b0..0x8131c0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 342 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x8131b0..0x8131b4
+              Pieces: []
+            - Range: 0x8131b4..0x8131b5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8131b5..0x8131c0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 177
+      Name: main.largeGenericType[go.shape.string].LargeGet
+      OutOfLinePCRanges: [0x8131c0..0x8131d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Type: 344 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x8131a0..0x8131b0
+            - Range: 0x8131c0..0x8131d0
+              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 334 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x8131c0..0x8131c4
+              Pieces: []
+            - Range: 0x8131c4..0x8131c5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8131c5..0x8131d0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 178
+      Name: main.largeGenericType[go.shape.int].LargeGet
+      OutOfLinePCRanges: [0x813250..0x813260]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 346 StructureType main.largeGenericType[go.shape.int]
+          Locations:
+            - Range: 0x813250..0x813260
+              Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 332 BaseType go.shape.int
+          Locations:
+            - Range: 0x813250..0x813254
+              Pieces: []
+            - Range: 0x813254..0x813255
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x813255..0x813260
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 179
+      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
+      OutOfLinePCRanges: [0x8132f0..0x813300]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 347 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Locations:
+            - Range: 0x8132f0..0x813300
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x8131a0..0x8131b0
+            - Range: 0x8132f0..0x813300
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 345 BaseType go.shape.bool
+          Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x8131a0..0x8131b0
+            - Range: 0x8132f0..0x813300
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 177
+    - ID: 180
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x813230..0x8132a0]
+      OutOfLinePCRanges: [0x813380..0x8133f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
+          Type: 350 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x813230..0x8132a0
+            - Range: 0x813380..0x8133f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x813230..0x8132a0
+            - Range: 0x813380..0x8133f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10661,22 +10784,22 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x813230..0x8132a0
+            - Range: 0x813380..0x8133f0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 178
+    - ID: 181
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x813320..0x813330]
+      OutOfLinePCRanges: [0x813470..0x813480]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x813320..0x813330
+            - Range: 0x813470..0x813480
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10685,61 +10808,61 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 345 BaseType go.shape.bool
+          Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x813320..0x813330
+            - Range: 0x813470..0x813480
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 345 BaseType go.shape.bool
+          Type: 349 BaseType go.shape.bool
           Locations:
-            - Range: 0x813320..0x813328
+            - Range: 0x813470..0x813478
               Pieces: []
-            - Range: 0x813328..0x813329
+            - Range: 0x813478..0x813479
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813329..0x813330
+            - Range: 0x813479..0x813480
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x813320..0x813328
+            - Range: 0x813470..0x813478
               Pieces: []
-            - Range: 0x813328..0x813329
+            - Range: 0x813478..0x813479
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x813329..0x813330
+            - Range: 0x813479..0x813480
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 179
+    - ID: 182
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x813330..0x813350]
+      OutOfLinePCRanges: [0x813480..0x8134a0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x813330..0x813340
+            - Range: 0x813480..0x813490
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x813330..0x81333c
+            - Range: 0x813480..0x81348c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81333c..0x813350
+            - Range: 0x81348c..0x8134a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10748,75 +10871,75 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x813330..0x813340
+            - Range: 0x813480..0x813490
               Pieces: []
-            - Range: 0x813340..0x813341
+            - Range: 0x813490..0x813491
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x813341..0x813350
+            - Range: 0x813491..0x8134a0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x813330..0x813340
+            - Range: 0x813480..0x813490
               Pieces: []
-            - Range: 0x813340..0x813341
+            - Range: 0x813490..0x813491
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x813341..0x813350
+            - Range: 0x813491..0x8134a0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 180
+    - ID: 183
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x813350..0x8133a0]
+      OutOfLinePCRanges: [0x8134a0..0x8134f0]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 348 StructureType go.shape.struct { main.i int }
+          Type: 352 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x813350..0x813378
+            - Range: 0x8134a0..0x8134c8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x813350..0x813378
+            - Range: 0x8134a0..0x8134c8
               Pieces: []
-            - Range: 0x813378..0x813379
+            - Range: 0x8134c8..0x8134c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x813379..0x8133a0
+            - Range: 0x8134c9..0x8134f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 184
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x8133a0..0x813400]
+      OutOfLinePCRanges: [0x8134f0..0x813550]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 349 StructureType go.shape.struct { main.s string }
+          Type: 353 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x8133a0..0x8133cc
+            - Range: 0x8134f0..0x81351c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8133cc..0x8133d0
+            - Range: 0x81351c..0x813520
               Pieces:
                 - Size: 8
                   Op: null
@@ -10827,65 +10950,65 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8133a0..0x8133d0
+            - Range: 0x8134f0..0x813520
               Pieces: []
-            - Range: 0x8133d0..0x8133d1
+            - Range: 0x813520..0x813521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8133d1..0x813400
+            - Range: 0x813521..0x813550
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 182
+    - ID: 185
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x813400..0x813410]
+      OutOfLinePCRanges: [0x813550..0x813560]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 350 PointerType *go.shape.string
+          Type: 354 PointerType *go.shape.string
           Locations:
-            - Range: 0x813400..0x813404
+            - Range: 0x813550..0x813554
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x813400..0x813404
+            - Range: 0x813550..0x813554
               Pieces: []
-            - Range: 0x813404..0x813405
+            - Range: 0x813554..0x813555
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x813405..0x813410
+            - Range: 0x813555..0x813560
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 183
+    - ID: 186
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x813410..0x813460]
+      OutOfLinePCRanges: [0x813560..0x8135b0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x813410..0x81344c
+            - Range: 0x813560..0x81359c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x813410..0x813450
+            - Range: 0x813560..0x8135a0
               Pieces: []
-            - Range: 0x813450..0x813451
+            - Range: 0x8135a0..0x8135a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10899,20 +11022,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x813451..0x813460
+            - Range: 0x8135a1..0x8135b0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 184
+    - ID: 187
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x813460..0x8134a0]
+      OutOfLinePCRanges: [0x8135b0..0x8135f0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 332 GoSliceHeaderType []go.shape.int
+          Type: 336 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x813460..0x81346c
+            - Range: 0x8135b0..0x8135bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10920,7 +11043,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81346c..0x8134a0
+            - Range: 0x8135bc..0x8135f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10931,44 +11054,44 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x813460..0x8134a0
+            - Range: 0x8135b0..0x8135f0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x813460..0x813488
+            - Range: 0x8135b0..0x8135d8
               Pieces: []
-            - Range: 0x813488..0x813489
+            - Range: 0x8135d8..0x8135d9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813489..0x813490
+            - Range: 0x8135d9..0x8135e0
               Pieces: []
-            - Range: 0x813490..0x813491
+            - Range: 0x8135e0..0x8135e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813491..0x8134a0
+            - Range: 0x8135e1..0x8135f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x81347c..0x81348c
+            - Range: 0x8135cc..0x8135dc
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 185
+    - ID: 188
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x8134a0..0x813560]
+      OutOfLinePCRanges: [0x8135f0..0x8136b0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 353 GoSliceHeaderType []go.shape.string
+          Type: 357 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x8134a0..0x8134c4
+            - Range: 0x8135f0..0x813614
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10976,7 +11099,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8134c4..0x8134c8
+            - Range: 0x813614..0x813618
               Pieces:
                 - Size: 8
                   Op: null
@@ -10987,15 +11110,15 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8134a0..0x8134f8
+            - Range: 0x8135f0..0x813648
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8134f8..0x813560
+            - Range: 0x813648..0x8136b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -11006,22 +11129,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8134a0..0x813514
+            - Range: 0x8135f0..0x813664
               Pieces: []
-            - Range: 0x813514..0x813515
+            - Range: 0x813664..0x813665
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813515..0x813524
+            - Range: 0x813665..0x813674
               Pieces: []
-            - Range: 0x813524..0x813525
+            - Range: 0x813674..0x813675
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813525..0x813560
+            - Range: 0x813675..0x8136b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8134e0..0x8134f8
+            - Range: 0x813630..0x813648
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11030,58 +11153,58 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 186
+    - ID: 189
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x813560..0x813570]
+      OutOfLinePCRanges: [0x8136b0..0x8136c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 354 StructureType main.typeWithGenerics[go.shape.int]
+          Type: 358 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x813560..0x813568
+            - Range: 0x8136b0..0x8136b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
           Locations:
-            - Range: 0x813560..0x813570
+            - Range: 0x8136b0..0x8136c0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x813560..0x813568
+            - Range: 0x8136b0..0x8136b8
               Pieces: []
-            - Range: 0x813568..0x813569
+            - Range: 0x8136b8..0x8136b9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x813569..0x813570
+            - Range: 0x8136b9..0x8136c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
-    - ID: 187
+    - ID: 190
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x8135e0..0x813650]
+      OutOfLinePCRanges: [0x813730..0x8137a0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 355 StructureType main.typeWithGenerics[go.shape.string]
+          Type: 359 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x8135e0..0x81360c
+            - Range: 0x813730..0x81375c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x81360c..0x813618
+            - Range: 0x81375c..0x813768
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x813618..0x81361c
+            - Range: 0x813768..0x81376c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11090,9 +11213,9 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8135e0..0x81361c
+            - Range: 0x813730..0x81376c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11103,22 +11226,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8135e0..0x81361c
+            - Range: 0x813730..0x81376c
               Pieces: []
-            - Range: 0x81361c..0x81361d
+            - Range: 0x81376c..0x81376d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x81361d..0x813650
+            - Range: 0x81376d..0x8137a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 188
+    - ID: 191
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x806e60..0x806f80]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 356 GoSliceHeaderType []go.shape.float64
+          Type: 360 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x806e60..0x806e8c
               Pieces:
@@ -11147,7 +11270,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 359 GoSubroutineType func(go.shape.float64) bool
+          Type: 363 GoSubroutineType func(go.shape.float64) bool
           Locations:
             - Range: 0x806e60..0x806e9c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
@@ -11156,7 +11279,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 356 GoSliceHeaderType []go.shape.float64
+          Type: 360 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x806e60..0x806f4c
               Pieces: []
@@ -11173,7 +11296,7 @@ Subprograms:
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 356 GoSliceHeaderType []go.shape.float64
+          Type: 360 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x806e8c..0x806e9c
               Pieces:
@@ -11242,7 +11365,7 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 358 BaseType go.shape.float64
+          Type: 362 BaseType go.shape.float64
           Locations:
             - Range: 0x806edc..0x806eec
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
@@ -11251,7 +11374,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 189
+    - ID: 192
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x80ba90..0x80bb00]
       InlinePCRanges:
@@ -11282,7 +11405,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 193
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11290,7 +11413,7 @@ Subprograms:
           RootRanges: [0x80bcb0..0x80bd70]
       Variables: []
       DictRegister: null
-    - ID: 191
+    - ID: 194
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11298,7 +11421,7 @@ Subprograms:
           RootRanges: [0x80bde0..0x80bef0]
       Variables: []
       DictRegister: null
-    - ID: 192
+    - ID: 195
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11306,7 +11429,7 @@ Subprograms:
           RootRanges: [0x80bde0..0x80bef0]
       Variables: []
       DictRegister: null
-    - ID: 193
+    - ID: 196
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11321,7 +11444,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 194
+    - ID: 197
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11340,15 +11463,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 195
+    - ID: 198
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x80c090..0x80c0f0]
       InlinePCRanges:
-        - Ranges: [0x8136f8..0x81371c]
-          RootRanges: [0x8136d0..0x813760]
+        - Ranges: [0x813848..0x81386c]
+          RootRanges: [0x813820..0x8138b0]
       Variables:
         - Name: b
-          Type: 360 StructureType main.firstBehavior
+          Type: 364 StructureType main.firstBehavior
           Locations:
             - Range: 0x80c090..0x80c0b4
               Pieces:
@@ -11374,43 +11497,43 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 196
+    - ID: 199
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x80c830..0x80c83c, 0x80c840..0x80c848]
-          RootRanges: [0x80c7a0..0x80c890]
+          RootRanges: [0x80c7a0..0x80c8a0]
         - Ranges: [0x8069e8..0x8069ec, 0x8069f0..0x8069f8]
           RootRanges: [0x8069e0..0x806a00]
       Variables: []
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1401
+      ID: 1402
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 141
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 142 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1406
+      ID: 1407
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1407 PointerType *main.deepSlice3
+      Pointee: 1408 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1441
+      ID: 1442
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1442 PointerType *main.deepSlice8
+      Pointee: 1443 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1447
+      ID: 1448
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1448 PointerType *main.deepSlice9
+      Pointee: 1449 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 155
       Name: '**main.stringType2'
@@ -11418,7 +11541,7 @@ Types:
       GoKind: 22
       Pointee: 156 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1386
+      ID: 1397
       Name: '**main.t'
       ByteSize: 8
       Pointee: 255 PointerType *main.t
@@ -11456,40 +11579,40 @@ Types:
       ByteSize: 8
       Pointee: 209 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 380
+      ID: 384
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 381 PointerType *table<context.canceler,struct {}>
+      Pointee: 385 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 149
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 150 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1414
+      ID: 1415
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1415 PointerType *table<int,*main.deepMap3>
+      Pointee: 1416 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1458
+      ID: 1459
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1459 PointerType *table<int,*main.deepMap8>
+      Pointee: 1460 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1473
+      ID: 1474
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1474 PointerType *table<int,*main.deepMap9>
+      Pointee: 1475 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 176
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 177 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1488
+      ID: 1489
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1489 PointerType *table<int,interface {}>
+      Pointee: 1490 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 243
       Name: '**table<int,struct {}>'
@@ -11501,10 +11624,10 @@ Types:
       ByteSize: 8
       Pointee: 214 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 689 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 696 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 203
       Name: '**table<string,[]main.structWithMap>'
@@ -11516,35 +11639,35 @@ Types:
       ByteSize: 8
       Pointee: 192 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 407
+      ID: 408
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 408 PointerType *table<string,float64>
+      Pointee: 409 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1137
+      ID: 1148
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1138 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1149 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 186
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 187 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 402
+      ID: 403
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 403 PointerType *table<string,interface {}>
+      Pointee: 404 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 181
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 182 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 397
+      ID: 398
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 398 PointerType *table<string,string>
+      Pointee: 399 PointerType *table<string,string>
     - __kind: PointerType
       ID: 238
       Name: '**table<struct {},int>'
@@ -11596,150 +11719,150 @@ Types:
       ByteSize: 8
       Pointee: 219 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1404
+      ID: 1405
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1403 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1404 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 433
+      ID: 434
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 432 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 433 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1410
+      ID: 1411
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1409 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1410 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1445
+      ID: 1446
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1444 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1445 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1451
+      ID: 1452
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1450 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1451 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 428
+      ID: 429
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 427 GoSliceDataType []*runtime.p.array
+      Pointee: 428 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 430
+      ID: 431
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 429 GoSliceDataType []*string.array
+      Pointee: 430 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 593
+      ID: 594
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 592 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 593 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 591
+      ID: 592
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 590 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 591 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 589
+      ID: 590
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 588 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 589 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 587
+      ID: 588
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 586 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 587 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 585
+      ID: 586
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 584 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 585 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 573
+      ID: 574
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 572 GoSliceDataType [][]uint.array
+      Pointee: 573 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 577
+      ID: 578
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 576 GoSliceDataType []bool.array
+      Pointee: 577 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1174
+      ID: 1185
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1173 GoSliceDataType []float64.array
+      Pointee: 1184 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 683 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 690 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 691 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 648 GoSliceDataType []go.shape.float64.array
+      Pointee: 655 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 644 GoSliceDataType []go.shape.int.array
+      Pointee: 651 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 646 GoSliceDataType []go.shape.string.array
+      Pointee: 653 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
-      ID: 1454
+      ID: 1455
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1453 GoSliceDataType []interface {}.array
+      Pointee: 1454 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 282
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 583
+      ID: 584
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 582 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 583 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 693 GoSliceDataType []main.structWithMap.array
+      Pointee: 700 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 575
+      ID: 576
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 574 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 575 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11748,111 +11871,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 445
+      ID: 446
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 444 GoSliceDataType []string.array
+      Pointee: 445 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 581
+      ID: 582
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 580 GoSliceDataType []struct {}.array
+      Pointee: 581 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 1397
+      ID: 703
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 1396 GoSliceDataType []time.zone.array
+      Pointee: 702 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 1399
+      ID: 705
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 1398 GoSliceDataType []time.zoneTrans.array
+      Pointee: 704 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 266
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 264 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 571
+      ID: 572
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 570 GoSliceDataType []uint.array
+      Pointee: 571 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 579
+      ID: 580
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 578 GoSliceDataType []uint16.array
+      Pointee: 579 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 423
+      ID: 424
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 422 GoSliceDataType []uint8.array
+      Pointee: 423 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 425
+      ID: 426
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 424 GoSliceDataType []uintptr.array
+      Pointee: 425 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1304
+      ID: 1315
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1996160
       GoKind: 22
-      Pointee: 1305 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1316 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 942
+      ID: 953
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 935040
       GoKind: 22
-      Pointee: 943 GoSliceHeaderType archive/tar.headerError
+      Pointee: 954 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 945
+      ID: 956
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 944 GoSliceDataType archive/tar.headerError.array
+      Pointee: 955 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1239
+      ID: 1250
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1442752
       GoKind: 22
-      Pointee: 1240 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1251 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1187
+      ID: 1198
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 935232
       GoKind: 22
-      Pointee: 1188 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1199 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1189
+      ID: 1200
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 935328
       GoKind: 22
-      Pointee: 1190 StructureType archive/zip.dirWriter
+      Pointee: 1201 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1283
+      ID: 1294
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1914304
       GoKind: 22
-      Pointee: 1284 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1295 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1215
+      ID: 1226
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1062400
       GoKind: 22
-      Pointee: 1216 StructureType archive/zip.nopCloser
+      Pointee: 1227 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1217
+      ID: 1228
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1062656
       GoKind: 22
-      Pointee: 1218 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1229 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -11861,491 +11984,491 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1262
+      ID: 1273
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2184960
       GoKind: 22
-      Pointee: 1263 UnresolvedPointeeType bufio.Reader
+      Pointee: 1274 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1293
+      ID: 1304
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1959808
       GoKind: 22
-      Pointee: 1294 UnresolvedPointeeType bufio.Writer
+      Pointee: 1305 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1342
+      ID: 1353
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2277824
       GoKind: 22
-      Pointee: 1343 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1354 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 850
+      ID: 861
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 741 BaseType compress/flate.CorruptInputError
+      Pointee: 752 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 851
+      ID: 862
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 742 GoStringHeaderType compress/flate.InternalError
+      Pointee: 753 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 744
+      ID: 755
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 743 GoStringDataType compress/flate.InternalError.str
+      Pointee: 754 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1237
+      ID: 1248
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1432352
       GoKind: 22
-      Pointee: 1238 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1249 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1183
+      ID: 1194
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 917664
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1195 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1259
+      ID: 1270
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1736192
       GoKind: 22
-      Pointee: 1260 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1271 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1434
+      ID: 1435
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1559456
       GoKind: 22
-      Pointee: 371 StructureType context.backgroundCtx
+      Pointee: 375 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 361
+      ID: 365
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1733888
       GoKind: 22
-      Pointee: 362 StructureType context.cancelCtx
+      Pointee: 366 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1058
+      ID: 1069
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1196672
       GoKind: 22
-      Pointee: 1059 StructureType context.deadlineExceededError
+      Pointee: 1070 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1429
+      ID: 1430
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1420352
       GoKind: 22
-      Pointee: 372 StructureType context.emptyCtx
+      Pointee: 376 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 363
+      ID: 367
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1420512
       GoKind: 22
-      Pointee: 364 StructureType context.stopCtx
+      Pointee: 368 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 365
+      ID: 369
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1734080
       GoKind: 22
-      Pointee: 366 StructureType context.timerCtx
+      Pointee: 370 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1435
+      ID: 1436
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1559616
       GoKind: 22
-      Pointee: 388 StructureType context.todoCtx
+      Pointee: 389 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 367
+      ID: 371
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1559136
       GoKind: 22
-      Pointee: 368 StructureType context.valueCtx
+      Pointee: 372 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 369
+      ID: 373
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1559296
       GoKind: 22
-      Pointee: 370 StructureType context.withoutCancelCtx
+      Pointee: 374 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 934
+      ID: 945
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929664
       GoKind: 22
-      Pointee: 755 BaseType crypto/aes.KeySizeError
+      Pointee: 766 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 935
+      ID: 946
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929856
       GoKind: 22
-      Pointee: 756 BaseType crypto/des.KeySizeError
+      Pointee: 767 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 936
+      ID: 947
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930144
       GoKind: 22
-      Pointee: 757 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 768 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1254
+      ID: 1265
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1676544
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1266 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1039
+      ID: 1050
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1070208
       GoKind: 22
-      Pointee: 1040 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 1051 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1285
+      ID: 1296
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1914816
       GoKind: 22
-      Pointee: 1286 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1297 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1315
+      ID: 1326
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2130112
       GoKind: 22
-      Pointee: 1316 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1327 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1289
+      ID: 1300
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1915328
       GoKind: 22
-      Pointee: 1290 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1301 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1287
+      ID: 1298
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1915072
       GoKind: 22
-      Pointee: 1288 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1299 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1281
+      ID: 1292
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1912512
       GoKind: 22
-      Pointee: 1282 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1293 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 937
+      ID: 948
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930432
       GoKind: 22
-      Pointee: 758 BaseType crypto/rc4.KeySizeError
+      Pointee: 769 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1302
+      ID: 1313
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1993280
       GoKind: 22
-      Pointee: 1303 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1314 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1277
+      ID: 1288
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1881888
       GoKind: 22
-      Pointee: 1278 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1289 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 858
+      ID: 869
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 919200
       GoKind: 22
-      Pointee: 745 BaseType crypto/tls.AlertError
+      Pointee: 756 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1028
+      ID: 1039
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1050752
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1040 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1368
+      ID: 1379
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2389344
       GoKind: 22
-      Pointee: 1369 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1380 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 854
+      ID: 865
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 918912
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 866 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 852
+      ID: 863
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 918816
       GoKind: 22
-      Pointee: 853 StructureType crypto/tls.RecordHeaderError
+      Pointee: 864 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1027
+      ID: 1038
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1049088
       GoKind: 22
-      Pointee: 982 BaseType crypto/tls.alert
+      Pointee: 993 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1247
+      ID: 1258
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1567936
       GoKind: 22
-      Pointee: 1248 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1259 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 856
+      ID: 867
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 857 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 868 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1252
+      ID: 1263
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1651200
       GoKind: 22
-      Pointee: 1253 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1264 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1125
+      ID: 1136
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1432832
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1137 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1139
+      ID: 1150
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2052448
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1151 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 928
+      ID: 939
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 928608
       GoKind: 22
-      Pointee: 929 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 940 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 922
+      ID: 933
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 928128
       GoKind: 22
-      Pointee: 923 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 934 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 924
+      ID: 935
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 928224
       GoKind: 22
-      Pointee: 925 StructureType crypto/x509.HostnameError
+      Pointee: 936 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 921
+      ID: 932
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 928032
       GoKind: 22
-      Pointee: 754 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 765 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1033
+      ID: 1044
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1056512
       GoKind: 22
-      Pointee: 1034 StructureType crypto/x509.SystemRootsError
+      Pointee: 1045 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 930
+      ID: 941
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 928704
       GoKind: 22
-      Pointee: 931 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 942 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 926
+      ID: 937
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 928512
       GoKind: 22
-      Pointee: 927 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 938 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 946
+      ID: 957
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 935520
       GoKind: 22
-      Pointee: 947 StructureType encoding/asn1.StructuralError
+      Pointee: 958 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 950
+      ID: 961
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 935712
       GoKind: 22
-      Pointee: 951 StructureType encoding/asn1.SyntaxError
+      Pointee: 962 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 948
+      ID: 959
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 935616
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 960 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 841
+      ID: 852
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 914880
       GoKind: 22
-      Pointee: 736 BaseType encoding/base64.CorruptInputError
+      Pointee: 747 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1205
+      ID: 1216
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1045504
       GoKind: 22
-      Pointee: 1206 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1217 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 844
+      ID: 855
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 915744
       GoKind: 22
-      Pointee: 737 BaseType encoding/hex.InvalidByteError
+      Pointee: 748 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 812
+      ID: 823
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 824 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1017
+      ID: 1028
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1041664
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1029 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 804
+      ID: 815
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 909312
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 816 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 810
+      ID: 821
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 822 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 808
+      ID: 819
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 820 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 806
+      ID: 817
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 818 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1348
+      ID: 1359
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2303360
       GoKind: 22
-      Pointee: 1349 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1360 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 814
+      ID: 825
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 815 StructureType encoding/json.jsonError
+      Pointee: 826 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1213
+      ID: 1224
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1059328
       GoKind: 22
-      Pointee: 1214 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1225 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 916
+      ID: 927
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927072
       GoKind: 22
-      Pointee: 917 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 928 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 914
+      ID: 925
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 926976
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 926 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 918
+      ID: 929
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927168
       GoKind: 22
-      Pointee: 751 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 762 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 753
+      ID: 764
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 752 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 763 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 919
+      ID: 930
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 927264
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 931 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1326
+      ID: 1337
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2169952
       GoKind: 22
-      Pointee: 1327 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1338 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -12354,19 +12477,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 780
+      ID: 791
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 900384
       GoKind: 22
-      Pointee: 781 UnresolvedPointeeType errors.errorString
+      Pointee: 792 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 984
+      ID: 995
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1027456
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType errors.joinError
+      Pointee: 996 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -12382,913 +12505,913 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1336
+      ID: 1347
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2270144
       GoKind: 22
-      Pointee: 1337 UnresolvedPointeeType fmt.pp
+      Pointee: 1348 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 986
+      ID: 997
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1027584
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType fmt.wrapError
+      Pointee: 998 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 988
+      ID: 999
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1027712
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 1000 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 842
+      ID: 853
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915264
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 854 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 823
+      ID: 834
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 912480
       GoKind: 22
-      Pointee: 824 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 835 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 825
+      ID: 836
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 837 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1151
+      ID: 1162
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 912288
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1163 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 829
+      ID: 840
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 912864
       GoKind: 22
-      Pointee: 830 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 841 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1153
+      ID: 1164
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 912384
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1165 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 827
+      ID: 838
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 730 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 741 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 732
+      ID: 743
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 731 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 742 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 822
+      ID: 833
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 912192
       GoKind: 22
-      Pointee: 727 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 738 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 729
+      ID: 740
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 728 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 739 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 828
+      ID: 839
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 912768
       GoKind: 22
-      Pointee: 733 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 744 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 735
+      ID: 746
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 745 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1225
+      ID: 1236
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1213952
       GoKind: 22
-      Pointee: 1226 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1237 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1312
+      ID: 1323
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2067136
       GoKind: 22
-      Pointee: 1313 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1324 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 940
+      ID: 951
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 933984
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 952 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 389
+      ID: 390
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2288576
       GoKind: 22
-      Pointee: 390 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 391 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 415
+      ID: 416
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2017312
       GoKind: 22
-      Pointee: 416 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 417 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 410
+      ID: 411
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1196928
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 413
+      ID: 414
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1197056
       GoKind: 22
-      Pointee: 414 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1427
+      ID: 1428
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1197696
       GoKind: 22
-      Pointee: 1428 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1429 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 701
+      ID: 712
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1197824
       GoKind: 22
-      Pointee: 702 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 713 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 417
+      ID: 418
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2235456
       GoKind: 22
-      Pointee: 418 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 419 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1093
+      ID: 1104
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1217536
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1105 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1344
+      ID: 1355
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2279872
       GoKind: 22
-      Pointee: 1345 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1356 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1430
+      ID: 1431
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1426592
       GoKind: 22
-      Pointee: 1431 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 1432 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 865
+      ID: 876
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 877 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 872
+      ID: 883
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 923616
       GoKind: 22
-      Pointee: 873 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 884 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 867
+      ID: 878
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 923328
       GoKind: 22
-      Pointee: 750 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 761 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 870
+      ID: 881
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 871 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 882 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 868
+      ID: 879
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 869 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 880 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 888
+      ID: 899
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 925536
       GoKind: 22
-      Pointee: 889 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 900 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 892
+      ID: 903
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 925728
       GoKind: 22
-      Pointee: 893 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 904 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 890
+      ID: 901
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 925632
       GoKind: 22
-      Pointee: 891 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 902 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 886
+      ID: 897
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 887 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 898 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1176
+      ID: 1187
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1175 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1186 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 900
+      ID: 911
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 901 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 912 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 894
+      ID: 905
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 925824
       GoKind: 22
-      Pointee: 895 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 906 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 898
+      ID: 909
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 926016
       GoKind: 22
-      Pointee: 899 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 910 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 896
+      ID: 907
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 925920
       GoKind: 22
-      Pointee: 897 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 908 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 902
+      ID: 913
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 903 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 914 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 908
+      ID: 919
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 909 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 920 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 910
+      ID: 921
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 926592
       GoKind: 22
-      Pointee: 911 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 922 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 906
+      ID: 917
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 926400
       GoKind: 22
-      Pointee: 907 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 918 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 904
+      ID: 915
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 926304
       GoKind: 22
-      Pointee: 905 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 916 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 912
+      ID: 923
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 926784
       GoKind: 22
-      Pointee: 913 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 924 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 831
+      ID: 842
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 914016
       GoKind: 22
-      Pointee: 832 StructureType github.com/cihub/seelog.baseError
+      Pointee: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1265
+      ID: 1276
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1812448
       GoKind: 22
-      Pointee: 1266 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1277 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 833
+      ID: 844
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 914112
       GoKind: 22
-      Pointee: 834 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 845 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1245
+      ID: 1256
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1566016
       GoKind: 22
-      Pointee: 1246 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1257 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1201
+      ID: 1212
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1044352
       GoKind: 22
-      Pointee: 1202 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1213 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1235
+      ID: 1246
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1430272
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1247 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 837
+      ID: 848
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 838 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 849 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1300
+      ID: 1311
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1984928
       GoKind: 22
-      Pointee: 1301 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1312 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1319
+      ID: 1330
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2142752
       GoKind: 22
-      Pointee: 1314 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1325 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1318
+      ID: 1329
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2142368
       GoKind: 22
-      Pointee: 1317 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1328 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1203
+      ID: 1214
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1044480
       GoKind: 22
-      Pointee: 1204 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1215 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 835
+      ID: 846
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 914208
       GoKind: 22
-      Pointee: 836 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 847 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 839
+      ID: 850
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 840 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 851 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1267
+      ID: 1278
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1814240
       GoKind: 22
-      Pointee: 1268 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1279 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1308
+      ID: 1319
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2021632
       GoKind: 22
-      Pointee: 1309 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1320 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1310
+      ID: 1321
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2052128
       GoKind: 22
-      Pointee: 1311 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1322 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1127
+      ID: 1138
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1445152
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1139 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1043
+      ID: 1054
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1070976
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1055 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1041
+      ID: 1052
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1070848
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1053 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1045
+      ID: 1056
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1074944
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1057 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1047
+      ID: 1058
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1075072
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1059 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1256
+      ID: 1267
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1678848
       GoKind: 22
-      Pointee: 1257 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1268 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1035
+      ID: 1046
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1057152
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1047 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 845
+      ID: 856
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 915936
       GoKind: 22
-      Pointee: 846 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 857 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1360
+      ID: 1371
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2365792
       GoKind: 22
-      Pointee: 1361 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1372 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1101
+      ID: 1112
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1227008
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1113 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1070
+      ID: 1081
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1205120
       GoKind: 22
-      Pointee: 1071 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1082 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1064
+      ID: 1075
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1204736
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1076 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1003
+      ID: 1014
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1035904
       GoKind: 22
-      Pointee: 1004 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1015 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1076
+      ID: 1087
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1205504
       GoKind: 22
-      Pointee: 1077 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1002
+      ID: 1013
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1035776
       GoKind: 22
-      Pointee: 981 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 992 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1068
+      ID: 1079
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1204992
       GoKind: 22
-      Pointee: 1069 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1080 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1066
+      ID: 1077
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1204864
       GoKind: 22
-      Pointee: 1067 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1078 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1074
+      ID: 1085
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1205376
       GoKind: 22
-      Pointee: 1075 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1072
+      ID: 1083
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1205248
       GoKind: 22
-      Pointee: 1073 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1364
+      ID: 1375
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2378400
       GoKind: 22
-      Pointee: 1365 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1376 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1080
+      ID: 1091
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1205888
       GoKind: 22
-      Pointee: 1081 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1092 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1007
+      ID: 1018
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1036160
       GoKind: 22
-      Pointee: 1008 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1019 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1005
+      ID: 1016
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1036032
       GoKind: 22
-      Pointee: 1006 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1017 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1078
+      ID: 1089
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1205760
       GoKind: 22
-      Pointee: 1079 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 962
+      ID: 973
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 948480
       GoKind: 22
-      Pointee: 763 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 774 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 765
+      ID: 776
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 764 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 775 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 357
+      ID: 361
       Name: '*go.shape.float64'
       ByteSize: 8
       GoRuntimeType: 482080
       GoKind: 22
-      Pointee: 358 BaseType go.shape.float64
+      Pointee: 362 BaseType go.shape.float64
     - __kind: PointerType
-      ID: 333
+      ID: 337
       Name: '*go.shape.int'
       ByteSize: 8
       GoRuntimeType: 481632
       GoKind: 22
-      Pointee: 328 BaseType go.shape.int
+      Pointee: 332 BaseType go.shape.int
     - __kind: PointerType
-      ID: 350
+      ID: 354
       Name: '*go.shape.string'
       ByteSize: 8
       GoRuntimeType: 481696
       GoKind: 22
-      Pointee: 330 GoStringHeaderType go.shape.string
+      Pointee: 334 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 642 GoStringDataType go.shape.string.str
+      Pointee: 649 GoStringDataType go.shape.string.str
     - __kind: PointerType
-      ID: 336
+      ID: 340
       Name: '*go.shape.struct { Name string }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 337 StructureType go.shape.struct { Name string }
+      Pointee: 341 StructureType go.shape.struct { Name string }
     - __kind: PointerType
-      ID: 338
+      ID: 342
       Name: '*go.shape.struct { X int; Y int }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 339 StructureType go.shape.struct { X int; Y int }
+      Pointee: 343 StructureType go.shape.struct { X int; Y int }
     - __kind: PointerType
-      ID: 351
+      ID: 355
       Name: '*go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+      Pointee: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1142
+      ID: 1153
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1677312
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1154 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1051
+      ID: 1062
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1089792
       GoKind: 22
-      Pointee: 1052 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1063 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1231
+      ID: 1242
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1266944
       GoKind: 22
-      Pointee: 1232 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1243 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1324
+      ID: 1335
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2158112
       GoKind: 22
-      Pointee: 1325 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1336 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1219
+      ID: 1230
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1092096
       GoKind: 22
-      Pointee: 1220 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1231 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 963
+      ID: 974
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 949728
       GoKind: 22
-      Pointee: 766 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 777 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1109
+      ID: 1120
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1268608
       GoKind: 22
-      Pointee: 1110 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1121 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 966
+      ID: 977
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 950016
       GoKind: 22
-      Pointee: 967 StructureType golang.org/x/net/http2.connError
+      Pointee: 978 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 965
+      ID: 976
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 949920
       GoKind: 22
-      Pointee: 770 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 781 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 772
+      ID: 783
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 771 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 782 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 969
+      ID: 980
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 950208
       GoKind: 22
-      Pointee: 776 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 787 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 778
+      ID: 789
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 777 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 788 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 968
+      ID: 979
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 950112
       GoKind: 22
-      Pointee: 773 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 784 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 775
+      ID: 786
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 774 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 785 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 964
+      ID: 975
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 949824
       GoKind: 22
-      Pointee: 767 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 778 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 769
+      ID: 780
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 768 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 779 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1322
+      ID: 1333
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2156192
       GoKind: 22
-      Pointee: 1323 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1334 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 970
+      ID: 981
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 950304
       GoKind: 22
-      Pointee: 971 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 982 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 972
+      ID: 983
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 950400
       GoKind: 22
-      Pointee: 779 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 790 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 958
+      ID: 969
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 943680
       GoKind: 22
-      Pointee: 959 StructureType google.golang.org/grpc.dropError
+      Pointee: 970 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1107
+      ID: 1118
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1265664
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1119 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1129
+      ID: 1140
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1452512
       GoKind: 22
-      Pointee: 1130 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1141 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 960
+      ID: 971
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 946752
       GoKind: 22
-      Pointee: 961 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 972 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1271
+      ID: 1282
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1820064
       GoKind: 22
-      Pointee: 1272 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1283 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1229
+      ID: 1240
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1262208
       GoKind: 22
-      Pointee: 1230 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1241 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1049
+      ID: 1060
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1084032
       GoKind: 22
-      Pointee: 1050 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1061 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1191
+      ID: 1202
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 946848
       GoKind: 22
-      Pointee: 1192 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1203 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 938
+      ID: 949
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 950 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1037
+      ID: 1048
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1060736
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1049 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1105
+      ID: 1116
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1233536
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1117 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1103
+      ID: 1114
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1233280
       GoKind: 22
-      Pointee: 1104 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1115 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 952
+      ID: 963
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 936576
       GoKind: 22
-      Pointee: 953 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 964 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 954
+      ID: 965
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 936672
       GoKind: 22
-      Pointee: 955 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 966 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 880
+      ID: 891
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 892 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1279
+      ID: 1290
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1910464
       GoKind: 22
-      Pointee: 1280 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1291 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 973
+      ID: 984
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 951168
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType html/template.Error
+      Pointee: 985 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 102
       Name: '*int'
@@ -13332,127 +13455,127 @@ Types:
       GoKind: 22
       Pointee: 164 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 1131
+      ID: 1142
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2222464
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType internal/abi.Type
+      Pointee: 1143 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 932
+      ID: 943
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 929280
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 944 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 848
+      ID: 859
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 917184
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 860 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1181
+      ID: 1192
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 916320
       GoKind: 22
-      Pointee: 1182 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1193 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1099
+      ID: 1110
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1218816
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1111 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1366
+      ID: 1377
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2384064
       GoKind: 22
-      Pointee: 1367 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1378 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1097
+      ID: 1108
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1218688
       GoKind: 22
-      Pointee: 1098 StructureType internal/poll.errNetClosing
+      Pointee: 1109 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 787
+      ID: 798
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 788 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 799 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 847
+      ID: 858
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 738 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 749 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 740
+      ID: 751
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 739 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 750 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 1021
+      ID: 1032
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1047680
       GoKind: 22
-      Pointee: 1022 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 1033 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1223
+      ID: 1234
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1196416
       GoKind: 22
-      Pointee: 1224 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1235 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1221
+      ID: 1232
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1196032
       GoKind: 22
-      Pointee: 1222 StructureType io.discard
+      Pointee: 1233 StructureType io.discard
     - __kind: PointerType
-      ID: 1195
+      ID: 1206
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1028480
       GoKind: 22
-      Pointee: 1196 UnresolvedPointeeType io.multiWriter
+      Pointee: 1207 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1095
+      ID: 1106
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1218176
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1107 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1269
+      ID: 1280
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1814464
       GoKind: 22
-      Pointee: 1270 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1281 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 343
+      ID: 347
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 344 StructureType main.Pair[go.shape.int,go.shape.bool]
+      Pointee: 348 StructureType main.Pair[go.shape.int,go.shape.bool]
     - __kind: PointerType
-      ID: 346
+      ID: 350
       Name: '*main.Pair[go.shape.string,go.shape.int]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 347 StructureType main.Pair[go.shape.string,go.shape.int]
+      Pointee: 351 StructureType main.Pair[go.shape.string,go.shape.int]
     - __kind: PointerType
       ID: 323
       Name: '*main.anotherStruct'
@@ -13460,19 +13583,19 @@ Types:
       GoKind: 22
       Pointee: 324 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 440
+      ID: 441
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 388064
       GoKind: 22
-      Pointee: 441 StructureType main.deepMap2
+      Pointee: 442 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1422
+      ID: 1423
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 388000
       GoKind: 22
-      Pointee: 1423 UnresolvedPointeeType main.deepMap3
+      Pointee: 1424 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 151
       Name: '*main.deepMap7'
@@ -13481,19 +13604,19 @@ Types:
       GoKind: 22
       Pointee: 152 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1466
+      ID: 1467
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 387680
       GoKind: 22
-      Pointee: 1467 StructureType main.deepMap8
+      Pointee: 1468 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1481
+      ID: 1482
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 387616
       GoKind: 22
-      Pointee: 1482 StructureType main.deepMap9
+      Pointee: 1483 StructureType main.deepMap9
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr2'
@@ -13502,12 +13625,12 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1370
+      ID: 1381
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 388576
       GoKind: 22
-      Pointee: 1371 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1382 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 137
       Name: '*main.deepPtr7'
@@ -13516,33 +13639,33 @@ Types:
       GoKind: 22
       Pointee: 138 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1436
+      ID: 1437
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 388256
       GoKind: 22
-      Pointee: 1437 StructureType main.deepPtr8
+      Pointee: 1438 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1438
+      ID: 1439
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 388192
       GoKind: 22
-      Pointee: 1439 StructureType main.deepPtr9
+      Pointee: 1440 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 142
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 389216
       GoKind: 22
-      Pointee: 431 StructureType main.deepSlice2
+      Pointee: 432 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1407
+      ID: 1408
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 389152
       GoKind: 22
-      Pointee: 1408 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1409 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepSlice7'
@@ -13551,19 +13674,19 @@ Types:
       GoKind: 22
       Pointee: 144 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1442
+      ID: 1443
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 388832
       GoKind: 22
-      Pointee: 1443 StructureType main.deepSlice8
+      Pointee: 1444 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1448
+      ID: 1449
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 388768
       GoKind: 22
-      Pointee: 1449 StructureType main.deepSlice9
+      Pointee: 1450 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 327
       Name: '*main.emptyStruct'
@@ -13578,14 +13701,14 @@ Types:
       GoKind: 22
       Pointee: 167 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1383
+      ID: 1394
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 900096
       GoKind: 22
-      Pointee: 360 StructureType main.firstBehavior
+      Pointee: 364 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1498
+      ID: 1499
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 389600
@@ -13611,19 +13734,19 @@ Types:
       GoKind: 22
       Pointee: 160 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1384
+      ID: 1395
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 1385 StructureType main.secondBehavior
+      Pointee: 1396 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1376
+      ID: 1387
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 900288
       GoKind: 22
-      Pointee: 1377 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1388 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 153
       Name: '*main.stringType1'
@@ -13631,28 +13754,28 @@ Types:
       GoKind: 22
       Pointee: 154 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1373
+      ID: 1384
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1372 GoStringDataType main.stringType1.str
+      Pointee: 1383 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 156
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1374 GoStringHeaderType main.stringType2
+      Pointee: 1385 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1500
+      ID: 1501
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1499 GoStringDataType main.stringType2.str
+      Pointee: 1500 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 280
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 278 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 494
+      ID: 495
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 387552
@@ -13676,10 +13799,10 @@ Types:
       GoKind: 22
       Pointee: 256 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1388
+      ID: 1399
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1387 GoSliceDataType main.t.array
+      Pointee: 1398 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 275
       Name: '*main.threeStringStruct'
@@ -13707,40 +13830,40 @@ Types:
       ByteSize: 8
       Pointee: 207 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 378
+      ID: 382
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 379 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 383 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 147
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 148 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1412
+      ID: 1413
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1413 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1414 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1456
+      ID: 1457
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1457 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1458 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1471
+      ID: 1472
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1472 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1473 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 174
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 175 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1486
+      ID: 1487
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1487 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1488 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 241
       Name: '*map<int,struct {}>'
@@ -13752,10 +13875,10 @@ Types:
       ByteSize: 8
       Pointee: 212 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 686
+      ID: 693
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 687 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 694 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 201
       Name: '*map<string,[]main.structWithMap>'
@@ -13767,35 +13890,35 @@ Types:
       ByteSize: 8
       Pointee: 190 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 405
+      ID: 406
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 406 GoSwissMapHeaderType map<string,float64>
+      Pointee: 407 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1135
+      ID: 1146
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1136 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1147 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 184
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 185 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 400
+      ID: 401
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 401 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 402 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 179
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 180 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 395
+      ID: 396
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 396 GoSwissMapHeaderType map<string,string>
+      Pointee: 397 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 236
       Name: '*map<struct {},int>'
@@ -13853,728 +13976,728 @@ Types:
       GoKind: 22
       Pointee: 183 GoMapType map[string]int
     - __kind: PointerType
-      ID: 884
+      ID: 895
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 924864
       GoKind: 22
-      Pointee: 885 StructureType math/big.ErrNaN
+      Pointee: 896 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1185
+      ID: 1196
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 919680
       GoKind: 22
-      Pointee: 1186 StructureType mime/multipart.writerOnly·1
+      Pointee: 1197 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1087
+      ID: 1098
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1211776
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType net.AddrError
+      Pointee: 1099 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1118
+      ID: 1129
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1428512
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType net.DNSError
+      Pointee: 1130 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1330
+      ID: 1341
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2242336
       GoKind: 22
-      Pointee: 1331 UnresolvedPointeeType net.IPConn
+      Pointee: 1342 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1116
+      ID: 1127
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1428192
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType net.OpError
+      Pointee: 1128 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1089
+      ID: 1100
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1211904
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType net.ParseError
+      Pointee: 1101 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1340
+      ID: 1351
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2271168
       GoKind: 22
-      Pointee: 1341 UnresolvedPointeeType net.TCPConn
+      Pointee: 1352 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1350
+      ID: 1361
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2316672
       GoKind: 22
-      Pointee: 1351 UnresolvedPointeeType net.UDPConn
+      Pointee: 1362 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1338
+      ID: 1349
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2270656
       GoKind: 22
-      Pointee: 1339 UnresolvedPointeeType net.UnixConn
+      Pointee: 1350 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1086
+      ID: 1097
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1211008
       GoKind: 22
-      Pointee: 1055 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1066 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1057
+      ID: 1068
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1056 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1067 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1019
+      ID: 1030
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1042560
       GoKind: 22
-      Pointee: 1020 StructureType net.canceledError
+      Pointee: 1031 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1306
+      ID: 1317
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2019040
       GoKind: 22
-      Pointee: 1307 UnresolvedPointeeType net.conn
+      Pointee: 1318 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1160
+      ID: 1171
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1856576
       GoKind: 22
-      Pointee: 1161 StructureType net.dialResult·1
+      Pointee: 1172 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1352
+      ID: 1363
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2320928
       GoKind: 22
-      Pointee: 1353 UnresolvedPointeeType net.netFD
+      Pointee: 1364 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 816
+      ID: 827
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 911040
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType net.notFoundError
+      Pointee: 828 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1432
+      ID: 1433
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1428352
       GoKind: 22
-      Pointee: 1433 StructureType net.onlyValuesCtx
+      Pointee: 1434 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 818
+      ID: 829
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 911712
       GoKind: 22
-      Pointee: 819 StructureType net.result·2
+      Pointee: 830 StructureType net.result·2
     - __kind: PointerType
-      ID: 1334
+      ID: 1345
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2256704
       GoKind: 22
-      Pointee: 1335 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1346 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1332
+      ID: 1343
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2256224
       GoKind: 22
-      Pointee: 1333 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1344 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1091
+      ID: 1102
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1212544
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType net.temporaryError
+      Pointee: 1103 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1120
+      ID: 1131
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1428672
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType net.timeoutError
+      Pointee: 1132 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1009
+      ID: 1020
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1038592
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1021 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1177
+      ID: 1188
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 906816
       GoKind: 22
-      Pointee: 1178 StructureType net/http.bufioFlushWriter
+      Pointee: 1189 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 793
+      ID: 804
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 907488
       GoKind: 22
-      Pointee: 708 BaseType net/http.http2ConnectionError
+      Pointee: 719 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 794
+      ID: 805
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 907584
       GoKind: 22
-      Pointee: 795 StructureType net/http.http2GoAwayError
+      Pointee: 806 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1112
+      ID: 1123
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1424512
       GoKind: 22
-      Pointee: 1113 StructureType net/http.http2StreamError
+      Pointee: 1124 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 798
+      ID: 809
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 799 StructureType net/http.http2connError
+      Pointee: 810 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1241
+      ID: 1252
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1563136
       GoKind: 22
-      Pointee: 1242 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1253 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 797
+      ID: 808
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908064
       GoKind: 22
-      Pointee: 712 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 723 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 714
+      ID: 725
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 713 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 724 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 801
+      ID: 812
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 718 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 729 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 720
+      ID: 731
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 719 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 730 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 800
+      ID: 811
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 715 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 726 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 717
+      ID: 728
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 716 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 727 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1084
+      ID: 1095
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1207808
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1096 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1015
+      ID: 1026
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1039232
       GoKind: 22
-      Pointee: 1016 StructureType net/http.http2noCachedConnError
+      Pointee: 1027 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1295
+      ID: 1306
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1961088
       GoKind: 22
-      Pointee: 1296 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1307 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 796
+      ID: 807
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 907968
       GoKind: 22
-      Pointee: 709 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 720 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 711
+      ID: 722
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 710 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 721 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1179
+      ID: 1190
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 908448
       GoKind: 22
-      Pointee: 1180 StructureType net/http.http2stickyErrWriter
+      Pointee: 1191 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1011
+      ID: 1022
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1038848
       GoKind: 22
-      Pointee: 1012 StructureType net/http.nothingWrittenError
+      Pointee: 1023 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1243
+      ID: 1254
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2186208
       GoKind: 22
-      Pointee: 1244 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1255 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1199
+      ID: 1210
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1038720
       GoKind: 22
-      Pointee: 1200 StructureType net/http.persistConnWriter
+      Pointee: 1211 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1233
+      ID: 1244
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1424672
       GoKind: 22
-      Pointee: 1234 StructureType net/http.readWriteCloserBody
+      Pointee: 1245 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 802
+      ID: 813
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 908544
       GoKind: 22
-      Pointee: 803 StructureType net/http.requestBodyReadError
+      Pointee: 814 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1114
+      ID: 1125
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1425792
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1126 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1082
+      ID: 1093
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1207680
       GoKind: 22
-      Pointee: 1083 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1094 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1013
+      ID: 1024
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1038976
       GoKind: 22
-      Pointee: 1014 StructureType net/http.transportReadFromServerError
+      Pointee: 1025 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1275
+      ID: 1286
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1853440
       GoKind: 22
-      Pointee: 1276 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1287 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 791
+      ID: 802
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 906720
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 803 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1297
+      ID: 1308
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1963136
       GoKind: 22
-      Pointee: 1298 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1309 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1209
+      ID: 1220
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1051904
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1221 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 876
+      ID: 887
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 923808
       GoKind: 22
-      Pointee: 877 StructureType net/netip.parseAddrError
+      Pointee: 888 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 874
+      ID: 885
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 875 StructureType net/netip.parsePrefixError
+      Pointee: 886 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1249
+      ID: 1260
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2128704
       GoKind: 22
-      Pointee: 1250 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1261 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1211
+      ID: 1222
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1056768
       GoKind: 22
-      Pointee: 1212 StructureType net/smtp.dataCloser
+      Pointee: 1223 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 860
+      ID: 871
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 919872
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType net/textproto.Error
+      Pointee: 872 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 859
+      ID: 870
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 746 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 757 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 748
+      ID: 759
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 747 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 758 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1207
+      ID: 1218
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1051136
       GoKind: 22
-      Pointee: 1208 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1219 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1122
+      ID: 1133
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1428992
       GoKind: 22
-      Pointee: 1123 UnresolvedPointeeType net/url.Error
+      Pointee: 1134 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 820
+      ID: 831
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 721 GoStringHeaderType net/url.EscapeError
+      Pointee: 732 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 723
+      ID: 734
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 722 GoStringDataType net/url.EscapeError.str
+      Pointee: 733 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 821
+      ID: 832
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 911904
       GoKind: 22
-      Pointee: 724 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 735 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 726
+      ID: 737
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 725 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 736 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 540
+      ID: 541
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 541 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 542 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 532
+      ID: 533
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 533 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 534 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 480
+      ID: 481
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 481 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 482 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 499
+      ID: 500
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 500 StructureType noalg.map.group[bool]main.node
+      Pointee: 501 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 652
+      ID: 659
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 653 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 660 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 436
+      ID: 437
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 437 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 438 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1418
+      ID: 1419
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1419 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1420 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1462
+      ID: 1463
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1463 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1464 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1477
+      ID: 1478
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1478 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 448
+      ID: 449
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 449 StructureType noalg.map.group[int]int
+      Pointee: 450 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1492
+      ID: 1493
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1493 StructureType noalg.map.group[int]interface {}
+      Pointee: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 556
+      ID: 557
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 557 StructureType noalg.map.group[int]struct {}
+      Pointee: 558 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 507
+      ID: 508
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 508 StructureType noalg.map.group[int]uint8
+      Pointee: 509 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 697
+      ID: 708
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 698 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 489
+      ID: 490
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 490 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 491 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 472
+      ID: 473
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 473 StructureType noalg.map.group[string][]string
+      Pointee: 474 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 677
+      ID: 684
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 678 StructureType noalg.map.group[string]float64
+      Pointee: 685 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1167
+      ID: 1178
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1168 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 464
+      ID: 465
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 465 StructureType noalg.map.group[string]int
+      Pointee: 466 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 669
+      ID: 676
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 670 StructureType noalg.map.group[string]interface {}
+      Pointee: 677 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 456
+      ID: 457
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 457 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 458 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 661
+      ID: 668
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 662 StructureType noalg.map.group[string]string
+      Pointee: 669 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 548
+      ID: 549
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 549 StructureType noalg.map.group[struct {}]int
+      Pointee: 550 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 596
+      ID: 597
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 597 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 604
+      ID: 605
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 605 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 612
+      ID: 613
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 613 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 620
+      ID: 621
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 628
+      ID: 629
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 636
+      ID: 637
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 564
+      ID: 565
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 565 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 566 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 523
+      ID: 524
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 524 StructureType noalg.map.group[uint8][4]int
+      Pointee: 525 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 515
+      ID: 516
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 516 StructureType noalg.map.group[uint8]uint8
+      Pointee: 517 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1358
+      ID: 1369
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2360416
       GoKind: 22
-      Pointee: 1359 UnresolvedPointeeType os.File
+      Pointee: 1370 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 992
+      ID: 1003
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1032192
       GoKind: 22
-      Pointee: 993 UnresolvedPointeeType os.LinkError
+      Pointee: 1004 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1060
+      ID: 1071
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1200896
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType os.SyscallError
+      Pointee: 1072 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1356
+      ID: 1367
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2358944
       GoKind: 22
-      Pointee: 1357 StructureType os.fileWithoutReadFrom
+      Pointee: 1368 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1354
+      ID: 1365
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2358208
       GoKind: 22
-      Pointee: 1355 StructureType os.fileWithoutWriteTo
+      Pointee: 1366 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1023
+      ID: 1034
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1047808
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType os/exec.Error
+      Pointee: 1035 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1163
+      ID: 1174
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2099264
       GoKind: 22
-      Pointee: 1164 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1175 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1227
+      ID: 1238
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1219712
       GoKind: 22
-      Pointee: 1228 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1239 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1025
+      ID: 1036
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1047936
       GoKind: 22
-      Pointee: 1026 StructureType os/exec.wrappedError
+      Pointee: 1037 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 957
+      ID: 968
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 941760
       GoKind: 22
-      Pointee: 760 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 771 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 762
+      ID: 773
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 761 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 772 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 956
+      ID: 967
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 941664
       GoKind: 22
-      Pointee: 759 BaseType os/user.UnknownUserIdError
+      Pointee: 770 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 789
+      ID: 800
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType reflect.ValueError
+      Pointee: 801 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 882
+      ID: 893
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 894 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 996
+      ID: 1007
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1033216
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1008 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 1000
+      ID: 1011
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1035008
       GoKind: 22
-      Pointee: 1001 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1012 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14590,12 +14713,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 998
+      ID: 1009
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1033344
       GoKind: 22
-      Pointee: 999 StructureType runtime.boundsError
+      Pointee: 1010 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -14611,24 +14734,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1062
+      ID: 1073
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1203328
       GoKind: 22
-      Pointee: 1063 StructureType runtime.errorAddressString
+      Pointee: 1074 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 994
+      ID: 1005
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1032832
       GoKind: 22
-      Pointee: 975 GoStringHeaderType runtime.errorString
+      Pointee: 986 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 977
+      ID: 988
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 976 GoStringDataType runtime.errorString.str
+      Pointee: 987 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -14649,19 +14772,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1034368
       GoKind: 22
-      Pointee: 426 UnresolvedPointeeType runtime.p
+      Pointee: 427 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 995
+      ID: 1006
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1032960
       GoKind: 22
-      Pointee: 978 GoStringHeaderType runtime.plainError
+      Pointee: 989 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 980
+      ID: 991
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 979 GoStringDataType runtime.plainError.str
+      Pointee: 990 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14677,12 +14800,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 785
+      ID: 796
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 786 StructureType runtime.synctestDeadlockError
+      Pointee: 797 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -14698,12 +14821,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 990
+      ID: 1001
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1031040
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType strconv.NumError
+      Pointee: 1002 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -14712,31 +14835,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 421
+      ID: 422
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 420 GoStringDataType string.str
+      Pointee: 421 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1291
+      ID: 1302
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1959296
       GoKind: 22
-      Pointee: 1292 UnresolvedPointeeType strings.Builder
+      Pointee: 1303 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1197
+      ID: 1208
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1031168
       GoKind: 22
-      Pointee: 1198 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1209 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1193
+      ID: 1204
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 975712
       GoKind: 22
-      Pointee: 1194 StructureType struct { io.Writer }
+      Pointee: 1205 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 273
       Name: '*struct {}'
@@ -14745,233 +14868,233 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType struct {}
     - __kind: PointerType
-      ID: 1124
+      ID: 1135
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1431232
       GoKind: 22
-      Pointee: 1111 BaseType syscall.Errno
+      Pointee: 1122 BaseType syscall.Errno
     - __kind: PointerType
       ID: 234
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 538 StructureType table<[4]int,[4]int>
+      Pointee: 539 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 229
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 530 StructureType table<[4]int,uint8>
+      Pointee: 531 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 197
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 478 StructureType table<[4]string,[2]int>
+      Pointee: 479 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 209
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 497 StructureType table<bool,main.node>
+      Pointee: 498 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 381
+      ID: 385
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 650 StructureType table<context.canceler,struct {}>
+      Pointee: 657 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 150
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 434 StructureType table<int,*main.deepMap2>
+      Pointee: 435 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1415
+      ID: 1416
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1416 StructureType table<int,*main.deepMap3>
+      Pointee: 1417 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1459
+      ID: 1460
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1460 StructureType table<int,*main.deepMap8>
+      Pointee: 1461 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1474
+      ID: 1475
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1475 StructureType table<int,*main.deepMap9>
+      Pointee: 1476 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 177
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 446 StructureType table<int,int>
+      Pointee: 447 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1489
+      ID: 1490
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1490 StructureType table<int,interface {}>
+      Pointee: 1491 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 244
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 554 StructureType table<int,struct {}>
+      Pointee: 555 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 214
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 505 StructureType table<int,uint8>
+      Pointee: 506 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 695 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 706 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 204
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 487 StructureType table<string,[]main.structWithMap>
+      Pointee: 488 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 192
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 470 StructureType table<string,[]string>
+      Pointee: 471 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 408
+      ID: 409
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 675 StructureType table<string,float64>
+      Pointee: 682 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1138
+      ID: 1149
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1165 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1176 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 187
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 462 StructureType table<string,int>
+      Pointee: 463 StructureType table<string,int>
     - __kind: PointerType
-      ID: 403
+      ID: 404
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 667 StructureType table<string,interface {}>
+      Pointee: 674 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 182
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 454 StructureType table<string,main.nestedStruct>
+      Pointee: 455 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 398
+      ID: 399
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 659 StructureType table<string,string>
+      Pointee: 666 StructureType table<string,string>
     - __kind: PointerType
       ID: 239
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 546 StructureType table<struct {},int>
+      Pointee: 547 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 296
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 594 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 595 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 301
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 602 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 603 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 306
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 610 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 611 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 311
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 618 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 619 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 316
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 626 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 627 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 321
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 634 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 635 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 249
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 562 StructureType table<struct {},struct {}>
+      Pointee: 563 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 224
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 521 StructureType table<uint8,[4]int>
+      Pointee: 522 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 219
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 513 StructureType table<uint8,uint8>
+      Pointee: 514 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1328
+      ID: 1339
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2170336
       GoKind: 22
-      Pointee: 1329 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1340 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1053
+      ID: 1064
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1093632
       GoKind: 22
-      Pointee: 1054 StructureType text/template.ExecError
+      Pointee: 1065 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 386
+      ID: 329
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1626432
       GoKind: 22
-      Pointee: 387 StructureType time.Location
+      Pointee: 330 StructureType time.Location
     - __kind: PointerType
-      ID: 783
+      ID: 794
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902784
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType time.ParseError
+      Pointee: 795 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 383
+      ID: 387
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1032576
       GoKind: 22
-      Pointee: 384 StructureType time.Timer
+      Pointee: 388 StructureType time.Timer
     - __kind: PointerType
-      ID: 782
+      ID: 793
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 705 GoStringHeaderType time.fileSizeError
+      Pointee: 716 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 707
+      ID: 718
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 706 GoStringDataType time.fileSizeError.str
+      Pointee: 717 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 1391
+      ID: 644
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394784
       GoKind: 22
-      Pointee: 1392 StructureType time.zone
+      Pointee: 645 StructureType time.zone
     - __kind: PointerType
-      ID: 1394
+      ID: 647
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394848
       GoKind: 22
-      Pointee: 1395 StructureType time.zoneTrans
+      Pointee: 648 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -15015,49 +15138,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 878
+      ID: 889
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 923904
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 890 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1320
+      ID: 1331
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2145824
       GoKind: 22
-      Pointee: 1321 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1332 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 862
+      ID: 873
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 920064
       GoKind: 22
-      Pointee: 863 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 874 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 864
+      ID: 875
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 749 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 760 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1030
+      ID: 1041
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1051648
       GoKind: 22
-      Pointee: 1031 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1042 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1032
+      ID: 1043
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1051776
       GoKind: 22
-      Pointee: 983 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 994 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1389
+      ID: 1400
       Name: <-chan time.Time
       GoRuntimeType: 600128
       GoKind: 18
@@ -15070,7 +15193,7 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 1773
+      ID: 1777
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15086,10 +15209,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 356 GoSliceHeaderType []go.shape.float64
+            Type: 360 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15099,10 +15222,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 356 GoSliceHeaderType []go.shape.float64
+            Type: 360 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15112,17 +15235,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 359 GoSubroutineType func(go.shape.float64) bool
+            Type: 363 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 1, name: pred}
+                  Variable: {subprogram: 191, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1774
+      ID: 1778
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -15132,17 +15255,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 356 GoSliceHeaderType []go.shape.float64
+            Type: 360 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 2, name: ~r0}
+                  Variable: {subprogram: 191, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1771
+      ID: 1775
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15158,10 +15281,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15171,10 +15294,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15184,17 +15307,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 334 GoSubroutineType func(go.shape.int) bool
+            Type: 338 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: pred}
+                  Variable: {subprogram: 172, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1772
+      ID: 1776
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -15204,20 +15327,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 2, name: ~r0}
+                  Variable: {subprogram: 172, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1829
+      ID: 1833
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1775
+      ID: 1779
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15233,10 +15356,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15246,10 +15369,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15259,17 +15382,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
+            Type: 339 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: f}
+                  Variable: {subprogram: 173, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1776
+      ID: 1780
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15279,17 +15402,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 2, name: ~r0}
+                  Variable: {subprogram: 173, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1787
+      ID: 1791
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15308,10 +15431,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15321,10 +15444,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
+            Type: 347 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: x}
+                  Variable: {subprogram: 179, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15334,10 +15457,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15347,20 +15470,20 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 345 BaseType go.shape.bool
+            Type: 349 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 2, name: v}
+                  Variable: {subprogram: 179, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1788
+      ID: 1792
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1789
+      ID: 1793
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15379,10 +15502,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15392,10 +15515,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
+            Type: 350 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: x}
+                  Variable: {subprogram: 180, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15405,10 +15528,10 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15418,20 +15541,20 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 2, name: v}
+                  Variable: {subprogram: 180, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1790
+      ID: 1794
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1827
+      ID: 1831
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15440,17 +15563,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 360 StructureType main.firstBehavior
+            Type: 364 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 0, name: b}
+                  Variable: {subprogram: 198, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1828
+      ID: 1832
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15462,14 +15585,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 1, name: ~r0}
+                  Variable: {subprogram: 198, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1803
+      ID: 1807
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15485,10 +15608,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15498,10 +15621,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15511,17 +15634,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1807
+      ID: 1811
       Name: Probe[main.genericContains[go.shape.int]]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15537,10 +15660,10 @@ Types:
           Offset: 17
           Kind: local
           Expression:
-            Type: 332 GoSliceHeaderType []go.shape.int
+            Type: 336 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15550,17 +15673,17 @@ Types:
           Offset: 41
           Kind: local
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1804
+      ID: 1808
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15572,14 +15695,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 187, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1805
+      ID: 1809
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15595,10 +15718,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15608,10 +15731,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 353 GoSliceHeaderType []go.shape.string
+            Type: 357 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: haystack}
+                  Variable: {subprogram: 188, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15621,17 +15744,17 @@ Types:
           Offset: 57
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1808
+      ID: 1812
       Name: Probe[main.genericContains[go.shape.string]]Line
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15641,17 +15764,17 @@ Types:
           Offset: 9
           Kind: local
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1806
+      ID: 1810
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15663,14 +15786,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 2, name: ~r0}
+                  Variable: {subprogram: 188, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1799
+      ID: 1803
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15680,10 +15803,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 350 PointerType *go.shape.string
+            Type: 354 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15693,17 +15816,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 350 PointerType *go.shape.string
+            Type: 354 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1800
+      ID: 1804
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15713,17 +15836,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: ~r0}
+                  Variable: {subprogram: 185, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1801
+      ID: 1805
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15733,10 +15856,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15746,17 +15869,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 355 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1802
+      ID: 1806
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15766,17 +15889,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: ~r0}
+                  Variable: {subprogram: 186, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1795
+      ID: 1799
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15786,10 +15909,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 348 StructureType go.shape.struct { main.i int }
+            Type: 352 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15799,17 +15922,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 348 StructureType go.shape.struct { main.i int }
+            Type: 352 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1796
+      ID: 1800
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15821,14 +15944,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: ~r0}
+                  Variable: {subprogram: 183, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1797
+      ID: 1801
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15838,10 +15961,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 349 StructureType go.shape.struct { main.s string }
+            Type: 353 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15851,17 +15974,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 349 StructureType go.shape.struct { main.s string }
+            Type: 353 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1798
+      ID: 1802
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15873,14 +15996,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: ~r0}
+                  Variable: {subprogram: 184, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1777
+      ID: 1781
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15890,10 +16013,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 333 PointerType *go.shape.int
+            Type: 337 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15903,17 +16026,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 333 PointerType *go.shape.int
+            Type: 337 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1778
+      ID: 1782
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15923,17 +16046,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 333 PointerType *go.shape.int
+            Type: 337 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 174, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1779
+      ID: 1783
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15943,10 +16066,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 336 PointerType *go.shape.struct { Name string }
+            Type: 340 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15956,17 +16079,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 336 PointerType *go.shape.struct { Name string }
+            Type: 340 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1780
+      ID: 1784
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15976,17 +16099,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 PointerType *go.shape.struct { Name string }
+            Type: 340 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: ~r0}
+                  Variable: {subprogram: 175, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1781
+      ID: 1785
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15996,10 +16119,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 338 PointerType *go.shape.struct { X int; Y int }
+            Type: 342 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16009,17 +16132,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 338 PointerType *go.shape.struct { X int; Y int }
+            Type: 342 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1782
+      ID: 1786
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16029,17 +16152,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 338 PointerType *go.shape.struct { X int; Y int }
+            Type: 342 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: ~r0}
+                  Variable: {subprogram: 176, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1793
+      ID: 1797
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16055,10 +16178,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16068,10 +16191,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16081,17 +16204,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: b}
+                  Variable: {subprogram: 182, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1794
+      ID: 1798
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16107,10 +16230,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16120,17 +16243,17 @@ Types:
           Offset: 33
           Kind: return
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 3, name: ~r1}
+                  Variable: {subprogram: 182, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1791
+      ID: 1795
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -16146,10 +16269,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16159,10 +16282,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16172,17 +16295,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 345 BaseType go.shape.bool
+            Type: 349 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: b}
+                  Variable: {subprogram: 181, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1792
+      ID: 1796
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -16198,10 +16321,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 345 BaseType go.shape.bool
+            Type: 349 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
@@ -16211,17 +16334,17 @@ Types:
           Offset: 18
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 3, name: ~r1}
+                  Variable: {subprogram: 181, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1785
+      ID: 1789
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -16231,10 +16354,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 342 StructureType main.largeGenericType[go.shape.int]
+            Type: 346 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
@@ -16244,17 +16367,17 @@ Types:
           Offset: 145
           Kind: argument
           Expression:
-            Type: 342 StructureType main.largeGenericType[go.shape.int]
+            Type: 346 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1786
+      ID: 1790
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16264,17 +16387,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: ~r0}
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1783
+      ID: 1787
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -16284,10 +16407,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 340 StructureType main.largeGenericType[go.shape.string]
+            Type: 344 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
@@ -16297,17 +16420,17 @@ Types:
           Offset: 153
           Kind: argument
           Expression:
-            Type: 340 StructureType main.largeGenericType[go.shape.string]
+            Type: 344 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1784
+      ID: 1788
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16317,17 +16440,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: ~r0}
+                  Variable: {subprogram: 177, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1767
+      ID: 1771
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16337,10 +16460,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16350,17 +16473,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1768
+      ID: 1772
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16370,17 +16493,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1769
+      ID: 1773
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16390,10 +16513,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16403,17 +16526,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1770
+      ID: 1774
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16423,20 +16546,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1733
+      ID: 1734
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1734
+      ID: 1735
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16455,7 +16578,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16487,7 +16610,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16506,7 +16629,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16538,7 +16661,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16557,7 +16680,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1704
+      ID: 1705
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16589,7 +16712,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1705
+      ID: 1706
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16608,7 +16731,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16640,7 +16763,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -16672,7 +16795,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16704,7 +16827,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16736,7 +16859,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16768,7 +16891,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16800,7 +16923,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16832,7 +16955,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -16851,7 +16974,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16883,10 +17006,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16918,7 +17041,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1501
+      ID: 1502
       Name: Probe[main.testByteArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16950,7 +17073,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testChannel]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16982,7 +17105,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1602
+      ID: 1603
       Name: Probe[main.testCombinedByte]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -17040,7 +17163,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       ExprStatusArraySize: 1
@@ -17072,7 +17195,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1604
+      ID: 1605
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -17117,7 +17240,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[main.testConflictingReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17149,7 +17272,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.testConflictingReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -17181,7 +17304,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testCycle]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17213,7 +17336,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17245,7 +17368,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17277,7 +17400,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17309,7 +17432,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17341,7 +17464,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17373,7 +17496,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17405,7 +17528,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1724
+      ID: 1725
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -17463,7 +17586,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1721
+      ID: 1722
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17495,7 +17618,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1747
+      ID: 1748
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17527,7 +17650,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1762
+      ID: 1763
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17559,7 +17682,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1761
+      ID: 1762
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -17591,7 +17714,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testErrorAtLine]Line
       ByteSize: 51
       ExprStatusArraySize: 2
@@ -17662,7 +17785,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testError]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17694,7 +17817,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17726,10 +17849,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -17761,10 +17884,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17796,7 +17919,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17828,7 +17951,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1570
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17847,7 +17970,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testFrameless]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17879,7 +18002,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17898,7 +18021,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17930,10 +18053,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17965,13 +18088,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1819
+      ID: 1823
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18029,28 +18152,28 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1820
+      ID: 1824
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1821
+      ID: 1825
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1822
+      ID: 1826
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1823
+      ID: 1827
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1816
+      ID: 1820
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18062,7 +18185,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18075,14 +18198,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1813
+      ID: 1817
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -18094,14 +18217,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1814
+      ID: 1818
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -18113,14 +18236,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1815
+      ID: 1819
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18132,7 +18255,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18145,14 +18268,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1818
+      ID: 1822
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18164,7 +18287,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18177,17 +18300,17 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1817
+      ID: 1821
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1824
+      ID: 1828
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18199,7 +18322,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18212,14 +18335,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1825
+      ID: 1829
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18231,7 +18354,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18244,14 +18367,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1826
+      ID: 1830
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18263,7 +18386,7 @@ Types:
             Type: 168 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
@@ -18276,14 +18399,14 @@ Types:
             Type: 168 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -18315,7 +18438,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18347,7 +18470,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18379,7 +18502,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -18411,7 +18534,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testIntArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18443,7 +18566,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18475,7 +18598,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1702
+      ID: 1703
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -18507,7 +18630,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1703
+      ID: 1704
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18526,7 +18649,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18558,40 +18681,8 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1548
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1549
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: aPerArch
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
     - __kind: EventRootType
       ID: 1550
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -18625,7 +18716,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1708
+      ID: 1551
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: aPerArch
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1709
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -18865,7 +18988,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1709
+      ID: 1710
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18884,7 +19007,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testManyPointers]
       ByteSize: 1121
       ExprStatusArraySize: 1
@@ -18916,7 +19039,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testManyStrings]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -18948,7 +19071,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18980,7 +19103,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1589
+      ID: 1590
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19012,7 +19135,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19044,7 +19167,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19076,7 +19199,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19108,7 +19231,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19140,7 +19263,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19172,7 +19295,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19198,38 +19321,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1587
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 200 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 200 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19268,7 +19359,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1589
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 200 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 200 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1597
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19300,7 +19423,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19332,7 +19455,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19364,7 +19487,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19396,7 +19519,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19428,7 +19551,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19460,7 +19583,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19492,7 +19615,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19524,7 +19647,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19556,7 +19679,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19584,38 +19707,6 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1744
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -19652,7 +19743,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1710
+      ID: 1746
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1711
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -19892,7 +20015,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1711
+      ID: 1712
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19911,7 +20034,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1714
+      ID: 1715
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19969,7 +20092,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1715
+      ID: 1716
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20001,7 +20124,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1706
+      ID: 1707
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -20059,7 +20182,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1707
+      ID: 1708
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20078,7 +20201,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20098,6 +20221,143 @@ Types:
           DictIndex: -1
         - Name: i
           Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1650
+      Name: Probe[main.testMultipleNamedReturn]
+    - __kind: EventRootType
+      ID: 1652
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1654
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1656
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1658
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1660
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -20111,21 +20371,63 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1649
-      Name: Probe[main.testMultipleNamedReturn]
-    - __kind: EventRootType
-      ID: 1651
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: return
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1651
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -20133,57 +20435,57 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1653
-      Name: Probe[main.testMultipleNamedReturn]
+      Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result
           Offset: 17
-          Kind: template_segment
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 25
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -20191,185 +20493,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1655
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1657
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1659
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1648
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1650
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1652
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result
-          Offset: 17
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 25
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1654
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20453,7 +20576,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1656
+      ID: 1657
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20485,7 +20608,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20517,7 +20640,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20562,7 +20685,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 63
       ExprStatusArraySize: 3
@@ -20698,7 +20821,42 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1644
+      Name: Probe[main.testNamedReturn]
+    - __kind: EventRootType
+      ID: 1646
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20731,41 +20889,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1643
-      Name: Probe[main.testNamedReturn]
-    - __kind: EventRootType
-      ID: 1645
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: i
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1642
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20784,7 +20907,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20803,7 +20926,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20835,7 +20958,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1756
+      ID: 1757
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20867,7 +20990,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1757
+      ID: 1758
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20894,10 +21017,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1758
+      ID: 1759
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1759
+      ID: 1760
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20924,7 +21047,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20982,7 +21105,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1725
+      ID: 1726
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -21040,7 +21163,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1727
+      ID: 1728
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -21124,7 +21247,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1728
+      ID: 1729
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21156,7 +21279,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1743
+      ID: 1744
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21188,7 +21311,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21220,7 +21343,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21252,7 +21375,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21284,7 +21407,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       ExprStatusArraySize: 1
@@ -21342,7 +21465,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1636
+      ID: 1637
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21374,7 +21497,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21406,7 +21529,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1638
+      ID: 1639
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21425,10 +21548,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21447,10 +21570,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1684
+      ID: 1685
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1685
+      ID: 1686
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -21469,10 +21592,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21491,10 +21614,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1688
+      ID: 1689
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1689
+      ID: 1690
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -21617,10 +21740,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1700
+      ID: 1701
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1701
+      ID: 1702
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -21652,10 +21775,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21687,7 +21810,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -21719,7 +21842,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21738,7 +21861,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21757,7 +21880,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21776,7 +21899,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1631
+      ID: 1632
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21808,7 +21931,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21853,7 +21976,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21898,7 +22021,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21930,7 +22053,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21962,7 +22085,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21981,29 +22104,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.testReturnsInt]
     - __kind: EventRootType
-      ID: 1619
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1621
+      ID: 1620
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22022,7 +22126,26 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1623
+      ID: 1622
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1624
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22054,7 +22177,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22073,7 +22196,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22105,7 +22228,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22137,7 +22260,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22156,7 +22279,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22188,7 +22311,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22207,10 +22330,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -22229,10 +22352,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1674
+      ID: 1675
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -22459,10 +22582,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1686
+      ID: 1687
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1687
+      ID: 1688
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22481,10 +22604,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1692
+      ID: 1693
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1693
+      ID: 1694
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -22555,10 +22678,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1698
+      ID: 1699
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1699
+      ID: 1700
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -22590,7 +22713,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.testReturnsNamedDeferLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22648,10 +22771,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1696
+      ID: 1697
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1697
+      ID: 1698
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22670,10 +22793,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1672
+      ID: 1673
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1673
+      ID: 1674
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -22783,10 +22906,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1694
+      ID: 1695
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1695
+      ID: 1696
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22805,10 +22928,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1690
+      ID: 1691
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1691
+      ID: 1692
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -22827,7 +22950,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1502
+      ID: 1503
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22859,7 +22982,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22891,7 +23014,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22923,13 +23046,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testSingleFloat32]
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testSingleFloat64]
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22961,7 +23084,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22993,7 +23116,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23025,7 +23148,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -23083,7 +23206,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23115,7 +23238,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23147,7 +23270,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1735
+      ID: 1736
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23179,7 +23302,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -23211,7 +23334,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23243,7 +23366,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23275,7 +23398,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -23307,7 +23430,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23339,7 +23462,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1731
+      ID: 1732
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23371,7 +23494,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1722
+      ID: 1723
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23403,7 +23526,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23435,7 +23558,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23454,10 +23577,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.testSomeNamedReturn]
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23476,7 +23599,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23508,7 +23631,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23566,7 +23689,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23585,7 +23708,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23643,7 +23766,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23688,7 +23811,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1712
+      ID: 1713
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -23720,7 +23843,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1713
+      ID: 1714
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23765,7 +23888,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1503
+      ID: 1504
       Name: Probe[main.testStringArray]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23797,7 +23920,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23829,7 +23952,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1726
+      ID: 1727
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23861,7 +23984,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testStringType1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23893,7 +24016,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testStringType2]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23925,7 +24048,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1723
+      ID: 1724
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23983,7 +24106,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1578
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24015,7 +24138,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1716
+      ID: 1717
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24047,7 +24170,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1717
+      ID: 1718
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24079,7 +24202,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1750
+      ID: 1751
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24111,10 +24234,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1751
+      ID: 1752
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1749
+      ID: 1750
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -24146,7 +24269,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24178,7 +24301,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1752
+      ID: 1753
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24197,7 +24320,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1754
+      ID: 1755
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -24229,13 +24352,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1753
+      ID: 1754
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1755
+      ID: 1756
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1732
+      ID: 1733
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -24319,7 +24442,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1748
+      ID: 1749
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24403,7 +24526,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testTakeContext]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24422,7 +24545,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1760
+      ID: 1761
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -24441,7 +24564,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1741
+      ID: 1742
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24473,7 +24596,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1742
+      ID: 1743
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24530,7 +24653,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1737
+      ID: 1738
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24562,7 +24685,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1739
+      ID: 1740
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24607,13 +24730,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1738
+      ID: 1739
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1740
+      ID: 1741
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1736
+      ID: 1737
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24697,7 +24820,103 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
+      ID: 1765
+      Name: Probe[main.testTimeFixedZone]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 328 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 328 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1766
+      Name: Probe[main.testTimeMonotonic]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 331 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: c
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 331 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1764
+      Name: Probe[main.testTimeUTC]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 328 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 328 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1537
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24729,7 +24948,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24761,7 +24980,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24793,7 +25012,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24825,7 +25044,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24857,7 +25076,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testUintArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24889,7 +25108,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24921,7 +25140,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1720
+      ID: 1721
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24953,7 +25172,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1746
+      ID: 1747
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24985,7 +25204,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25017,7 +25236,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       ExprStatusArraySize: 1
@@ -25045,38 +25264,6 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1729
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 264 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 264 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -25113,7 +25300,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1718
+      ID: 1731
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 264 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 264 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1719
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25171,7 +25390,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1719
+      ID: 1720
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -25203,7 +25422,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1809
+      ID: 1813
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25219,10 +25438,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25232,10 +25451,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 354 StructureType main.typeWithGenerics[go.shape.int]
+            Type: 358 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 0, name: x}
+                  Variable: {subprogram: 189, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25245,17 +25464,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1810
+      ID: 1814
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -25267,14 +25486,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 2, name: ~r0}
+                  Variable: {subprogram: 189, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1811
+      ID: 1815
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -25290,10 +25509,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25303,10 +25522,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 355 StructureType main.typeWithGenerics[go.shape.string]
+            Type: 359 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25316,17 +25535,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1812
+      ID: 1816
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -25338,14 +25557,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 2, name: ~r0}
+                  Variable: {subprogram: 190, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1763
+      ID: 1767
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25355,10 +25574,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25368,17 +25587,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 328 BaseType go.shape.int
+            Type: 332 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1764
+      ID: 1768
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25388,17 +25607,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 333 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1765
+      ID: 1769
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25408,10 +25627,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25421,17 +25640,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 330 GoStringHeaderType go.shape.string
+            Type: 334 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1766
+      ID: 1770
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25441,10 +25660,10 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25474,7 +25693,7 @@ Types:
       HasCount: true
       Element: 95 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 341
+      ID: 345
       Name: '[16]uint8'
       ByteSize: 16
       GoRuntimeType: 683904
@@ -25695,7 +25914,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 527
+      ID: 528
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 686592
@@ -25704,7 +25923,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 484
+      ID: 485
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 686880
@@ -25730,7 +25949,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1155
+      ID: 1166
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 688416
@@ -25739,7 +25958,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1375
+      ID: 1386
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25765,7 +25984,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1400
+      ID: 1401
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 484128
@@ -25773,20 +25992,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1401 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1402 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1403 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1404 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1403
+      ID: 1404
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 140
       Name: '[]*main.deepSlice2'
@@ -25803,15 +26022,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 432 GoSliceDataType []*main.deepSlice2.array
+      Data: 433 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 432
+      ID: 433
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 142 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1405
+      ID: 1406
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 480032
@@ -25819,22 +26038,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1406 PointerType **main.deepSlice3
+          Type: 1407 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1409 GoSliceDataType []*main.deepSlice3.array
+      Data: 1410 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1409
+      ID: 1410
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1407 PointerType *main.deepSlice3
+      Element: 1408 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1440
+      ID: 1441
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 479712
@@ -25842,22 +26061,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1441 PointerType **main.deepSlice8
+          Type: 1442 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1444 GoSliceDataType []*main.deepSlice8.array
+      Data: 1445 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1444
+      ID: 1445
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1442 PointerType *main.deepSlice8
+      Element: 1443 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1446
+      ID: 1447
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 479648
@@ -25865,20 +26084,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1447 PointerType **main.deepSlice9
+          Type: 1448 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1450 GoSliceDataType []*main.deepSlice9.array
+      Data: 1451 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1450
+      ID: 1451
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1448 PointerType *main.deepSlice9
+      Element: 1449 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 64
       Name: '[]*runtime.p'
@@ -25895,9 +26114,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 427 GoSliceDataType []*runtime.p.array
+      Data: 428 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 427
+      ID: 428
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25918,201 +26137,201 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 429 GoSliceDataType []*string.array
+      Data: 430 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 429
+      ID: 430
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 97 PointerType *string
     - __kind: GoSliceDataType
-      ID: 544
+      ID: 545
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 234 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 536
+      ID: 537
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 229 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 485
+      ID: 486
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 197 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 503
+      ID: 504
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 209 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 657
+      ID: 664
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 381 PointerType *table<context.canceler,struct {}>
+      Element: 385 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 442
+      ID: 443
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 150 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1424
+      ID: 1425
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1415 PointerType *table<int,*main.deepMap3>
+      Element: 1416 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1468
+      ID: 1469
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1459 PointerType *table<int,*main.deepMap8>
+      Element: 1460 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1483
+      ID: 1484
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1474 PointerType *table<int,*main.deepMap9>
+      Element: 1475 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 452
+      ID: 453
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 177 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1496
+      ID: 1497
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1489 PointerType *table<int,interface {}>
+      Element: 1490 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 560
+      ID: 561
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 244 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 511
+      ID: 512
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 214 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 703
+      ID: 714
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 689 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 696 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 496
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 204 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 477
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 192 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 681
+      ID: 688
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 408 PointerType *table<string,float64>
+      Element: 409 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1171
+      ID: 1182
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1138 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1149 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 468
+      ID: 469
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 187 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 673
+      ID: 680
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 403 PointerType *table<string,interface {}>
+      Element: 404 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 461
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 182 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 672
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 398 PointerType *table<string,string>
+      Element: 399 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 552
+      ID: 553
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 239 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 600
+      ID: 601
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 296 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 608
+      ID: 609
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 301 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 616
+      ID: 617
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 306 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 624
+      ID: 625
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 311 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 632
+      ID: 633
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 316 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 640
+      ID: 641
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 321 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 568
+      ID: 569
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 249 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 528
+      ID: 529
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 224 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 520
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26132,9 +26351,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 592 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 593 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 592
+      ID: 593
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26154,9 +26373,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 590 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 591 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 590
+      ID: 591
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26176,9 +26395,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 588 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 589 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 588
+      ID: 589
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26198,9 +26417,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 586 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 587 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 586
+      ID: 587
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26220,9 +26439,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 584 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 585 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 584
+      ID: 585
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26242,9 +26461,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 572 GoSliceDataType [][]uint.array
+      Data: 573 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 572
+      ID: 573
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26265,15 +26484,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 576 GoSliceDataType []bool.array
+      Data: 577 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 576
+      ID: 577
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1150
+      ID: 1161
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 490400
@@ -26288,15 +26507,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1173 GoSliceDataType []float64.array
+      Data: 1184 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1173
+      ID: 1184
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 409
+      ID: 410
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 483680
@@ -26304,22 +26523,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 410 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 683 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 690 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 690
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 411 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 412
+      ID: 413
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 483872
@@ -26327,22 +26546,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 413 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 414 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 691 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 691
+      ID: 698
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 414 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 356
+      ID: 360
       Name: '[]go.shape.float64'
       ByteSize: 24
       GoRuntimeType: 486240
@@ -26350,66 +26569,66 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 357 PointerType *go.shape.float64
+          Type: 361 PointerType *go.shape.float64
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 648 GoSliceDataType []go.shape.float64.array
+      Data: 655 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 648
+      ID: 655
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 358 BaseType go.shape.float64
+      Element: 362 BaseType go.shape.float64
     - __kind: GoSliceHeaderType
-      ID: 332
+      ID: 336
       Name: '[]go.shape.int'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 333 PointerType *go.shape.int
+          Type: 337 PointerType *go.shape.int
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 644 GoSliceDataType []go.shape.int.array
+      Data: 651 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 644
+      ID: 651
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 328 BaseType go.shape.int
+      Element: 332 BaseType go.shape.int
     - __kind: GoSliceHeaderType
-      ID: 353
+      ID: 357
       Name: '[]go.shape.string'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 350 PointerType *go.shape.string
+          Type: 354 PointerType *go.shape.string
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 646 GoSliceDataType []go.shape.string.array
+      Data: 653 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 646
+      ID: 653
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 330 GoStringHeaderType go.shape.string
+      Element: 334 GoStringHeaderType go.shape.string
     - __kind: GoSliceHeaderType
-      ID: 1452
+      ID: 1453
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 490848
@@ -26424,9 +26643,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1453 GoSliceDataType []interface {}.array
+      Data: 1454 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1453
+      ID: 1454
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26446,15 +26665,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 582 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 583 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 582
+      ID: 583
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 278 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 493
+      ID: 494
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 480672
@@ -26462,16 +26681,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 494 PointerType *main.structWithMap
+          Type: 495 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 693 GoSliceDataType []main.structWithMap.array
+      Data: 700 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 693
+      ID: 700
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26491,205 +26710,205 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 574 GoSliceDataType []main.structWithNoStrings.array
+      Data: 575 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 574
+      ID: 575
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 269 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 545
+      ID: 546
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 541 StructureType noalg.map.group[[4]int][4]int
+      Element: 542 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 537
+      ID: 538
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 533 StructureType noalg.map.group[[4]int]uint8
+      Element: 534 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 487
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 481 StructureType noalg.map.group[[4]string][2]int
+      Element: 482 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 504
+      ID: 505
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 500 StructureType noalg.map.group[bool]main.node
+      Element: 501 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 658
+      ID: 665
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 653 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 660 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 444
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 437 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 438 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1425
+      ID: 1426
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1419 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1420 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1469
+      ID: 1470
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1463 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1464 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1484
+      ID: 1485
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1478 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 454
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 449 StructureType noalg.map.group[int]int
+      Element: 450 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1497
+      ID: 1498
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1493 StructureType noalg.map.group[int]interface {}
+      Element: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 561
+      ID: 562
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 557 StructureType noalg.map.group[int]struct {}
+      Element: 558 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 512
+      ID: 513
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 508 StructureType noalg.map.group[int]uint8
+      Element: 509 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 704
+      ID: 715
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 698 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 497
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 490 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 491 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 478
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 473 StructureType noalg.map.group[string][]string
+      Element: 474 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 682
+      ID: 689
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 678 StructureType noalg.map.group[string]float64
+      Element: 685 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1172
+      ID: 1183
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1168 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 470
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 465 StructureType noalg.map.group[string]int
+      Element: 466 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 674
+      ID: 681
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 670 StructureType noalg.map.group[string]interface {}
+      Element: 677 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 462
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 457 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 458 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 666
+      ID: 673
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 662 StructureType noalg.map.group[string]string
+      Element: 669 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 553
+      ID: 554
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 549 StructureType noalg.map.group[struct {}]int
+      Element: 550 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 601
+      ID: 602
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 597 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 609
+      ID: 610
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 605 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 617
+      ID: 618
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 613 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 625
+      ID: 626
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 633
+      ID: 634
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 641
+      ID: 642
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 569
+      ID: 570
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 565 StructureType noalg.map.group[struct {}]struct {}
+      Element: 566 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 530
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 524 StructureType noalg.map.group[uint8][4]int
+      Element: 525 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 521
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 516 StructureType noalg.map.group[uint8]uint8
+      Element: 517 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -26710,9 +26929,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 444 GoSliceDataType []string.array
+      Data: 445 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 444
+      ID: 445
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26732,14 +26951,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 580 GoSliceDataType []struct {}.array
+      Data: 581 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 580
+      ID: 581
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 127 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 1390
+      ID: 643
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489056
@@ -26747,22 +26966,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1391 PointerType *time.zone
+          Type: 644 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1396 GoSliceDataType []time.zone.array
+      Data: 702 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 1396
+      ID: 702
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 1392 StructureType time.zone
+      Element: 645 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 1393
+      ID: 646
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489120
@@ -26770,20 +26989,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1394 PointerType *time.zoneTrans
+          Type: 647 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1398 GoSliceDataType []time.zoneTrans.array
+      Data: 704 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 1398
+      ID: 704
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 1395 StructureType time.zoneTrans
+      Element: 648 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 264
       Name: '[]uint'
@@ -26800,9 +27019,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 570 GoSliceDataType []uint.array
+      Data: 571 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 570
+      ID: 571
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26823,9 +27042,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 578 GoSliceDataType []uint16.array
+      Data: 579 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 578
+      ID: 579
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26846,9 +27065,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 422 GoSliceDataType []uint8.array
+      Data: 423 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 422
+      ID: 423
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26869,19 +27088,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 424 GoSliceDataType []uintptr.array
+      Data: 425 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 424
+      ID: 425
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1305
+      ID: 1316
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 943
+      ID: 954
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 935136
@@ -26896,33 +27115,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 944 GoSliceDataType archive/tar.headerError.array
+      Data: 955 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 944
+      ID: 955
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1240
+      ID: 1251
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1188
+      ID: 1199
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1190
+      ID: 1201
       Name: archive/zip.dirWriter
       GoRuntimeType: 1125824
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1284
+      ID: 1295
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1216
+      ID: 1227
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1573856
@@ -26932,7 +27151,7 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1218
+      ID: 1229
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26942,15 +27161,15 @@ Types:
       GoRuntimeType: 588096
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1263
+      ID: 1274
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1294
+      ID: 1305
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1343
+      ID: 1354
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -26976,13 +27195,13 @@ Types:
       GoRuntimeType: 587840
       GoKind: 15
     - __kind: BaseType
-      ID: 741
+      ID: 752
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 838112
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 742
+      ID: 753
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 838208
@@ -26990,26 +27209,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 744 PointerType *compress/flate.InternalError.str
+          Type: 755 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 743 GoStringDataType compress/flate.InternalError.str
+      Data: 754 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 743
+      ID: 754
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1238
+      ID: 1249
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1195
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1260
+      ID: 1271
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27026,19 +27245,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 371
+      ID: 375
       Name: context.backgroundCtx
       GoRuntimeType: 1808640
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 372 StructureType context.emptyCtx
+          Type: 376 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 362
+      ID: 366
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1975424
@@ -27049,23 +27268,23 @@ Types:
           Type: 157 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 373 StructureType sync.Mutex
+          Type: 377 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 376 StructureType sync/atomic.Value
+          Type: 380 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 377 GoMapType map[context.canceler]struct {}
+          Type: 381 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 376 StructureType sync/atomic.Value
+          Type: 380 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 16 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 656
+      ID: 663
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1116480
@@ -27078,13 +27297,13 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1059
+      ID: 1070
       Name: context.deadlineExceededError
       GoRuntimeType: 1471936
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 376
       Name: context.emptyCtx
       GoRuntimeType: 1603648
       GoKind: 25
@@ -27093,7 +27312,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 364
+      ID: 368
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1833888
@@ -27104,11 +27323,11 @@ Types:
           Type: 157 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 382 GoSubroutineType func() bool
+          Type: 386 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 370
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1622400
@@ -27116,29 +27335,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 362 StructureType context.cancelCtx
+          Type: 366 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 383 PointerType *time.Timer
+          Type: 387 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 385 StructureType time.Time
+          Type: 328 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 388
+      ID: 389
       Name: context.todoCtx
       GoRuntimeType: 1808864
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 372 StructureType context.emptyCtx
+          Type: 376 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 372
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1846272
@@ -27156,7 +27375,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 374
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1808416
@@ -27168,87 +27387,87 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 755
+      ID: 766
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 840704
       GoKind: 2
     - __kind: BaseType
-      ID: 756
+      ID: 767
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 840800
       GoKind: 2
     - __kind: BaseType
-      ID: 757
+      ID: 768
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 840896
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1266
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 1040
+      ID: 1051
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1295680
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1286
+      ID: 1297
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1316
+      ID: 1327
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1290
+      ID: 1301
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1288
+      ID: 1299
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1282
+      ID: 1293
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 758
+      ID: 769
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 840992
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1303
+      ID: 1314
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1278
+      ID: 1289
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 745
+      ID: 756
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 838688
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1040
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1369
+      ID: 1380
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 866
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 853
+      ID: 864
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1740416
@@ -27259,38 +27478,38 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1155 ArrayType [5]uint8
+          Type: 1166 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 982
+      ID: 993
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 998080
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1248
+      ID: 1259
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 857
+      ID: 868
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1253
+      ID: 1264
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1137
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1151
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 929
+      ID: 940
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1743296
@@ -27298,21 +27517,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1139 PointerType *crypto/x509.Certificate
+          Type: 1150 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1158 BaseType crypto/x509.InvalidReason
+          Type: 1169 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 923
+      ID: 934
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1123392
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 925
+      ID: 936
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1607968
@@ -27320,24 +27539,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1139 PointerType *crypto/x509.Certificate
+          Type: 1150 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 754
+      ID: 765
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 840320
       GoKind: 2
     - __kind: BaseType
-      ID: 1158
+      ID: 1169
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 593280
       GoKind: 2
     - __kind: StructureType
-      ID: 1034
+      ID: 1045
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1569856
@@ -27347,13 +27566,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 931
+      ID: 942
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1123648
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 927
+      ID: 938
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1743104
@@ -27361,15 +27580,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1139 PointerType *crypto/x509.Certificate
+          Type: 1150 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1139 PointerType *crypto/x509.Certificate
+          Type: 1150 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 947
+      ID: 958
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1443392
@@ -27379,7 +27598,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 951
+      ID: 962
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1443552
@@ -27389,55 +27608,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 960
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 736
+      ID: 747
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1206
+      ID: 1217
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 737
+      ID: 748
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 837824
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 824
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1029
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 816
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 822
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 820
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 818
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1349
+      ID: 1360
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 815
+      ID: 826
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1427232
@@ -27447,19 +27666,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1214
+      ID: 1225
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 917
+      ID: 928
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 926
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 751
+      ID: 762
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -27467,22 +27686,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 753 PointerType *encoding/xml.UnmarshalError.str
+          Type: 764 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 752 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 763 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 752
+      ID: 763
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 931
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1327
+      ID: 1338
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27499,11 +27718,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 781
+      ID: 792
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 996
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27519,15 +27738,15 @@ Types:
       GoRuntimeType: 588032
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1337
+      ID: 1348
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 998
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 1000
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27537,7 +27756,7 @@ Types:
       GoRuntimeType: 478112
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 382
+      ID: 386
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 598976
@@ -27549,44 +27768,44 @@ Types:
       GoRuntimeType: 852800
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 359
+      ID: 363
       Name: func(go.shape.float64) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 334
+      ID: 338
       Name: func(go.shape.int) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 335
+      ID: 339
       Name: func(go.shape.int) go.shape.string
       ByteSize: 8
       GoKind: 19
     - __kind: StructureType
-      ID: 329
+      ID: 333
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
     - __kind: StructureType
-      ID: 331
+      ID: 335
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 854
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 824
+      ID: 835
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1739264
@@ -27594,7 +27813,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1148 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1159 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27602,25 +27821,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 837
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1163
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 830
+      ID: 841
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1119168
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1165
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 730
+      ID: 741
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 837056
@@ -27628,18 +27847,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 732 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 743 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 731 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 742 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 731
+      ID: 742
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1148
+      ID: 1159
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2229632
@@ -27647,7 +27866,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1149 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1160 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27662,7 +27881,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1150 GoSliceHeaderType []float64
+          Type: 1161 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -27671,10 +27890,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1151 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1162 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1153 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1164 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 161 GoSliceHeaderType []string
@@ -27688,13 +27907,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 1149
+      ID: 1160
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 589696
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 727
+      ID: 738
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 836960
@@ -27702,18 +27921,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 729 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 740 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 728 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 739 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 728
+      ID: 739
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 733
+      ID: 744
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 837152
@@ -27721,30 +27940,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 746 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 745 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 734
+      ID: 745
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1226
+      ID: 1237
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1313
+      ID: 1324
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 952
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 390
+      ID: 391
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2350304
@@ -27752,7 +27971,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 391 StructureType sync.RWMutex
+          Type: 392 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -27773,13 +27992,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 399 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 400 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 404 GoMapType map[string]float64
+          Type: 405 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -27794,10 +28013,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 409 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 412 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 413 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27809,7 +28028,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 415 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -27832,7 +28051,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 416
+      ID: 417
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2227392
@@ -27843,13 +28062,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 417 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 418 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 392 StructureType sync/atomic.Int32
+          Type: 393 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27858,16 +28077,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 419 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 420 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 391 StructureType sync.RWMutex
+          Type: 392 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -27876,12 +28095,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 409 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 411
+      ID: 412
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1921664
@@ -27898,7 +28117,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27906,20 +28125,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 399
+      ID: 400
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1288896
       GoKind: 21
-      HeaderType: 401 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 402 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1402
+      ID: 1403
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 586880
       GoKind: 10
     - __kind: StructureType
-      ID: 414
+      ID: 415
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1759200
@@ -27933,16 +28152,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 685 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 692 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 690 GoMapType map[string]interface {}
+          Type: 697 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1428
+      ID: 1429
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 713
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1921920
@@ -27950,7 +28169,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1426 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1427 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27965,15 +28184,15 @@ Types:
           Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1427 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1428 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1426
+      ID: 1427
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 992992
       GoKind: 5
     - __kind: StructureType
-      ID: 418
+      ID: 419
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2114656
@@ -27981,16 +28200,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 391 StructureType sync.RWMutex
+          Type: 392 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1400 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1401 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 394 GoMapType map[string]string
+          Type: 395 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -28005,12 +28224,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1402 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1403 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 419
+      ID: 420
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 901344
@@ -28019,15 +28238,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1105
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1345
+      ID: 1356
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1431
+      ID: 1432
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1636416
@@ -28037,29 +28256,29 @@ Types:
           Offset: 0
           Type: 157 GoInterfaceType context.Context
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 877
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 873
+      ID: 884
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1122624
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 750
+      ID: 761
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 839360
       GoKind: 2
     - __kind: StructureType
-      ID: 871
+      ID: 882
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1122496
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 869
+      ID: 880
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1606048
@@ -28072,7 +28291,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 889
+      ID: 900
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1606848
@@ -28085,7 +28304,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 893
+      ID: 904
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1742528
@@ -28101,7 +28320,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 891
+      ID: 902
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1437312
@@ -28111,7 +28330,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 887
+      ID: 898
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1436992
@@ -28121,14 +28340,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1134
+      ID: 1145
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1508736
       GoKind: 21
-      HeaderType: 1136 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1147 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1157
+      ID: 1168
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1055232
@@ -28143,15 +28362,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1175 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1186 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1175
+      ID: 1186
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 901
+      ID: 912
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1607168
@@ -28159,12 +28378,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1134 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1145 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1134 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1145 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 895
+      ID: 906
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1437472
@@ -28174,7 +28393,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 899
+      ID: 910
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1742720
@@ -28185,12 +28404,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1157 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1157 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 897
+      ID: 908
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1607008
@@ -28203,7 +28422,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 903
+      ID: 914
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1437632
@@ -28211,9 +28430,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 385 StructureType time.Time
+          Type: 328 GoTimeType time.Time
     - __kind: StructureType
-      ID: 909
+      ID: 920
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1607488
@@ -28226,7 +28445,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 911
+      ID: 922
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1437952
@@ -28236,7 +28455,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 907
+      ID: 918
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1607328
@@ -28249,7 +28468,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 905
+      ID: 916
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1437792
@@ -28259,7 +28478,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 913
+      ID: 924
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1607648
@@ -28272,7 +28491,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 832
+      ID: 843
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1429472
@@ -28282,11 +28501,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1266
+      ID: 1277
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 845
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1429632
@@ -28294,21 +28513,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 832 StructureType github.com/cihub/seelog.baseError
+          Type: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1246
+      ID: 1257
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1202
+      ID: 1213
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1247
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 838
+      ID: 849
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1429952
@@ -28316,13 +28535,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 832 StructureType github.com/cihub/seelog.baseError
+          Type: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1301
+      ID: 1312
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1314
+      ID: 1325
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2117120
@@ -28330,12 +28549,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1300 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1311 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 1317
+      ID: 1328
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2141984
@@ -28343,7 +28562,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1300 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1311 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28351,11 +28570,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1204
+      ID: 1215
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 836
+      ID: 847
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1429792
@@ -28363,9 +28582,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 832 StructureType github.com/cihub/seelog.baseError
+          Type: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 840
+      ID: 851
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1430112
@@ -28373,64 +28592,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 832 StructureType github.com/cihub/seelog.baseError
+          Type: 843 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1268
+      ID: 1279
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1309
+      ID: 1320
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1311
+      ID: 1322
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1139
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1055
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1053
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1057
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1059
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1257
+      ID: 1268
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1047
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 846
+      ID: 857
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1431072
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1361
+      ID: 1372
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1113
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1071
+      ID: 1082
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1851648
@@ -28446,11 +28665,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1076
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1004
+      ID: 1015
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1711968
@@ -28463,7 +28682,7 @@ Types:
           Offset: 1
           Type: 19 BaseType int8
     - __kind: StructureType
-      ID: 1077
+      ID: 1088
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1852096
@@ -28479,13 +28698,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 981
+      ID: 992
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 994912
       GoKind: 8
     - __kind: StructureType
-      ID: 1069
+      ID: 1080
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1851424
@@ -28501,13 +28720,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1159
+      ID: 1170
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 835328
       GoKind: 8
     - __kind: StructureType
-      ID: 1067
+      ID: 1078
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1851200
@@ -28515,15 +28734,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1159 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1170 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1159 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1170 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1075
+      ID: 1086
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1764960
@@ -28536,7 +28755,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1073
+      ID: 1084
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1851872
@@ -28552,11 +28771,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1365
+      ID: 1376
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1081
+      ID: 1092
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1632192
@@ -28566,19 +28785,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1008
+      ID: 1019
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1289408
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1006
+      ID: 1017
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1289280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1079
+      ID: 1090
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1765152
@@ -28591,7 +28810,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 763
+      ID: 774
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 842816
@@ -28599,36 +28818,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 765 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 776 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 764 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 775 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 764
+      ID: 775
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 345
+      ID: 349
       Name: go.shape.bool
       ByteSize: 1
       GoRuntimeType: 599936
       GoKind: 1
     - __kind: BaseType
-      ID: 358
+      ID: 362
       Name: go.shape.float64
       ByteSize: 8
       GoRuntimeType: 600000
       GoKind: 14
     - __kind: BaseType
-      ID: 328
+      ID: 332
       Name: go.shape.int
       ByteSize: 8
       GoRuntimeType: 599808
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 330
+      ID: 334
       Name: go.shape.string
       ByteSize: 16
       GoRuntimeType: 599872
@@ -28636,18 +28855,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 643 PointerType *go.shape.string.str
+          Type: 650 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 642 GoStringDataType go.shape.string.str
+      Data: 649 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 642
+      ID: 649
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 337
+      ID: 341
       Name: go.shape.struct { Name string }
       ByteSize: 16
       GoKind: 25
@@ -28656,7 +28875,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 339
+      ID: 343
       Name: go.shape.struct { X int; Y int }
       ByteSize: 16
       GoKind: 25
@@ -28668,13 +28887,13 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 348
+      ID: 352
       Name: go.shape.struct { main.i int }
       ByteSize: 8
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 349
+      ID: 353
       Name: go.shape.struct { main.s string }
       ByteSize: 16
       GoKind: 25
@@ -28683,7 +28902,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 352
+      ID: 356
       Name: go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
       ByteSize: 48
       GoKind: 25
@@ -28698,11 +28917,11 @@ Types:
           Offset: 32
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1154
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1052
+      ID: 1063
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1455232
@@ -28712,7 +28931,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1232
+      ID: 1243
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1687680
@@ -28720,13 +28939,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1258 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1269 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1325
+      ID: 1336
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1258
+      ID: 1269
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1133376
@@ -28739,7 +28958,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1220
+      ID: 1231
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1578656
@@ -28749,19 +28968,19 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 766
+      ID: 777
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 843392
       GoKind: 10
     - __kind: BaseType
-      ID: 1141
+      ID: 1152
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1008544
       GoKind: 10
     - __kind: StructureType
-      ID: 1110
+      ID: 1121
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1890624
@@ -28772,12 +28991,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1141 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1152 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 967
+      ID: 978
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1614688
@@ -28785,12 +29004,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1141 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1152 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 770
+      ID: 781
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 843584
@@ -28798,18 +29017,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 772 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 783 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 771 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 782 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 771
+      ID: 782
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 776
+      ID: 787
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 843776
@@ -28817,18 +29036,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 778 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 789 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 777 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 788 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 777
+      ID: 788
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 773
+      ID: 784
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 843680
@@ -28836,18 +29055,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 775 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 786 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 774 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 785 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 774
+      ID: 785
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 767
+      ID: 778
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 843488
@@ -28855,22 +29074,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 769 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 780 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 768 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 779 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 768
+      ID: 779
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1323
+      ID: 1334
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 971
+      ID: 982
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1455872
@@ -28880,13 +29099,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 779
+      ID: 790
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 843872
       GoKind: 2
     - __kind: StructureType
-      ID: 959
+      ID: 970
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1450912
@@ -28896,11 +29115,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1119
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1130
+      ID: 1141
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1918400
@@ -28916,7 +29135,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 961
+      ID: 972
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1614208
@@ -28929,7 +29148,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1272
+      ID: 1283
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1976448
@@ -28937,16 +29156,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1299 GoInterfaceType io.Reader
+          Type: 1310 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1230
+      ID: 1241
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1050
+      ID: 1061
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1576256
@@ -28956,29 +29175,29 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1192
+      ID: 1203
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 950
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1049
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1117
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1104
+      ID: 1115
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1519456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 953
+      ID: 964
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1444192
@@ -28988,7 +29207,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 955
+      ID: 966
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1444352
@@ -28998,463 +29217,463 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 892
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 539
+      ID: 540
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 540 PointerType *noalg.map.group[[4]int][4]int
+          Type: 541 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 541 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 545 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 542 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 546 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 531
+      ID: 532
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 532 PointerType *noalg.map.group[[4]int]uint8
+          Type: 533 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 533 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 537 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 534 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 538 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 479
+      ID: 480
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 480 PointerType *noalg.map.group[[4]string][2]int
+          Type: 481 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 481 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 486 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 482 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 487 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 498
+      ID: 499
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 499 PointerType *noalg.map.group[bool]main.node
+          Type: 500 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 500 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 504 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 501 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 505 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 651
+      ID: 658
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 652 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 659 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 653 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 658 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 660 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 665 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 435
+      ID: 436
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 436 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 437 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 437 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 443 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 438 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 444 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1417
+      ID: 1418
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1418 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1419 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1419 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1425 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1420 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1426 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1461
+      ID: 1462
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1462 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1463 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1463 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1469 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1464 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1470 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1476
+      ID: 1477
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1477 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1478 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1478 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1484 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1479 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1485 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 447
+      ID: 448
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 448 PointerType *noalg.map.group[int]int
+          Type: 449 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 449 StructureType noalg.map.group[int]int
-      GroupSliceType: 453 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 450 StructureType noalg.map.group[int]int
+      GroupSliceType: 454 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1491
+      ID: 1492
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1492 PointerType *noalg.map.group[int]interface {}
+          Type: 1493 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1493 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1497 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1494 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1498 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 555
+      ID: 556
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 556 PointerType *noalg.map.group[int]struct {}
+          Type: 557 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 557 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 561 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 558 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 562 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 506
+      ID: 507
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 507 PointerType *noalg.map.group[int]uint8
+          Type: 508 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 508 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 512 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 509 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 513 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 696
+      ID: 707
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 697 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 708 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 698 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 704 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 715 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 488
+      ID: 489
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 489 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 490 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 490 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 496 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 491 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 497 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 471
+      ID: 472
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 472 PointerType *noalg.map.group[string][]string
+          Type: 473 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 473 StructureType noalg.map.group[string][]string
-      GroupSliceType: 477 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 474 StructureType noalg.map.group[string][]string
+      GroupSliceType: 478 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 676
+      ID: 683
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 677 PointerType *noalg.map.group[string]float64
+          Type: 684 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 678 StructureType noalg.map.group[string]float64
-      GroupSliceType: 682 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 685 StructureType noalg.map.group[string]float64
+      GroupSliceType: 689 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1166
+      ID: 1177
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1167 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1178 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1168 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1172 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1183 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 463
+      ID: 464
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 464 PointerType *noalg.map.group[string]int
+          Type: 465 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 465 StructureType noalg.map.group[string]int
-      GroupSliceType: 469 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 466 StructureType noalg.map.group[string]int
+      GroupSliceType: 470 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 668
+      ID: 675
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 669 PointerType *noalg.map.group[string]interface {}
+          Type: 676 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 670 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 674 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 677 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 681 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 455
+      ID: 456
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 456 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 457 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 457 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 461 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 458 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 462 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 660
+      ID: 667
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 661 PointerType *noalg.map.group[string]string
+          Type: 668 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 662 StructureType noalg.map.group[string]string
-      GroupSliceType: 666 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 669 StructureType noalg.map.group[string]string
+      GroupSliceType: 673 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 547
+      ID: 548
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 548 PointerType *noalg.map.group[struct {}]int
+          Type: 549 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 549 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 553 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 550 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 554 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 595
+      ID: 596
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 596 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 597 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 597 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 601 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 602 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 603
+      ID: 604
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 604 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 605 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 605 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 609 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 610 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 611
+      ID: 612
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 612 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 613 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 613 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 617 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 618 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 619
+      ID: 620
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 620 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 621 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 625 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 626 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 627
+      ID: 628
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 628 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 629 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 633 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 634 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 635
+      ID: 636
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 636 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 637 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 641 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 642 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 563
+      ID: 564
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 564 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 565 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 565 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 569 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 566 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 570 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 522
+      ID: 523
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 523 PointerType *noalg.map.group[uint8][4]int
+          Type: 524 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 524 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 529 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 525 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 530 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 514
+      ID: 515
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 515 PointerType *noalg.map.group[uint8]uint8
+          Type: 516 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 516 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 520 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 517 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 521 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1280
+      ID: 1291
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 985
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29501,11 +29720,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1143
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 944
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29531,29 +29750,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 860
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1182
+      ID: 1193
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1111
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1367
+      ID: 1378
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1098
+      ID: 1109
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1498176
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 788
+      ID: 799
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29634,7 +29853,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 738
+      ID: 749
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 838016
@@ -29642,18 +29861,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 740 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 751 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 739 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 750 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 739
+      ID: 750
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1022
+      ID: 1033
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1567616
@@ -29661,9 +29880,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 1131 PointerType *internal/abi.Type
+          Type: 1142 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 375
+      ID: 379
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1495616
@@ -29676,11 +29895,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1224
+      ID: 1235
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1264
+      ID: 1275
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1196160
@@ -29693,7 +29912,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1299
+      ID: 1310
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1028608
@@ -29706,7 +29925,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1251
+      ID: 1262
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1115968
@@ -29732,47 +29951,47 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1222
+      ID: 1233
       Name: io.discard
       GoRuntimeType: 1471616
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1196
+      ID: 1207
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1107
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1270
+      ID: 1281
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 344
+      ID: 348
       Name: main.Pair[go.shape.int,go.shape.bool]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
         - Name: Value
           Offset: 8
-          Type: 345 BaseType go.shape.bool
+          Type: 349 BaseType go.shape.bool
     - __kind: StructureType
-      ID: 347
+      ID: 351
       Name: main.Pair[go.shape.string,go.shape.int]
       ByteSize: 24
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
         - Name: Value
           Offset: 16
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
     - __kind: StructureType
       ID: 322
       Name: main.aStruct
@@ -29799,7 +30018,7 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1498 PointerType *main.nestedStruct
+          Type: 1499 PointerType *main.nestedStruct
     - __kind: GoInterfaceType
       ID: 169
       Name: main.behavior
@@ -29840,7 +30059,7 @@ Types:
           Offset: 0
           Type: 146 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 441
+      ID: 442
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1192320
@@ -29848,9 +30067,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1411 GoMapType map[int]*main.deepMap3
+          Type: 1412 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1423
+      ID: 1424
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -29862,9 +30081,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1455 GoMapType map[int]*main.deepMap8
+          Type: 1456 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1467
+      ID: 1468
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1191552
@@ -29872,9 +30091,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1470 GoMapType map[int]*main.deepMap9
+          Type: 1471 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1482
+      ID: 1483
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1191424
@@ -29882,7 +30101,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1485 GoMapType map[int]interface {}
+          Type: 1486 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 134
       Name: main.deepPtr1
@@ -29902,9 +30121,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1370 PointerType *main.deepPtr3
+          Type: 1381 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1371
+      ID: 1382
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -29916,9 +30135,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1436 PointerType *main.deepPtr8
+          Type: 1437 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1437
+      ID: 1438
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1192704
@@ -29926,9 +30145,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1438 PointerType *main.deepPtr9
+          Type: 1439 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1439
+      ID: 1440
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1192576
@@ -29948,7 +30167,7 @@ Types:
           Offset: 0
           Type: 140 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 431
+      ID: 432
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1194624
@@ -29956,9 +30175,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1405 GoSliceHeaderType []*main.deepSlice3
+          Type: 1406 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1408
+      ID: 1409
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -29970,9 +30189,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1440 GoSliceHeaderType []*main.deepSlice8
+          Type: 1441 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1443
+      ID: 1444
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1193856
@@ -29980,9 +30199,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1446 GoSliceHeaderType []*main.deepSlice9
+          Type: 1447 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1449
+      ID: 1450
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1193728
@@ -29990,7 +30209,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1452 GoSliceHeaderType []interface {}
+          Type: 1453 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 326
       Name: main.emptyStruct
@@ -30008,16 +30227,16 @@ Types:
           Type: 162 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 373 StructureType sync.Mutex
+          Type: 377 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1378 StructureType sync.Once
+          Type: 1389 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1380 StructureType sync.WaitGroup
+          Type: 1391 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 392 StructureType sync/atomic.Int32
+          Type: 393 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 162
       Name: main.esotericStack
@@ -30047,7 +30266,7 @@ Types:
           Offset: 56
           Type: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 360
+      ID: 364
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1419872
@@ -30057,71 +30276,71 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 342
+      ID: 346
       Name: main.largeGenericType[go.shape.int]
       ByteSize: 136
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
     - __kind: StructureType
-      ID: 340
+      ID: 344
       Name: main.largeGenericType[go.shape.string]
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 341 ArrayType [16]uint8
+          Type: 345 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 257
       Name: main.largeStruct
@@ -30435,9 +30654,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1375 ArrayType [63]uint64
+          Type: 1386 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1385
+      ID: 1396
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1420032
@@ -30457,7 +30676,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1377
+      ID: 1388
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30468,31 +30687,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1373 PointerType *main.stringType1.str
+          Type: 1384 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1372 GoStringDataType main.stringType1.str
+      Data: 1383 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1372
+      ID: 1383
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1374
+      ID: 1385
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1500 PointerType *main.stringType2.str
+          Type: 1501 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1499 GoStringDataType main.stringType2.str
+      Data: 1500 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1499
+      ID: 1500
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -30608,16 +30827,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1386 PointerType **main.t
+          Type: 1397 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1387 GoSliceDataType main.t.array
+      Data: 1398 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1387
+      ID: 1398
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -30673,29 +30892,38 @@ Types:
         - Name: c
           Offset: 32
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 331
+      Name: main.timeCapture
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: monotonicNow
+          Offset: 0
+          Type: 328 GoTimeType time.Time
     - __kind: BaseType
       ID: 129
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 354
+      ID: 358
       Name: main.typeWithGenerics[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 328 BaseType go.shape.int
+          Type: 332 BaseType go.shape.int
     - __kind: StructureType
-      ID: 355
+      ID: 359
       Name: main.typeWithGenerics[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 330 GoStringHeaderType go.shape.string
+          Type: 334 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 262
       Name: main.wideStruct
@@ -30768,8 +30996,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 544 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 541 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 545 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 542 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 227
       Name: map<[4]int,uint8>
@@ -30803,8 +31031,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 536 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 533 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 537 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 534 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 195
       Name: map<[4]string,[2]int>
@@ -30838,8 +31066,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 485 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 481 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 486 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 482 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 207
       Name: map<bool,main.node>
@@ -30873,10 +31101,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 503 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 500 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 504 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 501 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 379
+      ID: 383
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -30889,7 +31117,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 380 PointerType **table<context.canceler,struct {}>
+          Type: 384 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30908,8 +31136,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 657 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 653 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 664 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 660 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 148
       Name: map<int,*main.deepMap2>
@@ -30943,10 +31171,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 442 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 437 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 443 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 438 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1413
+      ID: 1414
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -30959,7 +31187,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1414 PointerType **table<int,*main.deepMap3>
+          Type: 1415 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30978,10 +31206,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1424 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1419 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1425 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1420 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1457
+      ID: 1458
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -30994,7 +31222,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1458 PointerType **table<int,*main.deepMap8>
+          Type: 1459 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31013,10 +31241,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1468 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1463 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1469 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1464 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1472
+      ID: 1473
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -31029,7 +31257,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1473 PointerType **table<int,*main.deepMap9>
+          Type: 1474 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31048,8 +31276,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1483 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1478 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1484 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 175
       Name: map<int,int>
@@ -31083,10 +31311,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 452 GoSliceDataType []*table<int,int>.array
-      GroupType: 449 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 453 GoSliceDataType []*table<int,int>.array
+      GroupType: 450 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1487
+      ID: 1488
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31099,7 +31327,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1488 PointerType **table<int,interface {}>
+          Type: 1489 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31118,8 +31346,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1496 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1493 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1497 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 242
       Name: map<int,struct {}>
@@ -31153,8 +31381,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 560 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 557 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 561 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 558 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 212
       Name: map<int,uint8>
@@ -31188,10 +31416,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 511 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 508 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 512 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 509 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 687
+      ID: 694
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -31204,7 +31432,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 688 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 695 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31223,8 +31451,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 703 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 698 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 714 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 202
       Name: map<string,[]main.structWithMap>
@@ -31258,8 +31486,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 495 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 490 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 496 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 491 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 190
       Name: map<string,[]string>
@@ -31293,10 +31521,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 476 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 473 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 477 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 474 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 406
+      ID: 407
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31309,7 +31537,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 407 PointerType **table<string,float64>
+          Type: 408 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31328,10 +31556,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 681 GoSliceDataType []*table<string,float64>.array
-      GroupType: 678 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 688 GoSliceDataType []*table<string,float64>.array
+      GroupType: 685 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1136
+      ID: 1147
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31344,7 +31572,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1137 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1148 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31363,8 +31591,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1171 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1168 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1182 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 185
       Name: map<string,int>
@@ -31398,10 +31626,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 468 GoSliceDataType []*table<string,int>.array
-      GroupType: 465 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 469 GoSliceDataType []*table<string,int>.array
+      GroupType: 466 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 401
+      ID: 402
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31414,7 +31642,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 402 PointerType **table<string,interface {}>
+          Type: 403 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31433,8 +31661,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 673 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 670 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 680 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 677 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 180
       Name: map<string,main.nestedStruct>
@@ -31468,10 +31696,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 460 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 457 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 461 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 458 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 396
+      ID: 397
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31484,7 +31712,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 397 PointerType **table<string,string>
+          Type: 398 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31503,8 +31731,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 665 GoSliceDataType []*table<string,string>.array
-      GroupType: 662 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 672 GoSliceDataType []*table<string,string>.array
+      GroupType: 669 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 237
       Name: map<struct {},int>
@@ -31538,8 +31766,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 552 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 549 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 553 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 550 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 294
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31573,8 +31801,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 600 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 597 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 601 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 299
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31608,8 +31836,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 608 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 605 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 609 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 304
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31643,8 +31871,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 616 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 613 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 617 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 309
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31678,8 +31906,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 624 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 625 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 314
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31713,8 +31941,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 632 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 633 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 319
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31748,8 +31976,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 640 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 641 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 247
       Name: map<struct {},struct {}>
@@ -31783,8 +32011,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 568 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 565 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 569 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 566 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 222
       Name: map<uint8,[4]int>
@@ -31818,8 +32046,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 528 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 524 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 529 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 525 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 217
       Name: map<uint8,uint8>
@@ -31853,8 +32081,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 519 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 516 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 520 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 517 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 230
       Name: map[[4]int][4]int
@@ -31884,12 +32112,12 @@ Types:
       GoKind: 21
       HeaderType: 207 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 377
+      ID: 381
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1137600
       GoKind: 21
-      HeaderType: 379 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 383 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 146
       Name: map[int]*main.deepMap2
@@ -31898,26 +32126,26 @@ Types:
       GoKind: 21
       HeaderType: 148 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1411
+      ID: 1412
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1135168
       GoKind: 21
-      HeaderType: 1413 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1414 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1455
+      ID: 1456
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1134528
       GoKind: 21
-      HeaderType: 1457 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1458 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1470
+      ID: 1471
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1134400
       GoKind: 21
-      HeaderType: 1472 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1473 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 173
       Name: map[int]int
@@ -31926,12 +32154,12 @@ Types:
       GoKind: 21
       HeaderType: 175 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1485
+      ID: 1486
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1134272
       GoKind: 21
-      HeaderType: 1487 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1488 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 240
       Name: map[int]struct {}
@@ -31947,12 +32175,12 @@ Types:
       GoKind: 21
       HeaderType: 212 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 685
+      ID: 692
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1137856
       GoKind: 21
-      HeaderType: 687 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 694 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 200
       Name: map[string][]main.structWithMap
@@ -31968,12 +32196,12 @@ Types:
       GoKind: 21
       HeaderType: 190 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 404
+      ID: 405
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1137728
       GoKind: 21
-      HeaderType: 406 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 407 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 183
       Name: map[string]int
@@ -31982,12 +32210,12 @@ Types:
       GoKind: 21
       HeaderType: 185 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 690
+      ID: 697
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1134144
       GoKind: 21
-      HeaderType: 401 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 402 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 178
       Name: map[string]main.nestedStruct
@@ -31996,12 +32224,12 @@ Types:
       GoKind: 21
       HeaderType: 180 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 394
+      ID: 395
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1137472
       GoKind: 21
-      HeaderType: 396 GoSwissMapHeaderType map<string,string>
+      HeaderType: 397 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 235
       Name: map[struct {}]int
@@ -32067,7 +32295,7 @@ Types:
       GoKind: 21
       HeaderType: 217 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 885
+      ID: 896
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1436512
@@ -32077,7 +32305,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1186
+      ID: 1197
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1433312
@@ -32087,11 +32315,11 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1099
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1156
+      ID: 1167
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1604768
@@ -32104,35 +32332,35 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1130
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1331
+      ID: 1342
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1128
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1101
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1341
+      ID: 1352
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1351
+      ID: 1362
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1339
+      ID: 1350
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1055
+      ID: 1066
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1118784
@@ -32140,28 +32368,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1057 PointerType *net.UnknownNetworkError.str
+          Type: 1068 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1056 GoStringDataType net.UnknownNetworkError.str
+      Data: 1067 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1056
+      ID: 1067
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1020
+      ID: 1031
       Name: net.canceledError
       GoRuntimeType: 1290304
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1307
+      ID: 1318
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1161
+      ID: 1172
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2116416
@@ -32169,7 +32397,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -32180,27 +32408,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1353
+      ID: 1364
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1347
+      ID: 1358
       Name: net.noReadFrom
       GoRuntimeType: 1119040
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1346
+      ID: 1357
       Name: net.noWriteTo
       GoRuntimeType: 1118912
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 828
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1433
+      ID: 1434
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1769952
@@ -32213,7 +32441,7 @@ Types:
           Offset: 16
           Type: 157 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 819
+      ID: 830
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1739072
@@ -32221,7 +32449,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1144 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1155 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -32229,7 +32457,7 @@ Types:
           Offset: 96
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1335
+      ID: 1346
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2299424
@@ -32237,12 +32465,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1347 StructureType net.noReadFrom
+          Type: 1358 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1340 PointerType *net.TCPConn
+          Type: 1351 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1333
+      ID: 1344
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2298880
@@ -32250,24 +32478,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1346 StructureType net.noWriteTo
+          Type: 1357 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1340 PointerType *net.TCPConn
+          Type: 1351 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1103
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1132
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1021
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1178
+      ID: 1189
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1424992
@@ -32277,19 +32505,19 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 708
+      ID: 719
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 835808
       GoKind: 10
     - __kind: BaseType
-      ID: 1133
+      ID: 1144
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 995008
       GoKind: 10
     - __kind: StructureType
-      ID: 795
+      ID: 806
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1737728
@@ -32300,12 +32528,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1133 BaseType net/http.http2ErrCode
+          Type: 1144 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1113
+      ID: 1124
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1908928
@@ -32316,12 +32544,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1133 BaseType net/http.http2ErrCode
+          Type: 1144 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 799
+      ID: 810
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1604448
@@ -32329,16 +32557,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1133 BaseType net/http.http2ErrCode
+          Type: 1144 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1242
+      ID: 1253
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 712
+      ID: 723
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836000
@@ -32346,18 +32574,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 714 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 725 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 713 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 724 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 713
+      ID: 724
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 718
+      ID: 729
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836192
@@ -32365,18 +32593,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 720 PointerType *net/http.http2headerFieldNameError.str
+          Type: 731 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 719 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 730 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 719
+      ID: 730
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 715
+      ID: 726
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836096
@@ -32384,32 +32612,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 717 PointerType *net/http.http2headerFieldValueError.str
+          Type: 728 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 716 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 727 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 716
+      ID: 727
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1096
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1016
+      ID: 1027
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1289664
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1296
+      ID: 1307
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 709
+      ID: 720
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 835904
@@ -32417,18 +32645,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 711 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 722 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 710 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 721 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 710
+      ID: 721
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1180
+      ID: 1191
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1835008
@@ -32436,18 +32664,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1273 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1284 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1274 BaseType time.Duration
+          Type: 1285 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 108 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1273
+      ID: 1284
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1424192
@@ -32460,14 +32688,14 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1261
+      ID: 1272
       Name: net/http.incomparable
       GoRuntimeType: 906528
       GoKind: 17
       HasCount: true
       Element: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1012
+      ID: 1023
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1563776
@@ -32477,11 +32705,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1244
+      ID: 1255
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1200
+      ID: 1211
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1563616
@@ -32489,9 +32717,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1243 PointerType *net/http.persistConn
+          Type: 1254 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1234
+      ID: 1245
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1810432
@@ -32499,15 +32727,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1261 ArrayType net/http.incomparable
+          Type: 1272 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1262 PointerType *bufio.Reader
+          Type: 1273 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1264 GoInterfaceType io.ReadWriteCloser
+          Type: 1275 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 803
+      ID: 814
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1425952
@@ -32517,17 +32745,17 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1126
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1083
+      ID: 1094
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1484736
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1014
+      ID: 1025
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1563936
@@ -32537,7 +32765,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1276
+      ID: 1287
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2035424
@@ -32545,16 +32773,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1156 GoInterfaceType net.Conn
+          Type: 1167 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 803
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1298
+      ID: 1309
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2051168
@@ -32562,13 +32790,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1293 PointerType *bufio.Writer
+          Type: 1304 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1221
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 888
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1742144
@@ -32584,7 +32812,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 875
+      ID: 886
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1606208
@@ -32597,11 +32825,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1250
+      ID: 1261
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1212
+      ID: 1223
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1608128
@@ -32609,16 +32837,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1249 PointerType *net/smtp.Client
+          Type: 1260 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1251 GoInterfaceType io.WriteCloser
+          Type: 1262 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 872
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 746
+      ID: 757
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 838784
@@ -32626,26 +32854,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 748 PointerType *net/textproto.ProtocolError.str
+          Type: 759 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 747 GoStringDataType net/textproto.ProtocolError.str
+      Data: 758 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 747
+      ID: 758
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1208
+      ID: 1219
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1123
+      ID: 1134
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 721
+      ID: 732
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 836672
@@ -32653,18 +32881,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 723 PointerType *net/url.EscapeError.str
+          Type: 734 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 722 GoStringDataType net/url.EscapeError.str
+      Data: 733 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 722
+      ID: 733
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 724
+      ID: 735
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -32672,299 +32900,299 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 726 PointerType *net/url.InvalidHostError.str
+          Type: 737 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 725 GoStringDataType net/url.InvalidHostError.str
+      Data: 736 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 725
+      ID: 736
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 542
+      ID: 543
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 686688
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 543 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 544 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 534
+      ID: 535
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 686784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 535 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 536 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 482
+      ID: 483
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 687072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 483 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 484 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 501
+      ID: 502
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 687168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 502 StructureType noalg.struct { key bool; elem main.node }
+      Element: 503 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 654
+      ID: 661
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 692640
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 655 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 662 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 438
+      ID: 439
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 685920
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 439 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 440 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1420
+      ID: 1421
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 685824
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1421 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1422 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1464
+      ID: 1465
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 685344
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1465 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1466 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1479
+      ID: 1480
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 685248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1480 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1481 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 450
+      ID: 451
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 451 StructureType noalg.struct { key int; elem int }
+      Element: 452 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1494
+      ID: 1495
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 685152
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1495 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1496 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 558
+      ID: 559
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 687264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 559 StructureType noalg.struct { key int; elem struct {} }
+      Element: 560 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 509
+      ID: 510
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 687360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 510 StructureType noalg.struct { key int; elem uint8 }
+      Element: 511 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 699
+      ID: 710
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 693280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 700 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 711 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 491
+      ID: 492
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 687456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 492 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 493 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 474
+      ID: 475
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 687552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 475 StructureType noalg.struct { key string; elem []string }
+      Element: 476 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 679
+      ID: 686
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 693184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 680 StructureType noalg.struct { key string; elem float64 }
+      Element: 687 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1169
+      ID: 1180
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 762720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1170 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1181 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 466
+      ID: 467
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 687648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 467 StructureType noalg.struct { key string; elem int }
+      Element: 468 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 671
+      ID: 678
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 684768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 672 StructureType noalg.struct { key string; elem interface {} }
+      Element: 679 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 458
+      ID: 459
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 687744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 459 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 460 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 663
+      ID: 670
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 690912
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 664 StructureType noalg.struct { key string; elem string }
+      Element: 671 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 550
+      ID: 551
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 687840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 551 StructureType noalg.struct { key struct {}; elem int }
+      Element: 552 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 598
+      ID: 599
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 599 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 600 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 606
+      ID: 607
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 607 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 608 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 614
+      ID: 615
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 615 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 616 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 622
+      ID: 623
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 623 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 624 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 630
+      ID: 631
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 631 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 632 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 638
+      ID: 639
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 639 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 640 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 566
+      ID: 567
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 687936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 567 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 568 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 525
+      ID: 526
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 526 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 527 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 517
+      ID: 518
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 688128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 518 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 519 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 541
+      ID: 542
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1301952
@@ -32975,9 +33203,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 542 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 543 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 533
+      ID: 534
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1302208
@@ -32988,9 +33216,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 534 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 535 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 481
+      ID: 482
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1302464
@@ -33001,9 +33229,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 482 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 483 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 500
+      ID: 501
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1302720
@@ -33014,9 +33242,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 501 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 502 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 653
+      ID: 660
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1306816
@@ -33027,9 +33255,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 654 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 661 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 437
+      ID: 438
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1301696
@@ -33040,9 +33268,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 438 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 439 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1419
+      ID: 1420
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1301440
@@ -33053,9 +33281,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1420 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1421 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1463
+      ID: 1464
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1300160
@@ -33066,9 +33294,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1464 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1465 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1478
+      ID: 1479
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1299904
@@ -33079,9 +33307,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1479 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1480 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 449
+      ID: 450
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1298624
@@ -33092,9 +33320,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 450 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 451 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1493
+      ID: 1494
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1299648
@@ -33105,9 +33333,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1494 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1495 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 557
+      ID: 558
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1302976
@@ -33118,9 +33346,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 558 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 559 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 508
+      ID: 509
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1303232
@@ -33131,9 +33359,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 509 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 510 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 698
+      ID: 709
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1307712
@@ -33144,9 +33372,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 699 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 710 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 490
+      ID: 491
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1303488
@@ -33157,9 +33385,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 491 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 492 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 473
+      ID: 474
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1303744
@@ -33170,9 +33398,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 474 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 475 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 678
+      ID: 685
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1307456
@@ -33183,9 +33411,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 679 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 686 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1168
+      ID: 1179
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1365440
@@ -33196,9 +33424,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1169 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1180 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 465
+      ID: 466
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1304000
@@ -33209,9 +33437,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 466 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 467 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 670
+      ID: 677
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1299392
@@ -33222,9 +33450,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 671 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 678 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 457
+      ID: 458
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1304256
@@ -33235,9 +33463,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 458 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 459 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 662
+      ID: 669
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1306048
@@ -33248,9 +33476,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 663 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 670 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 549
+      ID: 550
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1304512
@@ -33261,9 +33489,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 550 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 551 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 597
+      ID: 598
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33273,9 +33501,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 598 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 599 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 605
+      ID: 606
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33285,9 +33513,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 606 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 607 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 613
+      ID: 614
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33297,9 +33525,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 614 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 615 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 621
+      ID: 622
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33309,9 +33537,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 622 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 623 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 629
+      ID: 630
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33321,9 +33549,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 630 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 631 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 637
+      ID: 638
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33333,9 +33561,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 638 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 639 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 565
+      ID: 566
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1304768
@@ -33346,9 +33574,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 566 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 567 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 524
+      ID: 525
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1305024
@@ -33359,9 +33587,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 525 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 526 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 516
+      ID: 517
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1305280
@@ -33372,9 +33600,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 517 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 518 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 543
+      ID: 544
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1301824
@@ -33382,12 +33610,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 527 ArrayType [4]int
+          Type: 528 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 527 ArrayType [4]int
+          Type: 528 ArrayType [4]int
     - __kind: StructureType
-      ID: 535
+      ID: 536
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1302080
@@ -33395,12 +33623,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 527 ArrayType [4]int
+          Type: 528 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 483
+      ID: 484
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1302336
@@ -33408,12 +33636,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 484 ArrayType [4]string
+          Type: 485 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 115 ArrayType [2]int
     - __kind: StructureType
-      ID: 502
+      ID: 503
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1302592
@@ -33426,7 +33654,7 @@ Types:
           Offset: 8
           Type: 253 StructureType main.node
     - __kind: StructureType
-      ID: 655
+      ID: 662
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1306688
@@ -33434,12 +33662,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 656 GoInterfaceType context.canceler
+          Type: 663 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 439
+      ID: 440
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1301568
@@ -33450,9 +33678,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 440 PointerType *main.deepMap2
+          Type: 441 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1421
+      ID: 1422
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1301312
@@ -33463,9 +33691,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1422 PointerType *main.deepMap3
+          Type: 1423 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1465
+      ID: 1466
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1300032
@@ -33476,9 +33704,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1466 PointerType *main.deepMap8
+          Type: 1467 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1480
+      ID: 1481
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1299776
@@ -33489,9 +33717,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1481 PointerType *main.deepMap9
+          Type: 1482 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 451
+      ID: 452
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1298496
@@ -33504,7 +33732,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 1495
+      ID: 1496
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1299520
@@ -33517,7 +33745,7 @@ Types:
           Offset: 8
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 559
+      ID: 560
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1302848
@@ -33530,7 +33758,7 @@ Types:
           Offset: 8
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 510
+      ID: 511
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1303104
@@ -33543,7 +33771,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 700
+      ID: 711
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1307584
@@ -33554,9 +33782,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 701 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 712 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 492
+      ID: 493
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1303360
@@ -33567,9 +33795,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 493 GoSliceHeaderType []main.structWithMap
+          Type: 494 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 475
+      ID: 476
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1303616
@@ -33582,7 +33810,7 @@ Types:
           Offset: 16
           Type: 161 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 680
+      ID: 687
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1307328
@@ -33595,7 +33823,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 1170
+      ID: 1181
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1365312
@@ -33606,9 +33834,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1157 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 467
+      ID: 468
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1303872
@@ -33621,7 +33849,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 672
+      ID: 679
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1299264
@@ -33634,7 +33862,7 @@ Types:
           Offset: 16
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 459
+      ID: 460
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1304128
@@ -33647,7 +33875,7 @@ Types:
           Offset: 16
           Type: 125 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 664
+      ID: 671
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1305920
@@ -33660,7 +33888,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 551
+      ID: 552
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1304384
@@ -33673,7 +33901,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 599
+      ID: 600
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33685,7 +33913,7 @@ Types:
           Offset: 0
           Type: 291 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 607
+      ID: 608
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33697,7 +33925,7 @@ Types:
           Offset: 0
           Type: 292 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 615
+      ID: 616
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33709,7 +33937,7 @@ Types:
           Offset: 0
           Type: 297 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 623
+      ID: 624
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33721,7 +33949,7 @@ Types:
           Offset: 0
           Type: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 631
+      ID: 632
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33733,7 +33961,7 @@ Types:
           Offset: 0
           Type: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 639
+      ID: 640
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33745,7 +33973,7 @@ Types:
           Offset: 0
           Type: 312 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 567
+      ID: 568
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1304640
       GoKind: 25
@@ -33757,7 +33985,7 @@ Types:
           Offset: 0
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 526
+      ID: 527
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1304896
@@ -33768,9 +33996,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 527 ArrayType [4]int
+          Type: 528 ArrayType [4]int
     - __kind: StructureType
-      ID: 518
+      ID: 519
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1305152
@@ -33783,19 +34011,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1359
+      ID: 1370
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 993
+      ID: 1004
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1072
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1357
+      ID: 1368
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2369792
@@ -33803,12 +34031,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1363 StructureType os.noReadFrom
+          Type: 1374 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1358 PointerType *os.File
+          Type: 1369 PointerType *os.File
     - __kind: StructureType
-      ID: 1355
+      ID: 1366
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2368992
@@ -33816,36 +34044,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1362 StructureType os.noWriteTo
+          Type: 1373 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1358 PointerType *os.File
+          Type: 1369 PointerType *os.File
     - __kind: StructureType
-      ID: 1363
+      ID: 1374
       Name: os.noReadFrom
       GoRuntimeType: 1117248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1362
+      ID: 1373
       Name: os.noWriteTo
       GoRuntimeType: 1117120
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1035
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1164
+      ID: 1175
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1228
+      ID: 1239
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1026
+      ID: 1037
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1712544
@@ -33858,7 +34086,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 760
+      ID: 771
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 842048
@@ -33866,36 +34094,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 762 PointerType *os/user.UnknownGroupIdError.str
+          Type: 773 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 761 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 772 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 761
+      ID: 772
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 759
+      ID: 770
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 841952
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 801
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 894
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 1008
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1001
+      ID: 1012
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33907,7 +34135,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 999
+      ID: 1010
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1897792
@@ -33924,9 +34152,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1162 BaseType runtime.boundsErrorCode
+          Type: 1173 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1162
+      ID: 1173
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 588224
@@ -33946,7 +34174,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1063
+      ID: 1074
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1763040
@@ -33959,7 +34187,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 975
+      ID: 986
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 994048
@@ -33967,13 +34195,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 977 PointerType *runtime.errorString.str
+          Type: 988 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 976 GoStringDataType runtime.errorString.str
+      Data: 987 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 976
+      ID: 987
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34600,7 +34828,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 426
+      ID: 427
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -34636,7 +34864,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 978
+      ID: 989
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 994144
@@ -34644,13 +34872,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 980 PointerType *runtime.plainError.str
+          Type: 991 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 979 GoStringDataType runtime.plainError.str
+      Data: 990 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 979
+      ID: 990
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34691,7 +34919,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 786
+      ID: 797
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1604128
@@ -34749,7 +34977,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 1002
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -34761,26 +34989,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 421 PointerType *string.str
+          Type: 422 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 420 GoStringDataType string.str
+      Data: 421 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 420
+      ID: 421
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1292
+      ID: 1303
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1198
+      ID: 1209
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1194
+      ID: 1205
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1463232
@@ -34796,7 +35024,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 373
+      ID: 377
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1474656
@@ -34804,12 +35032,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 374 StructureType sync.noCopy
+          Type: 378 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 375 StructureType internal/sync.Mutex
+          Type: 379 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1378
+      ID: 1389
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1624896
@@ -34817,15 +35045,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 374 StructureType sync.noCopy
+          Type: 378 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1379 StructureType sync/atomic.Bool
+          Type: 1390 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 373 StructureType sync.Mutex
+          Type: 377 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 391
+      ID: 392
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1848960
@@ -34833,7 +35061,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 373 StructureType sync.Mutex
+          Type: 377 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -34842,12 +35070,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 392 StructureType sync/atomic.Int32
+          Type: 393 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 392 StructureType sync/atomic.Int32
+          Type: 393 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1380
+      ID: 1391
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1624704
@@ -34855,21 +35083,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 374 StructureType sync.noCopy
+          Type: 378 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1381 StructureType sync/atomic.Uint64
+          Type: 1392 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 374
+      ID: 378
       Name: sync.noCopy
       GoRuntimeType: 993664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1379
+      ID: 1390
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1475776
@@ -34877,12 +35105,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 393 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 392
+      ID: 393
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1475936
@@ -34890,12 +35118,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 393 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 1381
+      ID: 1392
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1625280
@@ -34903,15 +35131,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 393 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1382 StructureType sync/atomic.align64
+          Type: 1393 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 376
+      ID: 380
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1200384
@@ -34921,25 +35149,25 @@ Types:
           Offset: 0
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1382
+      ID: 1393
       Name: sync/atomic.align64
       GoRuntimeType: 993856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 393
+      ID: 394
       Name: sync/atomic.noCopy
       GoRuntimeType: 993760
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1111
+      ID: 1122
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1291712
       GoKind: 12
     - __kind: StructureType
-      ID: 538
+      ID: 539
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -34961,9 +35189,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 539 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 540 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 530
+      ID: 531
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -34985,9 +35213,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 531 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 532 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 478
+      ID: 479
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -35009,9 +35237,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 479 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 480 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 497
+      ID: 498
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -35033,9 +35261,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 498 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 499 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35057,9 +35285,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 651 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 658 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 434
+      ID: 435
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -35081,9 +35309,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 435 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 436 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1416
+      ID: 1417
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -35105,9 +35333,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1417 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1418 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1460
+      ID: 1461
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -35129,9 +35357,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1461 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1462 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1475
+      ID: 1476
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -35153,9 +35381,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1476 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1477 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 446
+      ID: 447
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -35177,9 +35405,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 447 GoSwissMapGroupsType groupReference<int,int>
+          Type: 448 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1490
+      ID: 1491
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35201,9 +35429,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1491 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1492 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 554
+      ID: 555
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35225,9 +35453,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 555 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 556 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 505
+      ID: 506
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35249,9 +35477,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 506 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 507 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 695
+      ID: 706
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -35273,9 +35501,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 696 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 707 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 487
+      ID: 488
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35297,9 +35525,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 488 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 489 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 470
+      ID: 471
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35321,9 +35549,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 471 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 472 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 675
+      ID: 682
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35345,9 +35573,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 676 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 683 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1165
+      ID: 1176
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35369,9 +35597,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1166 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1177 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 462
+      ID: 463
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35393,9 +35621,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 463 GoSwissMapGroupsType groupReference<string,int>
+          Type: 464 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35417,9 +35645,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 668 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 675 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 454
+      ID: 455
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35441,9 +35669,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 455 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 456 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 659
+      ID: 666
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35465,9 +35693,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 660 GoSwissMapGroupsType groupReference<string,string>
+          Type: 667 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 546
+      ID: 547
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35489,9 +35717,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 547 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 548 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 594
+      ID: 595
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35513,9 +35741,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 595 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 596 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 602
+      ID: 603
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35537,9 +35765,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 603 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 604 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 610
+      ID: 611
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35561,9 +35789,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 611 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 612 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 618
+      ID: 619
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35585,9 +35813,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 619 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 620 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 626
+      ID: 627
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35609,9 +35837,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 627 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 628 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 634
+      ID: 635
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35633,9 +35861,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 635 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 636 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 562
+      ID: 563
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35657,9 +35885,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 563 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 564 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 521
+      ID: 522
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35681,9 +35909,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 522 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 523 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 513
+      ID: 514
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35705,13 +35933,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 514 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 515 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1329
+      ID: 1340
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1054
+      ID: 1065
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1716960
@@ -35724,13 +35952,13 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 1274
+      ID: 1285
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1923456
       GoKind: 6
     - __kind: StructureType
-      ID: 387
+      ID: 330
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1980032
@@ -35741,10 +35969,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 1390 GoSliceHeaderType []time.zone
+          Type: 643 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 1393 GoSliceHeaderType []time.zoneTrans
+          Type: 646 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -35756,13 +35984,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 1391 PointerType *time.zone
+          Type: 644 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 795
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 385
+    - __kind: GoTimeType
+      ID: 328
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2383104
@@ -35776,9 +36004,17 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 386 PointerType *time.Location
+          Type: 329 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 384
+      ID: 388
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1476896
@@ -35786,12 +36022,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1389 GoChannelType <-chan time.Time
+          Type: 1400 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 705
+      ID: 716
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 834272
@@ -35799,18 +36035,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 707 PointerType *time.fileSizeError.str
+          Type: 718 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 706 GoStringDataType time.fileSizeError.str
+      Data: 717 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 706
+      ID: 717
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1392
+      ID: 645
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1626240
@@ -35826,7 +36062,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1395
+      ID: 648
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1761696
@@ -35887,7 +36123,7 @@ Types:
       GoRuntimeType: 588160
       GoKind: 26
     - __kind: StructureType
-      ID: 1144
+      ID: 1155
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2072896
@@ -35898,10 +36134,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1145 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1156 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1146 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1157 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -35916,18 +36152,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1147 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1158 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1147
+      ID: 1158
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 999712
       GoKind: 9
     - __kind: StructureType
-      ID: 1145
+      ID: 1156
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1936256
@@ -35952,21 +36188,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 890
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1146
+      ID: 1157
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 591808
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1321
+      ID: 1332
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 863
+      ID: 874
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1433632
@@ -35976,13 +36212,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 749
+      ID: 760
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 838880
       GoKind: 2
     - __kind: StructureType
-      ID: 1031
+      ID: 1042
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1712736
@@ -35995,12 +36231,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 983
+      ID: 994
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 998560
       GoKind: 5
-MaxTypeID: 1829
+MaxTypeID: 1833
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -12,12 +12,12 @@ Probes:
         - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1735 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80d868", Frameless: false}]
+              Type: 1736 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0x80d878", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1736 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80d898", Frameless: false}]
+              Type: 1737 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0x80d8a8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -32,11 +32,11 @@ Probes:
         - subprogram: {subprogram: 60}
           events:
             - Kind: Entry
-              Type: 1574 EventRootType Probe[main.testAny]
+              Type: 1575 EventRootType Probe[main.testAny]
               InjectionPoints: [{PC: "0x8089d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1575 EventRootType Probe[main.testAny]Return
+              Type: 1576 EventRootType Probe[main.testAny]Return
               InjectionPoints: [{PC: "0x808a00", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -58,11 +58,11 @@ Probes:
         - subprogram: {subprogram: 62}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testAnyPtr]
+              Type: 1578 EventRootType Probe[main.testAnyPtr]
               InjectionPoints: [{PC: "0x808a48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1578 EventRootType Probe[main.testAnyPtr]Return
+              Type: 1579 EventRootType Probe[main.testAnyPtr]Return
               InjectionPoints: [{PC: "0x808a70", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -83,12 +83,12 @@ Probes:
         - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1706 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80c49c", Frameless: false}]
+              Type: 1707 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0x80c4ac", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1707 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80c530", Frameless: false}]
+              Type: 1708 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0x80c540", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -109,7 +109,7 @@ Probes:
         - subprogram: {subprogram: 19}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testArrayEmptyStructs]
+              Type: 1523 EventRootType Probe[main.testArrayEmptyStructs]
               InjectionPoints: [{PC: "0x804450", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -131,7 +131,7 @@ Probes:
         - subprogram: {subprogram: 15}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testArrayOfArrays]
+              Type: 1519 EventRootType Probe[main.testArrayOfArrays]
               InjectionPoints: [{PC: "0x804410", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -153,7 +153,7 @@ Probes:
         - subprogram: {subprogram: 17}
           events:
             - Kind: Entry
-              Type: 1520 EventRootType Probe[main.testArrayOfArraysOfArrays]
+              Type: 1521 EventRootType Probe[main.testArrayOfArraysOfArrays]
               InjectionPoints: [{PC: "0x804430", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -175,8 +175,8 @@ Probes:
         - subprogram: {subprogram: 70}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x809190", Frameless: true}]
+              Type: 1587 EventRootType Probe[main.testArrayOfMaps]
+              InjectionPoints: [{PC: "0x8091a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -197,7 +197,7 @@ Probes:
         - subprogram: {subprogram: 16}
           events:
             - Kind: Entry
-              Type: 1519 EventRootType Probe[main.testArrayOfStrings]
+              Type: 1520 EventRootType Probe[main.testArrayOfStrings]
               InjectionPoints: [{PC: "0x804420", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -218,7 +218,7 @@ Probes:
         - subprogram: {subprogram: 18}
           events:
             - Kind: Entry
-              Type: 1521 EventRootType Probe[main.testArrayOfStructs]
+              Type: 1522 EventRootType Probe[main.testArrayOfStructs]
               InjectionPoints: [{PC: "0x804440", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -240,12 +240,12 @@ Probes:
         - subprogram: {subprogram: 90}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x80a880", Frameless: true}]
+              Type: 1609 EventRootType Probe[main.testAtomicAdd]
+              InjectionPoints: [{PC: "0x80a890", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1609 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x80a8bc", Frameless: true}]
+              Type: 1610 EventRootType Probe[main.testAtomicAdd]Return
+              InjectionPoints: [{PC: "0x80a8cc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -266,7 +266,7 @@ Probes:
         - subprogram: {subprogram: 37}
           events:
             - Kind: Entry
-              Type: 1540 EventRootType Probe[main.testBigStruct]
+              Type: 1541 EventRootType Probe[main.testBigStruct]
               InjectionPoints: [{PC: "0x8049a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -288,7 +288,7 @@ Probes:
         - subprogram: {subprogram: 4}
           events:
             - Kind: Entry
-              Type: 1507 EventRootType Probe[main.testBoolArray]
+              Type: 1508 EventRootType Probe[main.testBoolArray]
               InjectionPoints: [{PC: "0x804360", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -310,7 +310,7 @@ Probes:
         - subprogram: {subprogram: 1}
           events:
             - Kind: Entry
-              Type: 1504 EventRootType Probe[main.testByteArray]
+              Type: 1505 EventRootType Probe[main.testByteArray]
               InjectionPoints: [{PC: "0x804330", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -337,8 +337,8 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1751 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80db30", Frameless: true}]
+              Type: 1752 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x80db40", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -353,10 +353,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1810 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1814 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x8082f8"
                   Frameless: false
@@ -383,10 +383,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1811 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1815 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x8082f8"
                   Frameless: false
@@ -402,7 +402,7 @@ Probes:
                 Type: 6 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 189, index: 0, name: x}
+                      Variable: {subprogram: 192, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -429,10 +429,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1812 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1816 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x8082f8"
                   Frameless: false
@@ -469,8 +469,8 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80a620", Frameless: true}]
+              Type: 1606 EventRootType Probe[main.testCombinedString]
+              InjectionPoints: [{PC: "0x80a630", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -488,8 +488,8 @@ Probes:
         - subprogram: {subprogram: 88}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80a620", Frameless: true}]
+              Type: 1607 EventRootType Probe[main.testCombinedString]
+              InjectionPoints: [{PC: "0x80a630", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -514,8 +514,8 @@ Probes:
         - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1757 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80dba0", Frameless: true}]
+              Type: 1758 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0x80dbb0", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -552,8 +552,8 @@ Probes:
         - subprogram: {subprogram: 91}
           events:
             - Kind: Entry
-              Type: 1610 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x80a8c0", Frameless: true}]
+              Type: 1611 EventRootType Probe[main.testChannel]
+              InjectionPoints: [{PC: "0x80a8d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -582,8 +582,8 @@ Probes:
         - subprogram: {subprogram: 87}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x80a600", Frameless: true}]
+              Type: 1605 EventRootType Probe[main.testCombinedByte]
+              InjectionPoints: [{PC: "0x80a610", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -611,12 +611,12 @@ Probes:
         - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1671 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80b798", Frameless: false}]
+              Type: 1672 EventRootType Probe[main.testConflictingReturn]
+              InjectionPoints: [{PC: "0x80b7a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1672 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80b83c", Frameless: false}]
+              Type: 1673 EventRootType Probe[main.testConflictingReturn]Return
+              InjectionPoints: [{PC: "0x80b84c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -637,8 +637,8 @@ Probes:
         - subprogram: {subprogram: 99}
           events:
             - Kind: Entry
-              Type: 1618 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x80ab40", Frameless: true}]
+              Type: 1619 EventRootType Probe[main.testCycle]
+              InjectionPoints: [{PC: "0x80ab50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -659,7 +659,7 @@ Probes:
         - subprogram: {subprogram: 43}
           events:
             - Kind: Entry
-              Type: 1546 EventRootType Probe[main.testDeepMap1]
+              Type: 1547 EventRootType Probe[main.testDeepMap1]
               InjectionPoints: [{PC: "0x804e00", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -681,7 +681,7 @@ Probes:
         - subprogram: {subprogram: 44}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testDeepMap7]
+              Type: 1548 EventRootType Probe[main.testDeepMap7]
               InjectionPoints: [{PC: "0x804e10", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -703,7 +703,7 @@ Probes:
         - subprogram: {subprogram: 39}
           events:
             - Kind: Entry
-              Type: 1542 EventRootType Probe[main.testDeepPtr1]
+              Type: 1543 EventRootType Probe[main.testDeepPtr1]
               InjectionPoints: [{PC: "0x804b70", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -725,7 +725,7 @@ Probes:
         - subprogram: {subprogram: 40}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testDeepPtr7]
+              Type: 1544 EventRootType Probe[main.testDeepPtr7]
               InjectionPoints: [{PC: "0x804b80", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -747,7 +747,7 @@ Probes:
         - subprogram: {subprogram: 41}
           events:
             - Kind: Entry
-              Type: 1544 EventRootType Probe[main.testDeepSlice1]
+              Type: 1545 EventRootType Probe[main.testDeepSlice1]
               InjectionPoints: [{PC: "0x804ca0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -769,7 +769,7 @@ Probes:
         - subprogram: {subprogram: 42}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testDeepSlice7]
+              Type: 1546 EventRootType Probe[main.testDeepSlice7]
               InjectionPoints: [{PC: "0x804cb0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -791,8 +791,8 @@ Probes:
         - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1723 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80d220", Frameless: true}]
+              Type: 1724 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0x80d230", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -818,8 +818,8 @@ Probes:
         - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1726 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80d250", Frameless: true}]
+              Type: 1727 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0x80d260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -846,8 +846,8 @@ Probes:
         - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1747 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80d920", Frameless: true}]
+              Type: 1748 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0x80d930", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -868,8 +868,8 @@ Probes:
         - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1758 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80dbd0", Frameless: true}]
+              Type: 1759 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0x80dbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -889,8 +889,8 @@ Probes:
         - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1759 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80dbe0", Frameless: true}]
+              Type: 1760 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0x80dbf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -911,7 +911,7 @@ Probes:
         - subprogram: {subprogram: 61}
           events:
             - Kind: Entry
-              Type: 1576 EventRootType Probe[main.testError]
+              Type: 1577 EventRootType Probe[main.testError]
               InjectionPoints: [{PC: "0x808a20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -945,7 +945,7 @@ Probes:
         - subprogram: {subprogram: 38}
           events:
             - Kind: Line
-              Type: 1541 EventRootType Probe[main.testErrorAtLine]Line
+              Type: 1542 EventRootType Probe[main.testErrorAtLine]Line
               InjectionPoints: [{PC: "0x804a30", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -973,11 +973,11 @@ Probes:
         - subprogram: {subprogram: 52}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.testEsotericHeap]
+              Type: 1559 EventRootType Probe[main.testEsotericHeap]
               InjectionPoints: [{PC: "0x8073d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1559 EventRootType Probe[main.testEsotericHeap]Return
+              Type: 1560 EventRootType Probe[main.testEsotericHeap]Return
               InjectionPoints: [{PC: "0x807410", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -999,11 +999,11 @@ Probes:
         - subprogram: {subprogram: 51}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.testEsotericStack]
+              Type: 1557 EventRootType Probe[main.testEsotericStack]
               InjectionPoints: [{PC: "0x80731c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.testEsotericStack]Return
+              Type: 1558 EventRootType Probe[main.testEsotericStack]Return
               InjectionPoints: [{PC: "0x807378", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1025,11 +1025,11 @@ Probes:
         - subprogram: {subprogram: 57}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.testFrameless]
+              Type: 1569 EventRootType Probe[main.testFrameless]
               InjectionPoints: [{PC: "0x808740", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1569 EventRootType Probe[main.testFrameless]Return
+              Type: 1570 EventRootType Probe[main.testFrameless]Return
               InjectionPoints: [{PC: "0x808748", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -1051,11 +1051,11 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Entry
-              Type: 1570 EventRootType Probe[main.testFramelessArray]
+              Type: 1571 EventRootType Probe[main.testFramelessArray]
               InjectionPoints: [{PC: "0x80875c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1571 EventRootType Probe[main.testFramelessArray]Return
+              Type: 1572 EventRootType Probe[main.testFramelessArray]Return
               InjectionPoints: [{PC: "0x808790", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1080,7 +1080,7 @@ Probes:
         - subprogram: {subprogram: 58}
           events:
             - Kind: Line
-              Type: 1572 EventRootType Probe[main.testFramelessArray]Line
+              Type: 1573 EventRootType Probe[main.testFramelessArray]Line
               InjectionPoints: [{PC: "0x80875c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1099,15 +1099,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1796 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x80f9b0", Frameless: true}]
+              Type: 1800 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0x80fb00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1797 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80f9b4", Frameless: true}]
+              Type: 1801 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80fb04", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1117,15 +1117,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1798 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x80f9d0", Frameless: false}]
+              Type: 1802 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0x80fb20", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1799 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x80fa04", Frameless: false}]
+              Type: 1803 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0x80fb54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1144,15 +1144,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1792 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x80f918", Frameless: false}]
+              Type: 1796 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0x80fa68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1793 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x80f928", Frameless: false}]
+              Type: 1797 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0x80fa78", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1162,15 +1162,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1794 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x80f968", Frameless: false}]
+              Type: 1798 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0x80fab8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1795 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x80f980", Frameless: false}]
+              Type: 1799 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0x80fad0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1189,18 +1189,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1800 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fa10", Frameless: true}]
+              Type: 1804 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0x80fb60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1801 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1805 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x80fa38"
+                - PC: "0x80fb88"
                   Frameless: true
-                - PC: "0x80fa40"
+                - PC: "0x80fb90"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1211,18 +1211,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1802 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x80fa68", Frameless: false}]
+              Type: 1806 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0x80fbb8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1803 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1807 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x80fac8"
+                - PC: "0x80fc18"
                   Frameless: false
-                - PC: "0x80fad8"
+                - PC: "0x80fc28"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1245,11 +1245,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Line
-              Type: 1804 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x80fa14", Frameless: true}]
+              Type: 1808 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0x80fb64", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1257,11 +1257,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1805 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x80fa78", Frameless: false}]
+              Type: 1809 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0x80fbc8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1278,15 +1278,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1780 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x80f690", Frameless: true}]
+              Type: 1784 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0x80f7e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1781 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x80f694", Frameless: true}]
+              Type: 1785 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0x80f7e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1296,15 +1296,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1782 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x80f710", Frameless: true}]
+              Type: 1786 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0x80f860", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1783 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x80f714", Frameless: true}]
+              Type: 1787 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0x80f864", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1324,15 +1324,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 169}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1768 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80f29c", Frameless: false}]
+              Type: 1772 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0x80f3ec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1769 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80f3e8", Frameless: false}]
+              Type: 1773 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80f538", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1342,14 +1342,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1770 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1774 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x8035bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1771 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1775 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x803708", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1370,15 +1370,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1772 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80f438", Frameless: false}]
+              Type: 1776 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x80f588", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1773 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80f448", Frameless: false}]
+              Type: 1777 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80f598", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1397,15 +1397,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1806 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x80fb10", Frameless: true}]
+              Type: 1810 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0x80fc60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1807 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x80fb18", Frameless: true}]
+              Type: 1811 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0x80fc68", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1415,15 +1415,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1808 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x80fb88", Frameless: false}]
+              Type: 1812 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0x80fcd8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1809 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x80fbac", Frameless: false}]
+              Type: 1813 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0x80fcfc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1442,15 +1442,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
+        - subprogram: {subprogram: 170}
           events:
             - Kind: Entry
-              Type: 1764 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80f200", Frameless: true}]
+              Type: 1768 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0x80f350", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1765 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80f204", Frameless: true}]
+              Type: 1769 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80f354", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1460,15 +1460,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 168}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1766 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80f210", Frameless: true}]
+              Type: 1770 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0x80f360", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1767 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80f21c", Frameless: true}]
+              Type: 1771 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80f36c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1487,15 +1487,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1784 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x80f790", Frameless: true}]
+              Type: 1788 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0x80f8e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1785 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x80f798", Frameless: true}]
+              Type: 1789 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0x80f8e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1505,15 +1505,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1786 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x80f818", Frameless: false}]
+              Type: 1790 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0x80f968", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1787 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x80f840", Frameless: false}]
+              Type: 1791 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0x80f990", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1532,15 +1532,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1774 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x80f660", Frameless: true}]
+              Type: 1778 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x80f7b0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1775 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80f664", Frameless: true}]
+              Type: 1779 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80f7b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1550,15 +1550,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1776 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x80f670", Frameless: true}]
+              Type: 1780 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0x80f7c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1777 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x80f674", Frameless: true}]
+              Type: 1781 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0x80f7c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1568,15 +1568,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1778 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x80f680", Frameless: true}]
+              Type: 1782 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0x80f7d0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1779 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x80f684", Frameless: true}]
+              Type: 1783 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0x80f7d4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1595,15 +1595,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1788 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x80f8d0", Frameless: true}]
+              Type: 1792 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0x80fa20", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1789 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x80f8d8", Frameless: true}]
+              Type: 1793 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0x80fa28", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1613,15 +1613,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1790 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80f8e0", Frameless: true}]
+              Type: 1794 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x80fa30", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1791 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80f8f0", Frameless: true}]
+              Type: 1795 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80fa40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1640,15 +1640,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1760 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80f1e0", Frameless: true}]
+              Type: 1764 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0x80f330", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1761 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80f1e4", Frameless: true}]
+              Type: 1765 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80f334", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1658,15 +1658,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1762 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80f1f0", Frameless: true}]
+              Type: 1766 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0x80f340", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1763 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80f1fc", Frameless: true}]
+              Type: 1767 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80f34c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1688,11 +1688,11 @@ Probes:
         - subprogram: {subprogram: 53}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.testInlinedBA]
+              Type: 1561 EventRootType Probe[main.testInlinedBA]
               InjectionPoints: [{PC: "0x808488", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1561 EventRootType Probe[main.testInlinedBA]Return
+              Type: 1562 EventRootType Probe[main.testInlinedBA]Return
               InjectionPoints: [{PC: "0x8084d4", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1719,11 +1719,11 @@ Probes:
         - subprogram: {subprogram: 54}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.testInlinedBB]
+              Type: 1563 EventRootType Probe[main.testInlinedBB]
               InjectionPoints: [{PC: "0x808518", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1563 EventRootType Probe[main.testInlinedBB]Return
+              Type: 1564 EventRootType Probe[main.testInlinedBB]Return
               InjectionPoints: [{PC: "0x808598", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1750,11 +1750,11 @@ Probes:
         - subprogram: {subprogram: 55}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.testInlinedBBA]
+              Type: 1565 EventRootType Probe[main.testInlinedBBA]
               InjectionPoints: [{PC: "0x8085d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1565 EventRootType Probe[main.testInlinedBBA]Return
+              Type: 1566 EventRootType Probe[main.testInlinedBBA]Return
               InjectionPoints: [{PC: "0x808610", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1773,10 +1773,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1816 EventRootType Probe[main.testInlinedBBB]
+              Type: 1820 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0x808564", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1794,11 +1794,11 @@ Probes:
         - subprogram: {subprogram: 56}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.testInlinedBC]
+              Type: 1567 EventRootType Probe[main.testInlinedBC]
               InjectionPoints: [{PC: "0x808648", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1567 EventRootType Probe[main.testInlinedBC]Return
+              Type: 1568 EventRootType Probe[main.testInlinedBC]Return
               InjectionPoints: [{PC: "0x808724", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1813,10 +1813,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Entry
-              Type: 1817 EventRootType Probe[main.testInlinedBCA]
+              Type: 1821 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0x80864c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1834,10 +1834,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 194}
           events:
             - Kind: Line
-              Type: 1818 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1822 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0x80864c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1852,10 +1852,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Entry
-              Type: 1819 EventRootType Probe[main.testInlinedBCB]
+              Type: 1823 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0x8086f0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1873,10 +1873,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 195}
           events:
             - Kind: Line
-              Type: 1820 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1824 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0x8086f0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1891,10 +1891,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 196}
+        - subprogram: {subprogram: 199}
           events:
             - Kind: Entry
-              Type: 1826 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1830 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x803128"
                   Frameless: true
@@ -1914,10 +1914,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1813 EventRootType Probe[main.testInlinedPrint]
+              Type: 1817 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0x8082f8"
                   Frameless: false
@@ -1931,7 +1931,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1814 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1818 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0x80832c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1953,10 +1953,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Line
-              Type: 1815 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1819 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x8082f8"
                   Frameless: false
@@ -1985,10 +1985,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Entry
-              Type: 1821 EventRootType Probe[main.testInlinedSq]
+              Type: 1825 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0x808744", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2010,10 +2010,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 193}
+        - subprogram: {subprogram: 196}
           events:
             - Kind: Line
-              Type: 1822 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1826 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0x808744", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2033,10 +2033,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 194}
+        - subprogram: {subprogram: 197}
           events:
             - Kind: Entry
-              Type: 1823 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1827 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0x808774"
                   Frameless: false
@@ -2062,7 +2062,7 @@ Probes:
         - subprogram: {subprogram: 7}
           events:
             - Kind: Entry
-              Type: 1510 EventRootType Probe[main.testInt16Array]
+              Type: 1511 EventRootType Probe[main.testInt16Array]
               InjectionPoints: [{PC: "0x804390", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2084,7 +2084,7 @@ Probes:
         - subprogram: {subprogram: 8}
           events:
             - Kind: Entry
-              Type: 1511 EventRootType Probe[main.testInt32Array]
+              Type: 1512 EventRootType Probe[main.testInt32Array]
               InjectionPoints: [{PC: "0x8043a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2106,7 +2106,7 @@ Probes:
         - subprogram: {subprogram: 9}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testInt64Array]
+              Type: 1513 EventRootType Probe[main.testInt64Array]
               InjectionPoints: [{PC: "0x8043b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2128,7 +2128,7 @@ Probes:
         - subprogram: {subprogram: 6}
           events:
             - Kind: Entry
-              Type: 1509 EventRootType Probe[main.testInt8Array]
+              Type: 1510 EventRootType Probe[main.testInt8Array]
               InjectionPoints: [{PC: "0x804380", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2150,7 +2150,7 @@ Probes:
         - subprogram: {subprogram: 5}
           events:
             - Kind: Entry
-              Type: 1508 EventRootType Probe[main.testIntArray]
+              Type: 1509 EventRootType Probe[main.testIntArray]
               InjectionPoints: [{PC: "0x804370", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2172,7 +2172,7 @@ Probes:
         - subprogram: {subprogram: 59}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.testInterface]
+              Type: 1574 EventRootType Probe[main.testInterface]
               InjectionPoints: [{PC: "0x8089b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2193,12 +2193,12 @@ Probes:
         - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1704 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80c310", Frameless: false}]
+              Type: 1705 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0x80c320", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1705 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80c440", Frameless: false}]
+              Type: 1706 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x80c450", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2219,8 +2219,8 @@ Probes:
         - subprogram: {subprogram: 93}
           events:
             - Kind: Entry
-              Type: 1612 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x80aa50", Frameless: true}]
+              Type: 1613 EventRootType Probe[main.testLinkedList]
+              InjectionPoints: [{PC: "0x80aa60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2244,7 +2244,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1550 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1551 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x804e5c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2266,7 +2266,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1551 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1552 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x804efc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2288,7 +2288,7 @@ Probes:
         - subprogram: {subprogram: 47}
           events:
             - Kind: Line
-              Type: 1552 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+              Type: 1553 EventRootType Probe[main.testLongFunctionWithChangingState]Line
               InjectionPoints: [{PC: "0x804fa0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -2331,12 +2331,12 @@ Probes:
         - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1710 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80c77c", Frameless: false}]
+              Type: 1711 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0x80c78c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1711 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80c8d0", Frameless: false}]
+              Type: 1712 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0x80c8e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2398,7 +2398,7 @@ Probes:
         - subprogram: {subprogram: 49}
           events:
             - Kind: Entry
-              Type: 1554 EventRootType Probe[main.testManyPointers]
+              Type: 1555 EventRootType Probe[main.testManyPointers]
               InjectionPoints: [{PC: "0x805480", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2422,7 +2422,7 @@ Probes:
         - subprogram: {subprogram: 50}
           events:
             - Kind: Entry
-              Type: 1555 EventRootType Probe[main.testManyStrings]
+              Type: 1556 EventRootType Probe[main.testManyStrings]
               InjectionPoints: [{PC: "0x807030", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2444,8 +2444,8 @@ Probes:
         - subprogram: {subprogram: 68}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x809170", Frameless: true}]
+              Type: 1585 EventRootType Probe[main.testMapArrayToArray]
+              InjectionPoints: [{PC: "0x809180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2466,8 +2466,8 @@ Probes:
         - subprogram: {subprogram: 74}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x8091d0", Frameless: true}]
+              Type: 1592 EventRootType Probe[main.testMapEmbeddedMaps]
+              InjectionPoints: [{PC: "0x8091e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2488,8 +2488,8 @@ Probes:
         - subprogram: {subprogram: 84}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x809270", Frameless: true}]
+              Type: 1602 EventRootType Probe[main.testMapEmptyKey]
+              InjectionPoints: [{PC: "0x809280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2510,8 +2510,8 @@ Probes:
         - subprogram: {subprogram: 86}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x809290", Frameless: true}]
+              Type: 1604 EventRootType Probe[main.testMapEmptyKeyAndValue]
+              InjectionPoints: [{PC: "0x8092a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2532,8 +2532,8 @@ Probes:
         - subprogram: {subprogram: 85}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x809280", Frameless: true}]
+              Type: 1603 EventRootType Probe[main.testMapEmptyValue]
+              InjectionPoints: [{PC: "0x809290", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2554,8 +2554,8 @@ Probes:
         - subprogram: {subprogram: 72}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x8091b0", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.testMapIntToInt]
+              InjectionPoints: [{PC: "0x8091c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2576,8 +2576,8 @@ Probes:
         - subprogram: {subprogram: 83}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x809260", Frameless: true}]
+              Type: 1601 EventRootType Probe[main.testMapLargeKeyLargeValue]
+              InjectionPoints: [{PC: "0x809270", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2598,8 +2598,8 @@ Probes:
         - subprogram: {subprogram: 82}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x809250", Frameless: true}]
+              Type: 1600 EventRootType Probe[main.testMapLargeKeySmallValue]
+              InjectionPoints: [{PC: "0x809260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2622,8 +2622,8 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x8091c0", Frameless: true}]
+              Type: 1590 EventRootType Probe[main.testMapMassive]
+              InjectionPoints: [{PC: "0x8091d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2646,8 +2646,8 @@ Probes:
         - subprogram: {subprogram: 73}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x8091c0", Frameless: true}]
+              Type: 1591 EventRootType Probe[main.testMapMassive]
+              InjectionPoints: [{PC: "0x8091d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2668,8 +2668,8 @@ Probes:
         - subprogram: {subprogram: 81}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x809240", Frameless: true}]
+              Type: 1599 EventRootType Probe[main.testMapSmallKeyLargeValue]
+              InjectionPoints: [{PC: "0x809250", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2690,8 +2690,8 @@ Probes:
         - subprogram: {subprogram: 80}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x809230", Frameless: true}]
+              Type: 1598 EventRootType Probe[main.testMapSmallKeySmallValue]
+              InjectionPoints: [{PC: "0x809240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2712,8 +2712,8 @@ Probes:
         - subprogram: {subprogram: 66}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x809150", Frameless: true}]
+              Type: 1583 EventRootType Probe[main.testMapStringToInt]
+              InjectionPoints: [{PC: "0x809160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2734,8 +2734,8 @@ Probes:
         - subprogram: {subprogram: 67}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x809160", Frameless: true}]
+              Type: 1584 EventRootType Probe[main.testMapStringToSlice]
+              InjectionPoints: [{PC: "0x809170", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2756,8 +2756,8 @@ Probes:
         - subprogram: {subprogram: 65}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x809140", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.testMapStringToStruct]
+              InjectionPoints: [{PC: "0x809150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2778,8 +2778,8 @@ Probes:
         - subprogram: {subprogram: 75}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x8091e0", Frameless: true}]
+              Type: 1593 EventRootType Probe[main.testMapWithLinkedList]
+              InjectionPoints: [{PC: "0x8091f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2800,8 +2800,8 @@ Probes:
         - subprogram: {subprogram: 78}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x809210", Frameless: true}]
+              Type: 1596 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+              InjectionPoints: [{PC: "0x809220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2822,8 +2822,8 @@ Probes:
         - subprogram: {subprogram: 79}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x809220", Frameless: true}]
+              Type: 1597 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+              InjectionPoints: [{PC: "0x809230", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2844,8 +2844,8 @@ Probes:
         - subprogram: {subprogram: 76}
           events:
             - Kind: Entry
-              Type: 1593 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x8091f0", Frameless: true}]
+              Type: 1594 EventRootType Probe[main.testMapWithSmallValue]
+              InjectionPoints: [{PC: "0x809200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2868,8 +2868,8 @@ Probes:
         - subprogram: {subprogram: 77}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x809200", Frameless: true}]
+              Type: 1595 EventRootType Probe[main.testMapWithSmallValueMassive]
+              InjectionPoints: [{PC: "0x809210", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2890,8 +2890,8 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1744 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80d900", Frameless: true}]
+              Type: 1745 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x80d910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2913,8 +2913,8 @@ Probes:
         - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1745 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80d900", Frameless: true}]
+              Type: 1746 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x80d910", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2960,12 +2960,12 @@ Probes:
         - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1712 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80c930", Frameless: false}]
+              Type: 1713 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0x80c940", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1713 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80cabc", Frameless: false}]
+              Type: 1714 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0x80cacc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3030,12 +3030,12 @@ Probes:
         - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1716 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80cbac", Frameless: false}]
+              Type: 1717 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0x80cbbc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1717 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80cc48", Frameless: false}]
+              Type: 1718 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0x80cc58", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3065,12 +3065,12 @@ Probes:
         - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1708 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80c570", Frameless: false}]
+              Type: 1709 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0x80c580", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1709 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80c718", Frameless: false}]
+              Type: 1710 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0x80c728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3095,12 +3095,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1649 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80b618", Frameless: false}]
+              Type: 1650 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80b628", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1650 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b69c", Frameless: false}]
+              Type: 1651 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3135,8 +3135,8 @@ Probes:
         - subprogram: {subprogram: 89}
           events:
             - Kind: Entry
-              Type: 1607 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x80a6e0", Frameless: true}]
+              Type: 1608 EventRootType Probe[main.testMultipleSimpleParams]
+              InjectionPoints: [{PC: "0x80a6f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3176,12 +3176,12 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1643 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80b578", Frameless: false}]
+              Type: 1644 EventRootType Probe[main.testNamedReturn]
+              InjectionPoints: [{PC: "0x80b588", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1644 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b5d4", Frameless: false}]
+              Type: 1645 EventRootType Probe[main.testNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b5e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3204,12 +3204,12 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1645 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80b578", Frameless: false}]
+              Type: 1646 EventRootType Probe[main.testNamedReturn]
+              InjectionPoints: [{PC: "0x80b588", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1646 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b5d4", Frameless: false}]
+              Type: 1647 EventRootType Probe[main.testNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b5e4", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3227,12 +3227,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1651 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80b618", Frameless: false}]
+              Type: 1652 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80b628", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1652 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b69c", Frameless: false}]
+              Type: 1653 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3251,12 +3251,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1653 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80b618", Frameless: false}]
+              Type: 1654 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80b628", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1654 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b69c", Frameless: false}]
+              Type: 1655 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3288,12 +3288,12 @@ Probes:
         - subprogram: {subprogram: 107}
           events:
             - Kind: Entry
-              Type: 1647 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80b578", Frameless: false}]
+              Type: 1648 EventRootType Probe[main.testNamedReturn]
+              InjectionPoints: [{PC: "0x80b588", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1648 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b5d4", Frameless: false}]
+              Type: 1649 EventRootType Probe[main.testNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b5e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3320,8 +3320,8 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1753 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80db90", Frameless: true}]
+              Type: 1754 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80dba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3345,8 +3345,8 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1754 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80db90", Frameless: true}]
+              Type: 1755 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80dba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3376,8 +3376,8 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1755 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80db90", Frameless: true}]
+              Type: 1756 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80dba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3401,8 +3401,8 @@ Probes:
         - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1756 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80db90", Frameless: true}]
+              Type: 1757 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80dba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3428,8 +3428,8 @@ Probes:
         - subprogram: {subprogram: 98}
           events:
             - Kind: Entry
-              Type: 1617 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x80ab20", Frameless: true}]
+              Type: 1618 EventRootType Probe[main.testNilPointer]
+              InjectionPoints: [{PC: "0x80ab30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3455,8 +3455,8 @@ Probes:
         - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1730 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80d290", Frameless: true}]
+              Type: 1731 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0x80d2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3482,8 +3482,8 @@ Probes:
         - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1727 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80d260", Frameless: true}]
+              Type: 1728 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0x80d270", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3517,8 +3517,8 @@ Probes:
         - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1729 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80d280", Frameless: true}]
+              Type: 1730 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0x80d290", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3549,8 +3549,8 @@ Probes:
         - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1743 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80d8f0", Frameless: true}]
+              Type: 1744 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0x80d900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3571,8 +3571,8 @@ Probes:
         - subprogram: {subprogram: 94}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x80aa60", Frameless: true}]
+              Type: 1614 EventRootType Probe[main.testPointerLoop]
+              InjectionPoints: [{PC: "0x80aa70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3593,8 +3593,8 @@ Probes:
         - subprogram: {subprogram: 71}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x8091a0", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.testPointerToMap]
+              InjectionPoints: [{PC: "0x8091b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3615,8 +3615,8 @@ Probes:
         - subprogram: {subprogram: 92}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x80aa40", Frameless: true}]
+              Type: 1612 EventRootType Probe[main.testPointerToSimpleStruct]
+              InjectionPoints: [{PC: "0x80aa50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3639,12 +3639,12 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
+              Type: 1620 EventRootType Probe[main.testReturnsInt]
+              InjectionPoints: [{PC: "0x80ae68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1620 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80ae98", Frameless: false}]
+              Type: 1621 EventRootType Probe[main.testReturnsInt]Return
+              InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3663,12 +3663,12 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1663 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80b6d8", Frameless: false}]
+              Type: 1664 EventRootType Probe[main.testSomeNamedReturn]
+              InjectionPoints: [{PC: "0x80b6e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1664 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b760", Frameless: false}]
+              Type: 1665 EventRootType Probe[main.testSomeNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b770", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3712,12 +3712,12 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1629 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80af78", Frameless: false}]
+              Type: 1630 EventRootType Probe[main.testReturnsIntAndFloat]
+              InjectionPoints: [{PC: "0x80af88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1630 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80b008", Frameless: false}]
+              Type: 1631 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              InjectionPoints: [{PC: "0x80b018", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3758,12 +3758,12 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
+              Type: 1622 EventRootType Probe[main.testReturnsInt]
+              InjectionPoints: [{PC: "0x80ae68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1622 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80ae98", Frameless: false}]
+              Type: 1623 EventRootType Probe[main.testReturnsInt]Return
+              InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3807,12 +3807,12 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1631 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80af78", Frameless: false}]
+              Type: 1632 EventRootType Probe[main.testReturnsIntAndFloat]
+              InjectionPoints: [{PC: "0x80af88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1632 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80b008", Frameless: false}]
+              Type: 1633 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              InjectionPoints: [{PC: "0x80b018", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3855,12 +3855,12 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1665 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80b6d8", Frameless: false}]
+              Type: 1666 EventRootType Probe[main.testSomeNamedReturn]
+              InjectionPoints: [{PC: "0x80b6e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1666 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b760", Frameless: false}]
+              Type: 1667 EventRootType Probe[main.testSomeNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b770", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -3876,12 +3876,12 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1667 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80b6d8", Frameless: false}]
+              Type: 1668 EventRootType Probe[main.testSomeNamedReturn]
+              InjectionPoints: [{PC: "0x80b6e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1668 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b760", Frameless: false}]
+              Type: 1669 EventRootType Probe[main.testSomeNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b770", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -3902,12 +3902,12 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1623 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
+              Type: 1624 EventRootType Probe[main.testReturnsInt]
+              InjectionPoints: [{PC: "0x80ae68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1624 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80ae98", Frameless: false}]
+              Type: 1625 EventRootType Probe[main.testReturnsInt]Return
+              InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -3929,19 +3929,19 @@ Probes:
         - subprogram: {subprogram: 105}
           events:
             - Kind: Entry
-              Type: 1639 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80b248", Frameless: false}]
+              Type: 1640 EventRootType Probe[main.testReturnsAny]
+              InjectionPoints: [{PC: "0x80b258", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1640 EventRootType Probe[main.testReturnsAny]Return
+              Type: 1641 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80b2d0"
+                - PC: "0x80b2e0"
                   Frameless: false
-                - PC: "0x80b324"
+                - PC: "0x80b334"
                   Frameless: false
-                - PC: "0x80b3dc"
+                - PC: "0x80b3ec"
                   Frameless: false
-                - PC: "0x80b3f0"
+                - PC: "0x80b400"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -3968,19 +3968,19 @@ Probes:
         - subprogram: {subprogram: 104}
           events:
             - Kind: Entry
-              Type: 1637 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80b0c8", Frameless: false}]
+              Type: 1638 EventRootType Probe[main.testReturnsAnyAndError]
+              InjectionPoints: [{PC: "0x80b0d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1638 EventRootType Probe[main.testReturnsAnyAndError]Return
+              Type: 1639 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80b11c"
+                - PC: "0x80b12c"
                   Frameless: false
-                - PC: "0x80b178"
+                - PC: "0x80b188"
                   Frameless: false
-                - PC: "0x80b1c0"
+                - PC: "0x80b1d0"
                   Frameless: false
-                - PC: "0x80b204"
+                - PC: "0x80b214"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4006,12 +4006,12 @@ Probes:
         - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1682 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80bd4c", Frameless: false}]
+              Type: 1683 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0x80bd5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1683 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80bd9c", Frameless: false}]
+              Type: 1684 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0x80bdac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4027,12 +4027,12 @@ Probes:
         - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1684 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80bdd8", Frameless: false}]
+              Type: 1685 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0x80bde8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1685 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80be10", Frameless: false}]
+              Type: 1686 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0x80be20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4048,12 +4048,12 @@ Probes:
         - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1686 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80be48", Frameless: false}]
+              Type: 1687 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0x80be58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1687 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80be7c", Frameless: false}]
+              Type: 1688 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0x80be8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4069,12 +4069,12 @@ Probes:
         - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1690 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80bf38", Frameless: false}]
+              Type: 1691 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0x80bf48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1691 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80bf98", Frameless: false}]
+              Type: 1692 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0x80bfa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4090,12 +4090,12 @@ Probes:
         - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1702 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80c298", Frameless: false}]
+              Type: 1703 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0x80c2a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1703 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80c2d4", Frameless: false}]
+              Type: 1704 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0x80c2e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4111,12 +4111,12 @@ Probes:
         - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1678 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80bc08", Frameless: false}]
+              Type: 1679 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0x80bc18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1679 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80bc50", Frameless: false}]
+              Type: 1680 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0x80bc60", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4133,15 +4133,15 @@ Probes:
         - subprogram: {subprogram: 103}
           events:
             - Kind: Entry
-              Type: 1635 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80b048", Frameless: false}]
+              Type: 1636 EventRootType Probe[main.testReturnsError]
+              InjectionPoints: [{PC: "0x80b058", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1636 EventRootType Probe[main.testReturnsError]Return
+              Type: 1637 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80b07c"
+                - PC: "0x80b08c"
                   Frameless: false
-                - PC: "0x80b090"
+                - PC: "0x80b0a0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4162,12 +4162,12 @@ Probes:
         - subprogram: {subprogram: 100}
           events:
             - Kind: Entry
-              Type: 1625 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
+              Type: 1626 EventRootType Probe[main.testReturnsInt]
+              InjectionPoints: [{PC: "0x80ae68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1626 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80ae98", Frameless: false}]
+              Type: 1627 EventRootType Probe[main.testReturnsInt]Return
+              InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4187,12 +4187,12 @@ Probes:
         - subprogram: {subprogram: 102}
           events:
             - Kind: Entry
-              Type: 1633 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80af78", Frameless: false}]
+              Type: 1634 EventRootType Probe[main.testReturnsIntAndFloat]
+              InjectionPoints: [{PC: "0x80af88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1634 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80b008", Frameless: false}]
+              Type: 1635 EventRootType Probe[main.testReturnsIntAndFloat]Return
+              InjectionPoints: [{PC: "0x80b018", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4212,12 +4212,12 @@ Probes:
         - subprogram: {subprogram: 101}
           events:
             - Kind: Entry
-              Type: 1627 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80aed8", Frameless: false}]
+              Type: 1628 EventRootType Probe[main.testReturnsIntPointer]
+              InjectionPoints: [{PC: "0x80aee8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1628 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80af34", Frameless: false}]
+              Type: 1629 EventRootType Probe[main.testReturnsIntPointer]Return
+              InjectionPoints: [{PC: "0x80af44", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4238,15 +4238,15 @@ Probes:
         - subprogram: {subprogram: 106}
           events:
             - Kind: Entry
-              Type: 1641 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80b428", Frameless: false}]
+              Type: 1642 EventRootType Probe[main.testReturnsInterface]
+              InjectionPoints: [{PC: "0x80b438", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1642 EventRootType Probe[main.testReturnsInterface]Return
+              Type: 1643 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80b4e0"
+                - PC: "0x80b4f0"
                   Frameless: false
-                - PC: "0x80b4f4"
+                - PC: "0x80b504"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4267,12 +4267,12 @@ Probes:
         - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1680 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80bc90", Frameless: false}]
+              Type: 1681 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0x80bca0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1681 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80bd10", Frameless: false}]
+              Type: 1682 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0x80bd20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4288,12 +4288,12 @@ Probes:
         - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1676 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80bb58", Frameless: false}]
+              Type: 1677 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0x80bb68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1677 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80bbd8", Frameless: false}]
+              Type: 1678 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0x80bbe8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4309,12 +4309,12 @@ Probes:
         - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1694 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80c098", Frameless: false}]
+              Type: 1695 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0x80c0a8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1695 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80c0ec", Frameless: false}]
+              Type: 1696 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0x80c0fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4330,12 +4330,12 @@ Probes:
         - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1688 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80beb8", Frameless: false}]
+              Type: 1689 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0x80bec8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1689 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80befc", Frameless: false}]
+              Type: 1690 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0x80bf0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4351,12 +4351,12 @@ Probes:
         - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1700 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80c228", Frameless: false}]
+              Type: 1701 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0x80c238", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1701 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80c268", Frameless: false}]
+              Type: 1702 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0x80c278", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4375,8 +4375,8 @@ Probes:
         - subprogram: {subprogram: 111}
           events:
             - Kind: Line
-              Type: 1673 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80b924", Frameless: false}]
+              Type: 1674 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0x80b934", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4396,12 +4396,12 @@ Probes:
         - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1698 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80c1b8", Frameless: false}]
+              Type: 1699 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0x80c1c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1699 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80c1f4", Frameless: false}]
+              Type: 1700 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0x80c204", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4417,12 +4417,12 @@ Probes:
         - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1674 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
+              Type: 1675 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0x80bad8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1675 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80bb1c", Frameless: false}]
+              Type: 1676 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0x80bb2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4438,12 +4438,12 @@ Probes:
         - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1696 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80c12c", Frameless: false}]
+              Type: 1697 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0x80c13c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1697 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80c17c", Frameless: false}]
+              Type: 1698 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0x80c18c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4459,12 +4459,12 @@ Probes:
         - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1692 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80bfd0", Frameless: false}]
+              Type: 1693 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0x80bfe0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1693 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80c060", Frameless: false}]
+              Type: 1694 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0x80c070", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4481,7 +4481,7 @@ Probes:
         - subprogram: {subprogram: 2}
           events:
             - Kind: Entry
-              Type: 1505 EventRootType Probe[main.testRuneArray]
+              Type: 1506 EventRootType Probe[main.testRuneArray]
               InjectionPoints: [{PC: "0x804340", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4516,12 +4516,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1655 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80b618", Frameless: false}]
+              Type: 1656 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80b628", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1656 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b69c", Frameless: false}]
+              Type: 1657 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4566,7 +4566,7 @@ Probes:
         - subprogram: {subprogram: 23}
           events:
             - Kind: Entry
-              Type: 1526 EventRootType Probe[main.testSingleBool]
+              Type: 1527 EventRootType Probe[main.testSingleBool]
               InjectionPoints: [{PC: "0x8047d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4588,7 +4588,7 @@ Probes:
         - subprogram: {subprogram: 21}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testSingleByte]
+              Type: 1525 EventRootType Probe[main.testSingleByte]
               InjectionPoints: [{PC: "0x8047b0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4610,7 +4610,7 @@ Probes:
         - subprogram: {subprogram: 34}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testSingleFloat32]
+              Type: 1538 EventRootType Probe[main.testSingleFloat32]
               InjectionPoints: [{PC: "0x804880", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4628,7 +4628,7 @@ Probes:
         - subprogram: {subprogram: 35}
           events:
             - Kind: Entry
-              Type: 1538 EventRootType Probe[main.testSingleFloat64]
+              Type: 1539 EventRootType Probe[main.testSingleFloat64]
               InjectionPoints: [{PC: "0x804890", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4646,7 +4646,7 @@ Probes:
         - subprogram: {subprogram: 24}
           events:
             - Kind: Entry
-              Type: 1527 EventRootType Probe[main.testSingleInt]
+              Type: 1528 EventRootType Probe[main.testSingleInt]
               InjectionPoints: [{PC: "0x8047e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4668,7 +4668,7 @@ Probes:
         - subprogram: {subprogram: 26}
           events:
             - Kind: Entry
-              Type: 1529 EventRootType Probe[main.testSingleInt16]
+              Type: 1530 EventRootType Probe[main.testSingleInt16]
               InjectionPoints: [{PC: "0x804800", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4691,7 +4691,7 @@ Probes:
         - subprogram: {subprogram: 27}
           events:
             - Kind: Entry
-              Type: 1530 EventRootType Probe[main.testSingleInt32]
+              Type: 1531 EventRootType Probe[main.testSingleInt32]
               InjectionPoints: [{PC: "0x804810", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4713,7 +4713,7 @@ Probes:
         - subprogram: {subprogram: 28}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testSingleInt64]
+              Type: 1532 EventRootType Probe[main.testSingleInt64]
               InjectionPoints: [{PC: "0x804820", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4742,7 +4742,7 @@ Probes:
         - subprogram: {subprogram: 25}
           events:
             - Kind: Entry
-              Type: 1528 EventRootType Probe[main.testSingleInt8]
+              Type: 1529 EventRootType Probe[main.testSingleInt8]
               InjectionPoints: [{PC: "0x8047f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4773,7 +4773,7 @@ Probes:
         - subprogram: {subprogram: 22}
           events:
             - Kind: Entry
-              Type: 1525 EventRootType Probe[main.testSingleRune]
+              Type: 1526 EventRootType Probe[main.testSingleRune]
               InjectionPoints: [{PC: "0x8047c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4795,8 +4795,8 @@ Probes:
         - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1737 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80d8b0", Frameless: true}]
+              Type: 1738 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0x80d8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4817,7 +4817,7 @@ Probes:
         - subprogram: {subprogram: 29}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testSingleUint]
+              Type: 1533 EventRootType Probe[main.testSingleUint]
               InjectionPoints: [{PC: "0x804830", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4839,7 +4839,7 @@ Probes:
         - subprogram: {subprogram: 31}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testSingleUint16]
+              Type: 1535 EventRootType Probe[main.testSingleUint16]
               InjectionPoints: [{PC: "0x804850", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4861,7 +4861,7 @@ Probes:
         - subprogram: {subprogram: 32}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testSingleUint32]
+              Type: 1536 EventRootType Probe[main.testSingleUint32]
               InjectionPoints: [{PC: "0x804860", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4883,7 +4883,7 @@ Probes:
         - subprogram: {subprogram: 33}
           events:
             - Kind: Entry
-              Type: 1536 EventRootType Probe[main.testSingleUint64]
+              Type: 1537 EventRootType Probe[main.testSingleUint64]
               InjectionPoints: [{PC: "0x804870", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4905,7 +4905,7 @@ Probes:
         - subprogram: {subprogram: 30}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testSingleUint8]
+              Type: 1534 EventRootType Probe[main.testSingleUint8]
               InjectionPoints: [{PC: "0x804840", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -4927,8 +4927,8 @@ Probes:
         - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1733 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80d2b0", Frameless: true}]
+              Type: 1734 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0x80d2c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4949,8 +4949,8 @@ Probes:
         - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1724 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80d230", Frameless: true}]
+              Type: 1725 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0x80d240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4971,8 +4971,8 @@ Probes:
         - subprogram: {subprogram: 69}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x809180", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.testSmallMap]
+              InjectionPoints: [{PC: "0x809190", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -4992,12 +4992,12 @@ Probes:
         - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1669 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80b6d8", Frameless: false}]
+              Type: 1670 EventRootType Probe[main.testSomeNamedReturn]
+              InjectionPoints: [{PC: "0x80b6e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1670 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b760", Frameless: false}]
+              Type: 1671 EventRootType Probe[main.testSomeNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b770", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5017,12 +5017,12 @@ Probes:
         - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1714 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80cb18", Frameless: false}]
+              Type: 1715 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0x80cb28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1715 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80cb74", Frameless: false}]
+              Type: 1716 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0x80cb84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5043,7 +5043,7 @@ Probes:
         - subprogram: {subprogram: 3}
           events:
             - Kind: Entry
-              Type: 1506 EventRootType Probe[main.testStringArray]
+              Type: 1507 EventRootType Probe[main.testStringArray]
               InjectionPoints: [{PC: "0x804350", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5065,8 +5065,8 @@ Probes:
         - subprogram: {subprogram: 97}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x80ab00", Frameless: true}]
+              Type: 1617 EventRootType Probe[main.testStringPointer]
+              InjectionPoints: [{PC: "0x80ab10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5087,8 +5087,8 @@ Probes:
         - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1728 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80d270", Frameless: true}]
+              Type: 1729 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0x80d280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5109,7 +5109,7 @@ Probes:
         - subprogram: {subprogram: 45}
           events:
             - Kind: Entry
-              Type: 1548 EventRootType Probe[main.testStringType1]
+              Type: 1549 EventRootType Probe[main.testStringType1]
               InjectionPoints: [{PC: "0x804e20", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5131,7 +5131,7 @@ Probes:
         - subprogram: {subprogram: 46}
           events:
             - Kind: Entry
-              Type: 1549 EventRootType Probe[main.testStringType2]
+              Type: 1550 EventRootType Probe[main.testStringType2]
               InjectionPoints: [{PC: "0x804e30", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5153,8 +5153,8 @@ Probes:
         - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1752 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80db30", Frameless: true}]
+              Type: 1753 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x80db40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5180,8 +5180,8 @@ Probes:
         - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1725 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80d240", Frameless: true}]
+              Type: 1726 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0x80d250", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5207,7 +5207,7 @@ Probes:
         - subprogram: {subprogram: 63}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testStructWithAny]
+              Type: 1580 EventRootType Probe[main.testStructWithAny]
               InjectionPoints: [{PC: "0x808a90", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5228,12 +5228,12 @@ Probes:
         - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1718 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80cc7c", Frameless: false}]
+              Type: 1719 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0x80cc8c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1719 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80cd04", Frameless: false}]
+              Type: 1720 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0x80cd14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5254,8 +5254,8 @@ Probes:
         - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1750 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80da90", Frameless: true}]
+              Type: 1751 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0x80daa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5275,8 +5275,8 @@ Probes:
         - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1749 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80da80", Frameless: true}]
+              Type: 1750 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0x80da90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5302,8 +5302,8 @@ Probes:
         - subprogram: {subprogram: 64}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x809130", Frameless: true}]
+              Type: 1581 EventRootType Probe[main.testStructWithMap]
+              InjectionPoints: [{PC: "0x809140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5335,8 +5335,8 @@ Probes:
         - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1734 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80d2c0", Frameless: true}]
+              Type: 1735 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0x80d2d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5375,8 +5375,8 @@ Probes:
         - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1748 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80d930", Frameless: true}]
+              Type: 1749 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0x80d940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5407,7 +5407,7 @@ Probes:
         - subprogram: {subprogram: 48}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testTakeContext]
+              Type: 1554 EventRootType Probe[main.testTakeContext]
               InjectionPoints: [{PC: "0x805320", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
@@ -5423,12 +5423,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1657 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80b618", Frameless: false}]
+              Type: 1658 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80b628", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1658 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b69c", Frameless: false}]
+              Type: 1659 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5448,12 +5448,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80b618", Frameless: false}]
+              Type: 1660 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80b628", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1660 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b69c", Frameless: false}]
+              Type: 1661 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5475,12 +5475,12 @@ Probes:
         - subprogram: {subprogram: 108}
           events:
             - Kind: Entry
-              Type: 1661 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80b618", Frameless: false}]
+              Type: 1662 EventRootType Probe[main.testMultipleNamedReturn]
+              InjectionPoints: [{PC: "0x80b628", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1662 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80b69c", Frameless: false}]
+              Type: 1663 EventRootType Probe[main.testMultipleNamedReturn]Return
+              InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5511,8 +5511,8 @@ Probes:
         - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1738 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80d8c0", Frameless: true}]
+              Type: 1739 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0x80d8d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5543,8 +5543,8 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1739 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80d8d0", Frameless: true}]
+              Type: 1740 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x80d8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5573,8 +5573,8 @@ Probes:
         - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1740 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80d8d0", Frameless: true}]
+              Type: 1741 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x80d8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5605,8 +5605,8 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1741 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80d8e0", Frameless: true}]
+              Type: 1742 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x80d8f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5635,8 +5635,8 @@ Probes:
         - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1742 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80d8e0", Frameless: true}]
+              Type: 1743 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x80d8f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5655,6 +5655,72 @@ Probes:
                   DSL: a.c
                   EventKind: Entry
                   EventExpressionIndex: 2
+    - id: testTimeFixedZone
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeFixedZone}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 166}
+          events:
+            - Kind: Entry
+              Type: 1762 EventRootType Probe[main.testTimeFixedZone]
+              InjectionPoints: [{PC: "0x80e570", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeMonotonic
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeMonotonic}
+      tags: ['foo:bar']
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 167}
+          events:
+            - Kind: Entry
+              Type: 1763 EventRootType Probe[main.testTimeMonotonic]
+              InjectionPoints: [{PC: "0x80e580", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{c}'
+            Segments:
+                - JSON: {Ref: c}
+                  DSL: c
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+    - id: testTimeUTC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTimeUTC}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 165}
+          events:
+            - Kind: Entry
+              Type: 1761 EventRootType Probe[main.testTimeUTC]
+              InjectionPoints: [{PC: "0x80e560", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{x}'
+            Segments:
+                - JSON: {Ref: x}
+                  DSL: x
+                  EventKind: Entry
+                  EventExpressionIndex: 0
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -5667,7 +5733,7 @@ Probes:
         - subprogram: {subprogram: 36}
           events:
             - Kind: Entry
-              Type: 1539 EventRootType Probe[main.testTypeAlias]
+              Type: 1540 EventRootType Probe[main.testTypeAlias]
               InjectionPoints: [{PC: "0x8048a0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5689,7 +5755,7 @@ Probes:
         - subprogram: {subprogram: 12}
           events:
             - Kind: Entry
-              Type: 1515 EventRootType Probe[main.testUint16Array]
+              Type: 1516 EventRootType Probe[main.testUint16Array]
               InjectionPoints: [{PC: "0x8043e0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5711,7 +5777,7 @@ Probes:
         - subprogram: {subprogram: 13}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testUint32Array]
+              Type: 1517 EventRootType Probe[main.testUint32Array]
               InjectionPoints: [{PC: "0x8043f0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5733,7 +5799,7 @@ Probes:
         - subprogram: {subprogram: 14}
           events:
             - Kind: Entry
-              Type: 1517 EventRootType Probe[main.testUint64Array]
+              Type: 1518 EventRootType Probe[main.testUint64Array]
               InjectionPoints: [{PC: "0x804400", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5755,7 +5821,7 @@ Probes:
         - subprogram: {subprogram: 11}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testUint8Array]
+              Type: 1515 EventRootType Probe[main.testUint8Array]
               InjectionPoints: [{PC: "0x8043d0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5777,7 +5843,7 @@ Probes:
         - subprogram: {subprogram: 10}
           events:
             - Kind: Entry
-              Type: 1513 EventRootType Probe[main.testUintArray]
+              Type: 1514 EventRootType Probe[main.testUintArray]
               InjectionPoints: [{PC: "0x8043c0", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5799,8 +5865,8 @@ Probes:
         - subprogram: {subprogram: 96}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
+              Type: 1616 EventRootType Probe[main.testUintPointer]
+              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5821,8 +5887,8 @@ Probes:
         - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1722 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80d210", Frameless: true}]
+              Type: 1723 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0x80d220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5843,8 +5909,8 @@ Probes:
         - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1746 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80d910", Frameless: true}]
+              Type: 1747 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0x80d920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5865,8 +5931,8 @@ Probes:
         - subprogram: {subprogram: 95}
           events:
             - Kind: Entry
-              Type: 1614 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x80aa70", Frameless: true}]
+              Type: 1615 EventRootType Probe[main.testUnsafePointer]
+              InjectionPoints: [{PC: "0x80aa80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5887,7 +5953,7 @@ Probes:
         - subprogram: {subprogram: 20}
           events:
             - Kind: Entry
-              Type: 1523 EventRootType Probe[main.testVeryLargeArray]
+              Type: 1524 EventRootType Probe[main.testVeryLargeArray]
               InjectionPoints: [{PC: "0x804470", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -5909,8 +5975,8 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1731 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80d2a0", Frameless: true}]
+              Type: 1732 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x80d2b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5931,8 +5997,8 @@ Probes:
         - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1732 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80d2a0", Frameless: true}]
+              Type: 1733 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x80d2b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5950,18 +6016,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 195}
+        - subprogram: {subprogram: 198}
           events:
             - Kind: Entry
-              Type: 1824 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1828 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0x8088f8"
                   Frameless: false
-                - PC: "0x80fc60"
+                - PC: "0x80fdb0"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1825 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1829 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0x808920", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5983,12 +6049,12 @@ Probes:
         - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1720 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80cd38", Frameless: false}]
+              Type: 1721 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0x80cd48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1721 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80cd9c", Frameless: false}]
+              Type: 1722 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x80cdac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -7074,140 +7140,127 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x809130..0x809140]
+      OutOfLinePCRanges: [0x809140..0x809150]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 178 StructureType main.structWithMap
-          Locations:
-            - Range: 0x809130..0x809140
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 65
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x809140..0x809150]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 184 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x809140..0x809150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 66
-      Name: main.testMapStringToInt
+    - ID: 65
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x809150..0x809160]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 189 GoMapType map[string]int
+          Type: 184 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x809150..0x809160
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 67
-      Name: main.testMapStringToSlice
+    - ID: 66
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x809160..0x809170]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 194 GoMapType map[string][]string
+          Type: 189 GoMapType map[string]int
           Locations:
             - Range: 0x809160..0x809170
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 68
-      Name: main.testMapArrayToArray
+    - ID: 67
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x809170..0x809180]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 199 GoMapType map[[4]string][2]int
+          Type: 194 GoMapType map[string][]string
           Locations:
             - Range: 0x809170..0x809180
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 69
-      Name: main.testSmallMap
+    - ID: 68
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x809180..0x809190]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 189 GoMapType map[string]int
+          Type: 199 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x809180..0x809190
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 69
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x809190..0x8091a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 189 GoMapType map[string]int
+          Locations:
+            - Range: 0x809190..0x8091a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 70
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x809190..0x8091a0]
+      OutOfLinePCRanges: [0x8091a0..0x8091b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x809190..0x8091a0
+            - Range: 0x8091a0..0x8091b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 71
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x8091a0..0x8091b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 205 PointerType *map[string]int
-          Locations:
-            - Range: 0x8091a0..0x8091b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 72
-      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x8091b0..0x8091c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 179 GoMapType map[int]int
+          Type: 205 PointerType *map[string]int
           Locations:
             - Range: 0x8091b0..0x8091c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 73
-      Name: main.testMapMassive
+    - ID: 72
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x8091c0..0x8091d0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 206 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 179 GoMapType map[int]int
           Locations:
             - Range: 0x8091c0..0x8091d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 74
-      Name: main.testMapEmbeddedMaps
+    - ID: 73
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0x8091d0..0x8091e0]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 206 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x8091d0..0x8091e0
@@ -7215,38 +7268,38 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 75
-      Name: main.testMapWithLinkedList
+    - ID: 74
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x8091e0..0x8091f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 211 GoMapType map[bool]main.node
+          Type: 206 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x8091e0..0x8091f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 76
-      Name: main.testMapWithSmallValue
+    - ID: 75
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x8091f0..0x809200]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 216 GoMapType map[int]uint8
+          Type: 211 GoMapType map[bool]main.node
           Locations:
             - Range: 0x8091f0..0x809200
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 77
-      Name: main.testMapWithSmallValueMassive
+    - ID: 76
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x809200..0x809210]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 216 GoMapType map[int]uint8
           Locations:
             - Range: 0x809200..0x809210
@@ -7254,21 +7307,21 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 78
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 77
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x809210..0x809220]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 221 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 216 GoMapType map[int]uint8
           Locations:
             - Range: 0x809210..0x809220
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 79
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 78
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x809220..0x809230]
       InlinePCRanges: []
       Variables:
@@ -7280,8 +7333,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 80
-      Name: main.testMapSmallKeySmallValue
+    - ID: 79
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x809230..0x809240]
       InlinePCRanges: []
       Variables:
@@ -7293,127 +7346,140 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 81
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 80
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x809240..0x809250]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 226 GoMapType map[uint8][4]int
+          Type: 221 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x809240..0x809250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 82
-      Name: main.testMapLargeKeySmallValue
+    - ID: 81
+      Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x809250..0x809260]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 231 GoMapType map[[4]int]uint8
+          Type: 226 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x809250..0x809260
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 83
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 82
+      Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x809260..0x809270]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 236 GoMapType map[[4]int][4]int
+          Type: 231 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x809260..0x809270
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 84
-      Name: main.testMapEmptyKey
+    - ID: 83
+      Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x809270..0x809280]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 241 GoMapType map[struct {}]int
+          Type: 236 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x809270..0x809280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 85
-      Name: main.testMapEmptyValue
+    - ID: 84
+      Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x809280..0x809290]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 246 GoMapType map[int]struct {}
+          Type: 241 GoMapType map[struct {}]int
           Locations:
             - Range: 0x809280..0x809290
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 86
-      Name: main.testMapEmptyKeyAndValue
+    - ID: 85
+      Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x809290..0x8092a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 251 GoMapType map[struct {}]struct {}
+          Type: 246 GoMapType map[int]struct {}
           Locations:
             - Range: 0x809290..0x8092a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 86
+      Name: main.testMapEmptyKeyAndValue
+      OutOfLinePCRanges: [0x8092a0..0x8092b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 251 GoMapType map[struct {}]struct {}
+          Locations:
+            - Range: 0x8092a0..0x8092b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 87
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x80a600..0x80a610]
+      OutOfLinePCRanges: [0x80a610..0x80a620]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80a600..0x80a610
+            - Range: 0x80a610..0x80a620
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80a600..0x80a610
+            - Range: 0x80a610..0x80a620
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x80a600..0x80a610
+            - Range: 0x80a610..0x80a620
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 88
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x80a620..0x80a630]
+      OutOfLinePCRanges: [0x80a630..0x80a640]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80a620..0x80a630
+            - Range: 0x80a630..0x80a640
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80a620..0x80a630
+            - Range: 0x80a630..0x80a640
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7424,48 +7490,48 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x80a620..0x80a630
+            - Range: 0x80a630..0x80a640
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 89
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x80a6e0..0x80a6f0]
+      OutOfLinePCRanges: [0x80a6f0..0x80a700]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80a6e0..0x80a6f0
+            - Range: 0x80a6f0..0x80a700
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80a6e0..0x80a6f0
+            - Range: 0x80a6f0..0x80a700
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x80a6e0..0x80a6f0
+            - Range: 0x80a6f0..0x80a700
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x80a6e0..0x80a6f0
+            - Range: 0x80a6f0..0x80a700
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80a6e0..0x80a6f0
+            - Range: 0x80a6f0..0x80a700
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7476,63 +7542,63 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x80a880..0x80a8c0]
+      OutOfLinePCRanges: [0x80a890..0x80a8d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80a880..0x80a8bc
+            - Range: 0x80a890..0x80a8cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80a880..0x80a8bc
+            - Range: 0x80a890..0x80a8cc
               Pieces: []
-            - Range: 0x80a8bc..0x80a8bd
+            - Range: 0x80a8cc..0x80a8cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a8bd..0x80a8c0
+            - Range: 0x80a8cd..0x80a8d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 91
       Name: main.testChannel
-      OutOfLinePCRanges: [0x80a8c0..0x80a8d0]
+      OutOfLinePCRanges: [0x80a8d0..0x80a8e0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 256 GoChannelType chan bool
           Locations:
-            - Range: 0x80a8c0..0x80a8d0
+            - Range: 0x80a8d0..0x80a8e0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 92
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x80aa40..0x80aa50]
+      OutOfLinePCRanges: [0x80aa50..0x80aa60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x80aa40..0x80aa50
+            - Range: 0x80aa50..0x80aa60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 93
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x80aa50..0x80aa60]
+      OutOfLinePCRanges: [0x80aa60..0x80aa70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 StructureType main.node
           Locations:
-            - Range: 0x80aa50..0x80aa60
+            - Range: 0x80aa60..0x80aa70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7543,267 +7609,267 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x80aa60..0x80aa70]
+      OutOfLinePCRanges: [0x80aa70..0x80aa80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 260 PointerType *main.node
-          Locations:
-            - Range: 0x80aa60..0x80aa70
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 95
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x80aa70..0x80aa80]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 18 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x80aa70..0x80aa80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 95
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0x80aa80..0x80aa90]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 18 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x80aa80..0x80aa90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 96
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x80aa90..0x80aaa0]
+      OutOfLinePCRanges: [0x80aaa0..0x80aab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 114 PointerType *uint
           Locations:
-            - Range: 0x80aa90..0x80aaa0
+            - Range: 0x80aaa0..0x80aab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 97
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x80ab00..0x80ab10]
+      OutOfLinePCRanges: [0x80ab10..0x80ab20]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 103 PointerType *string
           Locations:
-            - Range: 0x80ab00..0x80ab10
+            - Range: 0x80ab10..0x80ab20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 98
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x80ab20..0x80ab30]
+      OutOfLinePCRanges: [0x80ab30..0x80ab40]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0x80ab20..0x80ab30
+            - Range: 0x80ab30..0x80ab40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x80ab20..0x80ab30
+            - Range: 0x80ab30..0x80ab40
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 99
       Name: main.testCycle
-      OutOfLinePCRanges: [0x80ab40..0x80ab50]
+      OutOfLinePCRanges: [0x80ab50..0x80ab60]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 261 PointerType *main.t
           Locations:
-            - Range: 0x80ab40..0x80ab50
+            - Range: 0x80ab50..0x80ab60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 100
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x80ae40..0x80aec0]
+      OutOfLinePCRanges: [0x80ae50..0x80aed0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ae40..0x80ae5c
+            - Range: 0x80ae50..0x80ae6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ae40..0x80ae98
+            - Range: 0x80ae50..0x80aea8
               Pieces: []
-            - Range: 0x80ae98..0x80ae99
+            - Range: 0x80aea8..0x80aea9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ae99..0x80aec0
+            - Range: 0x80aea9..0x80aed0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ae5c..0x80ae68
+            - Range: 0x80ae6c..0x80ae78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ae68..0x80aec0
+            - Range: 0x80ae78..0x80aed0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 101
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80aec0..0x80af60]
+      OutOfLinePCRanges: [0x80aed0..0x80af70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80aec0..0x80aee4
+            - Range: 0x80aed0..0x80aef4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aee4..0x80af60
+            - Range: 0x80aef4..0x80af70
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 107 PointerType *int
           Locations:
-            - Range: 0x80aec0..0x80af34
+            - Range: 0x80aed0..0x80af44
               Pieces: []
-            - Range: 0x80af34..0x80af35
+            - Range: 0x80af44..0x80af45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80af35..0x80af60
+            - Range: 0x80af45..0x80af70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: '&result'
           Type: 107 PointerType *int
           Locations:
-            - Range: 0x80aee8..0x80af00
+            - Range: 0x80aef8..0x80af10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80af00..0x80af60
+            - Range: 0x80af10..0x80af70
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 102
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80af60..0x80b030]
+      OutOfLinePCRanges: [0x80af70..0x80b040]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80af60..0x80afb8
+            - Range: 0x80af70..0x80afc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80af60..0x80b008
+            - Range: 0x80af70..0x80b018
               Pieces: []
-            - Range: 0x80b008..0x80b009
+            - Range: 0x80b018..0x80b019
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b009..0x80b030
+            - Range: 0x80b019..0x80b040
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80af60..0x80b030, Pieces: []}]
+          Locations: [{Range: 0x80af70..0x80b040, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80af7c..0x80afbc
+            - Range: 0x80af8c..0x80afcc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80afbc..0x80b030
+            - Range: 0x80afcc..0x80b040
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80af8c..0x80afbc
+            - Range: 0x80af9c..0x80afcc
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80afbc..0x80b030
+            - Range: 0x80afcc..0x80b040
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 103
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80b030..0x80b0b0]
+      OutOfLinePCRanges: [0x80b040..0x80b0c0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80b030..0x80b050
+            - Range: 0x80b040..0x80b060
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0x80b030..0x80b07c
+            - Range: 0x80b040..0x80b08c
               Pieces: []
-            - Range: 0x80b07c..0x80b07d
+            - Range: 0x80b08c..0x80b08d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b07d..0x80b090
+            - Range: 0x80b08d..0x80b0a0
               Pieces: []
-            - Range: 0x80b090..0x80b091
+            - Range: 0x80b0a0..0x80b0a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b091..0x80b0b0
+            - Range: 0x80b0a1..0x80b0c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 104
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80b0b0..0x80b230]
+      OutOfLinePCRanges: [0x80b0c0..0x80b240]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 170 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80b0b0..0x80b100
+            - Range: 0x80b0c0..0x80b110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b100..0x80b104
+            - Range: 0x80b110..0x80b114
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80b188..0x80b190
+            - Range: 0x80b198..0x80b1a0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b1d0..0x80b1d8
+            - Range: 0x80b1e0..0x80b1e8
               Pieces:
                 - Size: 8
                   Op: null
@@ -7814,117 +7880,117 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80b0b0..0x80b108
+            - Range: 0x80b0c0..0x80b118
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 170 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80b0b0..0x80b11c
+            - Range: 0x80b0c0..0x80b12c
               Pieces: []
-            - Range: 0x80b11c..0x80b11d
+            - Range: 0x80b12c..0x80b12d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b11d..0x80b178
+            - Range: 0x80b12d..0x80b188
               Pieces: []
-            - Range: 0x80b178..0x80b179
+            - Range: 0x80b188..0x80b189
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b179..0x80b1c0
+            - Range: 0x80b189..0x80b1d0
               Pieces: []
-            - Range: 0x80b1c0..0x80b1c1
+            - Range: 0x80b1d0..0x80b1d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b1c1..0x80b204
+            - Range: 0x80b1d1..0x80b214
               Pieces: []
-            - Range: 0x80b204..0x80b205
+            - Range: 0x80b214..0x80b215
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b205..0x80b230
+            - Range: 0x80b215..0x80b240
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0x80b0b0..0x80b11c
+            - Range: 0x80b0c0..0x80b12c
               Pieces: []
-            - Range: 0x80b11c..0x80b11d
+            - Range: 0x80b12c..0x80b12d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80b11d..0x80b178
+            - Range: 0x80b12d..0x80b188
               Pieces: []
-            - Range: 0x80b178..0x80b179
+            - Range: 0x80b188..0x80b189
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80b179..0x80b1c0
+            - Range: 0x80b189..0x80b1d0
               Pieces: []
-            - Range: 0x80b1c0..0x80b1c1
+            - Range: 0x80b1d0..0x80b1d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80b1c1..0x80b204
+            - Range: 0x80b1d1..0x80b214
               Pieces: []
-            - Range: 0x80b204..0x80b205
+            - Range: 0x80b214..0x80b215
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80b205..0x80b230
+            - Range: 0x80b215..0x80b240
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b100..0x80b108
+            - Range: 0x80b110..0x80b118
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 105
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80b230..0x80b410]
+      OutOfLinePCRanges: [0x80b240..0x80b420]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 170 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80b230..0x80b270
+            - Range: 0x80b240..0x80b280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b270..0x80b278
+            - Range: 0x80b280..0x80b288
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80b278..0x80b410
+            - Range: 0x80b288..0x80b420
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -7935,549 +8001,549 @@ Subprograms:
         - Name: ~r0
           Type: 170 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80b230..0x80b2d0
+            - Range: 0x80b240..0x80b2e0
               Pieces: []
-            - Range: 0x80b2d0..0x80b2d1
+            - Range: 0x80b2e0..0x80b2e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b2d1..0x80b324
+            - Range: 0x80b2e1..0x80b334
               Pieces: []
-            - Range: 0x80b324..0x80b325
+            - Range: 0x80b334..0x80b335
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b325..0x80b3dc
+            - Range: 0x80b335..0x80b3ec
               Pieces: []
-            - Range: 0x80b3dc..0x80b3dd
+            - Range: 0x80b3ec..0x80b3ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b3dd..0x80b3f0
+            - Range: 0x80b3ed..0x80b400
               Pieces: []
-            - Range: 0x80b3f0..0x80b3f1
+            - Range: 0x80b400..0x80b401
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b3f1..0x80b410
+            - Range: 0x80b401..0x80b420
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b2bc..0x80b2c4
+            - Range: 0x80b2cc..0x80b2d4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
         - Name: '&result'
           Type: 107 PointerType *int
           Locations:
-            - Range: 0x80b308..0x80b324
+            - Range: 0x80b318..0x80b334
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 106
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80b410..0x80b560]
+      OutOfLinePCRanges: [0x80b420..0x80b570]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 170 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80b410..0x80b44c
+            - Range: 0x80b420..0x80b45c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b44c..0x80b490
+            - Range: 0x80b45c..0x80b4a0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80b490..0x80b500
+            - Range: 0x80b4a0..0x80b510
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80b500..0x80b528
+            - Range: 0x80b510..0x80b538
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80b528..0x80b52c
+            - Range: 0x80b538..0x80b53c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80b52c..0x80b560
+            - Range: 0x80b53c..0x80b570
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 175 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80b410..0x80b4e0
+            - Range: 0x80b420..0x80b4f0
               Pieces: []
-            - Range: 0x80b4e0..0x80b4e1
+            - Range: 0x80b4f0..0x80b4f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b4e1..0x80b4f4
+            - Range: 0x80b4f1..0x80b504
               Pieces: []
-            - Range: 0x80b4f4..0x80b4f5
+            - Range: 0x80b504..0x80b505
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b4f5..0x80b560
+            - Range: 0x80b505..0x80b570
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 175 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80b410..0x80b44c
+            - Range: 0x80b420..0x80b45c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80b44c..0x80b490
+            - Range: 0x80b45c..0x80b4a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80b490..0x80b498
+            - Range: 0x80b4a0..0x80b4a8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80b498..0x80b4ec
+            - Range: 0x80b4a8..0x80b4fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80b4ec..0x80b4f0
+            - Range: 0x80b4fc..0x80b500
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80b4f0..0x80b4f4
+            - Range: 0x80b500..0x80b504
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80b4f4..0x80b560
+            - Range: 0x80b504..0x80b570
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 107
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80b560..0x80b600]
+      OutOfLinePCRanges: [0x80b570..0x80b610]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b560..0x80b57c
+            - Range: 0x80b570..0x80b58c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b560..0x80b5d4
+            - Range: 0x80b570..0x80b5e4
               Pieces: []
-            - Range: 0x80b5d4..0x80b5d5
+            - Range: 0x80b5e4..0x80b5e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b5d5..0x80b600
+            - Range: 0x80b5e5..0x80b610
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 108
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80b600..0x80b6c0]
+      OutOfLinePCRanges: [0x80b610..0x80b6d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b600..0x80b650
+            - Range: 0x80b610..0x80b660
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b600..0x80b69c
+            - Range: 0x80b610..0x80b6ac
               Pieces: []
-            - Range: 0x80b69c..0x80b69d
+            - Range: 0x80b6ac..0x80b6ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b69d..0x80b6c0
+            - Range: 0x80b6ad..0x80b6d0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b600..0x80b69c
+            - Range: 0x80b610..0x80b6ac
               Pieces: []
-            - Range: 0x80b69c..0x80b69d
+            - Range: 0x80b6ac..0x80b6ad
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b69d..0x80b6c0
+            - Range: 0x80b6ad..0x80b6d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 109
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80b6c0..0x80b780]
+      OutOfLinePCRanges: [0x80b6d0..0x80b790]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b6c0..0x80b700
+            - Range: 0x80b6d0..0x80b710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b700..0x80b780
+            - Range: 0x80b710..0x80b790
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b6c0..0x80b760
+            - Range: 0x80b6d0..0x80b770
               Pieces: []
-            - Range: 0x80b760..0x80b761
+            - Range: 0x80b770..0x80b771
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b761..0x80b780
+            - Range: 0x80b771..0x80b790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b6c0..0x80b760
+            - Range: 0x80b6d0..0x80b770
               Pieces: []
-            - Range: 0x80b760..0x80b761
+            - Range: 0x80b770..0x80b771
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b761..0x80b780
+            - Range: 0x80b771..0x80b790
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b6c0..0x80b760
+            - Range: 0x80b6d0..0x80b770
               Pieces: []
-            - Range: 0x80b760..0x80b761
+            - Range: 0x80b770..0x80b771
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b761..0x80b780
+            - Range: 0x80b771..0x80b790
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80b780..0x80b860]
+      OutOfLinePCRanges: [0x80b790..0x80b870]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b780..0x80b7c0
+            - Range: 0x80b790..0x80b7d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b7c0..0x80b860
+            - Range: 0x80b7d0..0x80b870
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b780..0x80b83c
+            - Range: 0x80b790..0x80b84c
               Pieces: []
-            - Range: 0x80b83c..0x80b83d
+            - Range: 0x80b84c..0x80b84d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b83d..0x80b860
+            - Range: 0x80b84d..0x80b870
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80b780..0x80b83c
+            - Range: 0x80b790..0x80b84c
               Pieces: []
-            - Range: 0x80b83c..0x80b83d
+            - Range: 0x80b84c..0x80b84d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80b83d..0x80b860
+            - Range: 0x80b84d..0x80b870
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80b860..0x80b9f0]
+      OutOfLinePCRanges: [0x80b870..0x80ba00]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80b860..0x80b8c0
+            - Range: 0x80b870..0x80b8d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b8c0..0x80b9f0
+            - Range: 0x80b8d0..0x80ba00
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80b88c..0x80b9f0
+            - Range: 0x80b89c..0x80ba00
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80b890..0x80b9f0
+            - Range: 0x80b8a0..0x80ba00
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 112
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80bab0..0x80bb40]
+      OutOfLinePCRanges: [0x80bac0..0x80bb50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 21 BaseType int8
           Locations:
-            - Range: 0x80bab0..0x80bb1c
+            - Range: 0x80bac0..0x80bb2c
               Pieces: []
-            - Range: 0x80bb1c..0x80bb1d
+            - Range: 0x80bb2c..0x80bb2d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bb1d..0x80bb40
+            - Range: 0x80bb2d..0x80bb50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 104 BaseType int16
           Locations:
-            - Range: 0x80bab0..0x80bb1c
+            - Range: 0x80bac0..0x80bb2c
               Pieces: []
-            - Range: 0x80bb1c..0x80bb1d
+            - Range: 0x80bb2c..0x80bb2d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80bb1d..0x80bb40
+            - Range: 0x80bb2d..0x80bb50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x80bab0..0x80bb1c
+            - Range: 0x80bac0..0x80bb2c
               Pieces: []
-            - Range: 0x80bb1c..0x80bb1d
+            - Range: 0x80bb2c..0x80bb2d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80bb1d..0x80bb40
+            - Range: 0x80bb2d..0x80bb50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x80bab0..0x80bb1c
+            - Range: 0x80bac0..0x80bb2c
               Pieces: []
-            - Range: 0x80bb1c..0x80bb1d
+            - Range: 0x80bb2c..0x80bb2d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80bb1d..0x80bb40
+            - Range: 0x80bb2d..0x80bb50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80bab0..0x80bb1c
+            - Range: 0x80bac0..0x80bb2c
               Pieces: []
-            - Range: 0x80bb1c..0x80bb1d
+            - Range: 0x80bb2c..0x80bb2d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80bb1d..0x80bb40
+            - Range: 0x80bb2d..0x80bb50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x80bab0..0x80bb1c
+            - Range: 0x80bac0..0x80bb2c
               Pieces: []
-            - Range: 0x80bb1c..0x80bb1d
+            - Range: 0x80bb2c..0x80bb2d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80bb1d..0x80bb40
+            - Range: 0x80bb2d..0x80bb50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x80bab0..0x80bb1c
+            - Range: 0x80bac0..0x80bb2c
               Pieces: []
-            - Range: 0x80bb1c..0x80bb1d
+            - Range: 0x80bb2c..0x80bb2d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80bb1d..0x80bb40
+            - Range: 0x80bb2d..0x80bb50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80bab0..0x80bb1c
+            - Range: 0x80bac0..0x80bb2c
               Pieces: []
-            - Range: 0x80bb1c..0x80bb1d
+            - Range: 0x80bb2c..0x80bb2d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80bb1d..0x80bb40
+            - Range: 0x80bb2d..0x80bb50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80bb40..0x80bbf0]
+      OutOfLinePCRanges: [0x80bb50..0x80bc00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80bb40..0x80bbf0, Pieces: []}]
+          Locations: [{Range: 0x80bb50..0x80bc00, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80bb40..0x80bbd8
+            - Range: 0x80bb50..0x80bbe8
               Pieces: []
-            - Range: 0x80bbd8..0x80bbd9
+            - Range: 0x80bbe8..0x80bbe9
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80bbd9..0x80bbf0
+            - Range: 0x80bbe9..0x80bc00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80bbf0..0x80bc70]
+      OutOfLinePCRanges: [0x80bc00..0x80bc80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 105 BaseType complex64
-          Locations: [{Range: 0x80bbf0..0x80bc70, Pieces: []}]
+          Locations: [{Range: 0x80bc00..0x80bc80, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 20 BaseType complex128
-          Locations: [{Range: 0x80bbf0..0x80bc70, Pieces: []}]
+          Locations: [{Range: 0x80bc00..0x80bc80, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80bc70..0x80bd30]
+      OutOfLinePCRanges: [0x80bc80..0x80bd40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x80bc70..0x80bd10
+            - Range: 0x80bc80..0x80bd20
               Pieces: []
-            - Range: 0x80bd10..0x80bd11
+            - Range: 0x80bd20..0x80bd21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8499,193 +8565,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80bd11..0x80bd30
+            - Range: 0x80bd21..0x80bd40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80bd30..0x80bdc0]
+      OutOfLinePCRanges: [0x80bd40..0x80bdd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0x80bd30..0x80bd9c
+            - Range: 0x80bd40..0x80bdac
               Pieces: []
-            - Range: 0x80bd9c..0x80bd9d
+            - Range: 0x80bdac..0x80bdad
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80bd9d..0x80bdc0
+            - Range: 0x80bdad..0x80bdd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 117
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80bdc0..0x80be30]
+      OutOfLinePCRanges: [0x80bdd0..0x80be40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 ArrayType [1]int
           Locations:
-            - Range: 0x80bdc0..0x80be10
+            - Range: 0x80bdd0..0x80be20
               Pieces: []
-            - Range: 0x80be10..0x80be11
+            - Range: 0x80be20..0x80be21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80be11..0x80be30
+            - Range: 0x80be21..0x80be40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80be30..0x80bea0]
+      OutOfLinePCRanges: [0x80be40..0x80beb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 ArrayType [0]int
           Locations:
-            - Range: 0x80be30..0x80be7c
+            - Range: 0x80be40..0x80be8c
               Pieces: []
-            - Range: 0x80be7c..0x80be7d
+            - Range: 0x80be8c..0x80be8d
               Pieces: []
-            - Range: 0x80be7d..0x80bea0
+            - Range: 0x80be8d..0x80beb0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80bea0..0x80bf20]
+      OutOfLinePCRanges: [0x80beb0..0x80bf30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.mixedStruct
-          Locations: [{Range: 0x80bea0..0x80bf20, Pieces: []}]
+          Locations: [{Range: 0x80beb0..0x80bf30, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80bf20..0x80bfb0]
+      OutOfLinePCRanges: [0x80bf30..0x80bfc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80bf20..0x80bf98
+            - Range: 0x80bf30..0x80bfa8
               Pieces: []
-            - Range: 0x80bf98..0x80bf99
+            - Range: 0x80bfa8..0x80bfa9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80bf99..0x80bfb0
+            - Range: 0x80bfa9..0x80bfc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80bfb0..0x80c080]
+      OutOfLinePCRanges: [0x80bfc0..0x80c090]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 268 StructureType main.wideStruct
           Locations:
-            - Range: 0x80bfb0..0x80c060
+            - Range: 0x80bfc0..0x80c070
               Pieces: []
-            - Range: 0x80c060..0x80c061
+            - Range: 0x80c070..0x80c071
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8709,145 +8775,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80c061..0x80c080
+            - Range: 0x80c071..0x80c090
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80c080..0x80c110]
+      OutOfLinePCRanges: [0x80c090..0x80c120]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c080..0x80c0ec
+            - Range: 0x80c090..0x80c0fc
               Pieces: []
-            - Range: 0x80c0ec..0x80c0ed
+            - Range: 0x80c0fc..0x80c0fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c0ed..0x80c110
+            - Range: 0x80c0fd..0x80c120
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c080..0x80c110, Pieces: []}]
+          Locations: [{Range: 0x80c090..0x80c120, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c080..0x80c0ec
+            - Range: 0x80c090..0x80c0fc
               Pieces: []
-            - Range: 0x80c0ec..0x80c0ed
+            - Range: 0x80c0fc..0x80c0fd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c0ed..0x80c110
+            - Range: 0x80c0fd..0x80c120
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c080..0x80c110, Pieces: []}]
+          Locations: [{Range: 0x80c090..0x80c120, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80c080..0x80c0ec
+            - Range: 0x80c090..0x80c0fc
               Pieces: []
-            - Range: 0x80c0ec..0x80c0ed
+            - Range: 0x80c0fc..0x80c0fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c0ed..0x80c110
+            - Range: 0x80c0fd..0x80c120
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 123
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80c110..0x80c1a0]
+      OutOfLinePCRanges: [0x80c120..0x80c1b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0x80c110..0x80c17c
+            - Range: 0x80c120..0x80c18c
               Pieces: []
-            - Range: 0x80c17c..0x80c17d
+            - Range: 0x80c18c..0x80c18d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80c17d..0x80c1a0
+            - Range: 0x80c18d..0x80c1b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 124
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80c1a0..0x80c210]
+      OutOfLinePCRanges: [0x80c1b0..0x80c220]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c1a0..0x80c210, Pieces: []}]
+          Locations: [{Range: 0x80c1b0..0x80c220, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 125
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80c210..0x80c280]
+      OutOfLinePCRanges: [0x80c220..0x80c290]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0x80c210..0x80c280, Pieces: []}]
+          Locations: [{Range: 0x80c220..0x80c290, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80c210..0x80c280, Pieces: []}]
+          Locations: [{Range: 0x80c220..0x80c290, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 126
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80c280..0x80c2f0]
+      OutOfLinePCRanges: [0x80c290..0x80c300]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80c280..0x80c2d4
+            - Range: 0x80c290..0x80c2e4
               Pieces: []
-            - Range: 0x80c2d4..0x80c2d5
+            - Range: 0x80c2e4..0x80c2e5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c2d5..0x80c2f0
+            - Range: 0x80c2e5..0x80c300
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0x80c280..0x80c2d4
+            - Range: 0x80c290..0x80c2e4
               Pieces: []
-            - Range: 0x80c2d4..0x80c2d5
+            - Range: 0x80c2e4..0x80c2e5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c2d5..0x80c2f0
+            - Range: 0x80c2e5..0x80c300
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 127
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80c2f0..0x80c480]
+      OutOfLinePCRanges: [0x80c300..0x80c490]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c2f0..0x80c324
+            - Range: 0x80c300..0x80c334
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8869,7 +8935,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c324..0x80c354
+            - Range: 0x80c334..0x80c364
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8891,7 +8957,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c354..0x80c35c
+            - Range: 0x80c364..0x80c36c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8913,7 +8979,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c35c..0x80c360
+            - Range: 0x80c36c..0x80c370
               Pieces:
                 - Size: 8
                   Op: null
@@ -8940,9 +9006,9 @@ Subprograms:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c2f0..0x80c440
+            - Range: 0x80c300..0x80c450
               Pieces: []
-            - Range: 0x80c440..0x80c441
+            - Range: 0x80c450..0x80c451
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8964,44 +9030,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c441..0x80c480
+            - Range: 0x80c451..0x80c490
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 128
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80c480..0x80c550]
+      OutOfLinePCRanges: [0x80c490..0x80c560]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0x80c480..0x80c550
+            - Range: 0x80c490..0x80c560
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0x80c480..0x80c530
+            - Range: 0x80c490..0x80c540
               Pieces: []
-            - Range: 0x80c530..0x80c531
+            - Range: 0x80c540..0x80c541
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80c531..0x80c550
+            - Range: 0x80c541..0x80c560
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 129
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80c550..0x80c760]
+      OutOfLinePCRanges: [0x80c560..0x80c770]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c550..0x80c584
+            - Range: 0x80c560..0x80c594
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9023,7 +9089,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c584..0x80c5b8
+            - Range: 0x80c594..0x80c5c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9045,7 +9111,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c5b8..0x80c5c0
+            - Range: 0x80c5c8..0x80c5d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9067,7 +9133,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c5c0..0x80c5c4
+            - Range: 0x80c5d0..0x80c5d4
               Pieces:
                 - Size: 8
                   Op: null
@@ -9094,16 +9160,16 @@ Subprograms:
         - Name: s2
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c550..0x80c760
+            - Range: 0x80c560..0x80c770
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c550..0x80c718
+            - Range: 0x80c560..0x80c728
               Pieces: []
-            - Range: 0x80c718..0x80c719
+            - Range: 0x80c728..0x80c729
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9125,196 +9191,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c719..0x80c760
+            - Range: 0x80c729..0x80c770
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 130
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80c760..0x80c910]
+      OutOfLinePCRanges: [0x80c770..0x80c920]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7e8
+            - Range: 0x80c770..0x80c7f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c7e8..0x80c910
+            - Range: 0x80c7f8..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7a8
+            - Range: 0x80c770..0x80c7b8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c7a8..0x80c910
+            - Range: 0x80c7b8..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7e0
+            - Range: 0x80c770..0x80c7f0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c7e0..0x80c910
+            - Range: 0x80c7f0..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7e8
+            - Range: 0x80c770..0x80c7f8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80c7e8..0x80c910
+            - Range: 0x80c7f8..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7e8
+            - Range: 0x80c770..0x80c7f8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80c7e8..0x80c910
+            - Range: 0x80c7f8..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7e8
+            - Range: 0x80c770..0x80c7f8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80c7e8..0x80c910
+            - Range: 0x80c7f8..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7e8
+            - Range: 0x80c770..0x80c7f8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80c7e8..0x80c910
+            - Range: 0x80c7f8..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7e8
+            - Range: 0x80c770..0x80c7f8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80c7e8..0x80c910
+            - Range: 0x80c7f8..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c760..0x80c7e8
+            - Range: 0x80c770..0x80c7f8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80c7e8..0x80c910
+            - Range: 0x80c7f8..0x80c920
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 121 ArrayType [2]int
           Locations:
-            - Range: 0x80c760..0x80c8d0
+            - Range: 0x80c770..0x80c8e0
               Pieces: []
-            - Range: 0x80c8d0..0x80c8d1
+            - Range: 0x80c8e0..0x80c8e1
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80c8d1..0x80c910
+            - Range: 0x80c8e1..0x80c920
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 131
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80c910..0x80cb00]
+      OutOfLinePCRanges: [0x80c920..0x80cb10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c910..0x80c998
+            - Range: 0x80c920..0x80c9a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c998..0x80cb00
+            - Range: 0x80c9a8..0x80cb10
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c910..0x80c95c
+            - Range: 0x80c920..0x80c96c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c95c..0x80cb00
+            - Range: 0x80c96c..0x80cb10
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c910..0x80c990
+            - Range: 0x80c920..0x80c9a0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c990..0x80cb00
+            - Range: 0x80c9a0..0x80cb10
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c910..0x80c998
+            - Range: 0x80c920..0x80c9a8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80c998..0x80cb00
+            - Range: 0x80c9a8..0x80cb10
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c910..0x80c998
+            - Range: 0x80c920..0x80c9a8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80c998..0x80cb00
+            - Range: 0x80c9a8..0x80cb10
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c910..0x80c998
+            - Range: 0x80c920..0x80c9a8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80c998..0x80cb00
+            - Range: 0x80c9a8..0x80cb10
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c910..0x80c998
+            - Range: 0x80c920..0x80c9a8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80c998..0x80cb00
+            - Range: 0x80c9a8..0x80cb10
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80c910..0x80c998
+            - Range: 0x80c920..0x80c9a8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80c998..0x80cb00
+            - Range: 0x80c9a8..0x80cb10
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80c910..0x80c998
+            - Range: 0x80c920..0x80c9a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c998..0x80cb00
+            - Range: 0x80c9a8..0x80cb10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9325,9 +9391,9 @@ Subprograms:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c910..0x80cabc
+            - Range: 0x80c920..0x80cacc
               Pieces: []
-            - Range: 0x80cabc..0x80cabd
+            - Range: 0x80cacc..0x80cacd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9349,208 +9415,189 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cabd..0x80cb00
+            - Range: 0x80cacd..0x80cb10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 132
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80cb00..0x80cb90]
+      OutOfLinePCRanges: [0x80cb10..0x80cba0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 174 ArrayType [5]int
           Locations:
-            - Range: 0x80cb00..0x80cb90
+            - Range: 0x80cb10..0x80cba0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cb00..0x80cb74
+            - Range: 0x80cb10..0x80cb84
               Pieces: []
-            - Range: 0x80cb74..0x80cb75
+            - Range: 0x80cb84..0x80cb85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cb75..0x80cb90
+            - Range: 0x80cb85..0x80cba0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cb00..0x80cb74
+            - Range: 0x80cb10..0x80cb84
               Pieces: []
-            - Range: 0x80cb74..0x80cb75
+            - Range: 0x80cb84..0x80cb85
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80cb75..0x80cb90
+            - Range: 0x80cb85..0x80cba0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cb00..0x80cb74
+            - Range: 0x80cb10..0x80cb84
               Pieces: []
-            - Range: 0x80cb74..0x80cb75
+            - Range: 0x80cb84..0x80cb85
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80cb75..0x80cb90
+            - Range: 0x80cb85..0x80cba0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 133
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80cb90..0x80cc60]
+      OutOfLinePCRanges: [0x80cba0..0x80cc70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 121 ArrayType [2]int
           Locations:
-            - Range: 0x80cb90..0x80cc60
+            - Range: 0x80cba0..0x80cc70
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0x80cb90..0x80cc60
+            - Range: 0x80cba0..0x80cc70
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cb90..0x80cc48
+            - Range: 0x80cba0..0x80cc58
               Pieces: []
-            - Range: 0x80cc48..0x80cc49
+            - Range: 0x80cc58..0x80cc59
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cc49..0x80cc60
+            - Range: 0x80cc59..0x80cc70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 121 ArrayType [2]int
           Locations:
-            - Range: 0x80cb90..0x80cc48
+            - Range: 0x80cba0..0x80cc58
               Pieces: []
-            - Range: 0x80cc48..0x80cc49
+            - Range: 0x80cc58..0x80cc59
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80cc49..0x80cc60
+            - Range: 0x80cc59..0x80cc70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 134
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80cc60..0x80cd20]
+      OutOfLinePCRanges: [0x80cc70..0x80cd30]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0x80cc60..0x80cd20
+            - Range: 0x80cc70..0x80cd30
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cc60..0x80cd04
+            - Range: 0x80cc70..0x80cd14
               Pieces: []
-            - Range: 0x80cd04..0x80cd05
+            - Range: 0x80cd14..0x80cd15
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cd05..0x80cd20
+            - Range: 0x80cd15..0x80cd30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0x80cc60..0x80cd04
+            - Range: 0x80cc70..0x80cd14
               Pieces: []
-            - Range: 0x80cd04..0x80cd05
+            - Range: 0x80cd14..0x80cd15
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80cd05..0x80cd20
+            - Range: 0x80cd15..0x80cd30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cce0..0x80cd20
+            - Range: 0x80ccf0..0x80cd30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
     - ID: 135
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80cd20..0x80cdc0]
+      OutOfLinePCRanges: [0x80cd30..0x80cdd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 ArrayType [0]int
-          Locations: [{Range: 0x80cd20..0x80cdc0, Pieces: []}]
+          Locations: [{Range: 0x80cd30..0x80cdd0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cd20..0x80cd60
+            - Range: 0x80cd30..0x80cd70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cd60..0x80cd78
+            - Range: 0x80cd70..0x80cd88
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80cd78..0x80cd80
+            - Range: 0x80cd88..0x80cd90
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80cd80..0x80cdc0
+            - Range: 0x80cd90..0x80cdd0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cd20..0x80cd9c
+            - Range: 0x80cd30..0x80cdac
               Pieces: []
-            - Range: 0x80cd9c..0x80cd9d
+            - Range: 0x80cdac..0x80cdad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cd9d..0x80cdc0
+            - Range: 0x80cdad..0x80cdd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 266 ArrayType [0]int
           Locations:
-            - Range: 0x80cd20..0x80cd9c
+            - Range: 0x80cd30..0x80cdac
               Pieces: []
-            - Range: 0x80cd9c..0x80cd9d
+            - Range: 0x80cdac..0x80cdad
               Pieces: []
-            - Range: 0x80cd9d..0x80cdc0
+            - Range: 0x80cdad..0x80cdd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 136
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80d210..0x80d220]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 270 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80d210..0x80d220
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 137
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80d220..0x80d230]
       InlinePCRanges: []
       Variables:
@@ -9568,13 +9615,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 138
-      Name: main.testSliceOfSlices
+    - ID: 137
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80d230..0x80d240]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 271 GoSliceHeaderType [][]uint
+          Type: 270 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80d230..0x80d240
               Pieces:
@@ -9587,13 +9634,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
-      Name: main.testStructSlice
+    - ID: 138
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80d240..0x80d250]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 273 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 271 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x80d240..0x80d250
               Pieces:
@@ -9605,16 +9652,9 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
           DictIndex: -1
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x80d240..0x80d250
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
       DictRegister: null
-    - ID: 140
-      Name: main.testEmptySliceOfStructs
+    - ID: 139
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x80d250..0x80d260]
       InlinePCRanges: []
       Variables:
@@ -9639,8 +9679,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 141
-      Name: main.testNilSliceOfStructs
+    - ID: 140
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x80d260..0x80d270]
       InlinePCRanges: []
       Variables:
@@ -9665,15 +9705,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 141
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x80d270..0x80d280]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 273 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80d270..0x80d280
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x80d270..0x80d280
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 142
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80d270..0x80d280]
+      OutOfLinePCRanges: [0x80d280..0x80d290]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 167 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80d270..0x80d280
+            - Range: 0x80d280..0x80d290
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9686,20 +9752,20 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80d280..0x80d290]
+      OutOfLinePCRanges: [0x80d290..0x80d2a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 21 BaseType int8
           Locations:
-            - Range: 0x80d280..0x80d290
+            - Range: 0x80d290..0x80d2a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 276 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80d280..0x80d290
+            - Range: 0x80d290..0x80d2a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9712,37 +9778,18 @@ Subprograms:
         - Name: x
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x80d280..0x80d290
+            - Range: 0x80d290..0x80d2a0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 144
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80d290..0x80d2a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 277 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x80d290..0x80d2a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 145
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x80d2a0..0x80d2b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 270 GoSliceHeaderType []uint
+          Type: 277 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x80d2a0..0x80d2b0
               Pieces:
@@ -9755,13 +9802,13 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
-      Name: main.testSliceEmptyStructs
+    - ID: 145
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x80d2b0..0x80d2c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 278 GoSliceHeaderType []struct {}
+          Type: 270 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80d2b0..0x80d2c0
               Pieces:
@@ -9774,15 +9821,34 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
+    - ID: 146
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80d2c0..0x80d2d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 278 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80d2c0..0x80d2d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 147
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80d2c0..0x80d2d0]
+      OutOfLinePCRanges: [0x80d2d0..0x80d2e0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80d2c0..0x80d2d0
+            - Range: 0x80d2d0..0x80d2e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9795,7 +9861,7 @@ Subprograms:
         - Name: bs
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80d2c0..0x80d2d0
+            - Range: 0x80d2d0..0x80d2e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9808,7 +9874,7 @@ Subprograms:
         - Name: cs
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80d2c0..0x80d2d0
+            - Range: 0x80d2d0..0x80d2e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9821,44 +9887,27 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.stackC
-      OutOfLinePCRanges: [0x80d850..0x80d8b0]
+      OutOfLinePCRanges: [0x80d860..0x80d8c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80d850..0x80d898
+            - Range: 0x80d860..0x80d8a8
               Pieces: []
-            - Range: 0x80d898..0x80d899
+            - Range: 0x80d8a8..0x80d8a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d899..0x80d8b0
+            - Range: 0x80d8a9..0x80d8c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 149
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80d8b0..0x80d8c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x80d8b0..0x80d8c0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 150
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x80d8c0..0x80d8d0]
       InlinePCRanges: []
       Variables:
@@ -9873,10 +9922,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 150
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0x80d8d0..0x80d8e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x80d8d0..0x80d8e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80d8c0..0x80d8d0
+            - Range: 0x80d8d0..0x80d8e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9887,7 +9953,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80d8c0..0x80d8d0
+            - Range: 0x80d8d0..0x80d8e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9898,13 +9964,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80d8d0..0x80d8e0]
+      OutOfLinePCRanges: [0x80d8e0..0x80d8f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80d8d0..0x80d8e0
+            - Range: 0x80d8e0..0x80d8f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9923,49 +9989,32 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80d8e0..0x80d8f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 281 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x80d8e0..0x80d8f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 153
-      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x80d8f0..0x80d900]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 282 PointerType *main.oneStringStruct
+          Type: 281 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x80d8f0..0x80d900
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
-      Name: main.testMassiveString
+    - ID: 153
+      Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x80d900..0x80d910]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
+        - Name: a
+          Type: 282 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x80d900..0x80d910
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
-      Name: main.testUnitializedString
+    - ID: 154
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0x80d910..0x80d920]
       InlinePCRanges: []
       Variables:
@@ -9981,8 +10030,8 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
-      Name: main.testEmptyString
+    - ID: 155
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x80d920..0x80d930]
       InlinePCRanges: []
       Variables:
@@ -9998,12 +10047,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
-      Name: main.testSubstrings
+    - ID: 156
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0x80d930..0x80d940]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x80d930..0x80d940
@@ -10014,10 +10063,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
           DictIndex: -1
+      DictRegister: null
+    - ID: 157
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x80d940..0x80d950]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x80d940..0x80d950
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80d930..0x80d940
+            - Range: 0x80d940..0x80d950
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10028,7 +10094,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80d930..0x80d940
+            - Range: 0x80d940..0x80d950
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10039,26 +10105,26 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80da80..0x80da90]
+      OutOfLinePCRanges: [0x80da90..0x80daa0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 284 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80da80..0x80da90
+            - Range: 0x80da90..0x80daa0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 159
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80da90..0x80daa0]
+      OutOfLinePCRanges: [0x80daa0..0x80dab0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 297 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80da90..0x80daa0
+            - Range: 0x80daa0..0x80dab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10077,13 +10143,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80db30..0x80db40]
+      OutOfLinePCRanges: [0x80db40..0x80db50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 328 StructureType main.aStruct
           Locations:
-            - Range: 0x80db30..0x80db40
+            - Range: 0x80db40..0x80db50
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10104,187 +10170,244 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80db90..0x80dba0]
+      OutOfLinePCRanges: [0x80dba0..0x80dbb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80db90..0x80dba0
+            - Range: 0x80dba0..0x80dbb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 162
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80dba0..0x80dbb0]
+      OutOfLinePCRanges: [0x80dbb0..0x80dbc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 331 StructureType main.tenStrings
           Locations:
-            - Range: 0x80dba0..0x80dbb0
+            - Range: 0x80dbb0..0x80dbc0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 163
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80dbd0..0x80dbe0]
+      OutOfLinePCRanges: [0x80dbe0..0x80dbf0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 332 StructureType main.emptyStruct
-          Locations: [{Range: 0x80dbd0..0x80dbe0, Pieces: []}]
+          Locations: [{Range: 0x80dbe0..0x80dbf0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 164
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80dbe0..0x80dbf0]
+      OutOfLinePCRanges: [0x80dbf0..0x80dc00]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 333 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80dbe0..0x80dbf0
+            - Range: 0x80dbf0..0x80dc00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 165
-      Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80f1e0..0x80f1f0]
+      Name: main.testTimeUTC
+      OutOfLinePCRanges: [0x80e560..0x80e570]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 334 BaseType go.shape.int
+        - Name: x
+          Type: 334 GoTimeType time.Time
           Locations:
-            - Range: 0x80f1e0..0x80f1f0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80e560..0x80e570
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
-          Locations:
-            - Range: 0x80f1e0..0x80f1e4
-              Pieces: []
-            - Range: 0x80f1e4..0x80f1e5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f1e5..0x80f1f0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+          DictIndex: -1
+      DictRegister: null
     - ID: 166
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80f1f0..0x80f200]
+      Name: main.testTimeFixedZone
+      OutOfLinePCRanges: [0x80e570..0x80e580]
       InlinePCRanges: []
       Variables:
-        - Name: val
-          Type: 336 GoStringHeaderType go.shape.string
+        - Name: x
+          Type: 334 GoTimeType time.Time
           Locations:
-            - Range: 0x80f1f0..0x80f1fc
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80f1fc..0x80f200
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x80f1f0..0x80f1fc
-              Pieces: []
-            - Range: 0x80f1fc..0x80f1fd
+            - Range: 0x80e570..0x80e580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f1fd..0x80f200
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
     - ID: 167
-      Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80f200..0x80f210]
+      Name: main.testTimeMonotonic
+      OutOfLinePCRanges: [0x80e580..0x80e590]
       InlinePCRanges: []
       Variables:
-        - Name: box
-          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+        - Name: c
+          Type: 337 StructureType main.timeCapture
           Locations:
-            - Range: 0x80f200..0x80f210
+            - Range: 0x80e580..0x80e590
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 168
+      Name: main.wrapBox[go.shape.int]
+      OutOfLinePCRanges: [0x80f330..0x80f340]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 338 BaseType go.shape.int
+          Locations:
+            - Range: 0x80f330..0x80f340
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 334 BaseType go.shape.int
+          Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80f200..0x80f204
+            - Range: 0x80f330..0x80f334
               Pieces: []
-            - Range: 0x80f204..0x80f205
+            - Range: 0x80f334..0x80f335
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f205..0x80f210
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 168
-      Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x80f210..0x80f220]
-      InlinePCRanges: []
-      Variables:
-        - Name: box
-          Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x80f210..0x80f21c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80f21c..0x80f220
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 336 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x80f210..0x80f21c
-              Pieces: []
-            - Range: 0x80f21c..0x80f21d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f21d..0x80f220
+            - Range: 0x80f335..0x80f340
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0x80f340..0x80f350]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 340 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x80f340..0x80f34c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x80f34c..0x80f350
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x80f340..0x80f34c
+              Pieces: []
+            - Range: 0x80f34c..0x80f34d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80f34d..0x80f350
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
+      Name: main.nestedGeneric[go.shape.int]
+      OutOfLinePCRanges: [0x80f350..0x80f360]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Locations:
+            - Range: 0x80f350..0x80f360
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 338 BaseType go.shape.int
+          Locations:
+            - Range: 0x80f350..0x80f354
+              Pieces: []
+            - Range: 0x80f354..0x80f355
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80f355..0x80f360
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 171
+      Name: main.nestedGeneric[go.shape.string]
+      OutOfLinePCRanges: [0x80f360..0x80f370]
+      InlinePCRanges: []
+      Variables:
+        - Name: box
+          Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x80f360..0x80f36c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x80f36c..0x80f370
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 340 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x80f360..0x80f36c
+              Pieces: []
+            - Range: 0x80f36c..0x80f36d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80f36d..0x80f370
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 172
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80f280..0x80f420]
+      OutOfLinePCRanges: [0x80f3d0..0x80f570]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 338 GoSliceHeaderType []go.shape.int
+          Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80f280..0x80f2b0
+            - Range: 0x80f3d0..0x80f400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10292,7 +10415,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80f2b0..0x80f2c4
+            - Range: 0x80f400..0x80f414
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10300,7 +10423,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80f2c4..0x80f420
+            - Range: 0x80f414..0x80f570
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10311,20 +10434,20 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 340 GoSubroutineType func(go.shape.int) bool
+          Type: 344 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80f280..0x80f2c4
+            - Range: 0x80f3d0..0x80f414
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80f2c4..0x80f420
+            - Range: 0x80f414..0x80f570
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 338 GoSliceHeaderType []go.shape.int
+          Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80f280..0x80f3e8
+            - Range: 0x80f3d0..0x80f538
               Pieces: []
-            - Range: 0x80f3e8..0x80f3e9
+            - Range: 0x80f538..0x80f539
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10332,14 +10455,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80f3e9..0x80f420
+            - Range: 0x80f539..0x80f570
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 338 GoSliceHeaderType []go.shape.int
+          Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80f2b0..0x80f2c4
+            - Range: 0x80f400..0x80f414
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10347,7 +10470,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80f2c4..0x80f2e4
+            - Range: 0x80f414..0x80f434
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10355,7 +10478,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80f2e4..0x80f2e8
+            - Range: 0x80f434..0x80f438
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10363,7 +10486,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80f2e8..0x80f2e8
+            - Range: 0x80f438..0x80f438
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10371,7 +10494,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80f2e8..0x80f318
+            - Range: 0x80f438..0x80f468
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10379,7 +10502,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80f318..0x80f3a8
+            - Range: 0x80f468..0x80f4f8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10387,7 +10510,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80f3a8..0x80f3bc
+            - Range: 0x80f4f8..0x80f50c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10395,7 +10518,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80f3bc..0x80f3d0
+            - Range: 0x80f50c..0x80f520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10403,7 +10526,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80f3d0..0x80f3dc
+            - Range: 0x80f520..0x80f52c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10411,7 +10534,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80f3dc..0x80f420
+            - Range: 0x80f52c..0x80f570
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10422,217 +10545,217 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x80f308..0x80f318
+            - Range: 0x80f458..0x80f468
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f318..0x80f3a8
+            - Range: 0x80f468..0x80f4f8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 170
+    - ID: 173
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80f420..0x80f470]
+      OutOfLinePCRanges: [0x80f570..0x80f5c0]
       InlinePCRanges: []
       Variables:
         - Name: box
-          Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+          Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80f420..0x80f448
+            - Range: 0x80f570..0x80f598
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
-          Type: 341 GoSubroutineType func(go.shape.int) go.shape.string
+          Type: 345 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80f420..0x80f448
+            - Range: 0x80f570..0x80f598
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80f420..0x80f448
+            - Range: 0x80f570..0x80f598
               Pieces: []
-            - Range: 0x80f448..0x80f449
+            - Range: 0x80f598..0x80f599
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f449..0x80f470
+            - Range: 0x80f599..0x80f5c0
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 171
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x80f660..0x80f670]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 339 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80f660..0x80f670
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 339 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80f660..0x80f664
-              Pieces: []
-            - Range: 0x80f664..0x80f665
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f665..0x80f670
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 172
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x80f670..0x80f680]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 342 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x80f670..0x80f680
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 342 PointerType *go.shape.struct { Name string }
-          Locations:
-            - Range: 0x80f670..0x80f674
-              Pieces: []
-            - Range: 0x80f674..0x80f675
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f675..0x80f680
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 173
-      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x80f680..0x80f690]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 344 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0x80f680..0x80f690
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 344 PointerType *go.shape.struct { X int; Y int }
-          Locations:
-            - Range: 0x80f680..0x80f684
-              Pieces: []
-            - Range: 0x80f684..0x80f685
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f685..0x80f690
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 174
-      Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x80f690..0x80f6a0]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0x80f7b0..0x80f7c0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 346 StructureType main.largeGenericType[go.shape.string]
+        - Name: p
+          Type: 343 PointerType *go.shape.int
           Locations:
-            - Range: 0x80f690..0x80f6a0
-              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+            - Range: 0x80f7b0..0x80f7c0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 343 PointerType *go.shape.int
           Locations:
-            - Range: 0x80f690..0x80f694
+            - Range: 0x80f7b0..0x80f7b4
               Pieces: []
-            - Range: 0x80f694..0x80f695
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f695..0x80f6a0
+            - Range: 0x80f7b4..0x80f7b5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80f7b5..0x80f7c0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 175
-      Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x80f710..0x80f720]
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x80f7c0..0x80f7d0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 348 StructureType main.largeGenericType[go.shape.int]
+        - Name: p
+          Type: 346 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x80f710..0x80f720
-              Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
+            - Range: 0x80f7c0..0x80f7d0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 334 BaseType go.shape.int
+          Type: 346 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x80f710..0x80f714
+            - Range: 0x80f7c0..0x80f7c4
               Pieces: []
-            - Range: 0x80f714..0x80f715
+            - Range: 0x80f7c4..0x80f7c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f715..0x80f720
+            - Range: 0x80f7c5..0x80f7d0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 176
-      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x80f790..0x80f7a0]
+      Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
+      OutOfLinePCRanges: [0x80f7d0..0x80f7e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 348 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x80f7d0..0x80f7e0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 348 PointerType *go.shape.struct { X int; Y int }
+          Locations:
+            - Range: 0x80f7d0..0x80f7d4
+              Pieces: []
+            - Range: 0x80f7d4..0x80f7d5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80f7d5..0x80f7e0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 177
+      Name: main.largeGenericType[go.shape.string].LargeGet
+      OutOfLinePCRanges: [0x80f7e0..0x80f7f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 349 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Type: 350 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x80f790..0x80f7a0
+            - Range: 0x80f7e0..0x80f7f0
+              Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 340 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x80f7e0..0x80f7e4
+              Pieces: []
+            - Range: 0x80f7e4..0x80f7e5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80f7e5..0x80f7f0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 178
+      Name: main.largeGenericType[go.shape.int].LargeGet
+      OutOfLinePCRanges: [0x80f860..0x80f870]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 352 StructureType main.largeGenericType[go.shape.int]
+          Locations:
+            - Range: 0x80f860..0x80f870
+              Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 338 BaseType go.shape.int
+          Locations:
+            - Range: 0x80f860..0x80f864
+              Pieces: []
+            - Range: 0x80f864..0x80f865
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80f865..0x80f870
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 179
+      Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
+      OutOfLinePCRanges: [0x80f8e0..0x80f8f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 353 PointerType *main.Pair[go.shape.int,go.shape.bool]
+          Locations:
+            - Range: 0x80f8e0..0x80f8f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x80f790..0x80f7a0
+            - Range: 0x80f8e0..0x80f8f0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 351 BaseType go.shape.bool
+          Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0x80f790..0x80f7a0
+            - Range: 0x80f8e0..0x80f8f0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 177
+    - ID: 180
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x80f800..0x80f870]
+      OutOfLinePCRanges: [0x80f950..0x80f9c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 352 PointerType *main.Pair[go.shape.string,go.shape.int]
+          Type: 356 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x80f800..0x80f870
+            - Range: 0x80f950..0x80f9c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80f800..0x80f870
+            - Range: 0x80f950..0x80f9c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10641,22 +10764,22 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: v
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x80f800..0x80f870
+            - Range: 0x80f950..0x80f9c0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 178
+    - ID: 181
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x80f8d0..0x80f8e0]
+      OutOfLinePCRanges: [0x80fa20..0x80fa30]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80f8d0..0x80f8e0
+            - Range: 0x80fa20..0x80fa30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10665,61 +10788,61 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 351 BaseType go.shape.bool
+          Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0x80f8d0..0x80f8e0
+            - Range: 0x80fa20..0x80fa30
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 351 BaseType go.shape.bool
+          Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0x80f8d0..0x80f8d8
+            - Range: 0x80fa20..0x80fa28
               Pieces: []
-            - Range: 0x80f8d8..0x80f8d9
+            - Range: 0x80fa28..0x80fa29
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f8d9..0x80f8e0
+            - Range: 0x80fa29..0x80fa30
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80f8d0..0x80f8d8
+            - Range: 0x80fa20..0x80fa28
               Pieces: []
-            - Range: 0x80f8d8..0x80f8d9
+            - Range: 0x80fa28..0x80fa29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80f8d9..0x80f8e0
+            - Range: 0x80fa29..0x80fa30
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 179
+    - ID: 182
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80f8e0..0x80f900]
+      OutOfLinePCRanges: [0x80fa30..0x80fa50]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x80f8e0..0x80f8f0
+            - Range: 0x80fa30..0x80fa40
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80f8e0..0x80f8ec
+            - Range: 0x80fa30..0x80fa3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80f8ec..0x80f900
+            - Range: 0x80fa3c..0x80fa50
               Pieces:
                 - Size: 8
                   Op: null
@@ -10728,75 +10851,75 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80f8e0..0x80f8f0
+            - Range: 0x80fa30..0x80fa40
               Pieces: []
-            - Range: 0x80f8f0..0x80f8f1
+            - Range: 0x80fa40..0x80fa41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f8f1..0x80f900
+            - Range: 0x80fa41..0x80fa50
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x80f8e0..0x80f8f0
+            - Range: 0x80fa30..0x80fa40
               Pieces: []
-            - Range: 0x80f8f0..0x80f8f1
+            - Range: 0x80fa40..0x80fa41
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80f8f1..0x80f900
+            - Range: 0x80fa41..0x80fa50
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 180
+    - ID: 183
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x80f900..0x80f950]
+      OutOfLinePCRanges: [0x80fa50..0x80faa0]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 354 StructureType go.shape.struct { main.i int }
+          Type: 358 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x80f900..0x80f928
+            - Range: 0x80fa50..0x80fa78
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f900..0x80f928
+            - Range: 0x80fa50..0x80fa78
               Pieces: []
-            - Range: 0x80f928..0x80f929
+            - Range: 0x80fa78..0x80fa79
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f929..0x80f950
+            - Range: 0x80fa79..0x80faa0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 184
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x80f950..0x80f9b0]
+      OutOfLinePCRanges: [0x80faa0..0x80fb00]
       InlinePCRanges: []
       Variables:
         - Name: val
-          Type: 355 StructureType go.shape.struct { main.s string }
+          Type: 359 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x80f950..0x80f97c
+            - Range: 0x80faa0..0x80facc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80f97c..0x80f980
+            - Range: 0x80facc..0x80fad0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10807,65 +10930,65 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f950..0x80f980
+            - Range: 0x80faa0..0x80fad0
               Pieces: []
-            - Range: 0x80f980..0x80f981
+            - Range: 0x80fad0..0x80fad1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f981..0x80f9b0
+            - Range: 0x80fad1..0x80fb00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 182
+    - ID: 185
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x80f9b0..0x80f9c0]
+      OutOfLinePCRanges: [0x80fb00..0x80fb10]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 356 PointerType *go.shape.string
+          Type: 360 PointerType *go.shape.string
           Locations:
-            - Range: 0x80f9b0..0x80f9b4
+            - Range: 0x80fb00..0x80fb04
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80f9b0..0x80f9b4
+            - Range: 0x80fb00..0x80fb04
               Pieces: []
-            - Range: 0x80f9b4..0x80f9b5
+            - Range: 0x80fb04..0x80fb05
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f9b5..0x80f9c0
+            - Range: 0x80fb05..0x80fb10
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 183
+    - ID: 186
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x80f9c0..0x80fa10]
+      OutOfLinePCRanges: [0x80fb10..0x80fb60]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 357 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 361 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80f9c0..0x80fa00
+            - Range: 0x80fb10..0x80fb50
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 358 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+          Type: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80f9c0..0x80fa04
+            - Range: 0x80fb10..0x80fb54
               Pieces: []
-            - Range: 0x80fa04..0x80fa05
+            - Range: 0x80fb54..0x80fb55
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10879,20 +11002,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80fa05..0x80fa10
+            - Range: 0x80fb55..0x80fb60
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 184
+    - ID: 187
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x80fa10..0x80fa50]
+      OutOfLinePCRanges: [0x80fb60..0x80fba0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 338 GoSliceHeaderType []go.shape.int
+          Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fa10..0x80fa1c
+            - Range: 0x80fb60..0x80fb6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10900,7 +11023,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80fa1c..0x80fa50
+            - Range: 0x80fb6c..0x80fba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10911,44 +11034,44 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x80fa10..0x80fa50
+            - Range: 0x80fb60..0x80fba0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80fa10..0x80fa38
+            - Range: 0x80fb60..0x80fb88
               Pieces: []
-            - Range: 0x80fa38..0x80fa39
+            - Range: 0x80fb88..0x80fb89
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fa39..0x80fa40
+            - Range: 0x80fb89..0x80fb90
               Pieces: []
-            - Range: 0x80fa40..0x80fa41
+            - Range: 0x80fb90..0x80fb91
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fa41..0x80fa50
+            - Range: 0x80fb91..0x80fba0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x80fa2c..0x80fa3c
+            - Range: 0x80fb7c..0x80fb8c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 185
+    - ID: 188
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x80fa50..0x80fb10]
+      OutOfLinePCRanges: [0x80fba0..0x80fc60]
       InlinePCRanges: []
       Variables:
         - Name: haystack
-          Type: 359 GoSliceHeaderType []go.shape.string
+          Type: 363 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x80fa50..0x80fa74
+            - Range: 0x80fba0..0x80fbc4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10956,7 +11079,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80fa74..0x80fa78
+            - Range: 0x80fbc4..0x80fbc8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10967,15 +11090,15 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: needle
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fa50..0x80faac
+            - Range: 0x80fba0..0x80fbfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80faac..0x80fb10
+            - Range: 0x80fbfc..0x80fc60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10986,22 +11109,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80fa50..0x80fac8
+            - Range: 0x80fba0..0x80fc18
               Pieces: []
-            - Range: 0x80fac8..0x80fac9
+            - Range: 0x80fc18..0x80fc19
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fac9..0x80fad8
+            - Range: 0x80fc19..0x80fc28
               Pieces: []
-            - Range: 0x80fad8..0x80fad9
+            - Range: 0x80fc28..0x80fc29
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fad9..0x80fb10
+            - Range: 0x80fc29..0x80fc60
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fa94..0x80faac
+            - Range: 0x80fbe4..0x80fbfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11010,58 +11133,58 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 186
+    - ID: 189
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x80fb10..0x80fb20]
+      OutOfLinePCRanges: [0x80fc60..0x80fc70]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 360 StructureType main.typeWithGenerics[go.shape.int]
+          Type: 364 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x80fb10..0x80fb18
+            - Range: 0x80fc60..0x80fc68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x80fb10..0x80fb20
+            - Range: 0x80fc60..0x80fc70
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80fb10..0x80fb18
+            - Range: 0x80fc60..0x80fc68
               Pieces: []
-            - Range: 0x80fb18..0x80fb19
+            - Range: 0x80fc68..0x80fc69
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fb19..0x80fb20
+            - Range: 0x80fc69..0x80fc70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
-    - ID: 187
+    - ID: 190
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x80fb70..0x80fbe0]
+      OutOfLinePCRanges: [0x80fcc0..0x80fd30]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 361 StructureType main.typeWithGenerics[go.shape.string]
+          Type: 365 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x80fb70..0x80fb9c
+            - Range: 0x80fcc0..0x80fcec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fb9c..0x80fba8
+            - Range: 0x80fcec..0x80fcf8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fba8..0x80fbac
+            - Range: 0x80fcf8..0x80fcfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11070,9 +11193,9 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: value
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fb70..0x80fbac
+            - Range: 0x80fcc0..0x80fcfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11083,22 +11206,22 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80fb70..0x80fbac
+            - Range: 0x80fcc0..0x80fcfc
               Pieces: []
-            - Range: 0x80fbac..0x80fbad
+            - Range: 0x80fcfc..0x80fcfd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fbad..0x80fbe0
+            - Range: 0x80fcfd..0x80fd30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 188
+    - ID: 191
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x8035a0..0x803740]
       InlinePCRanges: []
       Variables:
         - Name: items
-          Type: 362 GoSliceHeaderType []go.shape.float64
+          Type: 366 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x8035a0..0x8035d0
               Pieces:
@@ -11127,7 +11250,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 0
         - Name: pred
-          Type: 365 GoSubroutineType func(go.shape.float64) bool
+          Type: 369 GoSubroutineType func(go.shape.float64) bool
           Locations:
             - Range: 0x8035a0..0x8035e4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
@@ -11136,7 +11259,7 @@ Subprograms:
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
-          Type: 362 GoSliceHeaderType []go.shape.float64
+          Type: 366 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x8035a0..0x803708
               Pieces: []
@@ -11153,7 +11276,7 @@ Subprograms:
           Role: Return
           DictIndex: 2
         - Name: result
-          Type: 362 GoSliceHeaderType []go.shape.float64
+          Type: 366 GoSliceHeaderType []go.shape.float64
           Locations:
             - Range: 0x8035d0..0x8035e4
               Pieces:
@@ -11238,7 +11361,7 @@ Subprograms:
           Role: Local
           DictIndex: 3
         - Name: item
-          Type: 364 BaseType go.shape.float64
+          Type: 368 BaseType go.shape.float64
           Locations:
             - Range: 0x803628..0x803638
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
@@ -11247,7 +11370,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 189
+    - ID: 192
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x8082e0..0x808350]
       InlinePCRanges:
@@ -11278,7 +11401,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 193
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11286,7 +11409,7 @@ Subprograms:
           RootRanges: [0x808500..0x8085c0]
       Variables: []
       DictRegister: null
-    - ID: 191
+    - ID: 194
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11294,7 +11417,7 @@ Subprograms:
           RootRanges: [0x808630..0x808740]
       Variables: []
       DictRegister: null
-    - ID: 192
+    - ID: 195
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11302,7 +11425,7 @@ Subprograms:
           RootRanges: [0x808630..0x808740]
       Variables: []
       DictRegister: null
-    - ID: 193
+    - ID: 196
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11317,7 +11440,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 194
+    - ID: 197
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11336,15 +11459,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 195
+    - ID: 198
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x8088e0..0x808940]
       InlinePCRanges:
-        - Ranges: [0x80fc60..0x80fc84]
-          RootRanges: [0x80fc40..0x80fcb0]
+        - Ranges: [0x80fdb0..0x80fdd4]
+          RootRanges: [0x80fd90..0x80fe00]
       Variables:
         - Name: b
-          Type: 366 StructureType main.firstBehavior
+          Type: 370 StructureType main.firstBehavior
           Locations:
             - Range: 0x8088e0..0x808904
               Pieces:
@@ -11370,43 +11493,43 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 196
+    - ID: 199
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x8090d0..0x8090dc, 0x8090e0..0x8090e8]
-          RootRanges: [0x809040..0x809130]
+          RootRanges: [0x809040..0x809140]
         - Ranges: [0x803128..0x80312c, 0x803130..0x803138]
           RootRanges: [0x803120..0x803140]
       Variables: []
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1404
+      ID: 1405
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 400 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 147
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 148 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1409
+      ID: 1410
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1410 PointerType *main.deepSlice3
+      Pointee: 1411 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1444
+      ID: 1445
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1445 PointerType *main.deepSlice8
+      Pointee: 1446 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1450
+      ID: 1451
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1451 PointerType *main.deepSlice9
+      Pointee: 1452 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 161
       Name: '**main.stringType2'
@@ -11414,7 +11537,7 @@ Types:
       GoKind: 22
       Pointee: 162 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1389
+      ID: 1400
       Name: '**main.t'
       ByteSize: 8
       Pointee: 261 PointerType *main.t
@@ -11452,40 +11575,40 @@ Types:
       ByteSize: 8
       Pointee: 215 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 386
+      ID: 390
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 387 PointerType *table<context.canceler,struct {}>
+      Pointee: 391 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 155
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 156 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1417
+      ID: 1418
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1418 PointerType *table<int,*main.deepMap3>
+      Pointee: 1419 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1461
+      ID: 1462
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1462 PointerType *table<int,*main.deepMap8>
+      Pointee: 1463 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1476
+      ID: 1477
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1477 PointerType *table<int,*main.deepMap9>
+      Pointee: 1478 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 182
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 183 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1491
+      ID: 1492
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1492 PointerType *table<int,interface {}>
+      Pointee: 1493 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 249
       Name: '**table<int,struct {}>'
@@ -11497,10 +11620,10 @@ Types:
       ByteSize: 8
       Pointee: 220 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 699 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 706 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 209
       Name: '**table<string,[]main.structWithMap>'
@@ -11512,35 +11635,35 @@ Types:
       ByteSize: 8
       Pointee: 198 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 417
+      ID: 418
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 418 PointerType *table<string,float64>
+      Pointee: 419 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1143
+      ID: 1154
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1144 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1155 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 192
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 193 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 412
+      ID: 413
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 413 PointerType *table<string,interface {}>
+      Pointee: 414 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 187
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 188 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 407
+      ID: 408
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 408 PointerType *table<string,string>
+      Pointee: 409 PointerType *table<string,string>
     - __kind: PointerType
       ID: 244
       Name: '**table<struct {},int>'
@@ -11592,150 +11715,150 @@ Types:
       ByteSize: 8
       Pointee: 225 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1407
+      ID: 1408
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1406 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1407 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 443
+      ID: 444
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 442 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 443 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1413
+      ID: 1414
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1412 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1413 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1448
+      ID: 1449
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1447 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1448 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1454
+      ID: 1455
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1453 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1454 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 438
+      ID: 439
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 437 GoSliceDataType []*runtime.p.array
+      Pointee: 438 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 440
+      ID: 441
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 439 GoSliceDataType []*string.array
+      Pointee: 440 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 603
+      ID: 604
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 602 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 603 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 296
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 293 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 601
+      ID: 602
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 600 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 601 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 294
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 291 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 599
+      ID: 600
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 598 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 599 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 292
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 289 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 597
+      ID: 598
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 596 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 597 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 595
+      ID: 596
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 594 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 595 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 583
+      ID: 584
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 582 GoSliceDataType [][]uint.array
+      Pointee: 583 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 587
+      ID: 588
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 586 GoSliceDataType []bool.array
+      Pointee: 587 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1180
+      ID: 1191
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1179 GoSliceDataType []float64.array
+      Pointee: 1190 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 700 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 701 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 708 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 659
+      ID: 666
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 658 GoSliceDataType []go.shape.float64.array
+      Pointee: 665 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 655
+      ID: 662
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 654 GoSliceDataType []go.shape.int.array
+      Pointee: 661 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 657
+      ID: 664
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 656 GoSliceDataType []go.shape.string.array
+      Pointee: 663 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
-      ID: 1457
+      ID: 1458
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1456 GoSliceDataType []interface {}.array
+      Pointee: 1457 GoSliceDataType []interface {}.array
     - __kind: PointerType
       ID: 288
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 593
+      ID: 594
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 592 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 593 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 703 GoSliceDataType []main.structWithMap.array
+      Pointee: 710 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 585
+      ID: 586
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 584 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 585 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -11744,111 +11867,111 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 455
+      ID: 456
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 454 GoSliceDataType []string.array
+      Pointee: 455 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 591
+      ID: 592
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 590 GoSliceDataType []struct {}.array
+      Pointee: 591 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 1400
+      ID: 713
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 1399 GoSliceDataType []time.zone.array
+      Pointee: 712 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 1402
+      ID: 715
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 1401 GoSliceDataType []time.zoneTrans.array
+      Pointee: 714 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 272
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 270 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 581
+      ID: 582
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 580 GoSliceDataType []uint.array
+      Pointee: 581 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 589
+      ID: 590
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 588 GoSliceDataType []uint16.array
+      Pointee: 589 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 433
+      ID: 434
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 432 GoSliceDataType []uint8.array
+      Pointee: 433 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 435
+      ID: 436
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 434 GoSliceDataType []uintptr.array
+      Pointee: 435 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1311
+      ID: 1322
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2017088
       GoKind: 22
-      Pointee: 1312 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1323 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 948
+      ID: 959
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 943936
       GoKind: 22
-      Pointee: 949 GoSliceHeaderType archive/tar.headerError
+      Pointee: 960 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 951
+      ID: 962
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 950 GoSliceDataType archive/tar.headerError.array
+      Pointee: 961 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1245
+      ID: 1256
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1453824
       GoKind: 22
-      Pointee: 1246 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1257 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1193
+      ID: 1204
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 944128
       GoKind: 22
-      Pointee: 1194 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1205 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1195
+      ID: 1206
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 944224
       GoKind: 22
-      Pointee: 1196 StructureType archive/zip.dirWriter
+      Pointee: 1207 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1288
+      ID: 1299
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1933120
       GoKind: 22
-      Pointee: 1289 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1300 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1221
+      ID: 1232
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1070816
       GoKind: 22
-      Pointee: 1222 StructureType archive/zip.nopCloser
+      Pointee: 1233 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1223
+      ID: 1234
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1071072
       GoKind: 22
-      Pointee: 1224 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1235 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 12
       Name: '*bool'
@@ -11857,26 +11980,26 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1269
+      ID: 1280
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2207168
       GoKind: 22
-      Pointee: 1270 UnresolvedPointeeType bufio.Reader
+      Pointee: 1281 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1300
+      ID: 1311
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1979904
       GoKind: 22
-      Pointee: 1301 UnresolvedPointeeType bufio.Writer
+      Pointee: 1312 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1347
+      ID: 1358
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2309152
       GoKind: 22
-      Pointee: 1348 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1359 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 116
       Name: '*complex128'
@@ -11885,451 +12008,451 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 861
+      ID: 872
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 926080
       GoKind: 22
-      Pointee: 752 BaseType compress/flate.CorruptInputError
+      Pointee: 763 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 862
+      ID: 873
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 926176
       GoKind: 22
-      Pointee: 753 GoStringHeaderType compress/flate.InternalError
+      Pointee: 764 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 755
+      ID: 766
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 754 GoStringDataType compress/flate.InternalError.str
+      Pointee: 765 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1243
+      ID: 1254
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1442624
       GoKind: 22
-      Pointee: 1244 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1255 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1189
+      ID: 1200
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 1190 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1201 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1265
+      ID: 1276
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1753248
       GoKind: 22
-      Pointee: 1266 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1277 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 367
+      ID: 371
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 1751136
       GoKind: 22
-      Pointee: 368 StructureType context.afterFuncCtx
+      Pointee: 372 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 1437
+      ID: 1438
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1572576
       GoKind: 22
-      Pointee: 391 StructureType context.backgroundCtx
+      Pointee: 395 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 369
+      ID: 373
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1750560
       GoKind: 22
-      Pointee: 370 StructureType context.cancelCtx
+      Pointee: 374 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1064
+      ID: 1075
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1204448
       GoKind: 22
-      Pointee: 1065 StructureType context.deadlineExceededError
+      Pointee: 1076 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1432
+      ID: 1433
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1430944
       GoKind: 22
-      Pointee: 392 StructureType context.emptyCtx
+      Pointee: 396 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 371
+      ID: 375
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1431104
       GoKind: 22
-      Pointee: 372 StructureType context.stopCtx
+      Pointee: 376 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 373
+      ID: 377
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1750752
       GoKind: 22
-      Pointee: 374 StructureType context.timerCtx
+      Pointee: 378 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1438
+      ID: 1439
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1572736
       GoKind: 22
-      Pointee: 399 StructureType context.todoCtx
+      Pointee: 400 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 375
+      ID: 379
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1572256
       GoKind: 22
-      Pointee: 376 StructureType context.valueCtx
+      Pointee: 380 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 377
+      ID: 381
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1572416
       GoKind: 22
-      Pointee: 378 StructureType context.withoutCancelCtx
+      Pointee: 382 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 940
+      ID: 951
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 938560
       GoKind: 22
-      Pointee: 763 BaseType crypto/aes.KeySizeError
+      Pointee: 774 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 941
+      ID: 952
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 938752
       GoKind: 22
-      Pointee: 764 BaseType crypto/des.KeySizeError
+      Pointee: 775 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 942
+      ID: 953
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939040
       GoKind: 22
-      Pointee: 765 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 776 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1260
+      ID: 1271
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1693024
       GoKind: 22
-      Pointee: 1261 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1272 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1045
+      ID: 1056
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1078624
       GoKind: 22
-      Pointee: 1046 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 1057 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1290
+      ID: 1301
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1933632
       GoKind: 22
-      Pointee: 1291 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1302 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1322
+      ID: 1333
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2151168
       GoKind: 22
-      Pointee: 1323 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1334 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1296
+      ID: 1307
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1934400
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1292
+      ID: 1303
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1933888
       GoKind: 22
-      Pointee: 1293 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1304 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1286
+      ID: 1297
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1931072
       GoKind: 22
-      Pointee: 1287 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1298 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 943
+      ID: 954
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 766 BaseType crypto/rc4.KeySizeError
+      Pointee: 777 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1309
+      ID: 1320
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 2014784
       GoKind: 22
-      Pointee: 1310 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1321 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1294
+      ID: 1305
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1934144
       GoKind: 22
-      Pointee: 1295 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1306 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 1278
+      ID: 1289
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1836032
       GoKind: 22
-      Pointee: 1279 UnresolvedPointeeType crypto/sha3.SHAKE
+      Pointee: 1290 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
-      ID: 865
+      ID: 876
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 927520
       GoKind: 22
-      Pointee: 756 BaseType crypto/tls.AlertError
+      Pointee: 767 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1034
+      ID: 1045
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1059808
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1046 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1373
+      ID: 1384
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2411680
       GoKind: 22
-      Pointee: 1374 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1385 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 866
+      ID: 877
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 927616
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 878 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 863
+      ID: 874
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 927424
       GoKind: 22
-      Pointee: 864 StructureType crypto/tls.RecordHeaderError
+      Pointee: 875 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1033
+      ID: 1044
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1058144
       GoKind: 22
-      Pointee: 988 BaseType crypto/tls.alert
+      Pointee: 999 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1253
+      ID: 1264
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1581856
       GoKind: 22
-      Pointee: 1254 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1265 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 868
+      ID: 879
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 927712
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 880 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1258
+      ID: 1269
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1666720
       GoKind: 22
-      Pointee: 1259 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1270 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1131
+      ID: 1142
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1443104
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1143 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1145
+      ID: 1156
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2043424
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1157 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 934
+      ID: 945
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 937312
       GoKind: 22
-      Pointee: 935 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 946 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 928
+      ID: 939
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 936352
       GoKind: 22
-      Pointee: 929 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 940 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 930
+      ID: 941
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 936832
       GoKind: 22
-      Pointee: 931 StructureType crypto/x509.HostnameError
+      Pointee: 942 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 927
+      ID: 938
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 936256
       GoKind: 22
-      Pointee: 762 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 773 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1039
+      ID: 1050
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1065056
       GoKind: 22
-      Pointee: 1040 StructureType crypto/x509.SystemRootsError
+      Pointee: 1051 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 936
+      ID: 947
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 937 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 948 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 932
+      ID: 943
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 937216
       GoKind: 22
-      Pointee: 933 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 944 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 952
+      ID: 963
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 944416
       GoKind: 22
-      Pointee: 953 StructureType encoding/asn1.StructuralError
+      Pointee: 964 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 956
+      ID: 967
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 944608
       GoKind: 22
-      Pointee: 957 StructureType encoding/asn1.SyntaxError
+      Pointee: 968 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 954
+      ID: 965
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 944512
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 966 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 851
+      ID: 862
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 923392
       GoKind: 22
-      Pointee: 746 BaseType encoding/base64.CorruptInputError
+      Pointee: 757 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1211
+      ID: 1222
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1054560
       GoKind: 22
-      Pointee: 1212 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1223 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 854
+      ID: 865
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 924256
       GoKind: 22
-      Pointee: 747 BaseType encoding/hex.InvalidByteError
+      Pointee: 758 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 822
+      ID: 833
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918208
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 834 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1023
+      ID: 1034
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1050720
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1035 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 814
+      ID: 825
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 917824
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 826 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 820
+      ID: 831
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 832 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 818
+      ID: 829
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918016
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 830 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 816
+      ID: 827
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 917920
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 828 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1353
+      ID: 1364
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2330272
       GoKind: 22
-      Pointee: 1354 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1365 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 824
+      ID: 835
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 825 StructureType encoding/json.jsonError
+      Pointee: 836 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1219
+      ID: 1230
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1067616
       GoKind: 22
-      Pointee: 1220 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1231 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 925
+      ID: 936
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 935488
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 937 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -12338,19 +12461,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 788
+      ID: 799
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType errors.errorString
+      Pointee: 800 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 990
+      ID: 1001
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1036256
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType errors.joinError
+      Pointee: 1002 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -12366,913 +12489,913 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 1341
+      ID: 1352
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2291712
       GoKind: 22
-      Pointee: 1342 UnresolvedPointeeType fmt.pp
+      Pointee: 1353 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 992
+      ID: 1003
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1036384
       GoKind: 22
-      Pointee: 993 UnresolvedPointeeType fmt.wrapError
+      Pointee: 1004 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 994
+      ID: 1005
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1036512
       GoKind: 22
-      Pointee: 995 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 1006 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 852
+      ID: 863
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 864 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 833
+      ID: 844
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 920992
       GoKind: 22
-      Pointee: 834 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 845 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 835
+      ID: 846
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 921088
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 847 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1157
+      ID: 1168
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 920800
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1169 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 839
+      ID: 850
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 840 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 851 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1159
+      ID: 1170
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 920896
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1171 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 837
+      ID: 848
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 740 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 751 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 742
+      ID: 753
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 741 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 832
+      ID: 843
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 920704
       GoKind: 22
-      Pointee: 737 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 748 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 739
+      ID: 750
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 738 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 838
+      ID: 849
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 743 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 754 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 745
+      ID: 756
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 744 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 755 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1231
+      ID: 1242
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1222112
       GoKind: 22
-      Pointee: 1232 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1243 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1319
+      ID: 1330
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2088256
       GoKind: 22
-      Pointee: 1320 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1331 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 946
+      ID: 957
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 942880
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 958 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 400
+      ID: 401
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2308608
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 402 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 425
+      ID: 426
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2038240
       GoKind: 22
-      Pointee: 426 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 427 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 420
+      ID: 421
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1204704
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 422 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 423
+      ID: 424
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1204832
       GoKind: 22
-      Pointee: 424 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 425 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1430
+      ID: 1431
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1205472
       GoKind: 22
-      Pointee: 1431 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1432 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 711
+      ID: 722
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1205600
       GoKind: 22
-      Pointee: 712 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 723 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 427
+      ID: 428
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2257568
       GoKind: 22
-      Pointee: 428 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 429 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1099
+      ID: 1110
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1225568
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1111 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1349
+      ID: 1360
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2309696
       GoKind: 22
-      Pointee: 1350 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1361 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1433
+      ID: 1434
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1436864
       GoKind: 22
-      Pointee: 1434 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 1435 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 876
+      ID: 887
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 931168
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 888 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 883
+      ID: 894
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 932224
       GoKind: 22
-      Pointee: 884 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 895 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 878
+      ID: 889
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 931936
       GoKind: 22
-      Pointee: 761 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 772 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 881
+      ID: 892
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 932128
       GoKind: 22
-      Pointee: 882 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 893 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 879
+      ID: 890
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 932032
       GoKind: 22
-      Pointee: 880 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 891 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 899
+      ID: 910
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 934144
       GoKind: 22
-      Pointee: 900 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 911 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 903
+      ID: 914
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 904 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 915 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 901
+      ID: 912
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 934240
       GoKind: 22
-      Pointee: 902 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 913 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 897
+      ID: 908
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 934048
       GoKind: 22
-      Pointee: 898 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 909 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1182
+      ID: 1193
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1181 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1192 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 911
+      ID: 922
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 934720
       GoKind: 22
-      Pointee: 912 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 923 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 905
+      ID: 916
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 934432
       GoKind: 22
-      Pointee: 906 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 917 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 909
+      ID: 920
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 934624
       GoKind: 22
-      Pointee: 910 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 921 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 907
+      ID: 918
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 934528
       GoKind: 22
-      Pointee: 908 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 919 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 913
+      ID: 924
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 914 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 925 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 919
+      ID: 930
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 935104
       GoKind: 22
-      Pointee: 920 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 931 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 921
+      ID: 932
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 935200
       GoKind: 22
-      Pointee: 922 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 933 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 917
+      ID: 928
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 935008
       GoKind: 22
-      Pointee: 918 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 929 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 915
+      ID: 926
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 934912
       GoKind: 22
-      Pointee: 916 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 927 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 923
+      ID: 934
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 935392
       GoKind: 22
-      Pointee: 924 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 935 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 841
+      ID: 852
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 922528
       GoKind: 22
-      Pointee: 842 StructureType github.com/cihub/seelog.baseError
+      Pointee: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1272
+      ID: 1283
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1830432
       GoKind: 22
-      Pointee: 1273 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1284 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 843
+      ID: 854
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 922624
       GoKind: 22
-      Pointee: 844 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 855 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1251
+      ID: 1262
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1579936
       GoKind: 22
-      Pointee: 1252 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1263 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1207
+      ID: 1218
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1053408
       GoKind: 22
-      Pointee: 1208 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1219 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1241
+      ID: 1252
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1440544
       GoKind: 22
-      Pointee: 1242 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1253 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 847
+      ID: 858
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 848 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 859 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1307
+      ID: 1318
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 2006144
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1319 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1326
+      ID: 1337
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2164960
       GoKind: 22
-      Pointee: 1321 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1332 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1325
+      ID: 1336
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2164576
       GoKind: 22
-      Pointee: 1324 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1335 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1209
+      ID: 1220
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1053536
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1221 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 845
+      ID: 856
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 922720
       GoKind: 22
-      Pointee: 846 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 857 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 849
+      ID: 860
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 850 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 861 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1274
+      ID: 1285
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1832224
       GoKind: 22
-      Pointee: 1275 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1286 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1315
+      ID: 1326
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2043136
       GoKind: 22
-      Pointee: 1316 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1327 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1317
+      ID: 1328
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2074208
       GoKind: 22
-      Pointee: 1318 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1329 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1133
+      ID: 1144
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1456224
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1145 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1049
+      ID: 1060
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1079392
       GoKind: 22
-      Pointee: 1050 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1061 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1047
+      ID: 1058
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1079264
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1059 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1051
+      ID: 1062
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1083360
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1063 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1053
+      ID: 1064
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1083488
       GoKind: 22
-      Pointee: 1054 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1065 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1262
+      ID: 1273
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1695904
       GoKind: 22
-      Pointee: 1263 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1274 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1041
+      ID: 1052
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1065568
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1053 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 855
+      ID: 866
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 856 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 867 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1365
+      ID: 1376
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2385600
       GoKind: 22
-      Pointee: 1366 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1377 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1107
+      ID: 1118
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1235552
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1119 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1076
+      ID: 1087
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1213280
       GoKind: 22
-      Pointee: 1077 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1070
+      ID: 1081
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1212896
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1082 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1009
+      ID: 1020
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1044832
       GoKind: 22
-      Pointee: 1010 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1021 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1082
+      ID: 1093
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1213664
       GoKind: 22
-      Pointee: 1083 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1094 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1008
+      ID: 1019
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1044704
       GoKind: 22
-      Pointee: 987 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 998 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1074
+      ID: 1085
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1213152
       GoKind: 22
-      Pointee: 1075 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1072
+      ID: 1083
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1213024
       GoKind: 22
-      Pointee: 1073 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1080
+      ID: 1091
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1213536
       GoKind: 22
-      Pointee: 1081 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1092 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1078
+      ID: 1089
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1213408
       GoKind: 22
-      Pointee: 1079 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1369
+      ID: 1380
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2400704
       GoKind: 22
-      Pointee: 1370 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1381 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1086
+      ID: 1097
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1214048
       GoKind: 22
-      Pointee: 1087 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1098 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1013
+      ID: 1024
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1045088
       GoKind: 22
-      Pointee: 1014 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1025 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1011
+      ID: 1022
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1044960
       GoKind: 22
-      Pointee: 1012 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1023 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1084
+      ID: 1095
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1213920
       GoKind: 22
-      Pointee: 1085 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1096 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 968
+      ID: 979
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 957664
       GoKind: 22
-      Pointee: 771 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 782 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 773
+      ID: 784
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 772 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 783 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 363
+      ID: 367
       Name: '*go.shape.float64'
       ByteSize: 8
       GoRuntimeType: 487744
       GoKind: 22
-      Pointee: 364 BaseType go.shape.float64
+      Pointee: 368 BaseType go.shape.float64
     - __kind: PointerType
-      ID: 339
+      ID: 343
       Name: '*go.shape.int'
       ByteSize: 8
       GoRuntimeType: 487168
       GoKind: 22
-      Pointee: 334 BaseType go.shape.int
+      Pointee: 338 BaseType go.shape.int
     - __kind: PointerType
-      ID: 356
+      ID: 360
       Name: '*go.shape.string'
       ByteSize: 8
       GoRuntimeType: 487232
       GoKind: 22
-      Pointee: 336 GoStringHeaderType go.shape.string
+      Pointee: 340 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 653
+      ID: 660
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 652 GoStringDataType go.shape.string.str
+      Pointee: 659 GoStringDataType go.shape.string.str
     - __kind: PointerType
-      ID: 342
+      ID: 346
       Name: '*go.shape.struct { Name string }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 343 StructureType go.shape.struct { Name string }
+      Pointee: 347 StructureType go.shape.struct { Name string }
     - __kind: PointerType
-      ID: 344
+      ID: 348
       Name: '*go.shape.struct { X int; Y int }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 345 StructureType go.shape.struct { X int; Y int }
+      Pointee: 349 StructureType go.shape.struct { X int; Y int }
     - __kind: PointerType
-      ID: 357
+      ID: 361
       Name: '*go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }'
       ByteSize: 8
       GoKind: 22
-      Pointee: 358 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+      Pointee: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1148
+      ID: 1159
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1694368
       GoKind: 22
-      Pointee: 1149 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1160 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1057
+      ID: 1068
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1098208
       GoKind: 22
-      Pointee: 1058 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1069 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1237
+      ID: 1248
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1276512
       GoKind: 22
-      Pointee: 1238 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1249 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1331
+      ID: 1342
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2179936
       GoKind: 22
-      Pointee: 1332 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1343 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1225
+      ID: 1236
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1100512
       GoKind: 22
-      Pointee: 1226 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1237 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 969
+      ID: 980
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 958912
       GoKind: 22
-      Pointee: 774 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 785 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1115
+      ID: 1126
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1278176
       GoKind: 22
-      Pointee: 1116 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1127 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 972
+      ID: 983
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 959200
       GoKind: 22
-      Pointee: 973 StructureType golang.org/x/net/http2.connError
+      Pointee: 984 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 971
+      ID: 982
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 959104
       GoKind: 22
-      Pointee: 778 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 789 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 780
+      ID: 791
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 779 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 790 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 975
+      ID: 986
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 959392
       GoKind: 22
-      Pointee: 784 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 795 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 786
+      ID: 797
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 785 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 796 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 974
+      ID: 985
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 959296
       GoKind: 22
-      Pointee: 781 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 792 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 783
+      ID: 794
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 782 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 793 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 970
+      ID: 981
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 959008
       GoKind: 22
-      Pointee: 775 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 786 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 777
+      ID: 788
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 776 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 787 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1329
+      ID: 1340
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2178016
       GoKind: 22
-      Pointee: 1330 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1341 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 976
+      ID: 987
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 959488
       GoKind: 22
-      Pointee: 977 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 988 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 978
+      ID: 989
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 959584
       GoKind: 22
-      Pointee: 787 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 798 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 964
+      ID: 975
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 952864
       GoKind: 22
-      Pointee: 965 StructureType google.golang.org/grpc.dropError
+      Pointee: 976 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1113
+      ID: 1124
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1275232
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1125 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1135
+      ID: 1146
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1463584
       GoKind: 22
-      Pointee: 1136 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1147 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 966
+      ID: 977
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 955936
       GoKind: 22
-      Pointee: 967 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 978 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1280
+      ID: 1291
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1838272
       GoKind: 22
-      Pointee: 1281 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1292 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1235
+      ID: 1246
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1271776
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1247 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1055
+      ID: 1066
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1092448
       GoKind: 22
-      Pointee: 1056 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1067 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1197
+      ID: 1208
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 956032
       GoKind: 22
-      Pointee: 1198 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1209 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 944
+      ID: 955
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 940768
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 956 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1043
+      ID: 1054
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1069152
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1055 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1111
+      ID: 1122
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1242464
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1123 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1109
+      ID: 1120
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1242208
       GoKind: 22
-      Pointee: 1110 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1121 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 958
+      ID: 969
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 945472
       GoKind: 22
-      Pointee: 959 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 970 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 960
+      ID: 971
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 945568
       GoKind: 22
-      Pointee: 961 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 972 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 891
+      ID: 902
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 932608
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 903 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1284
+      ID: 1295
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1929024
       GoKind: 22
-      Pointee: 1285 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1296 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 979
+      ID: 990
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 960352
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType html/template.Error
+      Pointee: 991 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 107
       Name: '*int'
@@ -13316,61 +13439,61 @@ Types:
       GoKind: 22
       Pointee: 170 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 1137
+      ID: 1148
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2230432
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType internal/abi.Type
+      Pointee: 1149 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 938
+      ID: 949
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 938176
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 950 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 859
+      ID: 870
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 871 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1187
+      ID: 1198
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 1188 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1199 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1105
+      ID: 1116
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1226848
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1117 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1371
+      ID: 1382
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2406368
       GoKind: 22
-      Pointee: 1372 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1383 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1103
+      ID: 1114
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1226720
       GoKind: 22
-      Pointee: 1104 StructureType internal/poll.errNetClosing
+      Pointee: 1115 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 797
+      ID: 808
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 913312
       GoKind: 22
-      Pointee: 798 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 809 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -13379,78 +13502,78 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 858
+      ID: 869
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 925600
       GoKind: 22
-      Pointee: 749 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 760 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 751
+      ID: 762
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 761 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 1027
+      ID: 1038
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1056736
       GoKind: 22
-      Pointee: 1028 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 1039 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 857
+      ID: 868
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 924544
       GoKind: 22
-      Pointee: 748 BaseType internal/strconv.Error
+      Pointee: 759 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 1229
+      ID: 1240
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1204192
       GoKind: 22
-      Pointee: 1230 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1241 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1227
+      ID: 1238
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1203808
       GoKind: 22
-      Pointee: 1228 StructureType io.discard
+      Pointee: 1239 StructureType io.discard
     - __kind: PointerType
-      ID: 1201
+      ID: 1212
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1037280
       GoKind: 22
-      Pointee: 1202 UnresolvedPointeeType io.multiWriter
+      Pointee: 1213 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1101
+      ID: 1112
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1226208
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1113 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1276
+      ID: 1287
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1832448
       GoKind: 22
-      Pointee: 1277 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1288 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 349
+      ID: 353
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 350 StructureType main.Pair[go.shape.int,go.shape.bool]
+      Pointee: 354 StructureType main.Pair[go.shape.int,go.shape.bool]
     - __kind: PointerType
-      ID: 352
+      ID: 356
       Name: '*main.Pair[go.shape.string,go.shape.int]'
       ByteSize: 8
       GoKind: 22
-      Pointee: 353 StructureType main.Pair[go.shape.string,go.shape.int]
+      Pointee: 357 StructureType main.Pair[go.shape.string,go.shape.int]
     - __kind: PointerType
       ID: 329
       Name: '*main.anotherStruct'
@@ -13458,19 +13581,19 @@ Types:
       GoKind: 22
       Pointee: 330 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 450
+      ID: 451
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 393024
       GoKind: 22
-      Pointee: 451 StructureType main.deepMap2
+      Pointee: 452 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1425
+      ID: 1426
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 392960
       GoKind: 22
-      Pointee: 1426 UnresolvedPointeeType main.deepMap3
+      Pointee: 1427 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 157
       Name: '*main.deepMap7'
@@ -13479,19 +13602,19 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1469
+      ID: 1470
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 392640
       GoKind: 22
-      Pointee: 1470 StructureType main.deepMap8
+      Pointee: 1471 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1484
+      ID: 1485
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 392576
       GoKind: 22
-      Pointee: 1485 StructureType main.deepMap9
+      Pointee: 1486 StructureType main.deepMap9
     - __kind: PointerType
       ID: 141
       Name: '*main.deepPtr2'
@@ -13500,12 +13623,12 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1375
+      ID: 1386
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 393536
       GoKind: 22
-      Pointee: 1376 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1387 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepPtr7'
@@ -13514,33 +13637,33 @@ Types:
       GoKind: 22
       Pointee: 144 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1439
+      ID: 1440
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 393216
       GoKind: 22
-      Pointee: 1440 StructureType main.deepPtr8
+      Pointee: 1441 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1441
+      ID: 1442
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 393152
       GoKind: 22
-      Pointee: 1442 StructureType main.deepPtr9
+      Pointee: 1443 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 148
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 394176
       GoKind: 22
-      Pointee: 441 StructureType main.deepSlice2
+      Pointee: 442 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1410
+      ID: 1411
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 394112
       GoKind: 22
-      Pointee: 1411 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1412 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepSlice7'
@@ -13549,19 +13672,19 @@ Types:
       GoKind: 22
       Pointee: 150 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1445
+      ID: 1446
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 393792
       GoKind: 22
-      Pointee: 1446 StructureType main.deepSlice8
+      Pointee: 1447 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1451
+      ID: 1452
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 393728
       GoKind: 22
-      Pointee: 1452 StructureType main.deepSlice9
+      Pointee: 1453 StructureType main.deepSlice9
     - __kind: PointerType
       ID: 333
       Name: '*main.emptyStruct'
@@ -13576,14 +13699,14 @@ Types:
       GoKind: 22
       Pointee: 173 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1386
+      ID: 1397
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 908320
       GoKind: 22
-      Pointee: 366 StructureType main.firstBehavior
+      Pointee: 370 StructureType main.firstBehavior
     - __kind: PointerType
-      ID: 1501
+      ID: 1502
       Name: '*main.nestedStruct'
       ByteSize: 8
       GoRuntimeType: 394560
@@ -13609,19 +13732,19 @@ Types:
       GoKind: 22
       Pointee: 166 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1387
+      ID: 1398
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 908416
       GoKind: 22
-      Pointee: 1388 StructureType main.secondBehavior
+      Pointee: 1399 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1381
+      ID: 1392
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 1382 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1393 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 159
       Name: '*main.stringType1'
@@ -13629,28 +13752,28 @@ Types:
       GoKind: 22
       Pointee: 160 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1378
+      ID: 1389
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1377 GoStringDataType main.stringType1.str
+      Pointee: 1388 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 162
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1379 GoStringHeaderType main.stringType2
+      Pointee: 1390 GoStringHeaderType main.stringType2
     - __kind: PointerType
-      ID: 1503
+      ID: 1504
       Name: '*main.stringType2.str'
       ByteSize: 8
-      Pointee: 1502 GoStringDataType main.stringType2.str
+      Pointee: 1503 GoStringDataType main.stringType2.str
     - __kind: PointerType
       ID: 286
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 284 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 504
+      ID: 505
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 392512
@@ -13674,10 +13797,10 @@ Types:
       GoKind: 22
       Pointee: 262 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1391
+      ID: 1402
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1390 GoSliceDataType main.t.array
+      Pointee: 1401 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 281
       Name: '*main.threeStringStruct'
@@ -13705,40 +13828,40 @@ Types:
       ByteSize: 8
       Pointee: 213 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 384
+      ID: 388
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 385 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 389 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 153
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 154 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1415
+      ID: 1416
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1416 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1417 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1459
+      ID: 1460
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1460 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1461 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1474
+      ID: 1475
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1475 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1476 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 180
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 181 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1489
+      ID: 1490
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1490 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1491 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 247
       Name: '*map<int,struct {}>'
@@ -13750,10 +13873,10 @@ Types:
       ByteSize: 8
       Pointee: 218 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 697 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 704 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 207
       Name: '*map<string,[]main.structWithMap>'
@@ -13765,35 +13888,35 @@ Types:
       ByteSize: 8
       Pointee: 196 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 415
+      ID: 416
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 416 GoSwissMapHeaderType map<string,float64>
+      Pointee: 417 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1141
+      ID: 1152
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1142 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1153 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 190
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 191 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 410
+      ID: 411
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 411 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 412 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 185
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 186 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 405
+      ID: 406
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 406 GoSwissMapHeaderType map<string,string>
+      Pointee: 407 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 242
       Name: '*map<struct {},int>'
@@ -13851,728 +13974,728 @@ Types:
       GoKind: 22
       Pointee: 189 GoMapType map[string]int
     - __kind: PointerType
-      ID: 895
+      ID: 906
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 933472
       GoKind: 22
-      Pointee: 896 StructureType math/big.ErrNaN
+      Pointee: 907 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1191
+      ID: 1202
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 928288
       GoKind: 22
-      Pointee: 1192 StructureType mime/multipart.writerOnly·1
+      Pointee: 1203 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1093
+      ID: 1104
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1219936
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType net.AddrError
+      Pointee: 1105 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1124
+      ID: 1135
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1438784
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType net.DNSError
+      Pointee: 1136 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1335
+      ID: 1346
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2265344
       GoKind: 22
-      Pointee: 1336 UnresolvedPointeeType net.IPConn
+      Pointee: 1347 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1122
+      ID: 1133
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1438464
       GoKind: 22
-      Pointee: 1123 UnresolvedPointeeType net.OpError
+      Pointee: 1134 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1095
+      ID: 1106
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1220064
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType net.ParseError
+      Pointee: 1107 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1345
+      ID: 1356
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2292736
       GoKind: 22
-      Pointee: 1346 UnresolvedPointeeType net.TCPConn
+      Pointee: 1357 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1355
+      ID: 1366
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2337856
       GoKind: 22
-      Pointee: 1356 UnresolvedPointeeType net.UDPConn
+      Pointee: 1367 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1343
+      ID: 1354
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2292224
       GoKind: 22
-      Pointee: 1344 UnresolvedPointeeType net.UnixConn
+      Pointee: 1355 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1092
+      ID: 1103
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1219168
       GoKind: 22
-      Pointee: 1061 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1072 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1063
+      ID: 1074
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1062 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1073 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1025
+      ID: 1036
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1051616
       GoKind: 22
-      Pointee: 1026 StructureType net.canceledError
+      Pointee: 1037 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1313
+      ID: 1324
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2040256
       GoKind: 22
-      Pointee: 1314 UnresolvedPointeeType net.conn
+      Pointee: 1325 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1166
+      ID: 1177
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1875008
       GoKind: 22
-      Pointee: 1167 StructureType net.dialResult·1
+      Pointee: 1178 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1357
+      ID: 1368
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2342112
       GoKind: 22
-      Pointee: 1358 UnresolvedPointeeType net.netFD
+      Pointee: 1369 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 826
+      ID: 837
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 919552
       GoKind: 22
-      Pointee: 827 UnresolvedPointeeType net.notFoundError
+      Pointee: 838 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1435
+      ID: 1436
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1438624
       GoKind: 22
-      Pointee: 1436 StructureType net.onlyValuesCtx
+      Pointee: 1437 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 828
+      ID: 839
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 829 StructureType net.result·2
+      Pointee: 840 StructureType net.result·2
     - __kind: PointerType
-      ID: 1339
+      ID: 1350
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2278272
       GoKind: 22
-      Pointee: 1340 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1351 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1337
+      ID: 1348
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2277792
       GoKind: 22
-      Pointee: 1338 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1349 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1097
+      ID: 1108
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1220704
       GoKind: 22
-      Pointee: 1098 UnresolvedPointeeType net.temporaryError
+      Pointee: 1109 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1126
+      ID: 1137
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1438944
       GoKind: 22
-      Pointee: 1127 UnresolvedPointeeType net.timeoutError
+      Pointee: 1138 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1015
+      ID: 1026
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1047648
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1027 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1183
+      ID: 1194
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 915328
       GoKind: 22
-      Pointee: 1184 StructureType net/http.bufioFlushWriter
+      Pointee: 1195 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 803
+      ID: 814
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 718 BaseType net/http.http2ConnectionError
+      Pointee: 729 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 804
+      ID: 815
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 916096
       GoKind: 22
-      Pointee: 805 StructureType net/http.http2GoAwayError
+      Pointee: 816 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1118
+      ID: 1129
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1434784
       GoKind: 22
-      Pointee: 1119 StructureType net/http.http2StreamError
+      Pointee: 1130 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 808
+      ID: 819
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 916672
       GoKind: 22
-      Pointee: 809 StructureType net/http.http2connError
+      Pointee: 820 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1247
+      ID: 1258
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1576736
       GoKind: 22
-      Pointee: 1248 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1259 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 807
+      ID: 818
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916576
       GoKind: 22
-      Pointee: 722 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 733 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 724
+      ID: 735
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 723 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 734 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 811
+      ID: 822
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 916864
       GoKind: 22
-      Pointee: 728 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 739 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 730
+      ID: 741
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 729 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 740 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 810
+      ID: 821
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 916768
       GoKind: 22
-      Pointee: 725 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 736 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 727
+      ID: 738
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 726 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 737 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1090
+      ID: 1101
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1215968
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1102 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1021
+      ID: 1032
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1048160
       GoKind: 22
-      Pointee: 1022 StructureType net/http.http2noCachedConnError
+      Pointee: 1033 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1302
+      ID: 1313
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1981184
       GoKind: 22
-      Pointee: 1303 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1314 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 806
+      ID: 817
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916480
       GoKind: 22
-      Pointee: 719 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 730 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 721
+      ID: 732
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 720 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 731 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1185
+      ID: 1196
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 916960
       GoKind: 22
-      Pointee: 1186 StructureType net/http.http2stickyErrWriter
+      Pointee: 1197 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1017
+      ID: 1028
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1047904
       GoKind: 22
-      Pointee: 1018 StructureType net/http.nothingWrittenError
+      Pointee: 1029 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1249
+      ID: 1260
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2226688
       GoKind: 22
-      Pointee: 1250 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1261 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1205
+      ID: 1216
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1047776
       GoKind: 22
-      Pointee: 1206 StructureType net/http.persistConnWriter
+      Pointee: 1217 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1239
+      ID: 1250
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1434944
       GoKind: 22
-      Pointee: 1240 StructureType net/http.readWriteCloserBody
+      Pointee: 1251 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 812
+      ID: 823
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 917056
       GoKind: 22
-      Pointee: 813 StructureType net/http.requestBodyReadError
+      Pointee: 824 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1120
+      ID: 1131
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1436064
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1132 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1088
+      ID: 1099
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1215840
       GoKind: 22
-      Pointee: 1089 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1100 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1019
+      ID: 1030
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1048032
       GoKind: 22
-      Pointee: 1020 StructureType net/http.transportReadFromServerError
+      Pointee: 1031 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1282
+      ID: 1293
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1871424
       GoKind: 22
-      Pointee: 1283 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1294 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 801
+      ID: 812
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 915232
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 813 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1304
+      ID: 1315
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1983232
       GoKind: 22
-      Pointee: 1305 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1316 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1215
+      ID: 1226
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1060832
       GoKind: 22
-      Pointee: 1216 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1227 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 887
+      ID: 898
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 932416
       GoKind: 22
-      Pointee: 888 StructureType net/netip.parseAddrError
+      Pointee: 899 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 885
+      ID: 896
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 932320
       GoKind: 22
-      Pointee: 886 StructureType net/netip.parsePrefixError
+      Pointee: 897 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1255
+      ID: 1266
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2149760
       GoKind: 22
-      Pointee: 1256 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1267 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1217
+      ID: 1228
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1065184
       GoKind: 22
-      Pointee: 1218 StructureType net/smtp.dataCloser
+      Pointee: 1229 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 871
+      ID: 882
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 928480
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType net/textproto.Error
+      Pointee: 883 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 870
+      ID: 881
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 928384
       GoKind: 22
-      Pointee: 757 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 768 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 759
+      ID: 770
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 758 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 769 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1213
+      ID: 1224
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1060320
       GoKind: 22
-      Pointee: 1214 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1225 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1128
+      ID: 1139
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1439264
       GoKind: 22
-      Pointee: 1129 UnresolvedPointeeType net/url.Error
+      Pointee: 1140 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 830
+      ID: 841
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 920320
       GoKind: 22
-      Pointee: 731 GoStringHeaderType net/url.EscapeError
+      Pointee: 742 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 733
+      ID: 744
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 732 GoStringDataType net/url.EscapeError.str
+      Pointee: 743 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 831
+      ID: 842
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 920416
       GoKind: 22
-      Pointee: 734 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 745 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 736
+      ID: 747
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 735 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 746 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 550
+      ID: 551
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 551 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 552 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 542
+      ID: 543
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 543 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 544 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 490
+      ID: 491
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 491 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 492 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 509
+      ID: 510
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 510 StructureType noalg.map.group[bool]main.node
+      Pointee: 511 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 663 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 670 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 446
+      ID: 447
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 447 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 448 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1421
+      ID: 1422
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1422 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1423 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1465
+      ID: 1466
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1466 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1467 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1480
+      ID: 1481
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1481 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 458
+      ID: 459
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 459 StructureType noalg.map.group[int]int
+      Pointee: 460 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1495
+      ID: 1496
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1496 StructureType noalg.map.group[int]interface {}
+      Pointee: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 566
+      ID: 567
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 567 StructureType noalg.map.group[int]struct {}
+      Pointee: 568 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 517
+      ID: 518
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 518 StructureType noalg.map.group[int]uint8
+      Pointee: 519 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 707
+      ID: 718
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 708 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 499
+      ID: 500
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 500 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 501 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 482
+      ID: 483
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 483 StructureType noalg.map.group[string][]string
+      Pointee: 484 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 688 StructureType noalg.map.group[string]float64
+      Pointee: 695 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1173
+      ID: 1184
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1174 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 474
+      ID: 475
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 475 StructureType noalg.map.group[string]int
+      Pointee: 476 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 680 StructureType noalg.map.group[string]interface {}
+      Pointee: 687 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 466
+      ID: 467
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 467 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 468 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 671
+      ID: 678
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 672 StructureType noalg.map.group[string]string
+      Pointee: 679 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 558
+      ID: 559
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 559 StructureType noalg.map.group[struct {}]int
+      Pointee: 560 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 606
+      ID: 607
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 607 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 614
+      ID: 615
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 615 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 622
+      ID: 623
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 623 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 630
+      ID: 631
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 638
+      ID: 639
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 646
+      ID: 647
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 574
+      ID: 575
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 575 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 576 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 533
+      ID: 534
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 534 StructureType noalg.map.group[uint8][4]int
+      Pointee: 535 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 525
+      ID: 526
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 526 StructureType noalg.map.group[uint8]uint8
+      Pointee: 527 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1363
+      ID: 1374
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2380224
       GoKind: 22
-      Pointee: 1364 UnresolvedPointeeType os.File
+      Pointee: 1375 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 998
+      ID: 1009
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1040992
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType os.LinkError
+      Pointee: 1010 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1066
+      ID: 1077
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1208672
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType os.SyscallError
+      Pointee: 1078 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1361
+      ID: 1372
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2379488
       GoKind: 22
-      Pointee: 1362 StructureType os.fileWithoutReadFrom
+      Pointee: 1373 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1359
+      ID: 1370
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2378752
       GoKind: 22
-      Pointee: 1360 StructureType os.fileWithoutWriteTo
+      Pointee: 1371 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1029
+      ID: 1040
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1056864
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType os/exec.Error
+      Pointee: 1041 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1169
+      ID: 1180
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2120672
       GoKind: 22
-      Pointee: 1170 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1181 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1233
+      ID: 1244
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1227872
       GoKind: 22
-      Pointee: 1234 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1245 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1031
+      ID: 1042
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1056992
       GoKind: 22
-      Pointee: 1032 StructureType os/exec.wrappedError
+      Pointee: 1043 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 963
+      ID: 974
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 950944
       GoKind: 22
-      Pointee: 768 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 779 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 770
+      ID: 781
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 769 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 780 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 962
+      ID: 973
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 950848
       GoKind: 22
-      Pointee: 767 BaseType os/user.UnknownUserIdError
+      Pointee: 778 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 799
+      ID: 810
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 913984
       GoKind: 22
-      Pointee: 800 UnresolvedPointeeType reflect.ValueError
+      Pointee: 811 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 893
+      ID: 904
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 933088
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 905 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 1002
+      ID: 1013
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1043296
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1014 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 1006
+      ID: 1017
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1043936
       GoKind: 22
-      Pointee: 1007 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1018 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -14588,12 +14711,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 1004
+      ID: 1015
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1043424
       GoKind: 22
-      Pointee: 1005 StructureType runtime.boundsError
+      Pointee: 1016 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -14609,24 +14732,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1068
+      ID: 1079
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1211488
       GoKind: 22
-      Pointee: 1069 StructureType runtime.errorAddressString
+      Pointee: 1080 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 1000
+      ID: 1011
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1041632
       GoKind: 22
-      Pointee: 981 GoStringHeaderType runtime.errorString
+      Pointee: 992 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 983
+      ID: 994
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 982 GoStringDataType runtime.errorString.str
+      Pointee: 993 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -14647,19 +14770,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1043040
       GoKind: 22
-      Pointee: 436 UnresolvedPointeeType runtime.p
+      Pointee: 437 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 1001
+      ID: 1012
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1041760
       GoKind: 22
-      Pointee: 984 GoStringHeaderType runtime.plainError
+      Pointee: 995 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 986
+      ID: 997
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 985 GoStringDataType runtime.plainError.str
+      Pointee: 996 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -14675,12 +14798,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 795
+      ID: 806
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 913024
       GoKind: 22
-      Pointee: 796 StructureType runtime.synctestDeadlockError
+      Pointee: 807 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -14703,12 +14826,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 996
+      ID: 1007
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1039840
       GoKind: 22
-      Pointee: 997 UnresolvedPointeeType strconv.NumError
+      Pointee: 1008 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -14717,31 +14840,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 431
+      ID: 432
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 430 GoStringDataType string.str
+      Pointee: 431 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1298
+      ID: 1309
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1979392
       GoKind: 22
-      Pointee: 1299 UnresolvedPointeeType strings.Builder
+      Pointee: 1310 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1203
+      ID: 1214
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1039968
       GoKind: 22
-      Pointee: 1204 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1215 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1199
+      ID: 1210
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 985376
       GoKind: 22
-      Pointee: 1200 StructureType struct { io.Writer }
+      Pointee: 1211 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 279
       Name: '*struct {}'
@@ -14750,240 +14873,240 @@ Types:
       GoKind: 22
       Pointee: 133 StructureType struct {}
     - __kind: PointerType
-      ID: 1130
+      ID: 1141
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1441504
       GoKind: 22
-      Pointee: 1117 BaseType syscall.Errno
+      Pointee: 1128 BaseType syscall.Errno
     - __kind: PointerType
       ID: 240
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 548 StructureType table<[4]int,[4]int>
+      Pointee: 549 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 235
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 540 StructureType table<[4]int,uint8>
+      Pointee: 541 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 203
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 488 StructureType table<[4]string,[2]int>
+      Pointee: 489 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 215
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 507 StructureType table<bool,main.node>
+      Pointee: 508 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 387
+      ID: 391
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 660 StructureType table<context.canceler,struct {}>
+      Pointee: 667 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 156
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 444 StructureType table<int,*main.deepMap2>
+      Pointee: 445 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1418
+      ID: 1419
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1419 StructureType table<int,*main.deepMap3>
+      Pointee: 1420 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1462
+      ID: 1463
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1463 StructureType table<int,*main.deepMap8>
+      Pointee: 1464 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1477
+      ID: 1478
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1478 StructureType table<int,*main.deepMap9>
+      Pointee: 1479 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 183
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 456 StructureType table<int,int>
+      Pointee: 457 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1492
+      ID: 1493
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1493 StructureType table<int,interface {}>
+      Pointee: 1494 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 250
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 564 StructureType table<int,struct {}>
+      Pointee: 565 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 220
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 515 StructureType table<int,uint8>
+      Pointee: 516 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 699
+      ID: 706
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 705 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 716 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 210
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 497 StructureType table<string,[]main.structWithMap>
+      Pointee: 498 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 198
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 480 StructureType table<string,[]string>
+      Pointee: 481 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 418
+      ID: 419
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 685 StructureType table<string,float64>
+      Pointee: 692 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1144
+      ID: 1155
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1171 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1182 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 193
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 472 StructureType table<string,int>
+      Pointee: 473 StructureType table<string,int>
     - __kind: PointerType
-      ID: 413
+      ID: 414
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 677 StructureType table<string,interface {}>
+      Pointee: 684 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 188
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 464 StructureType table<string,main.nestedStruct>
+      Pointee: 465 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 408
+      ID: 409
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 669 StructureType table<string,string>
+      Pointee: 676 StructureType table<string,string>
     - __kind: PointerType
       ID: 245
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 556 StructureType table<struct {},int>
+      Pointee: 557 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 302
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 604 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 605 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 307
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 612 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 613 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 312
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 620 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 621 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 317
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 628 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 629 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 322
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 636 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 637 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 327
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 644 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 645 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 255
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 572 StructureType table<struct {},struct {}>
+      Pointee: 573 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 230
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 531 StructureType table<uint8,[4]int>
+      Pointee: 532 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 225
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 523 StructureType table<uint8,uint8>
+      Pointee: 524 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1333
+      ID: 1344
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2192160
       GoKind: 22
-      Pointee: 1334 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1345 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1059
+      ID: 1070
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1102048
       GoKind: 22
-      Pointee: 1060 StructureType text/template.ExecError
+      Pointee: 1071 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 397
+      ID: 335
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1641952
       GoKind: 22
-      Pointee: 398 StructureType time.Location
+      Pointee: 336 StructureType time.Location
     - __kind: PointerType
-      ID: 793
+      ID: 804
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 911104
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType time.ParseError
+      Pointee: 805 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 394
+      ID: 398
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1041376
       GoKind: 22
-      Pointee: 395 StructureType time.Timer
+      Pointee: 399 StructureType time.Timer
     - __kind: PointerType
-      ID: 790
+      ID: 801
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 910912
       GoKind: 22
-      Pointee: 715 GoStringHeaderType time.fileSizeError
+      Pointee: 726 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 717
+      ID: 728
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 716 GoStringDataType time.fileSizeError.str
+      Pointee: 727 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 791
+      ID: 802
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 911008
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType time.parseDurationError
+      Pointee: 803 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 1394
+      ID: 654
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399744
       GoKind: 22
-      Pointee: 1395 StructureType time.zone
+      Pointee: 655 StructureType time.zone
     - __kind: PointerType
-      ID: 1397
+      ID: 657
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399808
       GoKind: 22
-      Pointee: 1398 StructureType time.zoneTrans
+      Pointee: 658 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -15027,49 +15150,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 889
+      ID: 900
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 932512
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 901 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1327
+      ID: 1338
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2167648
       GoKind: 22
-      Pointee: 1328 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1339 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 873
+      ID: 884
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 928672
       GoKind: 22
-      Pointee: 874 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 885 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 875
+      ID: 886
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 928768
       GoKind: 22
-      Pointee: 760 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 771 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1036
+      ID: 1047
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1060576
       GoKind: 22
-      Pointee: 1037 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1048 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1038
+      ID: 1049
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1060704
       GoKind: 22
-      Pointee: 989 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 1000 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1392
+      ID: 1403
       Name: <-chan time.Time
       GoRuntimeType: 606240
       GoKind: 18
@@ -15082,7 +15205,7 @@ Types:
       Name: '@trace_context'
       ByteSize: 40
     - __kind: EventRootType
-      ID: 1770
+      ID: 1774
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15098,10 +15221,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 362 GoSliceHeaderType []go.shape.float64
+            Type: 366 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15111,10 +15234,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 362 GoSliceHeaderType []go.shape.float64
+            Type: 366 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 0, name: items}
+                  Variable: {subprogram: 191, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15124,17 +15247,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 365 GoSubroutineType func(go.shape.float64) bool
+            Type: 369 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 1, name: pred}
+                  Variable: {subprogram: 191, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1771
+      ID: 1775
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -15144,17 +15267,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 362 GoSliceHeaderType []go.shape.float64
+            Type: 366 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 188, index: 2, name: ~r0}
+                  Variable: {subprogram: 191, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1768
+      ID: 1772
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15170,10 +15293,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15183,10 +15306,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: items}
+                  Variable: {subprogram: 172, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15196,17 +15319,17 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 340 GoSubroutineType func(go.shape.int) bool
+            Type: 344 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: pred}
+                  Variable: {subprogram: 172, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1769
+      ID: 1773
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -15216,20 +15339,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 2, name: ~r0}
+                  Variable: {subprogram: 172, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1826
+      ID: 1830
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1772
+      ID: 1776
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15245,10 +15368,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15258,10 +15381,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: box}
+                  Variable: {subprogram: 173, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15271,17 +15394,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 341 GoSubroutineType func(go.shape.int) go.shape.string
+            Type: 345 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: f}
+                  Variable: {subprogram: 173, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1773
+      ID: 1777
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15291,17 +15414,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 2, name: ~r0}
+                  Variable: {subprogram: 173, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1784
+      ID: 1788
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15320,10 +15443,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15333,10 +15456,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 349 PointerType *main.Pair[go.shape.int,go.shape.bool]
+            Type: 353 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: x}
+                  Variable: {subprogram: 179, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15346,10 +15469,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: k}
+                  Variable: {subprogram: 179, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15359,20 +15482,20 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 351 BaseType go.shape.bool
+            Type: 355 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 2, name: v}
+                  Variable: {subprogram: 179, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1785
+      ID: 1789
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1786
+      ID: 1790
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15391,10 +15514,10 @@ Types:
           Offset: 25
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15404,10 +15527,10 @@ Types:
           Offset: 41
           Kind: argument
           Expression:
-            Type: 352 PointerType *main.Pair[go.shape.string,go.shape.int]
+            Type: 356 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: x}
+                  Variable: {subprogram: 180, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15417,10 +15540,10 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 1, name: k}
+                  Variable: {subprogram: 180, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15430,20 +15553,20 @@ Types:
           Offset: 65
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 2, name: v}
+                  Variable: {subprogram: 180, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1787
+      ID: 1791
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1824
+      ID: 1828
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15452,17 +15575,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 366 StructureType main.firstBehavior
+            Type: 370 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 0, name: b}
+                  Variable: {subprogram: 198, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1825
+      ID: 1829
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15474,14 +15597,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 195, index: 1, name: ~r0}
+                  Variable: {subprogram: 198, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1800
+      ID: 1804
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15497,10 +15620,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15510,10 +15633,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15523,17 +15646,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1804
+      ID: 1808
       Name: Probe[main.genericContains[go.shape.int]]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15549,10 +15672,10 @@ Types:
           Offset: 17
           Kind: local
           Expression:
-            Type: 338 GoSliceHeaderType []go.shape.int
+            Type: 342 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: haystack}
+                  Variable: {subprogram: 187, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15562,17 +15685,17 @@ Types:
           Offset: 41
           Kind: local
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: needle}
+                  Variable: {subprogram: 187, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1801
+      ID: 1805
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15584,14 +15707,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 187, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1802
+      ID: 1806
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15607,10 +15730,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15620,10 +15743,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 359 GoSliceHeaderType []go.shape.string
+            Type: 363 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: haystack}
+                  Variable: {subprogram: 188, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
             LeafBodies: []
@@ -15633,17 +15756,17 @@ Types:
           Offset: 57
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1805
+      ID: 1809
       Name: Probe[main.genericContains[go.shape.string]]Line
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15653,17 +15776,17 @@ Types:
           Offset: 9
           Kind: local
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 1, name: needle}
+                  Variable: {subprogram: 188, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1803
+      ID: 1807
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15675,14 +15798,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 2, name: ~r0}
+                  Variable: {subprogram: 188, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1796
+      ID: 1800
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15692,10 +15815,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 356 PointerType *go.shape.string
+            Type: 360 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15705,17 +15828,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 356 PointerType *go.shape.string
+            Type: 360 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: p}
+                  Variable: {subprogram: 185, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1797
+      ID: 1801
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15725,17 +15848,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: ~r0}
+                  Variable: {subprogram: 185, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1798
+      ID: 1802
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15745,10 +15868,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 357 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 361 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15758,17 +15881,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 357 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 361 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: p}
+                  Variable: {subprogram: 186, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1799
+      ID: 1803
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15778,17 +15901,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 358 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
+            Type: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: ~r0}
+                  Variable: {subprogram: 186, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1792
+      ID: 1796
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15798,10 +15921,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 354 StructureType go.shape.struct { main.i int }
+            Type: 358 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15811,17 +15934,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 354 StructureType go.shape.struct { main.i int }
+            Type: 358 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: val}
+                  Variable: {subprogram: 183, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1793
+      ID: 1797
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15833,14 +15956,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: ~r0}
+                  Variable: {subprogram: 183, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1794
+      ID: 1798
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15850,10 +15973,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 355 StructureType go.shape.struct { main.s string }
+            Type: 359 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -15863,17 +15986,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 355 StructureType go.shape.struct { main.s string }
+            Type: 359 StructureType go.shape.struct { main.s string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: val}
+                  Variable: {subprogram: 184, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1795
+      ID: 1799
       Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15885,14 +16008,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: ~r0}
+                  Variable: {subprogram: 184, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1774
+      ID: 1778
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15902,10 +16025,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 339 PointerType *go.shape.int
+            Type: 343 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15915,17 +16038,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 339 PointerType *go.shape.int
+            Type: 343 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: p}
+                  Variable: {subprogram: 174, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1775
+      ID: 1779
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15935,17 +16058,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 339 PointerType *go.shape.int
+            Type: 343 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 174, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1776
+      ID: 1780
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15955,10 +16078,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 342 PointerType *go.shape.struct { Name string }
+            Type: 346 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -15968,17 +16091,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 342 PointerType *go.shape.struct { Name string }
+            Type: 346 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: p}
+                  Variable: {subprogram: 175, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1777
+      ID: 1781
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15988,17 +16111,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 342 PointerType *go.shape.struct { Name string }
+            Type: 346 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: ~r0}
+                  Variable: {subprogram: 175, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1778
+      ID: 1782
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16008,10 +16131,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 344 PointerType *go.shape.struct { X int; Y int }
+            Type: 348 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16021,17 +16144,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 344 PointerType *go.shape.struct { X int; Y int }
+            Type: 348 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: p}
+                  Variable: {subprogram: 176, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1779
+      ID: 1783
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16041,17 +16164,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 344 PointerType *go.shape.struct { X int; Y int }
+            Type: 348 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: ~r0}
+                  Variable: {subprogram: 176, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1790
+      ID: 1794
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16067,10 +16190,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16080,10 +16203,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: a}
+                  Variable: {subprogram: 182, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16093,17 +16216,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: b}
+                  Variable: {subprogram: 182, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1791
+      ID: 1795
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16119,10 +16242,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16132,17 +16255,17 @@ Types:
           Offset: 33
           Kind: return
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 3, name: ~r1}
+                  Variable: {subprogram: 182, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1788
+      ID: 1792
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -16158,10 +16281,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16171,10 +16294,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: a}
+                  Variable: {subprogram: 181, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16184,17 +16307,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 351 BaseType go.shape.bool
+            Type: 355 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: b}
+                  Variable: {subprogram: 181, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1789
+      ID: 1793
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -16210,10 +16333,10 @@ Types:
           Offset: 17
           Kind: return
           Expression:
-            Type: 351 BaseType go.shape.bool
+            Type: 355 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
@@ -16223,17 +16346,17 @@ Types:
           Offset: 18
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 3, name: ~r1}
+                  Variable: {subprogram: 181, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1782
+      ID: 1786
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -16243,10 +16366,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 348 StructureType main.largeGenericType[go.shape.int]
+            Type: 352 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
@@ -16256,17 +16379,17 @@ Types:
           Offset: 145
           Kind: argument
           Expression:
-            Type: 348 StructureType main.largeGenericType[go.shape.int]
+            Type: 352 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: x}
+                  Variable: {subprogram: 178, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1783
+      ID: 1787
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16276,17 +16399,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: ~r0}
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1780
+      ID: 1784
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -16296,10 +16419,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 346 StructureType main.largeGenericType[go.shape.string]
+            Type: 350 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
@@ -16309,17 +16432,17 @@ Types:
           Offset: 153
           Kind: argument
           Expression:
-            Type: 346 StructureType main.largeGenericType[go.shape.string]
+            Type: 350 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: x}
+                  Variable: {subprogram: 177, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1781
+      ID: 1785
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16329,17 +16452,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: ~r0}
+                  Variable: {subprogram: 177, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1764
+      ID: 1768
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16349,10 +16472,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -16362,17 +16485,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: box}
+                  Variable: {subprogram: 170, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1765
+      ID: 1769
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16382,17 +16505,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1766
+      ID: 1770
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -16402,10 +16525,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -16415,17 +16538,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: box}
+                  Variable: {subprogram: 171, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1767
+      ID: 1771
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16435,20 +16558,20 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1735
+      ID: 1736
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1736
+      ID: 1737
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16467,7 +16590,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1578
       Name: Probe[main.testAnyPtr]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16499,7 +16622,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16518,7 +16641,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16550,7 +16673,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16569,7 +16692,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1706
+      ID: 1707
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16601,7 +16724,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1707
+      ID: 1708
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -16620,7 +16743,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16652,7 +16775,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -16684,7 +16807,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16716,7 +16839,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16748,7 +16871,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16780,7 +16903,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16812,7 +16935,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16844,7 +16967,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -16863,7 +16986,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testBigStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -16895,7 +17018,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1507
+      ID: 1508
       Name: Probe[main.testBoolArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16927,7 +17050,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1504
+      ID: 1505
       Name: Probe[main.testByteArray]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -16959,7 +17082,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testChannel]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16991,7 +17114,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1604
+      ID: 1605
       Name: Probe[main.testCombinedByte]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -17049,7 +17172,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testCombinedString]
       ByteSize: 18
       ExprStatusArraySize: 1
@@ -17081,7 +17204,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testCombinedString]
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -17126,7 +17249,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.testConflictingReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17158,7 +17281,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1672
+      ID: 1673
       Name: Probe[main.testConflictingReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -17190,7 +17313,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.testCycle]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17222,7 +17345,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testDeepMap1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17254,7 +17377,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testDeepMap7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17286,7 +17409,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testDeepPtr1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17318,7 +17441,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testDeepPtr7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17350,7 +17473,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testDeepSlice1]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17382,7 +17505,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testDeepSlice7]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17414,7 +17537,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1726
+      ID: 1727
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -17472,7 +17595,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1723
+      ID: 1724
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17504,7 +17627,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1747
+      ID: 1748
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17536,7 +17659,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1759
+      ID: 1760
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17568,7 +17691,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1758
+      ID: 1759
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -17600,7 +17723,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testErrorAtLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -17658,7 +17781,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testError]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -17690,7 +17813,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testEsotericHeap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17722,10 +17845,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testEsotericStack]
       ByteSize: 129
       ExprStatusArraySize: 1
@@ -17757,10 +17880,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testFramelessArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17792,7 +17915,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17824,7 +17947,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17843,7 +17966,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testFrameless]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17875,7 +17998,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1570
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -17894,7 +18017,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testInlinedBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17926,10 +18049,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testInlinedBBA]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17961,13 +18084,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1816
+      ID: 1820
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testInlinedBB]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18025,28 +18148,28 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1817
+      ID: 1821
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1818
+      ID: 1822
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1819
+      ID: 1823
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1820
+      ID: 1824
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1813
+      ID: 1817
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18058,7 +18181,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18071,14 +18194,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1810
+      ID: 1814
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -18090,14 +18213,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1811
+      ID: 1815
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -18109,14 +18232,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1812
+      ID: 1816
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18128,7 +18251,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18141,14 +18264,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1815
+      ID: 1819
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18160,7 +18283,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18173,17 +18296,17 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 192, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1814
+      ID: 1818
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1821
+      ID: 1825
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18195,7 +18318,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18208,14 +18331,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1822
+      ID: 1826
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18227,7 +18350,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -18240,14 +18363,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 193, index: 0, name: x}
+                  Variable: {subprogram: 196, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1823
+      ID: 1827
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18259,7 +18382,7 @@ Types:
             Type: 174 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
@@ -18272,14 +18395,14 @@ Types:
             Type: 174 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 194, index: 0, name: a}
+                  Variable: {subprogram: 197, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1510
+      ID: 1511
       Name: Probe[main.testInt16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -18311,7 +18434,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1511
+      ID: 1512
       Name: Probe[main.testInt32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18343,7 +18466,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testInt64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18375,7 +18498,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1509
+      ID: 1510
       Name: Probe[main.testInt8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -18407,7 +18530,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1508
+      ID: 1509
       Name: Probe[main.testIntArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18439,7 +18562,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18471,7 +18594,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1704
+      ID: 1705
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -18503,7 +18626,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1705
+      ID: 1706
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18522,7 +18645,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -18554,53 +18677,8 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1550
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-    - __kind: EventRootType
       ID: 1551
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 25
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: aPerArch
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: aPerArch}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: b
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
     - __kind: EventRootType
       ID: 1552
       Name: Probe[main.testLongFunctionWithChangingState]Line
@@ -18647,7 +18725,52 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1710
+      ID: 1553
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 25
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: aPerArch
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 1, name: aPerArch}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: b
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1711
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -18887,7 +19010,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1711
+      ID: 1712
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18906,7 +19029,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testManyPointers]
       ByteSize: 1121
       ExprStatusArraySize: 1
@@ -18938,7 +19061,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testManyStrings]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -18970,7 +19093,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19002,7 +19125,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19034,7 +19157,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19066,7 +19189,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19098,7 +19221,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1602
+      ID: 1603
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19130,7 +19253,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
+      ID: 1589
       Name: Probe[main.testMapIntToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19162,7 +19285,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19194,7 +19317,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19220,38 +19343,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1589
-      Name: Probe[main.testMapMassive]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 206 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: redactMyEntries
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 206 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -19290,7 +19381,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1591
+      Name: Probe[main.testMapMassive]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 206 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1599
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19322,7 +19445,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19354,7 +19477,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testMapStringToInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19386,7 +19509,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19418,7 +19541,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19450,7 +19573,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19482,7 +19605,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19514,7 +19637,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19546,7 +19669,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19578,7 +19701,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19606,38 +19729,6 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1744
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -19674,7 +19765,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1712
+      ID: 1746
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1713
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -19914,7 +20037,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1713
+      ID: 1714
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19933,7 +20056,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1716
+      ID: 1717
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -19991,7 +20114,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1717
+      ID: 1718
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20023,7 +20146,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1708
+      ID: 1709
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -20081,7 +20204,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1709
+      ID: 1710
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20100,7 +20223,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20120,6 +20243,143 @@ Types:
           DictIndex: -1
         - Name: i
           Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1652
+      Name: Probe[main.testMultipleNamedReturn]
+    - __kind: EventRootType
+      ID: 1654
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1656
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1658
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1660
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1662
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -20133,21 +20393,63 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1651
-      Name: Probe[main.testMultipleNamedReturn]
-    - __kind: EventRootType
-      ID: 1653
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: return
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1653
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: result2
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -20155,57 +20457,57 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1655
-      Name: Probe[main.testMultipleNamedReturn]
+      Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
       Expressions:
-        - Name: i
+        - Name: result
           Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result
           Offset: 17
-          Kind: template_segment
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
-        - Name: i
+        - Name: result2
           Offset: 25
-          Kind: argument
+          Kind: return
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
+                  Variable: {subprogram: 108, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -20213,185 +20515,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1657
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1659
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1661
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1650
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1652
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1654
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result
-          Offset: 17
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: result2
-          Offset: 25
-          Kind: return
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1656
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20475,7 +20598,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20507,7 +20630,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20539,7 +20662,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20584,7 +20707,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 63
       ExprStatusArraySize: 3
@@ -20720,7 +20843,42 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1646
+      Name: Probe[main.testNamedReturn]
+    - __kind: EventRootType
+      ID: 1648
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20753,41 +20911,6 @@ Types:
           DictIndex: -1
     - __kind: EventRootType
       ID: 1645
-      Name: Probe[main.testNamedReturn]
-    - __kind: EventRootType
-      ID: 1647
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: i
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1644
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20806,7 +20929,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20825,7 +20948,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20857,7 +20980,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1753
+      ID: 1754
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20889,7 +21012,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1754
+      ID: 1755
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -20916,10 +21039,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1755
+      ID: 1756
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1756
+      ID: 1757
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20946,7 +21069,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21004,7 +21127,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1727
+      ID: 1728
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -21062,7 +21185,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1729
+      ID: 1730
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -21146,7 +21269,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1730
+      ID: 1731
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21178,7 +21301,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1743
+      ID: 1744
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21210,7 +21333,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21242,7 +21365,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testPointerToMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21274,7 +21397,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21306,7 +21429,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       ExprStatusArraySize: 1
@@ -21364,7 +21487,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1638
+      ID: 1639
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21396,7 +21519,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.testReturnsAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21428,7 +21551,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21447,10 +21570,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1684
+      ID: 1685
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1685
+      ID: 1686
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21469,10 +21592,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1686
+      ID: 1687
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1687
+      ID: 1688
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -21491,10 +21614,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21513,10 +21636,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1690
+      ID: 1691
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1691
+      ID: 1692
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -21639,10 +21762,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1702
+      ID: 1703
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1703
+      ID: 1704
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -21674,10 +21797,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21709,7 +21832,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[main.testReturnsError]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -21741,7 +21864,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1636
+      ID: 1637
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21760,7 +21883,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21779,7 +21902,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1631
+      ID: 1632
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21798,7 +21921,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21830,7 +21953,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21875,7 +21998,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21920,7 +22043,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21952,7 +22075,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21984,7 +22107,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22003,29 +22126,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.testReturnsInt]
     - __kind: EventRootType
-      ID: 1621
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1623
+      ID: 1622
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22044,7 +22148,26 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1625
+      ID: 1624
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1626
       Name: Probe[main.testReturnsInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22076,7 +22199,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22095,7 +22218,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22127,7 +22250,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22159,7 +22282,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22178,7 +22301,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.testReturnsInterface]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22210,7 +22333,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22229,10 +22352,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -22251,10 +22374,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -22481,10 +22604,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1688
+      ID: 1689
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1689
+      ID: 1690
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22503,10 +22626,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1694
+      ID: 1695
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1695
+      ID: 1696
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -22577,10 +22700,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1700
+      ID: 1701
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1701
+      ID: 1702
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -22612,7 +22735,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1673
+      ID: 1674
       Name: Probe[main.testReturnsNamedDeferLine]Line
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22670,10 +22793,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1698
+      ID: 1699
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1699
+      ID: 1700
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22692,10 +22815,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1674
+      ID: 1675
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -22805,10 +22928,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1696
+      ID: 1697
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1697
+      ID: 1698
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22827,10 +22950,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1692
+      ID: 1693
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1693
+      ID: 1694
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -22849,7 +22972,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1505
+      ID: 1506
       Name: Probe[main.testRuneArray]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22881,7 +23004,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testSingleBool]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22913,7 +23036,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testSingleByte]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -22945,13 +23068,13 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testSingleFloat32]
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testSingleFloat64]
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testSingleInt16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -22983,7 +23106,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testSingleInt32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23015,7 +23138,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testSingleInt64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23047,7 +23170,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testSingleInt8]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -23105,7 +23228,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testSingleInt]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23137,7 +23260,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testSingleRune]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23169,7 +23292,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1737
+      ID: 1738
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23201,7 +23324,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testSingleUint16]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -23233,7 +23356,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testSingleUint32]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23265,7 +23388,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testSingleUint64]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23297,7 +23420,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testSingleUint8]
       ByteSize: 3
       ExprStatusArraySize: 1
@@ -23329,7 +23452,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testSingleUint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23361,7 +23484,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1733
+      ID: 1734
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23393,7 +23516,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1724
+      ID: 1725
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23425,7 +23548,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testSmallMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23457,7 +23580,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23476,10 +23599,10 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.testSomeNamedReturn]
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23498,7 +23621,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23530,7 +23653,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23588,7 +23711,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23607,7 +23730,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23665,7 +23788,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23710,7 +23833,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1714
+      ID: 1715
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -23742,7 +23865,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1715
+      ID: 1716
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23787,7 +23910,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1506
+      ID: 1507
       Name: Probe[main.testStringArray]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23819,7 +23942,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23851,7 +23974,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1728
+      ID: 1729
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23883,7 +24006,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testStringType1]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23915,7 +24038,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testStringType2]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23947,7 +24070,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1725
+      ID: 1726
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -24005,7 +24128,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testStructWithAny]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24037,7 +24160,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1718
+      ID: 1719
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24069,7 +24192,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1719
+      ID: 1720
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24101,7 +24224,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1750
+      ID: 1751
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24133,7 +24256,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1749
+      ID: 1750
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -24165,7 +24288,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testStructWithMap]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24197,7 +24320,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1751
+      ID: 1752
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24216,7 +24339,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1752
+      ID: 1753
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -24248,7 +24371,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1734
+      ID: 1735
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -24332,7 +24455,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1748
+      ID: 1749
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24416,7 +24539,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testTakeContext]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24435,7 +24558,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1757
+      ID: 1758
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -24454,7 +24577,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1741
+      ID: 1742
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24486,7 +24609,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1742
+      ID: 1743
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24543,7 +24666,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1739
+      ID: 1740
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -24575,7 +24698,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1740
+      ID: 1741
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24620,7 +24743,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1738
+      ID: 1739
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -24704,7 +24827,103 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1762
+      Name: Probe[main.testTimeFixedZone]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 334 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 334 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 166, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1763
+      Name: Probe[main.testTimeMonotonic]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 337 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: c
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 337 StructureType main.timeCapture
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 167, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1761
+      Name: Probe[main.testTimeUTC]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 334 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: x
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 334 GoTimeType time.Time
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 165, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1540
       Name: Probe[main.testTypeAlias]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24736,7 +24955,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testUint16Array]
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -24768,7 +24987,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testUint32Array]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24800,7 +25019,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testUint64Array]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24832,7 +25051,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testUint8Array]
       ByteSize: 5
       ExprStatusArraySize: 1
@@ -24864,7 +25083,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testUintArray]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24896,7 +25115,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -24928,7 +25147,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1722
+      ID: 1723
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -24960,7 +25179,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1746
+      ID: 1747
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -24992,7 +25211,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25024,7 +25243,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 1601
       ExprStatusArraySize: 1
@@ -25052,38 +25271,6 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1731
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 270 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-            LeafBodies: []
-            IsSplit: false
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 270 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
@@ -25120,7 +25307,39 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1720
+      ID: 1733
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 270 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 270 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+            LeafBodies: []
+            IsSplit: false
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1721
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25178,7 +25397,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1721
+      ID: 1722
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -25210,7 +25429,7 @@ Types:
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1806
+      ID: 1810
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25226,10 +25445,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25239,10 +25458,10 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 360 StructureType main.typeWithGenerics[go.shape.int]
+            Type: 364 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 0, name: x}
+                  Variable: {subprogram: 189, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25252,17 +25471,17 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 1, name: value}
+                  Variable: {subprogram: 189, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1807
+      ID: 1811
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -25274,14 +25493,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 186, index: 2, name: ~r0}
+                  Variable: {subprogram: 189, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1808
+      ID: 1812
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -25297,10 +25516,10 @@ Types:
           Offset: 17
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25310,10 +25529,10 @@ Types:
           Offset: 33
           Kind: argument
           Expression:
-            Type: 361 StructureType main.typeWithGenerics[go.shape.string]
+            Type: 365 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25323,17 +25542,17 @@ Types:
           Offset: 49
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 1, name: value}
+                  Variable: {subprogram: 190, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1809
+      ID: 1813
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -25345,14 +25564,14 @@ Types:
             Type: 6 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 187, index: 2, name: ~r0}
+                  Variable: {subprogram: 190, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
             LeafBodies: []
             IsSplit: false
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1760
+      ID: 1764
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25362,10 +25581,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
@@ -25375,17 +25594,17 @@ Types:
           Offset: 17
           Kind: argument
           Expression:
-            Type: 334 BaseType go.shape.int
+            Type: 338 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: val}
+                  Variable: {subprogram: 168, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1761
+      ID: 1765
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -25395,17 +25614,17 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 335 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
+            Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
             LeafBodies: []
             IsSplit: false
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1762
+      ID: 1766
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -25415,10 +25634,10 @@ Types:
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25428,17 +25647,17 @@ Types:
           Offset: 25
           Kind: argument
           Expression:
-            Type: 336 GoStringHeaderType go.shape.string
+            Type: 340 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: val}
+                  Variable: {subprogram: 169, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
             IsSplit: false
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1763
+      ID: 1767
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -25448,10 +25667,10 @@ Types:
           Offset: 9
           Kind: return
           Expression:
-            Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+            Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
             LeafBodies: []
@@ -25481,7 +25700,7 @@ Types:
       HasCount: true
       Element: 98 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 347
+      ID: 351
       Name: '[16]uint8'
       ByteSize: 16
       GoRuntimeType: 690144
@@ -25702,7 +25921,7 @@ Types:
       HasCount: true
       Element: 35 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 537
+      ID: 538
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 692832
@@ -25711,7 +25930,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 494
+      ID: 495
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 693120
@@ -25737,7 +25956,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1161
+      ID: 1172
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 694656
@@ -25746,7 +25965,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1380
+      ID: 1391
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25772,7 +25991,7 @@ Types:
       HasCount: true
       Element: 91 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1403
+      ID: 1404
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 489792
@@ -25780,20 +25999,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1404 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1405 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1406 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1407 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1406
+      ID: 1407
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 400 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 146
       Name: '[]*main.deepSlice2'
@@ -25810,15 +26029,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 442 GoSliceDataType []*main.deepSlice2.array
+      Data: 443 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 442
+      ID: 443
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 148 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1408
+      ID: 1409
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 485568
@@ -25826,22 +26045,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1409 PointerType **main.deepSlice3
+          Type: 1410 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1412 GoSliceDataType []*main.deepSlice3.array
+      Data: 1413 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1412
+      ID: 1413
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1410 PointerType *main.deepSlice3
+      Element: 1411 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1443
+      ID: 1444
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 485248
@@ -25849,22 +26068,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1444 PointerType **main.deepSlice8
+          Type: 1445 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1447 GoSliceDataType []*main.deepSlice8.array
+      Data: 1448 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1447
+      ID: 1448
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1445 PointerType *main.deepSlice8
+      Element: 1446 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1449
+      ID: 1450
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 485184
@@ -25872,20 +26091,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1450 PointerType **main.deepSlice9
+          Type: 1451 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1453 GoSliceDataType []*main.deepSlice9.array
+      Data: 1454 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1453
+      ID: 1454
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1451 PointerType *main.deepSlice9
+      Element: 1452 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 68
       Name: '[]*runtime.p'
@@ -25902,9 +26121,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 437 GoSliceDataType []*runtime.p.array
+      Data: 438 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 438
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25925,201 +26144,201 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 439 GoSliceDataType []*string.array
+      Data: 440 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 440
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 103 PointerType *string
     - __kind: GoSliceDataType
-      ID: 554
+      ID: 555
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 240 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 546
+      ID: 547
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 235 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 496
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 203 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 513
+      ID: 514
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 215 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 667
+      ID: 674
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 387 PointerType *table<context.canceler,struct {}>
+      Element: 391 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 452
+      ID: 453
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 156 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1427
+      ID: 1428
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1418 PointerType *table<int,*main.deepMap3>
+      Element: 1419 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1471
+      ID: 1472
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1462 PointerType *table<int,*main.deepMap8>
+      Element: 1463 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1486
+      ID: 1487
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1477 PointerType *table<int,*main.deepMap9>
+      Element: 1478 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 462
+      ID: 463
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 183 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1499
+      ID: 1500
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1492 PointerType *table<int,interface {}>
+      Element: 1493 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 570
+      ID: 571
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 250 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 521
+      ID: 522
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 220 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 713
+      ID: 724
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 699 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 706 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 505
+      ID: 506
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 210 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 487
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 198 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 691
+      ID: 698
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 418 PointerType *table<string,float64>
+      Element: 419 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1177
+      ID: 1188
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1144 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1155 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 479
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 193 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 690
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 413 PointerType *table<string,interface {}>
+      Element: 414 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 471
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 188 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 675
+      ID: 682
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 408 PointerType *table<string,string>
+      Element: 409 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 562
+      ID: 563
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 245 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 610
+      ID: 611
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 302 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 618
+      ID: 619
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 307 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 626
+      ID: 627
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 312 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 634
+      ID: 635
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 317 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 642
+      ID: 643
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 322 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 650
+      ID: 651
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 327 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 578
+      ID: 579
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 255 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 538
+      ID: 539
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 230 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 530
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26139,9 +26358,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 602 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 603 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 602
+      ID: 603
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26161,9 +26380,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 600 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 601 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 600
+      ID: 601
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26183,9 +26402,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 598 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 599 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 598
+      ID: 599
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26205,9 +26424,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 596 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 597 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 596
+      ID: 597
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26227,9 +26446,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 594 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 595 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 594
+      ID: 595
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26249,9 +26468,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 582 GoSliceDataType [][]uint.array
+      Data: 583 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 582
+      ID: 583
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26272,15 +26491,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 586 GoSliceDataType []bool.array
+      Data: 587 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 586
+      ID: 587
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1156
+      ID: 1167
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 496064
@@ -26295,15 +26514,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1179 GoSliceDataType []float64.array
+      Data: 1190 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1179
+      ID: 1190
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 16 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 419
+      ID: 420
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 489344
@@ -26311,22 +26530,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 420 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 421 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 700 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 693
+      ID: 700
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 421 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 422 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 422
+      ID: 423
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 489536
@@ -26334,22 +26553,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 423 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 424 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 701 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 708 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 701
+      ID: 708
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 424 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 425 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 362
+      ID: 366
       Name: '[]go.shape.float64'
       ByteSize: 24
       GoRuntimeType: 491904
@@ -26357,66 +26576,66 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 363 PointerType *go.shape.float64
+          Type: 367 PointerType *go.shape.float64
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 658 GoSliceDataType []go.shape.float64.array
+      Data: 665 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 658
+      ID: 665
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 364 BaseType go.shape.float64
+      Element: 368 BaseType go.shape.float64
     - __kind: GoSliceHeaderType
-      ID: 338
+      ID: 342
       Name: '[]go.shape.int'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 339 PointerType *go.shape.int
+          Type: 343 PointerType *go.shape.int
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 654 GoSliceDataType []go.shape.int.array
+      Data: 661 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 654
+      ID: 661
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 334 BaseType go.shape.int
+      Element: 338 BaseType go.shape.int
     - __kind: GoSliceHeaderType
-      ID: 359
+      ID: 363
       Name: '[]go.shape.string'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 356 PointerType *go.shape.string
+          Type: 360 PointerType *go.shape.string
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 656 GoSliceDataType []go.shape.string.array
+      Data: 663 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 656
+      ID: 663
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 336 GoStringHeaderType go.shape.string
+      Element: 340 GoStringHeaderType go.shape.string
     - __kind: GoSliceHeaderType
-      ID: 1455
+      ID: 1456
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 496512
@@ -26431,9 +26650,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1456 GoSliceDataType []interface {}.array
+      Data: 1457 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1456
+      ID: 1457
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26453,15 +26672,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 592 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 593 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 592
+      ID: 593
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 284 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 503
+      ID: 504
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 486208
@@ -26469,16 +26688,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 504 PointerType *main.structWithMap
+          Type: 505 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 703 GoSliceDataType []main.structWithMap.array
+      Data: 710 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 703
+      ID: 710
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26498,205 +26717,205 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 584 GoSliceDataType []main.structWithNoStrings.array
+      Data: 585 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 584
+      ID: 585
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 275 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 555
+      ID: 556
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 551 StructureType noalg.map.group[[4]int][4]int
+      Element: 552 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 547
+      ID: 548
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 543 StructureType noalg.map.group[[4]int]uint8
+      Element: 544 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 497
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 491 StructureType noalg.map.group[[4]string][2]int
+      Element: 492 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 515
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 510 StructureType noalg.map.group[bool]main.node
+      Element: 511 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 668
+      ID: 675
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 663 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 670 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 454
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 447 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 448 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1428
+      ID: 1429
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1422 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1423 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1472
+      ID: 1473
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1466 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1467 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1487
+      ID: 1488
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1481 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 464
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 459 StructureType noalg.map.group[int]int
+      Element: 460 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1500
+      ID: 1501
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1496 StructureType noalg.map.group[int]interface {}
+      Element: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 571
+      ID: 572
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 567 StructureType noalg.map.group[int]struct {}
+      Element: 568 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 522
+      ID: 523
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 518 StructureType noalg.map.group[int]uint8
+      Element: 519 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 725
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 708 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 507
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 500 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 501 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 488
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 483 StructureType noalg.map.group[string][]string
+      Element: 484 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 692
+      ID: 699
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 688 StructureType noalg.map.group[string]float64
+      Element: 695 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1178
+      ID: 1189
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1174 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 480
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 475 StructureType noalg.map.group[string]int
+      Element: 476 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 684
+      ID: 691
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 680 StructureType noalg.map.group[string]interface {}
+      Element: 687 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 472
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 467 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 468 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 676
+      ID: 683
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 672 StructureType noalg.map.group[string]string
+      Element: 679 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 563
+      ID: 564
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 559 StructureType noalg.map.group[struct {}]int
+      Element: 560 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 611
+      ID: 612
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 607 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 619
+      ID: 620
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 615 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 627
+      ID: 628
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 623 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 635
+      ID: 636
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 643
+      ID: 644
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 651
+      ID: 652
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 579
+      ID: 580
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 575 StructureType noalg.map.group[struct {}]struct {}
+      Element: 576 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 539
+      ID: 540
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 534 StructureType noalg.map.group[uint8][4]int
+      Element: 535 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 531
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 526 StructureType noalg.map.group[uint8]uint8
+      Element: 527 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: '[]runtime.ancestorInfo'
@@ -26717,9 +26936,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 454 GoSliceDataType []string.array
+      Data: 455 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 455
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26739,14 +26958,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 590 GoSliceDataType []struct {}.array
+      Data: 591 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 590
+      ID: 591
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 133 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 1393
+      ID: 653
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494720
@@ -26754,22 +26973,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1394 PointerType *time.zone
+          Type: 654 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1399 GoSliceDataType []time.zone.array
+      Data: 712 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 1399
+      ID: 712
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 1395 StructureType time.zone
+      Element: 655 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 1396
+      ID: 656
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494784
@@ -26777,20 +26996,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1397 PointerType *time.zoneTrans
+          Type: 657 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1401 GoSliceDataType []time.zoneTrans.array
+      Data: 714 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 1401
+      ID: 714
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 1398 StructureType time.zoneTrans
+      Element: 658 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 270
       Name: '[]uint'
@@ -26807,9 +27026,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 580 GoSliceDataType []uint.array
+      Data: 581 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 580
+      ID: 581
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26830,9 +27049,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 588 GoSliceDataType []uint16.array
+      Data: 589 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 588
+      ID: 589
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26853,9 +27072,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 432 GoSliceDataType []uint8.array
+      Data: 433 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 432
+      ID: 433
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26876,19 +27095,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 434 GoSliceDataType []uintptr.array
+      Data: 435 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 434
+      ID: 435
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1312
+      ID: 1323
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 949
+      ID: 960
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 944032
@@ -26903,33 +27122,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 950 GoSliceDataType archive/tar.headerError.array
+      Data: 961 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 950
+      ID: 961
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1246
+      ID: 1257
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1194
+      ID: 1205
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1196
+      ID: 1207
       Name: archive/zip.dirWriter
       GoRuntimeType: 1134176
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1289
+      ID: 1300
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1222
+      ID: 1233
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1587936
@@ -26939,7 +27158,7 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1224
+      ID: 1235
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26949,15 +27168,15 @@ Types:
       GoRuntimeType: 593760
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1270
+      ID: 1281
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1301
+      ID: 1312
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1348
+      ID: 1359
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -26983,13 +27202,13 @@ Types:
       GoRuntimeType: 593504
       GoKind: 15
     - __kind: BaseType
-      ID: 752
+      ID: 763
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 844992
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 753
+      ID: 764
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 845088
@@ -26997,26 +27216,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 755 PointerType *compress/flate.InternalError.str
+          Type: 766 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 754 GoStringDataType compress/flate.InternalError.str
+      Data: 765 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 754
+      ID: 765
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1244
+      ID: 1255
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1190
+      ID: 1201
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1266
+      ID: 1277
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27033,7 +27252,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 372
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 1750944
@@ -27041,29 +27260,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 370 StructureType context.cancelCtx
+          Type: 374 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 388 StructureType sync.Once
+          Type: 392 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 391
+      ID: 395
       Name: context.backgroundCtx
       GoRuntimeType: 1826624
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 392 StructureType context.emptyCtx
+          Type: 396 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 374
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1995776
@@ -27074,23 +27293,23 @@ Types:
           Type: 163 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 379 StructureType sync.Mutex
+          Type: 383 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 382 StructureType sync/atomic.Value
+          Type: 386 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 383 GoMapType map[context.canceler]struct {}
+          Type: 387 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 382 StructureType sync/atomic.Value
+          Type: 386 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 17 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 666
+      ID: 673
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1124704
@@ -27103,13 +27322,13 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1065
+      ID: 1076
       Name: context.deadlineExceededError
       GoRuntimeType: 1483136
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 392
+      ID: 396
       Name: context.emptyCtx
       GoRuntimeType: 1618528
       GoKind: 25
@@ -27118,7 +27337,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 376
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1852096
@@ -27129,11 +27348,11 @@ Types:
           Type: 163 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 393 GoSubroutineType func() bool
+          Type: 397 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 374
+      ID: 378
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1637920
@@ -27141,29 +27360,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 370 StructureType context.cancelCtx
+          Type: 374 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 394 PointerType *time.Timer
+          Type: 398 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 396 StructureType time.Time
+          Type: 334 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 399
+      ID: 400
       Name: context.todoCtx
       GoRuntimeType: 1826848
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 392 StructureType context.emptyCtx
+          Type: 396 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 376
+      ID: 380
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1864256
@@ -27181,7 +27400,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 378
+      ID: 382
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1826400
@@ -27193,91 +27412,91 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 763
+      ID: 774
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 2
     - __kind: BaseType
-      ID: 764
+      ID: 775
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 847680
       GoKind: 2
     - __kind: BaseType
-      ID: 765
+      ID: 776
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 847776
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1261
+      ID: 1272
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 1046
+      ID: 1057
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1306144
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1291
+      ID: 1302
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1323
+      ID: 1334
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1308
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1293
+      ID: 1304
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1287
+      ID: 1298
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 766
+      ID: 777
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 847872
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1310
+      ID: 1321
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1295
+      ID: 1306
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1279
+      ID: 1290
       Name: crypto/sha3.SHAKE
       ByteSize: 8
     - __kind: BaseType
-      ID: 756
+      ID: 767
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 845568
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1046
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1374
+      ID: 1385
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 878
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 875
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1757856
@@ -27288,38 +27507,38 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1161 ArrayType [5]uint8
+          Type: 1172 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 988
+      ID: 999
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1007072
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1254
+      ID: 1265
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 880
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1259
+      ID: 1270
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1143
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1157
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 935
+      ID: 946
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1760736
@@ -27327,21 +27546,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1145 PointerType *crypto/x509.Certificate
+          Type: 1156 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1164 BaseType crypto/x509.InvalidReason
+          Type: 1175 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 929
+      ID: 940
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1131616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 931
+      ID: 942
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1623168
@@ -27349,24 +27568,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1145 PointerType *crypto/x509.Certificate
+          Type: 1156 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 762
+      ID: 773
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 2
     - __kind: BaseType
-      ID: 1164
+      ID: 1175
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 598816
       GoKind: 2
     - __kind: StructureType
-      ID: 1040
+      ID: 1051
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1583776
@@ -27376,13 +27595,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 937
+      ID: 948
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1131872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 933
+      ID: 944
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1760544
@@ -27390,15 +27609,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1145 PointerType *crypto/x509.Certificate
+          Type: 1156 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1145 PointerType *crypto/x509.Certificate
+          Type: 1156 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 953
+      ID: 964
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1454464
@@ -27408,7 +27627,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 957
+      ID: 968
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1454624
@@ -27418,55 +27637,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 966
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 746
+      ID: 757
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 844416
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1212
+      ID: 1223
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 747
+      ID: 758
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 844608
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 834
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1035
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 826
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 832
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 830
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 828
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1354
+      ID: 1365
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 836
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1437504
@@ -27476,11 +27695,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1220
+      ID: 1231
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 937
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27497,11 +27716,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 800
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 1002
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27517,15 +27736,15 @@ Types:
       GoRuntimeType: 593696
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1342
+      ID: 1353
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 993
+      ID: 1004
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 995
+      ID: 1006
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27535,7 +27754,7 @@ Types:
       GoRuntimeType: 483648
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 393
+      ID: 397
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 604512
@@ -27547,44 +27766,44 @@ Types:
       GoRuntimeType: 859776
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 365
+      ID: 369
       Name: func(go.shape.float64) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 340
+      ID: 344
       Name: func(go.shape.int) bool
       ByteSize: 8
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 341
+      ID: 345
       Name: func(go.shape.int) go.shape.string
       ByteSize: 8
       GoKind: 19
     - __kind: StructureType
-      ID: 335
+      ID: 339
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
     - __kind: StructureType
-      ID: 337
+      ID: 341
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 864
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 845
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1756704
@@ -27592,7 +27811,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1154 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1165 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27600,25 +27819,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 847
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1169
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 840
+      ID: 851
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1127392
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1171
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 740
+      ID: 751
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 843840
@@ -27626,18 +27845,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 742 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 753 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 741 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 741
+      ID: 752
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1154
+      ID: 1165
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2252192
@@ -27645,7 +27864,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1155 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1166 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27660,7 +27879,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1156 GoSliceHeaderType []float64
+          Type: 1167 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -27669,10 +27888,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1157 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1168 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1159 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1170 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 167 GoSliceHeaderType []string
@@ -27686,13 +27905,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 1155
+      ID: 1166
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 595296
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 737
+      ID: 748
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 843744
@@ -27700,18 +27919,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 739 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 750 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 738 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 738
+      ID: 749
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 743
+      ID: 754
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 843936
@@ -27719,30 +27938,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 745 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 756 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 744 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 755 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 744
+      ID: 755
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1232
+      ID: 1243
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1320
+      ID: 1331
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 958
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 401
+      ID: 402
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2370816
@@ -27750,7 +27969,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 402 StructureType sync.RWMutex
+          Type: 403 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -27771,13 +27990,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 409 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 410 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 414 GoMapType map[string]float64
+          Type: 415 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -27792,10 +28011,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 419 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 420 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 422 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 423 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27807,7 +28026,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 425 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 426 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -27830,7 +28049,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 426
+      ID: 427
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2249952
@@ -27841,13 +28060,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 427 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 428 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 400 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 403 StructureType sync/atomic.Int32
+          Type: 404 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27856,16 +28075,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 429 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 430 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 402 StructureType sync.RWMutex
+          Type: 403 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -27874,12 +28093,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 419 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 420 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 421
+      ID: 422
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1940480
@@ -27896,7 +28115,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -27904,20 +28123,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 409
+      ID: 410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1298976
       GoKind: 21
-      HeaderType: 411 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 412 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1405
+      ID: 1406
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 592544
       GoKind: 10
     - __kind: StructureType
-      ID: 424
+      ID: 425
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1777184
@@ -27931,16 +28150,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 695 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 702 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 700 GoMapType map[string]interface {}
+          Type: 707 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1431
+      ID: 1432
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 712
+      ID: 723
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1940736
@@ -27948,7 +28167,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1429 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1430 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27963,15 +28182,15 @@ Types:
           Type: 16 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1430 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1431 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1429
+      ID: 1430
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1001984
       GoKind: 5
     - __kind: StructureType
-      ID: 428
+      ID: 429
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2136064
@@ -27979,16 +28198,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 402 StructureType sync.RWMutex
+          Type: 403 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1403 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1404 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 404 GoMapType map[string]string
+          Type: 405 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -28003,12 +28222,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1405 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1406 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 400 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 429
+      ID: 430
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 909568
@@ -28017,15 +28236,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1111
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1350
+      ID: 1361
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1434
+      ID: 1435
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1652128
@@ -28035,29 +28254,29 @@ Types:
           Offset: 0
           Type: 163 GoInterfaceType context.Context
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 888
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 884
+      ID: 895
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1130848
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 761
+      ID: 772
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 2
     - __kind: StructureType
-      ID: 882
+      ID: 893
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1130720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 880
+      ID: 891
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1621088
@@ -28070,7 +28289,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 911
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1621888
@@ -28083,7 +28302,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 904
+      ID: 915
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1759968
@@ -28099,7 +28318,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 902
+      ID: 913
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1447424
@@ -28109,7 +28328,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 898
+      ID: 909
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1447104
@@ -28119,14 +28338,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1140
+      ID: 1151
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1521216
       GoKind: 21
-      HeaderType: 1142 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1153 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1163
+      ID: 1174
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1064160
@@ -28141,15 +28360,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1181 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1192 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1181
+      ID: 1192
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 912
+      ID: 923
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1622208
@@ -28157,12 +28376,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1140 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1151 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1140 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1151 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 906
+      ID: 917
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1447584
@@ -28172,7 +28391,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 910
+      ID: 921
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1760160
@@ -28183,12 +28402,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1163 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1163 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 908
+      ID: 919
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1622048
@@ -28201,7 +28420,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 914
+      ID: 925
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1447744
@@ -28209,9 +28428,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 396 StructureType time.Time
+          Type: 334 GoTimeType time.Time
     - __kind: StructureType
-      ID: 920
+      ID: 931
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1622528
@@ -28224,7 +28443,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 922
+      ID: 933
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1448064
@@ -28234,7 +28453,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 918
+      ID: 929
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1622368
@@ -28247,7 +28466,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 916
+      ID: 927
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1447904
@@ -28257,7 +28476,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 924
+      ID: 935
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1622688
@@ -28270,7 +28489,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 842
+      ID: 853
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1439744
@@ -28280,11 +28499,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1273
+      ID: 1284
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 844
+      ID: 855
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1439904
@@ -28292,21 +28511,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 842 StructureType github.com/cihub/seelog.baseError
+          Type: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1252
+      ID: 1263
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1208
+      ID: 1219
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1242
+      ID: 1253
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 848
+      ID: 859
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1440224
@@ -28314,13 +28533,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 842 StructureType github.com/cihub/seelog.baseError
+          Type: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1319
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1321
+      ID: 1332
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2138528
@@ -28328,12 +28547,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1307 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 1324
+      ID: 1335
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2164192
@@ -28341,7 +28560,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1307 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28349,11 +28568,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1221
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 846
+      ID: 857
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1440064
@@ -28361,9 +28580,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 842 StructureType github.com/cihub/seelog.baseError
+          Type: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 850
+      ID: 861
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1440384
@@ -28371,64 +28590,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 842 StructureType github.com/cihub/seelog.baseError
+          Type: 853 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1275
+      ID: 1286
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1316
+      ID: 1327
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1318
+      ID: 1329
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1145
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1050
+      ID: 1061
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1059
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1063
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1054
+      ID: 1065
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1263
+      ID: 1274
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1053
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 856
+      ID: 867
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1441344
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1366
+      ID: 1377
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1119
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1077
+      ID: 1088
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1869632
@@ -28444,11 +28663,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1082
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1010
+      ID: 1021
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1729408
@@ -28461,7 +28680,7 @@ Types:
           Offset: 1
           Type: 21 BaseType int8
     - __kind: StructureType
-      ID: 1083
+      ID: 1094
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1870080
@@ -28477,13 +28696,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 987
+      ID: 998
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1003904
       GoKind: 8
     - __kind: StructureType
-      ID: 1075
+      ID: 1086
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1869408
@@ -28499,13 +28718,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1165
+      ID: 1176
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 842112
       GoKind: 8
     - __kind: StructureType
-      ID: 1073
+      ID: 1084
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1869184
@@ -28513,15 +28732,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1165 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1176 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1165 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1176 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1081
+      ID: 1092
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1783136
@@ -28534,7 +28753,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1079
+      ID: 1090
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1869856
@@ -28550,11 +28769,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1370
+      ID: 1381
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1087
+      ID: 1098
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1648096
@@ -28564,19 +28783,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1014
+      ID: 1025
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1299360
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1012
+      ID: 1023
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1299232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1085
+      ID: 1096
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1783328
@@ -28589,7 +28808,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 771
+      ID: 782
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 849696
@@ -28597,36 +28816,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 773 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 784 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 772 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 783 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 772
+      ID: 783
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 351
+      ID: 355
       Name: go.shape.bool
       ByteSize: 1
       GoRuntimeType: 605472
       GoKind: 1
     - __kind: BaseType
-      ID: 364
+      ID: 368
       Name: go.shape.float64
       ByteSize: 8
       GoRuntimeType: 606112
       GoKind: 14
     - __kind: BaseType
-      ID: 334
+      ID: 338
       Name: go.shape.int
       ByteSize: 8
       GoRuntimeType: 605344
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 336
+      ID: 340
       Name: go.shape.string
       ByteSize: 16
       GoRuntimeType: 605408
@@ -28634,18 +28853,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 653 PointerType *go.shape.string.str
+          Type: 660 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 652 GoStringDataType go.shape.string.str
+      Data: 659 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 652
+      ID: 659
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 343
+      ID: 347
       Name: go.shape.struct { Name string }
       ByteSize: 16
       GoKind: 25
@@ -28654,7 +28873,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 345
+      ID: 349
       Name: go.shape.struct { X int; Y int }
       ByteSize: 16
       GoKind: 25
@@ -28666,13 +28885,13 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 354
+      ID: 358
       Name: go.shape.struct { main.i int }
       ByteSize: 8
       GoKind: 25
       RawFields: [{Name: i, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 355
+      ID: 359
       Name: go.shape.struct { main.s string }
       ByteSize: 16
       GoKind: 25
@@ -28681,7 +28900,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 358
+      ID: 362
       Name: go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
       ByteSize: 48
       GoKind: 25
@@ -28696,11 +28915,11 @@ Types:
           Offset: 32
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1149
+      ID: 1160
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1058
+      ID: 1069
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1466304
@@ -28710,7 +28929,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1238
+      ID: 1249
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1704736
@@ -28718,13 +28937,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1264 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1275 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1332
+      ID: 1343
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1264
+      ID: 1275
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1141728
@@ -28737,7 +28956,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1226
+      ID: 1237
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1593056
@@ -28747,19 +28966,19 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 774
+      ID: 785
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 850272
       GoKind: 10
     - __kind: BaseType
-      ID: 1147
+      ID: 1158
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1017632
       GoKind: 10
     - __kind: StructureType
-      ID: 1116
+      ID: 1127
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1908608
@@ -28770,12 +28989,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1147 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1158 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 973
+      ID: 984
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1630208
@@ -28783,12 +29002,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1147 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1158 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 778
+      ID: 789
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850464
@@ -28796,18 +29015,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 780 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 791 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 779 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 790 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 779
+      ID: 790
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 784
+      ID: 795
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 850656
@@ -28815,18 +29034,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 786 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 797 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 785 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 796 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 785
+      ID: 796
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 781
+      ID: 792
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 850560
@@ -28834,18 +29053,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 783 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 794 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 782 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 793 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 782
+      ID: 793
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 775
+      ID: 786
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850368
@@ -28853,22 +29072,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 777 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 788 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 776 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 787 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 776
+      ID: 787
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1330
+      ID: 1341
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 977
+      ID: 988
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1466944
@@ -28878,13 +29097,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 787
+      ID: 798
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 2
     - __kind: StructureType
-      ID: 965
+      ID: 976
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1461984
@@ -28894,11 +29113,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1125
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1136
+      ID: 1147
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1937472
@@ -28914,7 +29133,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 967
+      ID: 978
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1629728
@@ -28927,7 +29146,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1281
+      ID: 1292
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1996800
@@ -28935,16 +29154,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1306 GoInterfaceType io.Reader
+          Type: 1317 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1247
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1056
+      ID: 1067
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1590656
@@ -28954,29 +29173,29 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1198
+      ID: 1209
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 956
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1055
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1123
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1110
+      ID: 1121
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1532736
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 959
+      ID: 970
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1455264
@@ -28986,7 +29205,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 961
+      ID: 972
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1455424
@@ -28996,463 +29215,463 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 903
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 549
+      ID: 550
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 550 PointerType *noalg.map.group[[4]int][4]int
+          Type: 551 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 551 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 555 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 552 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 556 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 541
+      ID: 542
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 542 PointerType *noalg.map.group[[4]int]uint8
+          Type: 543 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 543 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 547 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 544 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 548 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 489
+      ID: 490
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 490 PointerType *noalg.map.group[[4]string][2]int
+          Type: 491 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 491 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 496 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 492 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 497 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 508
+      ID: 509
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 509 PointerType *noalg.map.group[bool]main.node
+          Type: 510 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 510 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 514 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 511 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 515 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 661
+      ID: 668
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 662 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 669 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 663 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 668 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 670 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 675 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 445
+      ID: 446
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 446 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 447 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 447 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 453 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 448 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 454 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1420
+      ID: 1421
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1421 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1422 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1422 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1428 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1423 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1429 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1464
+      ID: 1465
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1465 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1466 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1466 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1472 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1467 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1473 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1479
+      ID: 1480
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1480 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1481 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1481 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1487 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1482 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1488 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 457
+      ID: 458
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 458 PointerType *noalg.map.group[int]int
+          Type: 459 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 459 StructureType noalg.map.group[int]int
-      GroupSliceType: 463 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 460 StructureType noalg.map.group[int]int
+      GroupSliceType: 464 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1494
+      ID: 1495
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1495 PointerType *noalg.map.group[int]interface {}
+          Type: 1496 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1496 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1500 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1497 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1501 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 565
+      ID: 566
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 566 PointerType *noalg.map.group[int]struct {}
+          Type: 567 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 567 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 571 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 568 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 572 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 516
+      ID: 517
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 517 PointerType *noalg.map.group[int]uint8
+          Type: 518 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 518 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 522 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 519 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 523 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 706
+      ID: 717
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 707 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 718 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 708 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 714 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 725 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 498
+      ID: 499
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 499 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 500 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 500 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 506 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 501 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 507 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 481
+      ID: 482
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 482 PointerType *noalg.map.group[string][]string
+          Type: 483 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 483 StructureType noalg.map.group[string][]string
-      GroupSliceType: 487 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 484 StructureType noalg.map.group[string][]string
+      GroupSliceType: 488 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 686
+      ID: 693
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 687 PointerType *noalg.map.group[string]float64
+          Type: 694 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 688 StructureType noalg.map.group[string]float64
-      GroupSliceType: 692 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 695 StructureType noalg.map.group[string]float64
+      GroupSliceType: 699 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1172
+      ID: 1183
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1173 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1184 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1174 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1178 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1189 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 473
+      ID: 474
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 474 PointerType *noalg.map.group[string]int
+          Type: 475 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 475 StructureType noalg.map.group[string]int
-      GroupSliceType: 479 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 476 StructureType noalg.map.group[string]int
+      GroupSliceType: 480 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 678
+      ID: 685
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 679 PointerType *noalg.map.group[string]interface {}
+          Type: 686 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 680 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 684 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 687 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 691 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 465
+      ID: 466
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 466 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 467 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 467 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 471 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 468 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 472 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 670
+      ID: 677
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 671 PointerType *noalg.map.group[string]string
+          Type: 678 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 672 StructureType noalg.map.group[string]string
-      GroupSliceType: 676 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 679 StructureType noalg.map.group[string]string
+      GroupSliceType: 683 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 557
+      ID: 558
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 558 PointerType *noalg.map.group[struct {}]int
+          Type: 559 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 559 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 563 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 560 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 564 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 605
+      ID: 606
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 606 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 607 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 607 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 611 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 612 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 613
+      ID: 614
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 614 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 615 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 615 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 619 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 620 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 621
+      ID: 622
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 622 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 623 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 623 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 627 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 628 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 629
+      ID: 630
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 630 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 631 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 635 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 636 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 637
+      ID: 638
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 638 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 639 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 643 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 644 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 645
+      ID: 646
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 646 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 647 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 651 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 652 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 573
+      ID: 574
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 574 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 575 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 575 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 579 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 576 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 580 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 532
+      ID: 533
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 533 PointerType *noalg.map.group[uint8][4]int
+          Type: 534 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 534 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 539 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 535 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 540 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 524
+      ID: 525
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 525 PointerType *noalg.map.group[uint8]uint8
+          Type: 526 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 526 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 530 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 527 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 531 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1285
+      ID: 1296
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 991
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29499,17 +29718,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 1168
+      ID: 1179
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 596192
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1149
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 950
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29535,29 +29754,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 871
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1188
+      ID: 1199
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1117
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1372
+      ID: 1383
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1104
+      ID: 1115
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1510176
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 798
+      ID: 809
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29629,7 +29848,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 760
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 844896
@@ -29637,18 +29856,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 762 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 750 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 761 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 761
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1028
+      ID: 1039
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1581536
@@ -29656,15 +29875,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 1137 PointerType *internal/abi.Type
+          Type: 1148 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 748
+      ID: 759
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 844704
       GoKind: 2
     - __kind: StructureType
-      ID: 381
+      ID: 385
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1507616
@@ -29677,11 +29896,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1230
+      ID: 1241
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1271
+      ID: 1282
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1203936
@@ -29694,7 +29913,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1306
+      ID: 1317
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1037408
@@ -29707,7 +29926,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1257
+      ID: 1268
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1124192
@@ -29733,47 +29952,47 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1228
+      ID: 1239
       Name: io.discard
       GoRuntimeType: 1482816
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1202
+      ID: 1213
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1113
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1277
+      ID: 1288
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 350
+      ID: 354
       Name: main.Pair[go.shape.int,go.shape.bool]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
         - Name: Value
           Offset: 8
-          Type: 351 BaseType go.shape.bool
+          Type: 355 BaseType go.shape.bool
     - __kind: StructureType
-      ID: 353
+      ID: 357
       Name: main.Pair[go.shape.string,go.shape.int]
       ByteSize: 24
       GoKind: 25
       RawFields:
         - Name: Key
           Offset: 0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
         - Name: Value
           Offset: 16
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
     - __kind: StructureType
       ID: 328
       Name: main.aStruct
@@ -29800,7 +30019,7 @@ Types:
       RawFields:
         - Name: nested
           Offset: 0
-          Type: 1501 PointerType *main.nestedStruct
+          Type: 1502 PointerType *main.nestedStruct
     - __kind: GoInterfaceType
       ID: 175
       Name: main.behavior
@@ -29841,7 +30060,7 @@ Types:
           Offset: 0
           Type: 152 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 451
+      ID: 452
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1200096
@@ -29849,9 +30068,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1414 GoMapType map[int]*main.deepMap3
+          Type: 1415 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1426
+      ID: 1427
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -29863,9 +30082,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1458 GoMapType map[int]*main.deepMap8
+          Type: 1459 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1470
+      ID: 1471
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1199328
@@ -29873,9 +30092,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1473 GoMapType map[int]*main.deepMap9
+          Type: 1474 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1485
+      ID: 1486
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1199200
@@ -29883,7 +30102,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1488 GoMapType map[int]interface {}
+          Type: 1489 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 140
       Name: main.deepPtr1
@@ -29903,9 +30122,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1375 PointerType *main.deepPtr3
+          Type: 1386 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1376
+      ID: 1387
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -29917,9 +30136,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1439 PointerType *main.deepPtr8
+          Type: 1440 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1440
+      ID: 1441
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1200480
@@ -29927,9 +30146,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1441 PointerType *main.deepPtr9
+          Type: 1442 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1442
+      ID: 1443
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1200352
@@ -29949,7 +30168,7 @@ Types:
           Offset: 0
           Type: 146 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 441
+      ID: 442
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1202400
@@ -29957,9 +30176,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1408 GoSliceHeaderType []*main.deepSlice3
+          Type: 1409 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1411
+      ID: 1412
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -29971,9 +30190,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1443 GoSliceHeaderType []*main.deepSlice8
+          Type: 1444 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1446
+      ID: 1447
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1201632
@@ -29981,9 +30200,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1449 GoSliceHeaderType []*main.deepSlice9
+          Type: 1450 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1452
+      ID: 1453
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1201504
@@ -29991,7 +30210,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1455 GoSliceHeaderType []interface {}
+          Type: 1456 GoSliceHeaderType []interface {}
     - __kind: StructureType
       ID: 332
       Name: main.emptyStruct
@@ -30009,16 +30228,16 @@ Types:
           Type: 168 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 379 StructureType sync.Mutex
+          Type: 383 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 388 StructureType sync.Once
+          Type: 392 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1383 StructureType sync.WaitGroup
+          Type: 1394 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 403 StructureType sync/atomic.Int32
+          Type: 404 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 168
       Name: main.esotericStack
@@ -30048,7 +30267,7 @@ Types:
           Offset: 56
           Type: 65 GoSubroutineType func()
     - __kind: StructureType
-      ID: 366
+      ID: 370
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1430464
@@ -30058,71 +30277,71 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 348
+      ID: 352
       Name: main.largeGenericType[go.shape.int]
       ByteSize: 136
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
     - __kind: StructureType
-      ID: 346
+      ID: 350
       Name: main.largeGenericType[go.shape.string]
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: A
           Offset: 0
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: B
           Offset: 16
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: C
           Offset: 32
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: D
           Offset: 48
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: E
           Offset: 64
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: F
           Offset: 80
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: G
           Offset: 96
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: H
           Offset: 112
-          Type: 347 ArrayType [16]uint8
+          Type: 351 ArrayType [16]uint8
         - Name: Value
           Offset: 128
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 263
       Name: main.largeStruct
@@ -30436,9 +30655,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1380 ArrayType [63]uint64
+          Type: 1391 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1388
+      ID: 1399
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1430624
@@ -30458,7 +30677,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1382
+      ID: 1393
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30469,31 +30688,31 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1378 PointerType *main.stringType1.str
+          Type: 1389 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1377 GoStringDataType main.stringType1.str
+      Data: 1388 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1377
+      ID: 1388
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1379
+      ID: 1390
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1503 PointerType *main.stringType2.str
+          Type: 1504 PointerType *main.stringType2.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1502 GoStringDataType main.stringType2.str
+      Data: 1503 GoStringDataType main.stringType2.str
     - __kind: GoStringDataType
-      ID: 1502
+      ID: 1503
       Name: main.stringType2.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -30609,16 +30828,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1389 PointerType **main.t
+          Type: 1400 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1390 GoSliceDataType main.t.array
+      Data: 1401 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1390
+      ID: 1401
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -30674,29 +30893,38 @@ Types:
         - Name: c
           Offset: 32
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 337
+      Name: main.timeCapture
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: monotonicNow
+          Offset: 0
+          Type: 334 GoTimeType time.Time
     - __kind: BaseType
       ID: 135
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 360
+      ID: 364
       Name: main.typeWithGenerics[go.shape.int]
       ByteSize: 8
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 334 BaseType go.shape.int
+          Type: 338 BaseType go.shape.int
     - __kind: StructureType
-      ID: 361
+      ID: 365
       Name: main.typeWithGenerics[go.shape.string]
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 336 GoStringHeaderType go.shape.string
+          Type: 340 GoStringHeaderType go.shape.string
     - __kind: StructureType
       ID: 268
       Name: main.wideStruct
@@ -30769,8 +30997,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 554 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 551 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 555 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 552 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 233
       Name: map<[4]int,uint8>
@@ -30804,8 +31032,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 546 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 543 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 547 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 544 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 201
       Name: map<[4]string,[2]int>
@@ -30839,8 +31067,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 495 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 491 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 496 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 492 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 213
       Name: map<bool,main.node>
@@ -30874,10 +31102,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 513 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 510 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 514 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 511 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 385
+      ID: 389
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -30890,7 +31118,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 386 PointerType **table<context.canceler,struct {}>
+          Type: 390 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30909,8 +31137,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 667 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 663 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 674 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 670 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 154
       Name: map<int,*main.deepMap2>
@@ -30944,10 +31172,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 452 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 447 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 453 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 448 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1416
+      ID: 1417
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -30960,7 +31188,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1417 PointerType **table<int,*main.deepMap3>
+          Type: 1418 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -30979,10 +31207,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1427 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1422 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1428 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1423 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1460
+      ID: 1461
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -30995,7 +31223,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1461 PointerType **table<int,*main.deepMap8>
+          Type: 1462 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31014,10 +31242,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1471 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1466 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1472 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1467 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1475
+      ID: 1476
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -31030,7 +31258,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1476 PointerType **table<int,*main.deepMap9>
+          Type: 1477 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31049,8 +31277,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1486 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1481 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1487 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 181
       Name: map<int,int>
@@ -31084,10 +31312,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 462 GoSliceDataType []*table<int,int>.array
-      GroupType: 459 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 463 GoSliceDataType []*table<int,int>.array
+      GroupType: 460 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1490
+      ID: 1491
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31100,7 +31328,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1491 PointerType **table<int,interface {}>
+          Type: 1492 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31119,8 +31347,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1499 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1496 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1500 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 248
       Name: map<int,struct {}>
@@ -31154,8 +31382,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 570 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 567 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 571 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 568 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 218
       Name: map<int,uint8>
@@ -31189,10 +31417,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 521 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 518 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 522 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 519 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 697
+      ID: 704
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -31205,7 +31433,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 698 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 705 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31224,8 +31452,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 713 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 708 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 724 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 208
       Name: map<string,[]main.structWithMap>
@@ -31259,8 +31487,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 505 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 500 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 506 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 501 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 196
       Name: map<string,[]string>
@@ -31294,10 +31522,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 486 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 483 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 487 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 484 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 416
+      ID: 417
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31310,7 +31538,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 417 PointerType **table<string,float64>
+          Type: 418 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31329,10 +31557,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 691 GoSliceDataType []*table<string,float64>.array
-      GroupType: 688 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 698 GoSliceDataType []*table<string,float64>.array
+      GroupType: 695 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1142
+      ID: 1153
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31345,7 +31573,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1143 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1154 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31364,8 +31592,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1177 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1174 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1188 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 191
       Name: map<string,int>
@@ -31399,10 +31627,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 478 GoSliceDataType []*table<string,int>.array
-      GroupType: 475 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 479 GoSliceDataType []*table<string,int>.array
+      GroupType: 476 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 411
+      ID: 412
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31415,7 +31643,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 412 PointerType **table<string,interface {}>
+          Type: 413 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31434,8 +31662,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 683 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 680 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 690 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 687 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 186
       Name: map<string,main.nestedStruct>
@@ -31469,10 +31697,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 470 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 467 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 471 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 468 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 406
+      ID: 407
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31485,7 +31713,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 407 PointerType **table<string,string>
+          Type: 408 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31504,8 +31732,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 675 GoSliceDataType []*table<string,string>.array
-      GroupType: 672 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 682 GoSliceDataType []*table<string,string>.array
+      GroupType: 679 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 243
       Name: map<struct {},int>
@@ -31539,8 +31767,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 562 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 559 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 563 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 560 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 300
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31574,8 +31802,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 610 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 607 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 611 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 305
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31609,8 +31837,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 618 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 615 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 619 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 310
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31644,8 +31872,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 626 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 623 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 627 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 315
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31679,8 +31907,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 634 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 635 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 320
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31714,8 +31942,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 642 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 643 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 325
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31749,8 +31977,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 650 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 651 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 253
       Name: map<struct {},struct {}>
@@ -31784,8 +32012,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 578 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 575 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 579 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 576 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 228
       Name: map<uint8,[4]int>
@@ -31819,8 +32047,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 538 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 534 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 539 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 535 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 223
       Name: map<uint8,uint8>
@@ -31854,8 +32082,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 529 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 526 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 530 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 527 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 236
       Name: map[[4]int][4]int
@@ -31885,12 +32113,12 @@ Types:
       GoKind: 21
       HeaderType: 213 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 383
+      ID: 387
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1145952
       GoKind: 21
-      HeaderType: 385 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 389 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 152
       Name: map[int]*main.deepMap2
@@ -31899,26 +32127,26 @@ Types:
       GoKind: 21
       HeaderType: 154 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1414
+      ID: 1415
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1143520
       GoKind: 21
-      HeaderType: 1416 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1417 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1458
+      ID: 1459
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1142880
       GoKind: 21
-      HeaderType: 1460 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1461 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1473
+      ID: 1474
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1142752
       GoKind: 21
-      HeaderType: 1475 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1476 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 179
       Name: map[int]int
@@ -31927,12 +32155,12 @@ Types:
       GoKind: 21
       HeaderType: 181 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1488
+      ID: 1489
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1142624
       GoKind: 21
-      HeaderType: 1490 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1491 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 246
       Name: map[int]struct {}
@@ -31948,12 +32176,12 @@ Types:
       GoKind: 21
       HeaderType: 218 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 695
+      ID: 702
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1146208
       GoKind: 21
-      HeaderType: 697 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 704 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 206
       Name: map[string][]main.structWithMap
@@ -31969,12 +32197,12 @@ Types:
       GoKind: 21
       HeaderType: 196 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 414
+      ID: 415
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1146080
       GoKind: 21
-      HeaderType: 416 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 417 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 189
       Name: map[string]int
@@ -31983,12 +32211,12 @@ Types:
       GoKind: 21
       HeaderType: 191 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 700
+      ID: 707
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1142496
       GoKind: 21
-      HeaderType: 411 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 412 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 184
       Name: map[string]main.nestedStruct
@@ -31997,12 +32225,12 @@ Types:
       GoKind: 21
       HeaderType: 186 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 404
+      ID: 405
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1145824
       GoKind: 21
-      HeaderType: 406 GoSwissMapHeaderType map<string,string>
+      HeaderType: 407 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 241
       Name: map[struct {}]int
@@ -32068,7 +32296,7 @@ Types:
       GoKind: 21
       HeaderType: 223 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 896
+      ID: 907
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1446624
@@ -32078,7 +32306,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1192
+      ID: 1203
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1443584
@@ -32088,11 +32316,11 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1105
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1162
+      ID: 1173
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1619808
@@ -32105,35 +32333,35 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1136
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1336
+      ID: 1347
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1123
+      ID: 1134
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1107
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1346
+      ID: 1357
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1356
+      ID: 1367
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1344
+      ID: 1355
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1061
+      ID: 1072
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1127008
@@ -32141,28 +32369,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1063 PointerType *net.UnknownNetworkError.str
+          Type: 1074 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1062 GoStringDataType net.UnknownNetworkError.str
+      Data: 1073 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1062
+      ID: 1073
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1026
+      ID: 1037
       Name: net.canceledError
       GoRuntimeType: 1300512
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1314
+      ID: 1325
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1167
+      ID: 1178
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2137824
@@ -32170,7 +32398,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -32181,27 +32409,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1358
+      ID: 1369
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1352
+      ID: 1363
       Name: net.noReadFrom
       GoRuntimeType: 1127264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1351
+      ID: 1362
       Name: net.noWriteTo
       GoRuntimeType: 1127136
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 838
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1436
+      ID: 1437
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1787744
@@ -32214,7 +32442,7 @@ Types:
           Offset: 16
           Type: 163 GoInterfaceType context.Context
     - __kind: StructureType
-      ID: 829
+      ID: 840
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1756512
@@ -32222,7 +32450,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1150 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1161 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -32230,7 +32458,7 @@ Types:
           Offset: 96
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1340
+      ID: 1351
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2320000
@@ -32238,12 +32466,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1352 StructureType net.noReadFrom
+          Type: 1363 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1345 PointerType *net.TCPConn
+          Type: 1356 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1338
+      ID: 1349
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2319456
@@ -32251,24 +32479,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1351 StructureType net.noWriteTo
+          Type: 1362 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1345 PointerType *net.TCPConn
+          Type: 1356 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1098
+      ID: 1109
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1127
+      ID: 1138
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1027
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1184
+      ID: 1195
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1435264
@@ -32278,19 +32506,19 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 718
+      ID: 729
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 842592
       GoKind: 10
     - __kind: BaseType
-      ID: 1139
+      ID: 1150
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1004000
       GoKind: 10
     - __kind: StructureType
-      ID: 805
+      ID: 816
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1754784
@@ -32301,12 +32529,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1139 BaseType net/http.http2ErrCode
+          Type: 1150 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1119
+      ID: 1130
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1926720
@@ -32317,12 +32545,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1139 BaseType net/http.http2ErrCode
+          Type: 1150 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 809
+      ID: 820
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1619488
@@ -32330,16 +32558,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1139 BaseType net/http.http2ErrCode
+          Type: 1150 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1248
+      ID: 1259
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 722
+      ID: 733
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 842784
@@ -32347,18 +32575,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 724 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 735 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 723 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 734 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 723
+      ID: 734
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 728
+      ID: 739
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 842976
@@ -32366,18 +32594,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 730 PointerType *net/http.http2headerFieldNameError.str
+          Type: 741 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 729 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 740 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 729
+      ID: 740
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 725
+      ID: 736
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 842880
@@ -32385,32 +32613,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 727 PointerType *net/http.http2headerFieldValueError.str
+          Type: 738 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 726 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 737 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 726
+      ID: 737
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1102
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1033
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1299872
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1303
+      ID: 1314
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 719
+      ID: 730
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 842688
@@ -32418,18 +32646,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 721 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 732 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 720 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 731 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 720
+      ID: 731
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1186
+      ID: 1197
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1755552
@@ -32437,22 +32665,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1267 BaseType time.Duration
+          Type: 1278 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 113 PointerType *error
     - __kind: ArrayType
-      ID: 1268
+      ID: 1279
       Name: net/http.incomparable
       GoRuntimeType: 915040
       GoKind: 17
       HasCount: true
       Element: 65 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1018
+      ID: 1029
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1577536
@@ -32462,11 +32690,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1250
+      ID: 1261
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1206
+      ID: 1217
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1577376
@@ -32474,9 +32702,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1249 PointerType *net/http.persistConn
+          Type: 1260 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1240
+      ID: 1251
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1828640
@@ -32484,15 +32712,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1268 ArrayType net/http.incomparable
+          Type: 1279 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1269 PointerType *bufio.Reader
+          Type: 1280 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1271 GoInterfaceType io.ReadWriteCloser
+          Type: 1282 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 813
+      ID: 824
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1436224
@@ -32502,17 +32730,17 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1132
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1089
+      ID: 1100
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1496736
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1020
+      ID: 1031
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1577696
@@ -32522,7 +32750,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1283
+      ID: 1294
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2057504
@@ -32530,16 +32758,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1162 GoInterfaceType net.Conn
+          Type: 1173 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 813
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1305
+      ID: 1316
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2073248
@@ -32547,13 +32775,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1300 PointerType *bufio.Writer
+          Type: 1311 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1216
+      ID: 1227
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 899
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1759584
@@ -32569,7 +32797,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 886
+      ID: 897
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1621248
@@ -32582,11 +32810,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1256
+      ID: 1267
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1218
+      ID: 1229
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1623488
@@ -32594,16 +32822,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1255 PointerType *net/smtp.Client
+          Type: 1266 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1257 GoInterfaceType io.WriteCloser
+          Type: 1268 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 883
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 757
+      ID: 768
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 845664
@@ -32611,26 +32839,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 759 PointerType *net/textproto.ProtocolError.str
+          Type: 770 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 758 GoStringDataType net/textproto.ProtocolError.str
+      Data: 769 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 758
+      ID: 769
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1214
+      ID: 1225
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1129
+      ID: 1140
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 731
+      ID: 742
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 843456
@@ -32638,18 +32866,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 733 PointerType *net/url.EscapeError.str
+          Type: 744 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 732 GoStringDataType net/url.EscapeError.str
+      Data: 743 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 732
+      ID: 743
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 734
+      ID: 745
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 843552
@@ -32657,299 +32885,299 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 736 PointerType *net/url.InvalidHostError.str
+          Type: 747 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 735 GoStringDataType net/url.InvalidHostError.str
+      Data: 746 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 735
+      ID: 746
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 552
+      ID: 553
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 692928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 553 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 554 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 544
+      ID: 545
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 693024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 545 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 546 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 492
+      ID: 493
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 693312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 493 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 494 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 511
+      ID: 512
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 512 StructureType noalg.struct { key bool; elem main.node }
+      Element: 513 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 664
+      ID: 671
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 699744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 665 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 672 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 448
+      ID: 449
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 692160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 449 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 450 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1423
+      ID: 1424
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 692064
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1424 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1425 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1467
+      ID: 1468
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 691584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1468 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1469 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1482
+      ID: 1483
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 691488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1483 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1484 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 460
+      ID: 461
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 690240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 461 StructureType noalg.struct { key int; elem int }
+      Element: 462 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1497
+      ID: 1498
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 691392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1498 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1499 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 568
+      ID: 569
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 693504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 569 StructureType noalg.struct { key int; elem struct {} }
+      Element: 570 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 519
+      ID: 520
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 693600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 520 StructureType noalg.struct { key int; elem uint8 }
+      Element: 521 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 709
+      ID: 720
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 700384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 710 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 721 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 501
+      ID: 502
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 693696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 502 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 503 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 484
+      ID: 485
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 693792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 485 StructureType noalg.struct { key string; elem []string }
+      Element: 486 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 689
+      ID: 696
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 700288
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 690 StructureType noalg.struct { key string; elem float64 }
+      Element: 697 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1175
+      ID: 1186
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 769408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1176 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1187 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 476
+      ID: 477
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 477 StructureType noalg.struct { key string; elem int }
+      Element: 478 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 681
+      ID: 688
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 691008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 682 StructureType noalg.struct { key string; elem interface {} }
+      Element: 689 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 468
+      ID: 469
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 693984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 469 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 470 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 673
+      ID: 680
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 698016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 674 StructureType noalg.struct { key string; elem string }
+      Element: 681 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 560
+      ID: 561
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 694080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 561 StructureType noalg.struct { key struct {}; elem int }
+      Element: 562 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 608
+      ID: 609
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 609 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 610 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 616
+      ID: 617
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 617 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 618 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 624
+      ID: 625
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 625 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 626 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 632
+      ID: 633
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 633 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 634 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 640
+      ID: 641
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 641 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 642 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 648
+      ID: 649
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 649 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 650 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 576
+      ID: 577
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 694176
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 577 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 578 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 535
+      ID: 536
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 694272
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 536 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 537 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 527
+      ID: 528
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 694368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 528 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 529 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 551
+      ID: 552
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1312416
@@ -32960,9 +33188,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 552 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 553 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 543
+      ID: 544
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1312672
@@ -32973,9 +33201,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 544 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 545 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 491
+      ID: 492
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1312928
@@ -32986,9 +33214,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 492 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 493 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 510
+      ID: 511
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1313184
@@ -32999,9 +33227,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 511 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 512 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 663
+      ID: 670
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1317280
@@ -33012,9 +33240,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 664 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 671 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 447
+      ID: 448
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1312160
@@ -33025,9 +33253,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 448 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 449 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1422
+      ID: 1423
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1311904
@@ -33038,9 +33266,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1423 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1424 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1466
+      ID: 1467
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1310624
@@ -33051,9 +33279,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1467 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1468 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1481
+      ID: 1482
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1310368
@@ -33064,9 +33292,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1482 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1483 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 459
+      ID: 460
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1309088
@@ -33077,9 +33305,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 460 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 461 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1496
+      ID: 1497
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1310112
@@ -33090,9 +33318,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1497 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1498 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 567
+      ID: 568
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1313440
@@ -33103,9 +33331,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 568 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 569 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 518
+      ID: 519
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1313696
@@ -33116,9 +33344,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 519 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 520 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 708
+      ID: 719
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1318304
@@ -33129,9 +33357,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 709 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 720 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 500
+      ID: 501
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1313952
@@ -33142,9 +33370,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 501 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 502 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 483
+      ID: 484
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1314208
@@ -33155,9 +33383,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 484 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 485 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 688
+      ID: 695
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1318048
@@ -33168,9 +33396,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 689 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 696 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1174
+      ID: 1185
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1375904
@@ -33181,9 +33409,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1175 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1186 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 475
+      ID: 476
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1314464
@@ -33194,9 +33422,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 476 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 477 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 680
+      ID: 687
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1309856
@@ -33207,9 +33435,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 681 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 688 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 467
+      ID: 468
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1314720
@@ -33220,9 +33448,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 468 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 469 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 672
+      ID: 679
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1316512
@@ -33233,9 +33461,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 673 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 680 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 559
+      ID: 560
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1314976
@@ -33246,9 +33474,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 560 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 561 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 607
+      ID: 608
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33258,9 +33486,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 608 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 609 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 615
+      ID: 616
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33270,9 +33498,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 616 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 617 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 623
+      ID: 624
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33282,9 +33510,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 624 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 625 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 631
+      ID: 632
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33294,9 +33522,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 632 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 633 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 639
+      ID: 640
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33306,9 +33534,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 640 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 641 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 647
+      ID: 648
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33318,9 +33546,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 648 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 649 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 575
+      ID: 576
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1315232
@@ -33331,9 +33559,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 576 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 577 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 534
+      ID: 535
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1315488
@@ -33344,9 +33572,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 535 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 536 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 526
+      ID: 527
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1315744
@@ -33357,9 +33585,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 527 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 528 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 553
+      ID: 554
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1312288
@@ -33367,12 +33595,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 537 ArrayType [4]int
+          Type: 538 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 537 ArrayType [4]int
+          Type: 538 ArrayType [4]int
     - __kind: StructureType
-      ID: 545
+      ID: 546
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1312544
@@ -33380,12 +33608,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 537 ArrayType [4]int
+          Type: 538 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 493
+      ID: 494
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1312800
@@ -33393,12 +33621,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 494 ArrayType [4]string
+          Type: 495 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 121 ArrayType [2]int
     - __kind: StructureType
-      ID: 512
+      ID: 513
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1313056
@@ -33411,7 +33639,7 @@ Types:
           Offset: 8
           Type: 259 StructureType main.node
     - __kind: StructureType
-      ID: 665
+      ID: 672
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1317152
@@ -33419,12 +33647,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 666 GoInterfaceType context.canceler
+          Type: 673 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 449
+      ID: 450
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1312032
@@ -33435,9 +33663,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 450 PointerType *main.deepMap2
+          Type: 451 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1424
+      ID: 1425
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1311776
@@ -33448,9 +33676,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1425 PointerType *main.deepMap3
+          Type: 1426 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1468
+      ID: 1469
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1310496
@@ -33461,9 +33689,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1469 PointerType *main.deepMap8
+          Type: 1470 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1483
+      ID: 1484
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1310240
@@ -33474,9 +33702,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1484 PointerType *main.deepMap9
+          Type: 1485 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 461
+      ID: 462
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1308960
@@ -33489,7 +33717,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 1498
+      ID: 1499
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1309984
@@ -33502,7 +33730,7 @@ Types:
           Offset: 8
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 569
+      ID: 570
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1313312
@@ -33515,7 +33743,7 @@ Types:
           Offset: 8
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 520
+      ID: 521
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1313568
@@ -33528,7 +33756,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 710
+      ID: 721
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1318176
@@ -33539,9 +33767,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 711 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 722 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 502
+      ID: 503
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1313824
@@ -33552,9 +33780,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 503 GoSliceHeaderType []main.structWithMap
+          Type: 504 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 485
+      ID: 486
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1314080
@@ -33567,7 +33795,7 @@ Types:
           Offset: 16
           Type: 167 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 690
+      ID: 697
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1317920
@@ -33580,7 +33808,7 @@ Types:
           Offset: 16
           Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 1176
+      ID: 1187
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1375776
@@ -33591,9 +33819,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1163 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 477
+      ID: 478
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1314336
@@ -33606,7 +33834,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 682
+      ID: 689
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1309728
@@ -33619,7 +33847,7 @@ Types:
           Offset: 16
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 469
+      ID: 470
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1314592
@@ -33632,7 +33860,7 @@ Types:
           Offset: 16
           Type: 131 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 674
+      ID: 681
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1316384
@@ -33645,7 +33873,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 561
+      ID: 562
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1314848
@@ -33658,7 +33886,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 609
+      ID: 610
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33670,7 +33898,7 @@ Types:
           Offset: 0
           Type: 297 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 617
+      ID: 618
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33682,7 +33910,7 @@ Types:
           Offset: 0
           Type: 298 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 625
+      ID: 626
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33694,7 +33922,7 @@ Types:
           Offset: 0
           Type: 303 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 633
+      ID: 634
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33706,7 +33934,7 @@ Types:
           Offset: 0
           Type: 308 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 641
+      ID: 642
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33718,7 +33946,7 @@ Types:
           Offset: 0
           Type: 313 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 649
+      ID: 650
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33730,7 +33958,7 @@ Types:
           Offset: 0
           Type: 318 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 577
+      ID: 578
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1315104
       GoKind: 25
@@ -33742,7 +33970,7 @@ Types:
           Offset: 0
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 536
+      ID: 537
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1315360
@@ -33753,9 +33981,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 537 ArrayType [4]int
+          Type: 538 ArrayType [4]int
     - __kind: StructureType
-      ID: 528
+      ID: 529
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1315616
@@ -33768,19 +33996,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1364
+      ID: 1375
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1010
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1078
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1362
+      ID: 1373
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2390400
@@ -33788,12 +34016,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1368 StructureType os.noReadFrom
+          Type: 1379 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1363 PointerType *os.File
+          Type: 1374 PointerType *os.File
     - __kind: StructureType
-      ID: 1360
+      ID: 1371
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2389600
@@ -33801,36 +34029,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1367 StructureType os.noWriteTo
+          Type: 1378 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1363 PointerType *os.File
+          Type: 1374 PointerType *os.File
     - __kind: StructureType
-      ID: 1368
+      ID: 1379
       Name: os.noReadFrom
       GoRuntimeType: 1125472
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1367
+      ID: 1378
       Name: os.noWriteTo
       GoRuntimeType: 1125344
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1041
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1170
+      ID: 1181
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1234
+      ID: 1245
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1032
+      ID: 1043
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1729984
@@ -33843,7 +34071,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 768
+      ID: 779
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 848928
@@ -33851,36 +34079,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 770 PointerType *os/user.UnknownGroupIdError.str
+          Type: 781 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 769 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 780 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 769
+      ID: 780
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 767
+      ID: 778
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 848832
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 800
+      ID: 811
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 905
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1014
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1007
+      ID: 1018
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33892,7 +34120,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 1005
+      ID: 1016
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1915776
@@ -33909,7 +34137,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1168 BaseType internal/abi.BoundsErrorCode
+          Type: 1179 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -33925,7 +34153,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1069
+      ID: 1080
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1781024
@@ -33938,7 +34166,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 981
+      ID: 992
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1003040
@@ -33946,13 +34174,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 983 PointerType *runtime.errorString.str
+          Type: 994 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 982 GoStringDataType runtime.errorString.str
+      Data: 993 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 982
+      ID: 993
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34601,7 +34829,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 436
+      ID: 437
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -34637,7 +34865,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 984
+      ID: 995
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1003136
@@ -34645,13 +34873,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 986 PointerType *runtime.plainError.str
+          Type: 997 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 985 GoStringDataType runtime.plainError.str
+      Data: 996 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 985
+      ID: 996
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34692,7 +34920,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 796
+      ID: 807
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1619168
@@ -34764,7 +34992,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 997
+      ID: 1008
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -34776,26 +35004,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 431 PointerType *string.str
+          Type: 432 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 430 GoStringDataType string.str
+      Data: 431 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 430
+      ID: 431
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1299
+      ID: 1310
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1204
+      ID: 1215
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1200
+      ID: 1211
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1474304
@@ -34811,7 +35039,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 379
+      ID: 383
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1485856
@@ -34819,12 +35047,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 380 StructureType sync.noCopy
+          Type: 384 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 381 StructureType internal/sync.Mutex
+          Type: 385 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 388
+      ID: 392
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1640416
@@ -34832,15 +35060,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 380 StructureType sync.noCopy
+          Type: 384 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 389 StructureType sync/atomic.Bool
+          Type: 393 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 379 StructureType sync.Mutex
+          Type: 383 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 402
+      ID: 403
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1866944
@@ -34848,7 +35076,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 379 StructureType sync.Mutex
+          Type: 383 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -34857,12 +35085,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 403 StructureType sync/atomic.Int32
+          Type: 404 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 403 StructureType sync/atomic.Int32
+          Type: 404 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1383
+      ID: 1394
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1640224
@@ -34870,21 +35098,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 380 StructureType sync.noCopy
+          Type: 384 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1384 StructureType sync/atomic.Uint64
+          Type: 1395 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 380
+      ID: 384
       Name: sync.noCopy
       GoRuntimeType: 1002656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 389
+      ID: 393
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1486976
@@ -34892,12 +35120,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 390 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 403
+      ID: 404
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1487136
@@ -34905,12 +35133,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 390 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 1384
+      ID: 1395
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1640800
@@ -34918,15 +35146,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 390 StructureType sync/atomic.noCopy
+          Type: 394 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1385 StructureType sync/atomic.align64
+          Type: 1396 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 382
+      ID: 386
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1208160
@@ -34936,25 +35164,25 @@ Types:
           Offset: 0
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1385
+      ID: 1396
       Name: sync/atomic.align64
       GoRuntimeType: 1002848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 390
+      ID: 394
       Name: sync/atomic.noCopy
       GoRuntimeType: 1002752
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1117
+      ID: 1128
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1301920
       GoKind: 12
     - __kind: StructureType
-      ID: 548
+      ID: 549
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -34976,9 +35204,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 549 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 550 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 540
+      ID: 541
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35000,9 +35228,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 541 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 542 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 488
+      ID: 489
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -35024,9 +35252,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 489 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 490 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 507
+      ID: 508
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -35048,9 +35276,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 508 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 509 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 660
+      ID: 667
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35072,9 +35300,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 661 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 668 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 444
+      ID: 445
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -35096,9 +35324,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 445 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 446 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1419
+      ID: 1420
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -35120,9 +35348,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1420 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1421 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1463
+      ID: 1464
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -35144,9 +35372,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1464 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1465 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1478
+      ID: 1479
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -35168,9 +35396,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1479 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1480 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 456
+      ID: 457
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -35192,9 +35420,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 457 GoSwissMapGroupsType groupReference<int,int>
+          Type: 458 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1493
+      ID: 1494
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35216,9 +35444,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1494 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1495 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 564
+      ID: 565
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35240,9 +35468,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 565 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 566 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 515
+      ID: 516
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35264,9 +35492,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 516 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 517 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 705
+      ID: 716
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -35288,9 +35516,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 706 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 717 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 497
+      ID: 498
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35312,9 +35540,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 498 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 499 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 480
+      ID: 481
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35336,9 +35564,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 481 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 482 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 685
+      ID: 692
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35360,9 +35588,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 686 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 693 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1171
+      ID: 1182
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35384,9 +35612,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1172 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1183 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 472
+      ID: 473
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35408,9 +35636,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 473 GoSwissMapGroupsType groupReference<string,int>
+          Type: 474 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 677
+      ID: 684
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35432,9 +35660,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 678 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 685 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 464
+      ID: 465
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35456,9 +35684,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 465 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 466 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 669
+      ID: 676
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35480,9 +35708,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 670 GoSwissMapGroupsType groupReference<string,string>
+          Type: 677 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 556
+      ID: 557
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35504,9 +35732,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 557 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 558 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 604
+      ID: 605
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35528,9 +35756,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 605 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 606 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 612
+      ID: 613
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35552,9 +35780,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 613 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 614 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 620
+      ID: 621
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35576,9 +35804,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 621 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 622 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 628
+      ID: 629
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35600,9 +35828,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 629 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 630 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 636
+      ID: 637
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35624,9 +35852,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 637 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 638 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 644
+      ID: 645
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35648,9 +35876,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 645 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 646 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 572
+      ID: 573
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35672,9 +35900,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 573 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 574 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 531
+      ID: 532
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35696,9 +35924,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 532 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 533 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 523
+      ID: 524
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35720,13 +35948,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 524 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 525 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1334
+      ID: 1345
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1060
+      ID: 1071
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1734400
@@ -35739,13 +35967,13 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 1267
+      ID: 1278
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1942272
       GoKind: 6
     - __kind: StructureType
-      ID: 398
+      ID: 336
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2000384
@@ -35756,10 +35984,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 1393 GoSliceHeaderType []time.zone
+          Type: 653 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 1396 GoSliceHeaderType []time.zoneTrans
+          Type: 656 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -35771,13 +35999,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 1394 PointerType *time.zone
+          Type: 654 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 805
       Name: time.ParseError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 396
+    - __kind: GoTimeType
+      ID: 334
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2405408
@@ -35791,9 +36019,17 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 397 PointerType *time.Location
+          Type: 335 PointerType *time.Location
+      ExtFieldOffset: 8
+      LocFieldOffset: 16
+      CacheResolved: true
+      CacheStartOffset: 80
+      CacheEndOffset: 88
+      CacheZoneOffset: 96
+      ZoneOffsetFieldOffset: 16
+      ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 395
+      ID: 399
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1488256
@@ -35801,12 +36037,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1392 GoChannelType <-chan time.Time
+          Type: 1403 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 715
+      ID: 726
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 841056
@@ -35814,22 +36050,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 717 PointerType *time.fileSizeError.str
+          Type: 728 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 716 GoStringDataType time.fileSizeError.str
+      Data: 727 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 716
+      ID: 727
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 803
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1395
+      ID: 655
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1641760
@@ -35845,7 +36081,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1398
+      ID: 658
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1779680
@@ -35906,7 +36142,7 @@ Types:
       GoRuntimeType: 593824
       GoKind: 26
     - __kind: StructureType
-      ID: 1150
+      ID: 1161
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2094016
@@ -35917,10 +36153,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1151 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1162 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1152 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1163 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -35935,18 +36171,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1153 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1164 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1153
+      ID: 1164
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1008704
       GoKind: 9
     - __kind: StructureType
-      ID: 1151
+      ID: 1162
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1955328
@@ -35971,21 +36207,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 901
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1152
+      ID: 1163
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 597536
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1328
+      ID: 1339
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 874
+      ID: 885
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1443744
@@ -35995,13 +36231,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 760
+      ID: 771
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 2
     - __kind: StructureType
-      ID: 1037
+      ID: 1048
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1730176
@@ -36014,12 +36250,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 989
+      ID: 1000
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1007552
       GoKind: 5
-MaxTypeID: 1826
+MaxTypeID: 1830
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/visit_type_references.go
+++ b/pkg/dyninst/irgen/visit_type_references.go
@@ -80,6 +80,7 @@ func visitTypeReferences(tc *typeCatalog, f func(t *ir.Type)) {
 		case *ir.GoSubroutineType:
 		case *ir.GoSwissMapGroupsType:
 		case *ir.GoSwissMapHeaderType:
+		case *ir.GoTimeType:
 		case *ir.VoidPointerType:
 		case *ir.UnresolvedPointeeType:
 		default:

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -337,6 +337,7 @@ var allTypes = []reflect.Type{
 	reflect.TypeOf((*ir.GoSubroutineType)(nil)),
 	reflect.TypeOf((*ir.GoSwissMapGroupsType)(nil)),
 	reflect.TypeOf((*ir.GoSwissMapHeaderType)(nil)),
+	reflect.TypeOf((*ir.GoTimeType)(nil)),
 	reflect.TypeOf((*ir.PointerType)(nil)),
 	reflect.TypeOf((*ir.StructureType)(nil)),
 	reflect.TypeOf((*ir.GoContextImplementationType)(nil)),

--- a/pkg/dyninst/loader/types.go
+++ b/pkg/dyninst/loader/types.go
@@ -129,6 +129,8 @@ func opcodeByte(opcode compiler.Opcode) uint8 {
 		return C.SM_OP_GO_CONTEXT_CHAIN_INIT
 	case compiler.OpcodeGoContextChainHop:
 		return C.SM_OP_GO_CONTEXT_CHAIN_HOP
+	case compiler.OpcodeProcessGoTime:
+		return C.SM_OP_PROCESS_GO_TIME
 	default:
 		panic(fmt.Sprintf("unknown opcode: %s", opcode))
 	}

--- a/pkg/dyninst/loader/types_linux.go
+++ b/pkg/dyninst/loader/types_linux.go
@@ -150,6 +150,8 @@ func opcodeByte(opcode compiler.Opcode) uint8 {
 		return 0x2f
 	case compiler.OpcodeGoContextChainHop:
 		return 0x30
+	case compiler.OpcodeProcessGoTime:
+		return 0x31
 	default:
 		panic(fmt.Sprintf("unknown opcode: %s", opcode))
 	}

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -233,6 +233,8 @@ Package: main
 		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
 		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
 		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
+		Var: ist: *time.Location (declared at line 48, available: [49-49])
 	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
 		Arg: x: []int (declared at line 22, available: [22-25])
 	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
@@ -685,6 +687,8 @@ Package: main
 		Field: f: main.tierD
 	Type: main.tierD
 		Field: g: int
+	Type: main.timeCapture
+		Field: monotonicNow: time.Time
 	Type: main.tinyStruct
 		Field: Name: string
 	Type: main.triggerVerifierErrorForTesting
@@ -728,9 +732,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:85] injectible: [52-65], [67-68], [70-72], [74-75], [78-85]
-		Var: it: main.iterExample (declared at line 69, available: [52-85])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-85])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:86] injectible: [52-65], [67-68], [70-72], [74-76], [79-86]
+		Var: it: main.iterExample (declared at line 69, available: [52-86])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-86])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -1379,6 +1383,12 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
+		Arg: x: time.Time (declared at line 31, available: [31-31])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
+		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
+		Arg: x: time.Time (declared at line 27, available: [27-27])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -221,6 +221,8 @@ Package: main
 		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
 		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
 		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
+		Var: ist: *time.Location (declared at line 48, available: [49-49])
 	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
 		Arg: x: []int (declared at line 22, available: [22-25])
 	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
@@ -672,6 +674,8 @@ Package: main
 		Field: f: main.tierD
 	Type: main.tierD
 		Field: g: int
+	Type: main.timeCapture
+		Field: monotonicNow: time.Time
 	Type: main.tinyStruct
 		Field: Name: string
 	Type: main.triggerVerifierErrorForTesting
@@ -715,9 +719,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:85] injectible: [52-65], [67-68], [70-72], [74-75], [78-85]
-		Var: it: main.iterExample (declared at line 69, available: [52-85])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-85])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:86] injectible: [52-65], [67-68], [70-72], [74-76], [79-86]
+		Var: it: main.iterExample (declared at line 69, available: [52-86])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-86])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -1366,6 +1370,12 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
+		Arg: x: time.Time (declared at line 31, available: [31-31])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
+		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
+		Arg: x: time.Time (declared at line 27, available: [27-27])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -217,6 +217,8 @@ Package: main
 		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
 		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
 		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
+		Var: ist: *time.Location (declared at line 48, available: [49-49])
 	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
 		Arg: x: []int (declared at line 22, available: [22-25])
 	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
@@ -664,6 +666,8 @@ Package: main
 		Field: f: main.tierD
 	Type: main.tierD
 		Field: g: int
+	Type: main.timeCapture
+		Field: monotonicNow: time.Time
 	Type: main.tinyStruct
 		Field: Name: string
 	Type: main.triggerVerifierErrorForTesting
@@ -707,9 +711,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:85] injectible: [52-65], [67-68], [70-72], [74-75], [78-85]
-		Var: it: main.iterExample (declared at line 69, available: [52-85])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-85])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:86] injectible: [52-65], [67-68], [70-72], [74-76], [79-86]
+		Var: it: main.iterExample (declared at line 69, available: [52-86])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-86])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -1358,6 +1362,12 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
+		Arg: x: time.Time (declared at line 31, available: [31-31])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
+		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
+		Arg: x: time.Time (declared at line 27, available: [27-27])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -217,6 +217,8 @@ Package: main
 		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
 		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
 		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
+		Var: ist: *time.Location (declared at line 48, available: [49-49])
 	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
 		Arg: x: []int (declared at line 22, available: [22-25])
 	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
@@ -668,6 +670,8 @@ Package: main
 		Field: f: main.tierD
 	Type: main.tierD
 		Field: g: int
+	Type: main.timeCapture
+		Field: monotonicNow: time.Time
 	Type: main.tinyStruct
 		Field: Name: string
 	Type: main.triggerVerifierErrorForTesting
@@ -711,9 +715,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:85] injectible: [52-65], [67-68], [70-72], [74-75], [78-85]
-		Var: it: main.iterExample (declared at line 69, available: [52-85])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-85])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:86] injectible: [52-65], [67-68], [70-72], [74-76], [79-86]
+		Var: it: main.iterExample (declared at line 69, available: [52-86])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-86])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -1362,6 +1366,12 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
+		Arg: x: time.Time (declared at line 31, available: [31-31])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
+		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
+		Arg: x: time.Time (declared at line 27, available: [27-27])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -233,6 +233,8 @@ Package: main
 		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
 		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
 		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
+		Var: ist: *time.Location (declared at line 48, available: [49-49])
 	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
 		Arg: x: []int (declared at line 22, available: [22-25])
 	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
@@ -687,6 +689,8 @@ Package: main
 		Field: f: main.tierD
 	Type: main.tierD
 		Field: g: int
+	Type: main.timeCapture
+		Field: monotonicNow: time.Time
 	Type: main.tinyStruct
 		Field: Name: string
 	Type: main.triggerVerifierErrorForTesting
@@ -730,9 +734,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:85] injectible: [52-65], [67-68], [70-72], [74-75], [78-85]
-		Var: it: main.iterExample (declared at line 69, available: [52-85])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-85])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:86] injectible: [52-65], [67-68], [70-72], [74-76], [79-86]
+		Var: it: main.iterExample (declared at line 69, available: [52-86])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-86])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -1386,6 +1390,12 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
+		Arg: x: time.Time (declared at line 31, available: [31-31])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
+		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
+		Arg: x: time.Time (declared at line 27, available: [27-27])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -221,6 +221,8 @@ Package: main
 		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
 		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
 		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
+		Var: ist: *time.Location (declared at line 48, available: [49-49])
 	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
 		Arg: x: []int (declared at line 22, available: [22-25])
 	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
@@ -674,6 +676,8 @@ Package: main
 		Field: f: main.tierD
 	Type: main.tierD
 		Field: g: int
+	Type: main.timeCapture
+		Field: monotonicNow: time.Time
 	Type: main.tinyStruct
 		Field: Name: string
 	Type: main.triggerVerifierErrorForTesting
@@ -717,9 +721,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [44-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:85] injectible: [52-65], [67-68], [70-72], [74-75], [78-85]
-		Var: it: main.iterExample (declared at line 69, available: [52-85])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-85])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:86] injectible: [52-65], [67-68], [70-72], [74-76], [79-86]
+		Var: it: main.iterExample (declared at line 69, available: [52-86])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-86])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -1373,6 +1377,12 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
+		Arg: x: time.Time (declared at line 31, available: [31-31])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
+		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
+		Arg: x: time.Time (declared at line 27, available: [27-27])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -217,6 +217,8 @@ Package: main
 		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
 		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
 		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
+		Var: ist: *time.Location (declared at line 48, available: [49-50])
 	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
 		Arg: x: []int (declared at line 22, available: [22-23], [24-24], [25-25])
 	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
@@ -666,6 +668,8 @@ Package: main
 		Field: f: main.tierD
 	Type: main.tierD
 		Field: g: int
+	Type: main.timeCapture
+		Field: monotonicNow: time.Time
 	Type: main.tinyStruct
 		Field: Name: string
 	Type: main.triggerVerifierErrorForTesting
@@ -709,9 +713,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:85] injectible: [52-65], [67-68], [70-72], [74-75], [78-85]
-		Var: it: main.iterExample (declared at line 69, available: [52-85])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-85])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:86] injectible: [52-65], [67-68], [70-72], [74-76], [79-86]
+		Var: it: main.iterExample (declared at line 69, available: [52-86])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-86])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -1365,6 +1369,12 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
+		Arg: x: time.Time (declared at line 31, available: [31-31])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
+		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
+		Arg: x: time.Time (declared at line 27, available: [27-27])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -217,6 +217,8 @@ Package: main
 		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
 		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
 		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
+		Var: ist: *time.Location (declared at line 48, available: [49-50])
 	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
 		Arg: x: []int (declared at line 22, available: [22-23], [24-24], [25-25])
 	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
@@ -670,6 +672,8 @@ Package: main
 		Field: f: main.tierD
 	Type: main.tierD
 		Field: g: int
+	Type: main.timeCapture
+		Field: monotonicNow: time.Time
 	Type: main.tinyStruct
 		Field: Name: string
 	Type: main.triggerVerifierErrorForTesting
@@ -713,9 +717,9 @@ Package: main
 		Arg: ~r0: uint64 (declared at line 40, available: )
 		Var: n: uint64 (declared at line 45, available: [44-46])
 		Var: b: []uint8 (declared at line 41, available: [42-45])
-	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:85] injectible: [52-65], [67-68], [70-72], [74-75], [78-85]
-		Var: it: main.iterExample (declared at line 69, available: [52-85])
-		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-85])
+	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:86] injectible: [52-65], [67-68], [70-72], [74-76], [79-86]
+		Var: it: main.iterExample (declared at line 69, available: [52-86])
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 66, available: [52-86])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -1369,6 +1373,12 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
+		Arg: x: time.Time (declared at line 31, available: [31-31])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
+		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
+		Arg: x: time.Time (declared at line 27, available: [27-27])
 	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
 		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -112,7 +112,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -196,7 +196,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -280,7 +280,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -364,7 +364,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -448,7 +448,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -532,7 +532,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -611,7 +611,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -695,7 +695,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -780,7 +780,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -107,7 +107,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -187,7 +187,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -272,7 +272,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -357,7 +357,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -448,7 +448,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 78
+            "lineNumber": 79
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 78
+            "lineNumber": 79
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -134,7 +134,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -112,7 +112,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -125,7 +125,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -222,7 +222,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -319,7 +319,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -416,7 +416,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -102,7 +102,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -194,7 +194,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -286,7 +286,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -378,7 +378,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -672,7 +672,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
@@ -140,7 +140,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -116,7 +116,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -112,7 +112,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -117,7 +117,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -127,7 +127,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -218,7 +218,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -119,7 +119,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -112,7 +112,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -108,7 +108,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -189,7 +189,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -269,7 +269,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -350,7 +350,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",
@@ -425,7 +425,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",
@@ -107,7 +107,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",
@@ -196,7 +196,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",
@@ -135,7 +135,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",
@@ -118,7 +118,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",
@@ -112,7 +112,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",
@@ -211,7 +211,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 80
+            "lineNumber": 81
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTakeContext.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTakeContext.json
@@ -30,7 +30,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 83
+            "lineNumber": 84
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTimeFixedZone.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTimeFixedZone.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testReturnsNamedDeferLine",
+      "method": "main.testTimeFixedZone",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,19 +16,19 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testReturnsNamedDeferLine",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 121
+            "function": "main.testTimeFixedZone",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
+            "lineNumber": 31
           },
           {
-            "function": "main.executeReturns",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 414
+            "function": "main.executeTimeFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
+            "lineNumber": 51
           },
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 83
+            "lineNumber": 76
           },
           {
             "function": "main.main",
@@ -47,29 +47,17 @@
           }
         ],
         "probe": {
-          "id": "testReturnsNamedDeferLine",
+          "id": "testTimeFixedZone",
           "location": {
-            "method": "main.testReturnsNamedDeferLine",
-            "file": "returns.go",
-            "line": 121
+            "method": "main.testTimeFixedZone"
           }
         },
         "captures": {
-          "lines": {
-            "121": {
-              "locals": {
-                "i": {
-                  "type": "int",
-                  "value": "43"
-                },
-                "a": {
-                  "type": "string",
-                  "value": "a43"
-                },
-                "b": {
-                  "type": "string",
-                  "value": "b43"
-                }
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "time.Time",
+                "value": "2023-11-15T03:43:20.123456789+05:30"
               }
             }
           }
@@ -78,7 +66,7 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "43",
+    "message": "2023-11-15T03:43:20.123456789+05:30",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testTimeMonotonic.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTimeMonotonic.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testReturnsStructWithArray",
+      "method": "main.testTimeMonotonic",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,19 +16,19 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testReturnsStructWithArray",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 247
+            "function": "main.testTimeMonotonic",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
+            "lineNumber": 35
           },
           {
-            "function": "main.executeReturns",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 428
+            "function": "main.executeTimeFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
+            "lineNumber": 56
           },
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 83
+            "lineNumber": 76
           },
           {
             "function": "main.main",
@@ -47,34 +47,20 @@
           }
         ],
         "probe": {
-          "id": "testReturnsStructWithArray",
+          "id": "testTimeMonotonic",
           "location": {
-            "method": "main.testReturnsStructWithArray"
+            "method": "main.testTimeMonotonic"
           }
         },
         "captures": {
-          "return": {
-            "locals": {
-              "@return": {
-                "type": "main.structWithArray",
+          "entry": {
+            "arguments": {
+              "c": {
+                "type": "main.timeCapture",
                 "fields": {
-                  "arr": {
-                    "type": "[2]int",
-                    "size": "2",
-                    "elements": [
-                      {
-                        "type": "int",
-                        "value": "1"
-                      },
-                      {
-                        "type": "int",
-                        "value": "2"
-                      }
-                    ]
-                  },
-                  "x": {
-                    "type": "int",
-                    "value": "3"
+                  "monotonicNow": {
+                    "type": "time.Time",
+                    "value": "[monotonic-time]"
                   }
                 }
               }
@@ -85,8 +71,7 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "duration": "[duration]",
-    "message": "testReturnsStructWithArray",
+    "message": "{monotonicNow: [monotonic-time]}",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testTimeUTC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTimeUTC.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testReturnsNamedDeferLine",
+      "method": "main.testTimeUTC",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,19 +16,19 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testReturnsNamedDeferLine",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 121
+            "function": "main.testTimeUTC",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
+            "lineNumber": 27
           },
           {
-            "function": "main.executeReturns",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 414
+            "function": "main.executeTimeFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
+            "lineNumber": 42
           },
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 83
+            "lineNumber": 76
           },
           {
             "function": "main.main",
@@ -47,29 +47,17 @@
           }
         ],
         "probe": {
-          "id": "testReturnsNamedDeferLine",
+          "id": "testTimeUTC",
           "location": {
-            "method": "main.testReturnsNamedDeferLine",
-            "file": "returns.go",
-            "line": 121
+            "method": "main.testTimeUTC"
           }
         },
         "captures": {
-          "lines": {
-            "121": {
-              "locals": {
-                "i": {
-                  "type": "int",
-                  "value": "43"
-                },
-                "a": {
-                  "type": "string",
-                  "value": "a43"
-                },
-                "b": {
-                  "type": "string",
-                  "value": "b43"
-                }
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "time.Time",
+                "value": "2023-11-14T22:13:20.123456789Z"
               }
             }
           }
@@ -78,7 +66,7 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "message": "43",
+    "message": "2023-11-14T22:13:20.123456789Z",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
@@ -33,7 +33,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 79
+            "lineNumber": 80
           },
           {
             "function": "main.main",
@@ -122,7 +122,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",
@@ -197,7 +197,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -28,7 +28,7 @@
           {
             "function": "main.runAll",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 82
+            "lineNumber": 83
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -73,6 +73,7 @@ func runAll() {
 
 	executeContinuationFuncs()
 	executeContinuationStringFuncs()
+	executeTimeFuncs()
 
 	// unsupported for MVP, should not cause failures
 	executeEsoteric()

--- a/pkg/dyninst/testprogs/progs/sample/times.go
+++ b/pkg/dyninst/testprogs/progs/sample/times.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package main
+
+import "time"
+
+// testTimeUTC and testTimeFixedZone use literal Unix timestamps so the
+// captured instant is deterministic across runs; their snapshot values
+// are pinned in testdata.
+//
+// testTimeMonotonic captures time.Now() which carries a monotonic clock
+// reading. Its value is non-deterministic, so the test harness's redactor
+// asserts the captured timestamp falls within a known window and replaces
+// it with a sentinel.
+
+// timeCapture exists to give the monotonic time.Time a recognizable
+// field name (monotonicNow) so the redactor matcher can scope to it.
+type timeCapture struct {
+	monotonicNow time.Time
+}
+
+//nolint:all
+//go:noinline
+func testTimeUTC(x time.Time) {}
+
+//nolint:all
+//go:noinline
+func testTimeFixedZone(x time.Time) {}
+
+//nolint:all
+//go:noinline
+func testTimeMonotonic(c timeCapture) {}
+
+//nolint:all
+//go:noinline
+func executeTimeFuncs() {
+	// 2023-11-14T22:13:20Z (Unix 1_700_000_000) — past, no monotonic.
+	t := time.Unix(1_700_000_000, 123_456_789).UTC()
+	testTimeUTC(t)
+
+	// Same instant, observed through a +05:30 (IST) fixed zone. The
+	// captured loc pointer points at a process-local *Location whose
+	// cache must be warmed for the BPF fast path to find an offset; we
+	// warm it by calling Format() once.
+	ist := time.FixedZone("IST", 5*3600+30*60)
+	tIST := time.Unix(1_700_000_000, 123_456_789).In(ist)
+	_ = tIST.Format(time.RFC3339Nano)
+	testTimeFixedZone(tIST)
+
+	// time.Now() sets hasMonotonic; exercising it confirms the decoder
+	// extracts wall seconds from the packed 33-bit field rather than
+	// reading ext (which holds the monotonic delta in this case).
+	testTimeMonotonic(timeCapture{monotonicNow: time.Now()})
+}

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -2941,3 +2941,39 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 2
+  - id: testTimeUTC
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testTimeUTC
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
+    captureSnapshot: true
+  - id: testTimeFixedZone
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testTimeFixedZone
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
+    captureSnapshot: true
+  - id: testTimeMonotonic
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testTimeMonotonic
+    template: "{c}"
+    segments:
+      - json:
+          ref: "c"
+        dsl: "c"
+    captureSnapshot: true


### PR DESCRIPTION
### What does this PR do?

  Teaches the dyninst decoder to recognize time.Time values captured by probes and render them as RFC3339Nano timestamps (e.g. 2023-11-14T22:13:20.123456789Z) instead of leaking the private wall/ext bit layout through the generic struct
  decoder.

  Lands in two commits:

  1. Phase 1 — RFC3339Nano in UTC. Decoder-side only. Recognizes time.Time by name in pkg/dyninst/decode/types.go, mirrors time.Time.sec()/nsec() arithmetic to recover the Unix instant from the captured wall/ext bytes, formats with
  time.Unix(...).UTC().Format(time.RFC3339Nano). The loc pointer is dropped (it isn't captured today anyway — irgen leaves *time.Location as UnresolvedPointeeType).
  2. Phase 2 — honor the timezone offset. Cross-cutting change that chases the *time.Location pointer in BPF and writes the resolved UTC offset back into the captured struct.
    - New *ir.GoTimeType wraps the time.Time StructureType and carries the resolved cache field offsets.
    - irgen's completeGoTimeType recognizes the struct, force-resolves *time.Location's placeholder pointee, and reads cacheStart/cacheEnd/cacheZone/zone.offset DWARF offsets. If any field is missing the type degrades to a CacheResolved:
   false GoTimeType and the decoder still renders in UTC.
    - Compiler emits a new ProcessGoTimeOp (opcode 0x2f) in place of the generic struct walk, which suppresses the recursive loc-pointer chase that would otherwise dereference an entire Location tree.
    - BPF's SM_OP_PROCESS_GO_TIME reads (wall, ext, loc), reproduces the wall-time arithmetic, then walks the one-element Location cache fast path: bpf_probe_read_user of cacheStart/cacheEnd, window check, then cacheZone and zone.offset.
   The 8 bytes at the loc-pointer slot are overwritten in place with the resolved offset (or INT64_MIN as the "could not resolve" sentinel). Wire footprint stays at 24 bytes per time.Time.
    - Decode-side reads the int64 at the loc slot. Sentinel → render with Z; anything else → render with time.FixedZone("", int(off)).

###  Motivation

  Before this change, capturing a time.Time argument returned an opaque struct showing private fields (wall, ext, loc) — useless for debugging. Tools expecting a snapshot of "what time was this called at" got bytes they couldn't
  interpret.

  Reading the wall component directly was straightforward (Go's own Time.Unix()/Time.Format() derive it from wall alone when monotonic is set), so phase 1 was a localized decoder fix. Honoring the timezone the user attached to the value
  required more: it lives behind a heap pointer, and the obvious "let BPF chase it" approach risks dereferencing an unbounded Location tree (named zones with strings, tx transition tables, etc.). The cache-fast-path design in phase 2
  keeps the work bounded — two bpf_probe_read_user calls in the common case — and matches the user-visible behavior of Go's own Time.Format.

###  Describe how you validated your changes

  - Unit tests in pkg/dyninst/decode/time_test.go:
    - TestDecodeGoTime exercises decodeGoTime for monotonic time.Now(), non-monotonic time.Unix(...), the zero value, the Unix epoch, year 1900, year 2100, a time.Time constructed in a non-UTC location, and short-buffer fallback. Each
  case is built by writing a real time.Time into a byte buffer with unsafe.Pointer and round-tripping.
    - TestGoTimeTypeFormat exercises the full goTimeType.format() decoder path with synthetic 24-byte buffers: UTC sentinel renders Z, +3600s renders +01:00, -18000s renders -05:00, zero-time returns isZero, short buffer falls back to
  UTC.
  - End-to-end via a new pair of probes in pkg/dyninst/testprogs/progs/sample:
    - testTimeUTC captures time.Unix(1_700_000_000, 123_456_789).UTC() → snapshot value is "2023-11-14T22:13:20.123456789Z".
    - testTimeFixedZone captures the same instant .In(time.FixedZone("IST", 5*3600+30*60)) after a Format() call warms the Location cache → snapshot value is "2023-11-15T03:43:20.123456789+05:30".
  - Full pkg/dyninst/... test suite passes on the ubuntu-22 VM after rebuilding testprogs and BPF objects (dda inv system-probe.build-dyninst-test-programs system-probe.build-object-files) and running sudo -E go test -tags linux_bpf,test
   -short -count=1 ./pkg/dyninst/....
  - BPF verifier load-tested on all toolchains the integration test exercises (go1.23.11, go1.24.3, go1.25.0, go1.26rc1; amd64 and arm64 binaries built; verifier runs at probe attach time on the test kernel).

 ### Additional Notes

https://datadoghq.atlassian.net/browse/DEBUG-4452