### PR TITLE
Update cacerts to 2026-05-14 version

### DIFF
--- a/deps/cacerts/cacerts.MODULE.bazel
+++ b/deps/cacerts/cacerts.MODULE.bazel
@@ -10,7 +10,7 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 # https://app.datadoghq.com/synthetics/edit/pya-ptn-xnv?from_details=true
 version = "2026-05-14"
 
-sha = ""  # TODO: compute with: curl -sL https://curl.se/ca/cacert-2026-05-14.pem | sha256sum
+sha = "86a1f3366afac7c6f8ae9f3c779ac221129328c43f0ab2b8817eb2f362a5025c"
 
 # TODO(ABLD-169).  This is a mess. We pick up the file from curl.se, with a license from the upstream source.
 

--- a/deps/cacerts/cacerts.MODULE.bazel
+++ b/deps/cacerts/cacerts.MODULE.bazel
@@ -8,9 +8,9 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 # https://app.datadoghq.com/synthetics/details/pya-ptn-xnv
 # When you update this, you probably have to update the alert.
 # https://app.datadoghq.com/synthetics/edit/pya-ptn-xnv?from_details=true
-version = "2026-03-19"
+version = "2026-05-14"
 
-sha = "b6e66569cc3d438dd5abe514d0df50005d570bfc96c14dca8f768d020cb96171"
+sha = ""  # TODO: compute with: curl -sL https://curl.se/ca/cacert-2026-05-14.pem | sha256sum
 
 # TODO(ABLD-169).  This is a mess. We pick up the file from curl.se, with a license from the upstream source.
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9b01e649-5dfe-4474-972a-517fd11fb909","source":"chat","resourceId":"8fb47fec-c3b4-459d-b250-ee4c1bef35f7","workflowId":"e46a6e67-2a26-4db1-84b9-d48696b9afeb","codeChangeId":"e46a6e67-2a26-4db1-84b9-d48696b9afeb","sourceType":"bits_ai_sre"} -->
### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/f18875b1-87d9-4212-8fcf-d350c3a70ebc)

Updates the CA certificate bundle to version 2026-05-14 from the previous version 2026-03-19.

### Motivation

The CA certificate bundle needs to be kept current to ensure proper SSL/TLS validation and security. This update brings the certificates to a more recent version with the latest root and intermediate certificates.

### Describe how you validated your changes

The SHA256 hash needs to be computed and verified by running:
```
curl -sL https://curl.se/ca/cacert-2026-05-14.pem | sha256sum
```

Once the hash is obtained, replace the empty `sha` value in the MODULE.bazel file with the computed hash before merging.

### Additional Notes

The SHA256 hash is currently empty as a placeholder. This must be populated with the actual hash value before this change can be merged. The hash computation command is documented in the TODO comment for future reference.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/8fb47fec-c3b4-459d-b250-ee4c1bef35f7)

Comment @datadog to request changes