### PR TITLE
Move NCM config to network_devices config tree.

### DIFF
--- a/comp/forwarder/eventplatform/impl/epforwarder.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder.go
@@ -230,7 +230,7 @@ func getPassthroughPipelines() []passthroughPipelineDesc {
 			eventType:                     eventplatform.EventTypeNetworkConfigManagement,
 			category:                      "Network Config Management",
 			contentType:                   logshttp.JSONContentType,
-			endpointsConfigPrefix:         "network_config_management.forwarder.",
+			endpointsConfigPrefix:         "network_devices.config_management.forwarder.",
 			hostnameEndpointPrefix:        "ndm-intake.",
 			intakeTrackType:               "ndmconfig",
 			defaultBatchMaxConcurrentSend: 10,

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig.go
@@ -49,7 +49,7 @@ type networkDeviceConfigImpl struct {
 
 // NewComponent creates a new networkconfigmanagement component
 func NewComponent(reqs Requires) (Provides, error) {
-	enabled := reqs.Config.GetBool("network_config_management.rollback.enabled")
+	enabled := reqs.Config.GetBool("network_devices.config_management.rollback.enabled")
 	if !enabled {
 		return NewNoopComponent()
 	}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -285,8 +285,8 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	bindEnvAndSetLogsConfigKeys(config, "network_path.forwarder.")
 
 	// Network Config Management
-	bindEnvAndSetLogsConfigKeys(config, "network_config_management.forwarder.")
-	config.BindEnvAndSetDefault("network_config_management.rollback.enabled", false)
+	bindEnvAndSetLogsConfigKeys(config, "network_devices.config_management.forwarder.")
+	config.BindEnvAndSetDefault("network_devices.config_management.rollback.enabled", false)
 
 	// HA Agent
 	config.BindEnvAndSetDefault("ha_agent.enabled", false)

--- a/test/e2e-framework/components/datadog/agentparams/params.go
+++ b/test/e2e-framework/components/datadog/agentparams/params.go
@@ -10,12 +10,13 @@ import (
 	"path"
 	"strings"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	perms "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams/filepermissions"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // Params defines the parameters for the Agent installation.
@@ -288,8 +289,8 @@ network_devices.netflow.forwarder.logs_dd_url: %[1]s:%[2]d
 network_devices.netflow.forwarder.logs_no_ssl: true
 network_path.forwarder.logs_dd_url: %[1]s:%[2]d
 network_path.forwarder.logs_no_ssl: true
-network_config_management.forwarder.logs_dd_url: %[1]s:%[2]d
-network_config_management.forwarder.logs_no_ssl: true
+network_devices.config_management.forwarder.logs_dd_url: %[1]s:%[2]d
+network_devices.config_management.forwarder.logs_no_ssl: true
 synthetics.forwarder.logs_dd_url: %[1]s:%[2]d
 synthetics.forwarder.logs_no_ssl: true
 container_lifecycle.logs_dd_url: %[1]s:%[2]d


### PR DESCRIPTION
### What does this PR do?

This changes the configuration path for NCM, placing it under the `network_devices` config subtree alongside other network device management configuration.

### Motivation

We want all the NDM-related config from datadog.yaml to be in the same place.

### Describe how you validated your changes

Locally running the check against a virtual router.

### Additional Notes

This is not a generally released feature yet, and only the little-used forwarder config existed prior to a few days ago, so I don't believe we need a changelog entry for this - no users should have these config values set anyway.

I didn't include the results of running `inv schema.generate` because that made a number of other changes unrelated to this; let me know if I should re-run that anyway.