### PR TITLE
fix(e2e-framework): cleanup leaks when SetupSuite fails

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -204,6 +204,7 @@ new-e2e-unit-tests:
   script:
     - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - dda inv -- -e new-e2e-tests.run --module-name test/e2e-framework --targets ./testing/utils --tags "e2eunit" --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS}
+    - dda inv -- -e new-e2e-tests.run --module-name test/e2e-framework --targets ./testing/e2e --tags "e2eunit" --junit-tar junit-${CI_JOB_ID}-suite.tgz ${EXTRA_PARAMS}
     - dda inv -- -e new-e2e-tests.run --module-name test/new-e2e --targets ./tests/windows/common/agent --tags "e2eunit" --no-recursive --junit-tar junit-${CI_JOB_ID}-win-agent.tgz ${EXTRA_PARAMS}
     - dda inv -- -e new-e2e-tests.run --module-name test/new-e2e --targets ./tests/installer/windows --tags "e2eunit" --no-recursive --junit-tar junit-${CI_JOB_ID}-win-installer.tgz ${EXTRA_PARAMS}
   after_script:

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -214,6 +214,14 @@ type BaseSuite[Env any] struct {
 	coverageOutDir string
 
 	outputDir string
+
+	// cleanupCalled is true once TearDownSuite has executed (regardless of caller). Used by
+	// the t.Cleanup hook registered in SetupSuite to skip cleanup when testify or a
+	// derived-suite defer has already handled it. testify calls TearDownSuite reliably on
+	// every path *except* SetupSuite failure (testify suite.go:214 defers TearDownSuite
+	// after SetupSuite returns, so a Goexit during setup never registers the defer); the
+	// t.Cleanup hook covers that one gap.
+	cleanupCalled bool
 }
 
 //
@@ -267,9 +275,17 @@ func (bs *BaseSuite[Env]) EventuallyWithTf(condition func(*assert.CollectT), wai
 	}, waitFor, tick, msg, args...)
 }
 
