### PR TITLE
[EXPERIMENTAL] feat(discovery): config-file discovery from cmdline

### DIFF
--- a/pkg/discovery/model/model.go
+++ b/pkg/discovery/model/model.go
@@ -14,6 +14,7 @@ import (
 type Service struct {
 	PID                      int                             `json:"pid"`
 	LogFiles                 []string                        `json:"log_files,omitempty"`
+	ConfigFiles              []string                        `json:"config_files,omitempty"`
 	GeneratedName            string                          `json:"generated_name"`
 	GeneratedNameSource      string                          `json:"generated_name_source"`
 	AdditionalGeneratedNames []string                        `json:"additional_generated_names"`

--- a/pkg/discovery/module/impl_rust_linux.go
+++ b/pkg/discovery/module/impl_rust_linux.go
@@ -143,5 +143,12 @@ func convertRustService(svc *C.struct_dd_service) model.Service {
 		}
 	}
 
+	if configs := sliceFromC(svc.config_files.data, svc.config_files.len); len(configs) > 0 {
+		result.ConfigFiles = make([]string, len(configs))
+		for i, c := range configs {
+			result.ConfigFiles[i] = fromDDStr(c)
+		}
+	}
+
 	return result
 }

--- a/pkg/discovery/module/rust/include/dd_discovery.h
+++ b/pkg/discovery/module/rust/include/dd_discovery.h
@@ -87,6 +87,7 @@ struct dd_service {
   struct dd_u16_slice tcp_ports;
   struct dd_u16_slice udp_ports;
   struct dd_strs log_files;
+  struct dd_strs config_files;
   bool apm_instrumentation;
   struct dd_str language;
 };

