### PR TITLE
[AMCC-192] Only run tag filter when ADP is enabled.

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -81,6 +81,9 @@ type contextResolver struct {
 	// tagFilterCache maps a pre-filter contextKey to the post-filter (contextKey, taggerKey, metricKey).
 	// This avoids repeated RetainFunc calls for metrics we have already processed.
 	tagFilterCache *tagFilterCache
+	// tagFilterEnabled controls whether metric_tag_filterlist tag stripping is applied.
+	// True when data_plane.enabled is true, or metric_tag_filterlist_adp_only is false.
+	tagFilterEnabled bool
 }
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
@@ -89,6 +92,9 @@ func (cr *contextResolver) generateContextKey(metricSampleContext metrics.Metric
 }
 
 func newContextResolver(tagger tagger.Component, cache *tags.Store, id string) *contextResolver {
+	cfg := pkgconfigsetup.Datadog()
+	adpEnabled := cfg.GetBool("data_plane.enabled")
+	adpOnly := cfg.GetBool("metric_tag_filterlist_adp_only")
 	return &contextResolver{
 		id:               id,
 		contextsByKey:    make(map[ckey.ContextKey]resolverEntry),
@@ -101,7 +107,8 @@ func newContextResolver(tagger tagger.Component, cache *tags.Store, id string) *
 		keyGenerator:     ckey.NewKeyGenerator(),
 		taggerBuffer:     tagset.NewHashingTagsAccumulator(),
 		metricBuffer:     tagset.NewHashingTagsAccumulator(),
-		tagFilterCache:   newTagFilterCache(pkgconfigsetup.Datadog().GetInt("aggregator_tag_filter_cache_capacity")),
+		tagFilterCache:   newTagFilterCache(cfg.GetInt("aggregator_tag_filter_cache_capacity")),
+		tagFilterEnabled: adpEnabled || !adpOnly,
 	}
 }
 
