### PR TITLE
test/new-e2e/tests/autoscaling/spot: avoid duplicated DD_LOG_LEVEL entry

### DIFF
--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -76,8 +76,6 @@ clusterAgent:
     enabled: true
     mutateUnlabelled: false
   env:
-    - name: DD_LOG_LEVEL
-      value: "DEBUG"
     - name: DD_AUTOSCALING_CLUSTER_SPOT_DEFAULTS_PERCENTAGE
       value: "100"
     - name: DD_AUTOSCALING_CLUSTER_SPOT_DEFAULTS_MIN_ON_DEMAND_REPLICAS
@@ -100,6 +98,7 @@ agents:
 clusterChecksRunner:
   enabled: false
 datadog:
+  logLevel: DEBUG
   logs:
     enabled: true
     containerCollectAll: false


### PR DESCRIPTION
### What does this PR do?

Replaces `DD_LOG_LEVEL: DEBUG` from `clusterAgent.env` with `datadog.logLevel: DEBUG` in the `datadog:` section. This is intended to avoid a conflict between conflicting `INFO` and `DEBUG` settings for that variable.

### Motivation

These tests have had a high rate of failure since their [introduction](https://github.com/DataDog/datadog-agent/pull/49985): [dd link](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22new-e2e-autoscaling%22&agg_m=%40ci.job.name&agg_m_source=base&agg_t=cardinality&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cipipeline_explorer_sort=timestamp%2Casc&colorByAttr=meta%5B%27ci.stage.name%27%5D&cols=%40git.branch%2C%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40ci.stage.name%2C%40ci.job.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name&currentTab=trace&fromUser=false&graphType=flamegraph&index=cipipeline&mode=sliding&refresh_mode=sliding&sort=time&spanViewType=metadata&step=86400000&tab=overview&viz=stream&start=1773561982332&end=1778745982332&paused=false).

Example failure: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1682332182

It looks like this is caused by duplicated contradictory `DD_LOG_LEVEL` entries.

```
Error: Helm Release datadog/dda-linux: cannot patch "dda-linux-datadog-cluster-agent" with kind Deployment: The order in patch list:
           [map[name:DD_LOG_LEVEL value:INFO] map[name:DD_LOG_LEVEL value:DEBUG] map[name:DD_LEADER_ELECTION_DEFAULT_RESOURCE value:]]
           doesn't match $setElementOrder list:
```

This is possibly due to the default here being `INFO`: https://github.com/DataDog/helm-charts/blob/ec583a6513900d946ccbe90a63a95835d11f55de/charts/datadog/values.yaml#L165

### Describe how you validated your changes

Passing CI.

### Additional Notes

The author is not familiar with helm charts nor this domain, the investigation was heavily Claude-assisted.