### PR TITLE
test(e2e): restore Windows VM disk throughput to 400 MiB/s

### DIFF
--- a/test/e2e-framework/scenarios/aws/ec2/vm.go
+++ b/test/e2e-framework/scenarios/aws/ec2/vm.go
@@ -152,12 +152,11 @@ func defaultVMArgs(e aws.Environment, vmArgs *vmArgs) error {
 		}
 	}
 
-	// TODO: disabled for now while testing diffrent instance types
-	// if vmArgs.volumeThroughput == 0 && vmArgs.osInfo.Family() == os.WindowsFamily {
-	// 	// Increase throughput for Windows instances to 400 MiB/s to reduce test flakiness
-	// 	// May be able to lower this if we can disable some on-boot services in custom AMIs
-	// 	vmArgs.volumeThroughput = 400
-	// }
+	if vmArgs.volumeThroughput == 0 && vmArgs.osInfo.Family() == os.WindowsFamily {
+		// Increase throughput for Windows instances to 400 MiB/s to reduce test flakiness
+		// May be able to lower this if we can disable some on-boot services in custom AMIs
+		vmArgs.volumeThroughput = 400
+	}
 
 	// macOS dedicated host defaults
 	if vmArgs.osInfo.Family() == os.MacOSFamily {


### PR DESCRIPTION
### What does this PR do?

Re-enables the GP3 root volume throughput bump from 125 to 400 MiB/s for Windows E2E test instances in `test/e2e-framework/scenarios/aws/ec2/vm.go`. This had been commented out while testing different instance types.

### Motivation

Windows E2E tests are still hitting `Disk: throughput exceeded` checks frequently even after bumping the instance RAM to 8 GB. See investigation notebook: https://app.datadoghq.com/notebook/13871685/2026-02-windows-e2e-agent-timeout-disk-throughput-investigation

### Describe how you validated your changes

Code change only — restores prior default behavior that was in place before the experiment.