--- a/pkg/discovery/module/rust/src/configs.rs
+++ b/pkg/discovery/module/rust/src/configs.rs
@@ -1,0 +1,240 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Discovery of on-disk config files for a target process.
+//!
+//! Counterpart to `procfs::fd::get_log_files`: log files are typically held
+//! open and discoverable via `/proc/<pid>/fd/`, but config files are read
+//! once at startup and closed. We instead inspect the process command line
+//! for well-known "config" flags (`-c`, `--config`, `--config-file`, etc.)
+//! and treat the adjacent argument (or the `--flag=value` inline form) as
+//! a candidate path. The candidate is then verified to actually exist inside
+//! the target process's mount namespace via the caller-provided `SubDirFs`
+//! (typically rooted at `/proc/<pid>/root/`), which uses cap-std to reject
+//! `..` traversal and symlink escapes.
+//!
+//! This is intentionally generic — no per-integration knowledge yet. A
+//! follow-up can add well-known fallback paths (Redis `/etc/redis/redis.conf`,
+//! Kafka `/etc/kafka/server.properties`, …) keyed off the generated service
+//! name, and env-var-based location hints (Spring `SPRING_CONFIG_LOCATIONS`,
+//! `JAVA_TOOL_OPTIONS -Dconfig.file=…`).
+
+use std::collections::HashSet;
+
+use crate::fs::SubDirFs;
+use crate::procfs::Cmdline;
+
+/// Short-form flags (`-c value`, `-f value`) that introduce a config path.
+const SHORT_CONFIG_FLAGS: &[&str] = &["-c", "-f"];
+
+/// Long-form flag names (without the leading `--`) recognised in both
+/// separated (`--config value`) and inline (`--config=value`) forms.
+const LONG_CONFIG_FLAGS: &[&str] = &["config", "config-file", "conf-file", "configFile"];
+
+/// Extract config-file paths referenced by the process command line.
+///
+/// Returns absolute paths that (a) appear after a known config flag in
+/// `cmdline` and (b) actually exist inside the `fs` sandbox. The result
+/// is deduplicated and order-preserving (first occurrence wins).
+///
+/// Relative paths are skipped: the process's cwd is ambiguous in this
+/// context (cap-std would resolve relative paths against the sandbox root,
+/// not the process's cwd, which would silently produce wrong results).
+pub fn get_config_files(cmdline: &Cmdline, fs: &SubDirFs) -> Vec<String> {
+    if cmdline.is_empty() {
+        return Vec::new();
+    }
+
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for candidate in extract_candidates(cmdline) {
+        if !candidate.starts_with('/') {
+            continue;
+        }
+        // Reject `..` components. The kernel clamps `..` at the filesystem
+        // root, so cap-std's sandbox is not actually escapable through this
+        // path — but the reported string is later handed to a downstream
+        // ingester that may re-resolve it outside the sandbox, so we keep
+        // the reported path free of traversal segments.
+        if candidate.split('/').any(|c| c == "..") {
+            continue;
+        }
+        if !seen.insert(candidate.clone()) {
+            continue;
+        }
+        if fs.exists(&candidate) {
+            result.push(candidate);
+        }
+    }
+    result
+}
+
+/// Parse cmdline args, returning all path-like tokens that follow a known
+/// config flag (separated form) or are attached via `--flag=value`.
+fn extract_candidates(cmdline: &Cmdline) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut iter = cmdline.args().peekable();
+    while let Some(arg) = iter.next() {
+        // Inline form: `--config=/etc/myapp.yaml`
+        if let Some(rest) = arg.strip_prefix("--")
+            && let Some((key, value)) = rest.split_once('=')
+            && LONG_CONFIG_FLAGS.contains(&key)
+            && !value.is_empty()
+        {
+            out.push(value.to_string());
+            continue;
+        }
+
+        // Separated form: `-c /etc/redis/redis.conf` or `--config /path`
+        if is_separated_config_flag(arg)
+            && let Some(&value) = iter.peek()
+            && !value.is_empty()
+            && !value.starts_with('-')
+        {
+            out.push(value.to_string());
+            iter.next();
+        }
+    }
+    out
+}
+
+fn is_separated_config_flag(arg: &str) -> bool {
+    SHORT_CONFIG_FLAGS.contains(&arg)
+        || arg
+            .strip_prefix("--")
+            .is_some_and(|k| LONG_CONFIG_FLAGS.contains(&k))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmdline;
+
+    fn host_root_fs() -> SubDirFs {
+        // Any existing directory works for the existence-check tests that
+        // either reach absolute host paths (Linux) or never hit the FS.
+        SubDirFs::new("/").expect("open / as SubDirFs root")
+    }
+
+    #[test]
+    fn separated_short_flag() {
+        let cmd = cmdline!["redis-server", "-c", "/etc/redis/redis.conf"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/redis/redis.conf"]);
+    }
+
+    #[test]
+    fn separated_long_flag() {
+        let cmd = cmdline!["mongod", "--config", "/etc/mongod.conf"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/mongod.conf"]);
+    }
+
+    #[test]
+    fn inline_long_flag() {
+        let cmd = cmdline!["myapp", "--config=/etc/myapp.yaml"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/myapp.yaml"]);
+    }
+
+    #[test]
+    fn camel_case_long_flag() {
+        let cmd = cmdline!["mongod", "--configFile=/etc/mongod.conf"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/mongod.conf"]);
+    }
+
+    #[test]
+    fn multiple_flags_preserve_order() {
+        let cmd = cmdline![
+            "kafka-server",
+            "-f",
+            "/etc/kafka/server.properties",
+            "--config-file",
+            "/etc/kafka/extra.conf",
+        ];
+        assert_eq!(
+            extract_candidates(&cmd),
+            vec!["/etc/kafka/server.properties", "/etc/kafka/extra.conf",],
+        );
+    }
+
+    #[test]
+    fn flag_with_no_following_value_is_ignored() {
+        let cmd = cmdline!["foo", "--config"];
+        assert!(extract_candidates(&cmd).is_empty());
+    }
+
+    #[test]
+    fn flag_followed_by_another_flag_is_ignored() {
+        // `-c -f /etc/x.conf` should NOT treat `-f` as `-c`'s value;
+        // `-f /etc/x.conf` is then recognised on its own.
+        let cmd = cmdline!["foo", "-c", "-f", "/etc/x.conf"];
+        assert_eq!(extract_candidates(&cmd), vec!["/etc/x.conf"]);
+    }
+
+    #[test]
+    fn unknown_flag_is_ignored() {
+        let cmd = cmdline!["foo", "--bogus", "/etc/x.conf"];
+        assert!(extract_candidates(&cmd).is_empty());
+    }
+
+    #[test]
+    fn inline_with_empty_value_is_ignored() {
+        let cmd = cmdline!["foo", "--config="];
+        assert!(extract_candidates(&cmd).is_empty());
+    }
+
+    #[test]
+    fn empty_cmdline_returns_empty() {
+        let cmd = cmdline![];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+    }
+
+    #[test]
+    fn relative_paths_are_skipped() {
+        let cmd = cmdline!["app", "-c", "relative/path.yaml"];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+    }
+
+    #[test]
+    fn dot_dot_components_are_rejected() {
+        // cap-std rejects `..` traversal from the sandbox `Dir`, so the
+        // candidate never resolves to an existing file even if the agent
+        // has access to the target on the host.
+        let cmd = cmdline!["app", "-c", "/etc/../../etc/passwd"];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+
+        let cmd = cmdline!["app", "--config=/..//root/.bashrc"];
+        assert!(get_config_files(&cmd, &host_root_fs()).is_empty());
+    }
+
+    // Only runs on Linux because the temp-file path under `/tmp` is
+    // resolved as a relative path inside the SubDirFs sandbox; the test
+    // assumes the sandbox is rooted at `/` (the host's root view).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn existence_filter_drops_missing_paths_and_dedupes() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let real = temp_dir.path().join("real.conf");
+        fs::write(&real, "key=value\n").expect("write conf");
+        let real_str = real.to_str().expect("utf-8 path").to_string();
+
+        let cmd = Cmdline::from(
+            &[
+                "app",
+                "-c",
+                real_str.as_str(),
+                "--config",
+                real_str.as_str(),
+                "-f",
+                "/this/path/does/not/exist.conf",
+            ][..],
+        );
+
+        let got = get_config_files(&cmd, &host_root_fs());
+        assert_eq!(got.len(), 1, "expected dedup + existence filter, got: {got:?}");
+        assert!(got.first().is_some_and(|p| p.ends_with("real.conf")));
+    }
+}

--- a/pkg/discovery/module/rust/src/ffi.rs
+++ b/pkg/discovery/module/rust/src/ffi.rs
@@ -93,6 +93,7 @@ pub struct dd_service {
     pub tcp_ports: dd_u16_slice,
     pub udp_ports: dd_u16_slice,
     pub log_files: dd_strs,
+    pub config_files: dd_strs,
     pub apm_instrumentation: bool,
     pub language: dd_str,
 }
@@ -252,6 +253,7 @@ impl From<Service> for dd_service {
             tcp_ports: vec_u16_to_slice(svc.tcp_ports),
             udp_ports: vec_u16_to_slice(svc.udp_ports),
             log_files: dd_strs::from(svc.log_files),
+            config_files: dd_strs::from(svc.config_files),
             apm_instrumentation: svc.apm_instrumentation,
             language: dd_str::from(svc.language),
         }
@@ -588,6 +590,7 @@ unsafe fn free_dd_service(service: &dd_service) {
         tcp_ports,
         udp_ports,
         log_files,
+        config_files,
         apm_instrumentation: _,
         language,
     } = service;
@@ -601,6 +604,7 @@ unsafe fn free_dd_service(service: &dd_service) {
         free_dd_u16_slice(tcp_ports);
         free_dd_u16_slice(udp_ports);
         free_dd_strs(log_files);
+        free_dd_strs(config_files);
         free_dd_str(language);
     }
 }
@@ -796,6 +800,7 @@ mod tests {
                 tcp_ports: Some(vec![8080, 8443]),
                 udp_ports: Some(vec![9000]),
                 log_files: vec!["/var/log/app.log".to_string()],
+                config_files: vec!["/etc/app/app.conf".to_string()],
                 apm_instrumentation: true,
                 language: Some(Language::Python),
             }],
@@ -890,6 +895,14 @@ mod tests {
             unsafe { std::slice::from_raw_parts(service.log_files.data, service.log_files.len) };
         assert_eq!(unsafe { dd_str_to_str(&logs[0]) }, "/var/log/app.log");
 
+        // Verify config_files
+        assert!(!service.config_files.data.is_null());
+        assert_eq!(service.config_files.len, 1);
+        let configs = unsafe {
+            std::slice::from_raw_parts(service.config_files.data, service.config_files.len)
+        };
+        assert_eq!(unsafe { dd_str_to_str(&configs[0]) }, "/etc/app/app.conf");
+
         // Verify injected_pids
         assert!(!result.injected_pids.is_null());
         assert_eq!(result.injected_pids_len, 2);
@@ -925,6 +938,7 @@ mod tests {
                 tcp_ports: None,
                 udp_ports: Some(vec![]),
                 log_files: vec![],
+                config_files: vec![],
                 apm_instrumentation: false,
                 language: None,
             }],
@@ -956,6 +970,8 @@ mod tests {
         assert_eq!(service.udp_ports.len, 0);
         assert!(service.log_files.data.is_null());
         assert_eq!(service.log_files.len, 0);
+        assert!(service.config_files.data.is_null());
+        assert_eq!(service.config_files.len, 0);
         assert_eq!(service.apm_instrumentation, false);
 
         assert!(result.injected_pids.is_null());

--- a/pkg/discovery/module/rust/src/lib.rs
+++ b/pkg/discovery/module/rust/src/lib.rs
@@ -22,6 +22,7 @@
 mod apm;
 mod binary;
 mod comm;
+mod configs;
 mod envs;
 mod ephemeral;
 mod errors;

--- a/pkg/discovery/module/rust/src/services.rs
+++ b/pkg/discovery/module/rust/src/services.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 
 use crate::apm;
 use crate::comm;
+use crate::configs;
 use crate::envs;
 use crate::fs::SubDirFs;
 use crate::language::Language;
@@ -51,6 +52,8 @@ pub struct Service {
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub log_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub config_files: Vec<String>,
     pub apm_instrumentation: bool,
     pub language: Option<Language>,
 }
@@ -171,6 +174,7 @@ fn get_service(
     // Open filesystem for the process at /proc/<pid>/root
     let proc_root = procfs::root_path().join(pid.to_string()).join("root");
     let fs = SubDirFs::new(&proc_root).ok()?;
+    let config_files = configs::get_config_files(&cmdline, &fs);
 
     // Create detection context for service name generation
     let mut ctx = service_name::DetectionContext::new(pid, envs.clone(), &fs);
@@ -193,12 +197,15 @@ fn get_service(
         tcp_ports,
         udp_ports,
         log_files,
+        config_files,
         apm_instrumentation,
         language,
     })
 }
 
 // GPU state is not re-detected on heartbeat; the caller preserves it from the initial detection.
+// Config files are also not re-discovered: they're derived from cmdline which is stable for the
+// lifetime of the process. Callers should retain config_files from the initial new_pids response.
 fn get_heartbeat_service(pid: i32, context: &mut ParsingContext) -> Option<Service> {
     let open_files_info = procfs::fd::get_open_files_info(pid).ok()?;
 


### PR DESCRIPTION
> **>>> EXPERIMENTAL — DO NOT MERGE, DO NOT REVIEW <<<**
>
> This PR is **local scaffolding** intended only for my own iteration and (eventually) a conversation with Salvatore and Emilio about whether the cmdline-parsing approach is the right direction for config-file discovery. It will most likely **never be merged in this form**; if any of it lands upstream, it will be a rewritten PR. Please ignore it — no reviewers have been requested intentionally.

### What does this PR do?

Adds a `config_files` field to the discovered `Service`, parallel to the existing `log_files`. Populated by parsing the target process cmdline for known config flags and validating each candidate path inside the process's mount namespace.

Threading end-to-end:
- Rust `services::Service.config_files`
- FFI `dd_service.config_files` (`ffi.rs` + `include/dd_discovery.h`)
- Go `model.Service.ConfigFiles` (`json:"config_files,omitempty"`)

Flags recognised (both separated `-c value` and inline `--flag=value` forms): `-c`, `-f`, `--config`, `--config-file`, `--conf-file`, `--configFile`.

Validation uses `SubDirFs` (cap-std) rooted at `/proc/<pid>/root/`, matching the sandbox model `services.rs` already uses for service-name detection.

### Motivation

Foundation for *Integration Config Ingestion* (Redis / Kafka / Spark / Elasticsearch / MongoDB / Cassandra configs). Logs are already discovered via `/proc/<pid>/fd/`, but config files are typically read once at startup and closed, so FD enumeration alone won't find them. Salvatore suggested cmdline parsing as the cheapest starting point — this PR validates that hypothesis.

### Describe how you validated your changes

- 12 unit tests in `configs.rs` covering: separated short/long, inline, camelCase, order preservation, missing values, value-is-another-flag, unknown flag, empty value, empty cmdline, `..` rejection, relative-path skip, dedup+existence (Linux-gated).
- FFI round-trip tests (`populated_response`, `empty_optionals`) assert the new field mirrors the `log_files` plumbing end-to-end (allocation, conversion, free).
- `dda inv test --targets=./pkg/discovery/...` — 288 / 288 pass.
- `bazel test //pkg/discovery/...` — 3 pass, 7 skipped (Rust targets `target_compatible_with = linux`, ran on Darwin).
- Local validation was on macOS. The Linux-gated tests and any production `/proc` paths still need a Linux run before being trusted.

### Additional Notes

**Heartbeat behaviour:** `config_files` is empty on heartbeats. Cmdline is stable for a process's lifetime, so this matches the convention used by other cmdline-derived fields (`generated_name`, `language`, `apm_instrumentation`, ...). Downstream must retain the value from the initial `new_pids` response. If product needs *temporal* drift detection without restart, this becomes ~4 lines in `get_heartbeat_service`.

**Deliberately out of scope (each a separate follow-up):**
- FD-based config scan complementary to cmdline parsing (catches `mmap`'d / SIGHUP-reloaded configs that stay open)
- Per-integration well-known paths (Redis `/etc/redis/redis.conf`, Kafka `/etc/kafka/server.properties`, ...) keyed off the generated service name
- Env-var-based location hints (`SPRING_CONFIG_LOCATIONS`, `JAVA_TOOL_OPTIONS -Dconfig.file=...`)
- Reading config-file contents (that's the ingestion layer, separate concern)

**Caveats (only relevant if this ever moves beyond experimental):**
- `pkg/discovery/module/rust/include/dd_discovery.h` was hand-edited to mirror the Rust struct change. The header is normally cbindgen-generated; the regen step should be run to confirm the hand-edit matches what the tool would emit.
- The `..` rejection in `get_config_files` is *defense in depth*, not strictly required: cap-std clamps paths inside the sandbox `Dir`. The justification for keeping it is that the reported path string is later handed to a downstream ingester that may re-resolve it without our sandbox, so the reported string is kept free of traversal segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)