### PR TITLE
chore(adp): revert having datadog-agent-data-plane service include PartOf datadog-agent

### DIFF
--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-data-plane.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-data-plane.service.tmpl
@@ -3,13 +3,11 @@
 Description=Datadog Agent Data Plane
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-PartOf=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-data-plane-exp.service
 {{- else}}
 Description=Datadog Agent Data Plane Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-PartOf=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-data-plane.service
 {{- end}}
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-data-plane-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-data-plane-exp.service
@@ -2,7 +2,6 @@
 Description=Datadog Agent Data Plane Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-PartOf=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-data-plane.service
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-data-plane.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-data-plane.service
@@ -2,7 +2,6 @@
 Description=Datadog Agent Data Plane
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-PartOf=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-data-plane-exp.service
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-data-plane-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-data-plane-exp.service
@@ -2,7 +2,6 @@
 Description=Datadog Agent Data Plane Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-PartOf=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-data-plane.service
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-data-plane.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-data-plane.service
@@ -2,7 +2,6 @@
 Description=Datadog Agent Data Plane
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-PartOf=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-data-plane-exp.service
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-data-plane-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-data-plane-exp.service
@@ -2,7 +2,6 @@
 Description=Datadog Agent Data Plane Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-PartOf=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-data-plane.service
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-data-plane.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-data-plane.service
@@ -2,7 +2,6 @@
 Description=Datadog Agent Data Plane
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-PartOf=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-data-plane-exp.service
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-data-plane-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-data-plane-exp.service
@@ -2,7 +2,6 @@
 Description=Datadog Agent Data Plane Experiment
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
-PartOf=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-data-plane.service
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-data-plane.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-data-plane.service
@@ -2,7 +2,6 @@
 Description=Datadog Agent Data Plane
 After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
-PartOf=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-data-plane-exp.service
 
 [Service]


### PR DESCRIPTION
Reverts DataDog/datadog-agent#50526

Turns out that `BindsTo` already guarantees this in a stronger fashion (it'll also stop ADP if the Agent service dies or exits on its own where `PartOf` doesn't) so `PartOf` isn't necessary.