-// CleanupOnSetupFailure is a helper to cleanup on setup failure
-// It should be defered in `SetupSuite` if you override it in your custom test suite.
-// When deferred, any panic or assertion failure will stop the test execution and call `TearDownSuite`.
+// CleanupOnSetupFailure is a helper to cleanup on setup failure.
+//
+// BaseSuite registers a `t.Cleanup` hook that invokes this method automatically when
+// SetupSuite fails to complete, so derived suites do not need to `defer` it themselves.
+// Existing `defer s.CleanupOnSetupFailure()` callers continue to work; on the rare path
+// where both fire, `provisioner.Destroy` is idempotent so duplicate calls are harmless.
+//
+// When called from a `defer`, `recover()` captures any panic in the deferring frame; in
+// that case the panic is consumed here (testify's outer recoverAndFailOnPanic will not see
+// it). When called from the t.Cleanup hook, `recover()` returns nil and we fall through to
+// the `T().Failed()` branch.
 func (bs *BaseSuite[Env]) CleanupOnSetupFailure() {
 	if err := recover(); err != nil || bs.T().Failed() {
 		bs.firstFailTest = "Initial provisioning SetupSuite" // This is required to handle skipDeleteOnFailure
@@ -601,7 +617,8 @@ func (bs *BaseSuite[Env]) providerContext(opTimeout time.Duration) (context.Cont
 // This function is called by [testify Suite].
 //
 // If you override SetupSuite in your custom test suite type, the function must call [e2e.BaseSuite.SetupSuite].
-// Please also call `defer bs.CleanupOnSetupFailure()` in your `SetupSuite` implementation. It is needed to make sure that we cleanup on panic or on SetupSuite failure.
+// The framework registers a `t.Cleanup` hook that handles cleanup on `SetupSuite` failure
+// (panic or `T.FailNow`), so derived suites do not need to add a defer themselves.
 //
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (bs *BaseSuite[Env]) SetupSuite() {
@@ -612,6 +629,23 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 		bs.T().Skip("TEARDOWN_ONLY is set, skipping setup and tests")
 		return
 	}
+
+	// Register a t.Cleanup hook that invokes CleanupOnSetupFailure if testify never gets
+	// the chance to call TearDownSuite. testify's own defer of TearDownSuite (testify
+	// suite.go:214) is registered *after* SetupSuite returns, so a panic or T.FailNow in
+	// any SetupSuite layer (framework or derived override) leaves the goroutine without
+	// ever invoking it. t.Cleanup runs against the *testing.T regardless of how the test
+	// goroutine terminates, so it is robust to Goexit/panic during setup. The cleanupCalled
+	// flag (set at the start of TearDownSuite) ensures the hook is a no-op when testify
+	// or a legacy `defer s.CleanupOnSetupFailure()` already handled cleanup. When the hook
+	// does invoke CleanupOnSetupFailure, recover() returns nil and we fall through to its
+	// T().Failed() branch to run the diagnose + TearDownSuite + T.Fatal sequence.
+	bs.T().Cleanup(func() {
+		if bs.cleanupCalled {
+			return
+		}
+		bs.CleanupOnSetupFailure()
+	})
 
 	// Create the root output directory for the test suite session
 	sessionDirectory, err := runner.GetProfile().CreateOutputSubDir(bs.getSuiteSessionSubdirectory())
@@ -624,10 +658,6 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 	}
 	bs.outputDir = sessionDirectory
 	utils.Logf(bs.T(), "Suite session output directory: %s", bs.outputDir)
-	// In `SetupSuite` we cannot fail as `TearDownSuite` will not be called otherwise.
-	// Meaning that stack clean up may not be called.
-	// We do implement an explicit recover to handle this manuallay.
-	defer bs.CleanupOnSetupFailure()
 
 	// Setup Datadog Client to be used to send telemetry when writing e2e tests
 	apiKey, err := runner.GetProfile().SecretStore().Get(parameters.APIKey)
@@ -720,8 +750,17 @@ func (bs *BaseSuite[Env]) IsWithinCI() bool {
 //
 // If you override TearDownSuite in your custom test suite type, the function must call [e2e.BaseSuite.TearDownSuite].
 //
+// Idempotent: a `cleanupCalled` flag is set on the first call so subsequent calls return
+// early. This coordinates the various paths that reach cleanup — testify's normal
+// after-tests defer, the t.Cleanup hook in SetupSuite, the legacy
+// `defer s.CleanupOnSetupFailure()` in derived suites — to result in exactly one teardown.
+//
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (bs *BaseSuite[Env]) TearDownSuite() {
+	if bs.cleanupCalled {
+		return
+	}
+	bs.cleanupCalled = true
 	bs.endTime = time.Now()
 
 	if bs.params.devMode {
@@ -752,13 +791,18 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 	defer cancel()
 
 	for id, provisioner := range bs.originalProvisioners {
-		// Run provisioner Diagnose before tearing down the stack
-		stackName, err := infra.GetStackManager().GetPulumiStackName(bs.params.stackName)
-		if err != nil {
-			utils.Logf(bs.T(), "unable to get stack name for diagnose, err: %v", err)
-			continue
+		// Look up the Pulumi stack name for the diagnose and remote-cleanup paths. The
+		// local Destroy path uses bs.params.stackName directly and does not depend on
+		// this lookup, so a failure here must NOT skip Destroy. In practice this lookup
+		// only fails when no Pulumi state exists (e.g. our unit tests with mock
+		// provisioners).
+		stackName, stackNameErr := infra.GetStackManager().GetPulumiStackName(bs.params.stackName)
+		if stackNameErr != nil {
+			utils.Logf(bs.T(), "unable to get pulumi stack name (used by diagnose / remote cleanup): %v", stackNameErr)
 		}
-		if diagnosableProvisioner, ok := provisioner.(provisioners.Diagnosable); ok && !bs.teardownOnly {
+
+		// Run provisioner Diagnose before tearing down the stack. Requires the looked-up stack name.
+		if diagnosableProvisioner, ok := provisioner.(provisioners.Diagnosable); ok && !bs.teardownOnly && stackNameErr == nil {
 			utils.Logf(bs.T(), "Running Diagnose for provisioner %s", id)
 			diagnoseResult, diagnoseErr := diagnosableProvisioner.Diagnose(ctx, stackName)
 			if diagnoseErr != nil {
@@ -772,6 +816,11 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 		}
 
 		if bs.IsWithinCI() && os.Getenv("REMOTE_STACK_CLEANING") == "true" {
+			// Remote cleanup requires the looked-up Pulumi stack name. Skip if unavailable.
+			if stackNameErr != nil {
+				utils.Logf(bs.T(), "skipping remote stack cleaning because pulumi stack name lookup failed")
+				continue
+			}
 			fullStackName := "organization/e2eci/" + stackName
 			utils.Logf(bs.T(), "Remote stack cleaning enabled for stack %s", fullStackName)
 

--- a/test/e2e-framework/testing/e2e/suite_test.go
+++ b/test/e2e-framework/testing/e2e/suite_test.go
@@ -110,7 +110,15 @@ func TestProvisioningSequence(t *testing.T) {
 	tempProvisioner.On("ID").Return("temp")
 	tempProvisioner.On("Provision", mock.Anything, mock.Anything, mock.Anything).Return(testRawResources("myWrapper2", "temp"), nil)
 
-	Run(t, &testSuiteWithTests{permanentProvisioner: permanentProvisioner, tempProvisioner: tempProvisioner}, WithProvisioner(permanentProvisioner), WithProvisioner(tempProvisioner))
+	s := &testSuiteWithTests{permanentProvisioner: permanentProvisioner, tempProvisioner: tempProvisioner}
+	Run(t, s, WithProvisioner(permanentProvisioner), WithProvisioner(tempProvisioner))
+
+	// TearDownSuite ran after the last test method. Verify final Destroy counts:
+	// permanent destroyed once (TearDownSuite); temp destroyed twice (once mid-suite
+	// by UpdateEnv in TestOrderA, then re-provisioned at the start of TestOrderB and
+	// destroyed again by TearDownSuite).
+	permanentProvisioner.AssertNumberOfCalls(t, "Destroy", 1)
+	tempProvisioner.AssertNumberOfCalls(t, "Destroy", 2)
 }
 
 func (s *testSuiteWithTests) TestOrderA() {
@@ -128,13 +136,20 @@ func (s *testSuiteWithTests) TestOrderA() {
 	s.tempProvisioner.AssertNumberOfCalls(s.T(), "Provision", 1)
 
 	// Remove temp provisioner, destroy should be called.
-	// `Provide` will be called again on permanent provisioner
-	// The call will panic because missing resource `myWrapper2`
+	// `Provide` will be called again on permanent provisioner.
+	// The call will fail because of missing resource `myWrapper2`.
+	//
+	// We call reconcileEnv directly here instead of UpdateEnv: UpdateEnv calls
+	// bs.T().Fail() before panicking on reconcile errors (added in PR #35167 for the
+	// skipDeleteOnFailure flow), which would mark this test as failed even though the
+	// failure is the expected outcome we're asserting against.
 	s.tempProvisioner.On("Destroy", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	s.Assert().PanicsWithError(
-		"unable to build env: *e2e.testEnv from resources for stack: e2e-testSuiteWithTests-e3e6e49fc651fcb8, err: expected resource named: Wrapper2 with key: myWrapper2 but not returned by provisioners",
-		func() { s.UpdateEnv(s.permanentProvisioner) },
+	expectedErr := fmt.Sprintf(
+		"unable to build env: *e2e.testEnv from resources for stack: %s, err: expected resource named: Wrapper2 with key: myWrapper2 but not returned by provisioners",
+		s.params.stackName,
 	)
+	err := s.reconcileEnv(provisioners.ProvisionerMap{s.permanentProvisioner.ID(): s.permanentProvisioner})
+	s.Assert().EqualError(err, expectedErr)
 
 	s.permanentProvisioner.AssertExpectations(s.T())
 	s.permanentProvisioner.AssertNumberOfCalls(s.T(), "Provision", 2)
@@ -160,4 +175,64 @@ func (s *testSuiteWithTests) TestOrderC() {
 	s.permanentProvisioner.AssertNumberOfCalls(s.T(), "Provision", 3)
 	s.tempProvisioner.AssertNumberOfCalls(s.T(), "Provision", 2)
 	s.tempProvisioner.AssertNumberOfCalls(s.T(), "Destroy", 1)
+
+	// Register Destroy expectation on permanent here (last test method before
+	// TearDownSuite). Doing it earlier would trip mid-test AssertExpectations calls,
+	// since AssertExpectations demands every registered On() to have fired.
+	s.permanentProvisioner.On("Destroy", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+}
+
+// testNoOpSuite is a BaseSuite with a single no-op test method. The no-op is required
+// because testify's suite.Run skips SetupSuite/TearDownSuite when no test methods exist.
+type testNoOpSuite struct {
+	BaseSuite[testEnv]
+}
+
+func (s *testNoOpSuite) TestNoOp() {}
+
+func makeTestEnvResources() provisioners.RawResources {
+	resources := testRawResources("myWrapper1", "x")
+	resources.Merge(testRawResources("myWrapper2", "y"))
+	return resources
+}
+
+// TestTearDownSuiteIdempotent verifies the cleanupCalled guard:
+//   - testify's post-test defer runs TearDownSuite once, calling Destroy.
+//   - A second direct TearDownSuite call observes cleanupCalled and short-circuits
+//     without calling Destroy again.
+func TestTearDownSuiteIdempotent(t *testing.T) {
+	p := &testProvisioner{}
+	p.On("ID").Return("test")
+	p.On("Provision", mock.Anything, mock.Anything, mock.Anything).Return(makeTestEnvResources(), nil)
+	p.On("Destroy", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	s := &testNoOpSuite{}
+	Run(t, s, WithProvisioner(p))
+
+	p.AssertNumberOfCalls(t, "Destroy", 1)
+	require.True(t, s.cleanupCalled, "cleanupCalled should be true after TearDownSuite ran")
+
+	// Second TearDownSuite call must observe the guard and not call Destroy again.
+	s.TearDownSuite()
+	p.AssertNumberOfCalls(t, "Destroy", 1)
+}
+
+// TestTCleanupHookIsNoOpAfterNormalTeardown verifies the happy-path behavior of the
+// t.Cleanup hook registered by SetupSuite:
+//   - Suite runs as a sub-test so the hook fires when the sub-test completes.
+//   - testify already ran TearDownSuite normally, so cleanupCalled is true.
+//   - The hook observes the guard and must not call Destroy a second time.
+func TestTCleanupHookIsNoOpAfterNormalTeardown(t *testing.T) {
+	p := &testProvisioner{}
+	p.On("ID").Return("test")
+	p.On("Provision", mock.Anything, mock.Anything, mock.Anything).Return(makeTestEnvResources(), nil)
+	p.On("Destroy", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	t.Run("inner", func(subT *testing.T) {
+		Run(subT, &testNoOpSuite{}, WithProvisioner(p))
+	})
+
+	// The t.Cleanup hook fired after the sub-test completed. If it had erroneously
+	// re-run cleanup, Destroy would have been called twice.
+	p.AssertNumberOfCalls(t, "Destroy", 1)
 }


### PR DESCRIPTION
### What does this PR do?

Replaces the per-suite `defer s.CleanupOnSetupFailure()` convention with a `t.Cleanup` hook registered by `BaseSuite.SetupSuite`. The hook fires guaranteed-once via the testing runtime regardless of how the suite goroutine terminates (normal return, `T.FailNow`/`Goexit`, panic), so cleanup runs even when a derived `SetupSuite` override does post-parent work that fails. A `cleanupCalled` guard on `TearDownSuite` coordinates the new hook with testify's post-test defer and any legacy `defer s.CleanupOnSetupFailure()` callers, keeping teardown idempotent.

Also includes two pre-existing regressions discovered while writing the validation tests:

- `TearDownSuite` no longer skips local `Destroy` when the Pulumi stack-name lookup fails. Regressed in #37357 — only the diagnose and remote-cleanup paths actually need the looked-up name; the local `Destroy` path uses `bs.params.stackName` directly. Though I wonder if this only applies to unit tests rather than real cases.
- `TestProvisioningSequence` rewired so the panic-on-bad-resources path uses `reconcileEnv` directly rather than `UpdateEnv`. `UpdateEnv` calls `bs.T().Fail()` before panicking (added in #35167 to support `skipDeleteOnFailure`), which silently broke the existing `PanicsWithError` assertion. While here, the hardcoded stack-name hash literal was replaced with `s.params.stackName` (it had been stale since the package move out of `test/new-e2e/`).

Adds two unit tests (`TestTearDownSuiteIdempotent`, `TestTCleanupHookIsNoOpAfterNormalTeardown`) for the cleanup guard and the t.Cleanup hook.

Extends the `tests_e2e_e2e_tests` GitLab job to run `./testing/e2e/...` under the `e2eunit` tag. That directory had not been part of CI since the move out of `test/new-e2e/pkg/e2e`, which is why both regressions above went undetected for 10-14 months.

### Motivation

Failures during `SetupSuite` skip `TearDownSuite` (testify registers it after `SetupSuite` returns at testify suite.go:214), so any Pulumi stack created mid-setup is orphaned until `stackcleaner-worker` reclaims it ~24h later. The existing `CleanupOnSetupFailure` workaround required every overriding suite to remember a `defer`; an audit found 7 files missing it. The `t.Cleanup` hook removes the requirement entirely — derived suites no longer need to think about it.

### Describe how you validated your changes

- Temporary derived-suite `SetupSuite`-failure test (removed before this commit) was used to manually validate the hook: with the hook disabled, `cleanupCalled` stays `false` and `Destroy` is never called; with the hook enabled, the full `CleanupOnSetupFailure → TearDownSuite → Destroy` chain runs. Removed because it required the `bs.T().Fail()` call which meant the unit test would always fail.

### Additional Notes

The 23 existing `defer s.CleanupOnSetupFailure()` callers under `test/new-e2e/tests/` continue to work unchanged; they become harmless no-ops because of the `cleanupCalled` guard. Removing them is mechanical churn best done as a follow-up.