@@ -114,7 +121,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 
 	contextKey, taggerKey, metricKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates (and doesn't mind the order)
 
-	if filterList != nil && shouldAggregateTags(metricSampleContext) {
+	if filterList != nil && cr.tagFilterEnabled && shouldAggregateTags(metricSampleContext) {
 		if tagMatcher, filter := filterList.ShouldStripTags(metricSampleContext.GetName()); filter {
 			contextKey, taggerKey, metricKey = cr.filterTags(metricSampleContext, tagMatcher, contextKey)
 		}

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -21,6 +21,7 @@ import (
 	filterlistimpl "github.com/DataDog/datadog-agent/comp/filterlist/impl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	taggertypespkg "github.com/DataDog/datadog-agent/pkg/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
@@ -321,6 +322,7 @@ func setupTagger(t *testing.T) tagger.Component {
 // testStrippingOriginTagsSameKey checks that two samples whose only difference is
 // in origin tags covered by the strip list resolve to the same context key.
 func testStrippingOriginTagsSameKey(t *testing.T, store *tags.Store) {
+	configmock.New(t).SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	cases := []struct {
 		metricName string
 		mtype      metrics.MetricType
@@ -370,6 +372,7 @@ func TestStrippingOriginTagsSameKey(t *testing.T) {
 // testStrippingOriginTagsDiffersKey checks that when the strip list does not cover
 // all differing origin tags, contexts remain distinct.
 func testStrippingOriginTagsDiffersKey(t *testing.T, store *tags.Store) {
+	configmock.New(t).SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	cases := []struct {
 		metricName string
 		mtype      metrics.MetricType
@@ -417,6 +420,7 @@ func TestStrippingOriginTagsDiffersKey(t *testing.T) {
 // are stripped together for Distribution. Samples differ on a metric tag ("thing")
 // AND on origin container; both are in the strip list, so they collapse to one key.
 func testTrackContextStrippingMetricTags(t *testing.T, store *tags.Store) {
+	configmock.New(t).SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	matcher := filterlistimpl.NewTagMatcher(map[string]filterlistimpl.MetricTagList{
 		"distribution.metric": {
 			Tags:   []string{"env", "pod_name", "thing"},
@@ -466,6 +470,7 @@ func TestTrackContextStrippingMetricTags(t *testing.T) {
 // testStrippingMetricTagsSameKey checks that two samples whose only difference is
 // in metric tags covered by the strip list resolve to the same context key.
 func testStrippingMetricTagsSameKey(t *testing.T, store *tags.Store) {
+	configmock.New(t).SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	cases := []struct {
 		metricName string
 		mtype      metrics.MetricType
@@ -518,6 +523,7 @@ func TestStrippingMetricTagsSameKey(t *testing.T) {
 // strip list, samples remain in separate contexts even when other tags differ and
 // are stripped.
 func testStrippingMetricTagsDiffersKey(t *testing.T, store *tags.Store) {
+	configmock.New(t).SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	cases := []struct {
 		metricName string
 		mtype      metrics.MetricType
@@ -678,4 +684,65 @@ func TestShouldAggregateTags(t *testing.T) {
 			assert.Equal(t, want, shouldAggregateTags(ms))
 		})
 	}
+}
+
+// tagFilterEnabledCases covers all combinations of data_plane.enabled and
+// metric_tag_filterlist_adp_only, verifying when tag stripping is active.
+//
+// Filtering is active iff: adpEnabled || !adpOnly
+var tagFilterEnabledCases = []struct {
+	name             string
+	adpEnabled       bool
+	adpOnly          bool
+	filteringEnabled bool
+}{
+	{"adp_disabled_adp_only_true", false, true, false},
+	{"adp_enabled_adp_only_true", true, true, true},
+	{"adp_disabled_adp_only_false", false, false, true},
+	{"adp_enabled_adp_only_false", true, false, true},
+}
+
+// testTagFilterADPGate verifies that tag stripping respects the data_plane.enabled
+// and metric_tag_filterlist_adp_only config values.
+func testTagFilterADPGate(t *testing.T, store *tags.Store) {
+	for _, tc := range tagFilterEnabledCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCfg := configmock.New(t)
+			mockCfg.SetWithoutSource("data_plane.enabled", tc.adpEnabled)
+			mockCfg.SetWithoutSource("metric_tag_filterlist_adp_only", tc.adpOnly)
+
+			matcher := filterlistimpl.NewTagMatcher(map[string]filterlistimpl.MetricTagList{
+				"dist.metric": {Tags: []string{"env"}, Action: "exclude"},
+			}, logmock.New(t))
+
+			cr := newContextResolver(nooptagger.NewComponent(), store, "test")
+			assert.Equal(t, tc.filteringEnabled, cr.tagFilterEnabled)
+
+			s1 := &metrics.MetricSample{
+				Name:       "dist.metric",
+				Mtype:      metrics.DistributionType,
+				Tags:       []string{"env:prod", "version:1"},
+				SampleRate: 1,
+			}
+			s2 := &metrics.MetricSample{
+				Name:       "dist.metric",
+				Mtype:      metrics.DistributionType,
+				Tags:       []string{"env:dev", "version:1"},
+				SampleRate: 1,
+			}
+
+			key1 := cr.trackContext(s1, 0, matcher)
+			key2 := cr.trackContext(s2, 0, matcher)
+
+			if tc.filteringEnabled {
+				assert.Equal(t, key1, key2, "tag stripping should merge contexts when filtering is active")
+			} else {
+				assert.NotEqual(t, key1, key2, "tag stripping must not apply when filtering is inactive")
+			}
+		})
+	}
+}
+
+func TestTagFilterADPGate(t *testing.T) {
+	testWithTagsStore(t, testTagFilterADPGate)
 }

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -178,6 +178,7 @@ func TestUpdateTagFilterList(t *testing.T) {
 	require := require.New(t)
 
 	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	opts := demuxTestOptions()
 	deps := createDemultiplexerAgentTestDeps(t)
 	filterList := filterlistimpl.NewFilterList(deps.Log, mockConfig, deps.Telemetry)
@@ -287,6 +288,7 @@ func TestUpdateTagFilterListCheckSamplerCacheInvalidation(t *testing.T) {
 	require := require.New(t)
 
 	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	opts := demuxTestOptions()
 	deps := createDemultiplexerAgentTestDeps(t)
 	filterList := filterlistimpl.NewFilterList(deps.Log, mockConfig, deps.Telemetry)

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -20,6 +20,7 @@ import (
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/impl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/quantile"
@@ -680,6 +681,7 @@ func TestForcedFlush(t *testing.T) {
 // filterlist must collapse to a single context AND their values must
 // sum in the resulting Serie's Point.
 func testTimeSamplerStripCountAggregates(t *testing.T, store *tags.Store) {
+	configmock.New(t).SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	sampler := testTimeSampler(store)
 	matcher := filterlist.NewTagMatcher(map[string]filterlist.MetricTagList{
 		"count.metric": {
@@ -737,6 +739,7 @@ func TestTimeSamplerStripCountAggregates(t *testing.T) {
 //	sample2: 3 * (1/0.25) = 12
 //	total = 20  →  rate = 20/10 = 2.0
 func testTimeSamplerStripCounterAggregates(t *testing.T, store *tags.Store) {
+	configmock.New(t).SetWithoutSource("metric_tag_filterlist_adp_only", false)
 	sampler := testTimeSampler(store)
 	matcher := filterlist.NewTagMatcher(map[string]filterlist.MetricTagList{
 		"counter.metric": {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1089,6 +1089,9 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("metric_filterlist_match_prefix", false)
 	config.BindEnvAndSetDefault("statsd_metric_blocklist_match_prefix", false)
 	config.BindEnvAndSetDefault("metric_tag_filterlist", []interface{}{})
+	// When true (default), metric_tag_filterlist tag stripping is only applied when data_plane.enabled is true.
+	// Set to false to apply tag stripping regardless of whether ADP is running.
+	config.BindEnvAndSetDefault("metric_tag_filterlist_adp_only", true)
 
 	// Integration security
 


### PR DESCRIPTION
### What does this PR do?

Only enables tag filtering when ADP is enabled.

### Motivation

We want to encourage the use of ADP for tag filtering due to the performance characteristics of the feature. This means all tag filtering from dogstatsd (potentially high traffic metrics) must happen in ADP. The core agent will only handle check metric tag filtering.

This can be overridden by setting `metric_tag_filterlist_adp_only` to false.

### Describe how you validated your changes

- Unit tests
- Manual tests

### Additional Notes
