### PR TITLE
Disable bazel rtloader windows tests

### DIFF
--- a/rtloader/test/defs.bzl
+++ b/rtloader/test/defs.bzl
@@ -63,5 +63,12 @@ def rtloader_go_test(**kwargs):
                       "PYTHON_LIB": "$(rlocationpath @cpython//:python_win_lib)",
                   },
               }),
+        # TODO(agent-build): Windows tests are temporarily disabled due to LoadLibraryA returning
+        # ERROR_ACCESS_DENIED (5) for libdatadog-agent-three.dll in CI environments.
+        # #incident-54552
+        target_compatible_with = kwargs.pop("target_compatible_with", []) + select({
+            "@platforms//os:windows": ["@platforms//:incompatible"],
+            "//conditions:default": [],
+        }),
         **kwargs
     )


### PR DESCRIPTION
### What does this PR do?

Prevents Bazel-driven rtloader tests from running on windows.

### Motivation

#incident-54552

Windows rtloader tests are failing fairly often in bazel jobs (e.g. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1682607799). We want to unblock colleagues while we investigate.

### Describe how you validated your changes

As soon as bazel test jobs pass this is good to merge.

### Additional Notes

It's acceptable to disable these tests temporarily given that:
- rtloader sees very little changes
- There's still test coverage in the "legacy" CMake-based tests.
- Tests keep running for other platforms.