### PR TITLE
[AD] http-sd: support multiple endpoints via prometheus_http_sd.configs

### DIFF
--- a/comp/core/autodiscovery/providers/prometheus_http_sd.go
+++ b/comp/core/autodiscovery/providers/prometheus_http_sd.go
@@ -209,6 +209,7 @@ func (h *PrometheusHTTPSDConfigProvider) Collect(_ context.Context) ([]integrati
 	h.configErrorsMu.Unlock()
 
 	var configs []integration.Config
+	var entryErrors []string
 	successes := 0
 	for _, entry := range h.entries {
 		entryConfigs, err := entry.collect()
@@ -217,10 +218,15 @@ func (h *PrometheusHTTPSDConfigProvider) Collect(_ context.Context) ([]integrati
 			h.configErrorsMu.Lock()
 			h.configErrors["fetch:"+entry.url] = types.ErrorMsgSet{err.Error(): struct{}{}}
 			h.configErrorsMu.Unlock()
+			entryErrors = append(entryErrors, fmt.Sprintf("%s: %v", entry.url, err))
 			continue
 		}
 		configs = append(configs, entryConfigs...)
 		successes++
+	}
+
+	if successes == 0 && len(h.entries) > 0 {
+		return nil, fmt.Errorf("prometheus_http_sd: all %d endpoint(s) failed: %s", len(h.entries), strings.Join(entryErrors, "; "))
 	}
 
 	log.Infof("http_sd: collected %d configs from %d/%d endpoint(s)", len(configs), successes, len(h.entries))

--- a/comp/core/autodiscovery/providers/prometheus_http_sd.go
+++ b/comp/core/autodiscovery/providers/prometheus_http_sd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup" //nolint:depguard
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -49,12 +50,54 @@ type httpSDCheckTemplate struct {
 	Instances  []map[string]interface{} `json:"instances"`
 }
 
-// PrometheusHTTPSDConfigProvider polls a Prometheus HTTP Service Discovery endpoint
-// and generates check configurations for each discovered target.
+// httpSDEntry represents a single Prometheus HTTP SD endpoint to poll along
+// with the check template applied to each of its discovered targets.
+type httpSDEntry struct {
+	url           string
+	client        *http.Client
+	checkTemplate httpSDCheckTemplate
+}
+
+// httpSDConfigEntry mirrors a single entry under prometheus_http_sd.configs in
+// the agent's YAML configuration.
+type httpSDConfigEntry struct {
+	URL           string `mapstructure:"url" yaml:"url"`
+	CheckTemplate string `mapstructure:"check_template" yaml:"check_template"`
+}
+
+// buildEntries validates each raw config entry and produces the corresponding
+// httpSDEntry values that share a single HTTP client.
+func buildEntries(rawConfigs []httpSDConfigEntry, sharedClient *http.Client) ([]*httpSDEntry, error) {
+	if len(rawConfigs) == 0 {
+		return nil, errors.New("prometheus_http_sd provider requires at least one endpoint (set prometheus_http_sd.configs)")
+	}
+
+	entries := make([]*httpSDEntry, 0, len(rawConfigs))
+	for i, raw := range rawConfigs {
+		if raw.URL == "" {
+			return nil, fmt.Errorf("prometheus_http_sd entry %d: url is required", i)
+		}
+		if raw.CheckTemplate == "" {
+			return nil, fmt.Errorf("prometheus_http_sd entry %d: check_template is required", i)
+		}
+		tmpl, err := parseCheckTemplate(raw.CheckTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("prometheus_http_sd entry %d: %v", i, err)
+		}
+		entries = append(entries, &httpSDEntry{
+			url:           raw.URL,
+			client:        sharedClient,
+			checkTemplate: tmpl,
+		})
+	}
+	return entries, nil
+}
+
+// PrometheusHTTPSDConfigProvider polls one or more Prometheus HTTP Service
+// Discovery endpoints and generates check configurations for each discovered
+// target.
 type PrometheusHTTPSDConfigProvider struct {
-	url            string
-	client         *http.Client
-	checkTemplate  httpSDCheckTemplate
+	entries        []*httpSDEntry
 	configErrors   map[string]types.ErrorMsgSet
 	configErrorsMu sync.RWMutex
 }
@@ -64,23 +107,17 @@ func NewPrometheusHTTPSDConfigProvider(
 	providerConfig *pkgconfigsetup.ConfigurationProviders,
 	_ *telemetry.Store,
 ) (types.ConfigProvider, error) {
-	url := pkgconfigsetup.Datadog().GetString("prometheus_http_sd.url")
-	if url == "" {
-		return nil, errors.New("prometheus_http_sd provider requires a URL (set prometheus_http_sd.url)")
+	cfg := pkgconfigsetup.Datadog()
+
+	var rawConfigs []httpSDConfigEntry
+	if err := structure.UnmarshalKey(cfg, "prometheus_http_sd.configs", &rawConfigs); err != nil {
+		return nil, fmt.Errorf("cannot parse prometheus_http_sd.configs: %v", err)
 	}
-	templateJSON := pkgconfigsetup.Datadog().GetString("prometheus_http_sd.check_template")
-	if templateJSON == "" {
-		return nil, errors.New("prometheus_http_sd provider requires a check template (set prometheus_http_sd.check_template)")
-	}
-	var tmpl httpSDCheckTemplate
-	if err := json.Unmarshal([]byte(templateJSON), &tmpl); err != nil {
-		return nil, fmt.Errorf("cannot parse check_template: %v", err)
-	}
-	if tmpl.Name == "" {
-		return nil, errors.New("prometheus_http_sd check_template must specify a check name")
-	}
-	if len(tmpl.Instances) == 0 {
-		return nil, errors.New("prometheus_http_sd check_template must specify one instance template")
+	if legacyURL := cfg.GetString("prometheus_http_sd.url"); legacyURL != "" {
+		rawConfigs = append([]httpSDConfigEntry{{
+			URL:           legacyURL,
+			CheckTemplate: cfg.GetString("prometheus_http_sd.check_template"),
+		}}, rawConfigs...)
 	}
 
 	client, err := buildHTTPSDClient(providerConfig)
@@ -88,12 +125,29 @@ func NewPrometheusHTTPSDConfigProvider(
 		return nil, err
 	}
 
+	entries, err := buildEntries(rawConfigs, client)
+	if err != nil {
+		return nil, err
+	}
+
 	return &PrometheusHTTPSDConfigProvider{
-		url:           url,
-		client:        client,
-		checkTemplate: tmpl,
-		configErrors:  make(map[string]types.ErrorMsgSet),
+		entries:      entries,
+		configErrors: make(map[string]types.ErrorMsgSet),
 	}, nil
+}
+
+func parseCheckTemplate(templateJSON string) (httpSDCheckTemplate, error) {
+	var tmpl httpSDCheckTemplate
+	if err := json.Unmarshal([]byte(templateJSON), &tmpl); err != nil {
+		return tmpl, fmt.Errorf("cannot parse check_template: %v", err)
+	}
+	if tmpl.Name == "" {
+		return tmpl, errors.New("prometheus_http_sd check_template must specify a check name")
+	}
+	if len(tmpl.Instances) == 0 {
+		return tmpl, errors.New("prometheus_http_sd check_template must specify one instance template")
+	}
+	return tmpl, nil
 }
 
 func buildHTTPSDClient(providerConfig *pkgconfigsetup.ConfigurationProviders) (*http.Client, error) {
@@ -147,19 +201,36 @@ func (h *PrometheusHTTPSDConfigProvider) IsUpToDate(_ context.Context) (bool, er
 	return false, nil
 }
 
-// Collect fetches the HTTP SD endpoint and returns check configurations
-// for each discovered target.
+// Collect fetches every configured HTTP SD endpoint and returns check
+// configurations for each discovered target.
 func (h *PrometheusHTTPSDConfigProvider) Collect(_ context.Context) ([]integration.Config, error) {
 	h.configErrorsMu.Lock()
 	h.configErrors = make(map[string]types.ErrorMsgSet)
 	h.configErrorsMu.Unlock()
 
-	targetGroups, err := h.fetchTargets()
+	var configs []integration.Config
+	successes := 0
+	for _, entry := range h.entries {
+		entryConfigs, err := entry.collect()
+		if err != nil {
+			log.Warnf("http_sd: failed to fetch targets from %s: %v", entry.url, err)
+			h.configErrorsMu.Lock()
+			h.configErrors["fetch:"+entry.url] = types.ErrorMsgSet{err.Error(): struct{}{}}
+			h.configErrorsMu.Unlock()
+			continue
+		}
+		configs = append(configs, entryConfigs...)
+		successes++
+	}
+
+	log.Infof("http_sd: collected %d configs from %d/%d endpoint(s)", len(configs), successes, len(h.entries))
+	return configs, nil
+}
+
+func (e *httpSDEntry) collect() ([]integration.Config, error) {
+	targetGroups, err := e.fetchTargets()
 	if err != nil {
-		h.configErrorsMu.Lock()
-		h.configErrors["fetch"] = types.ErrorMsgSet{err.Error(): struct{}{}}
-		h.configErrorsMu.Unlock()
-		return nil, fmt.Errorf("prometheus_http_sd: failed to fetch targets from %s: %v", h.url, err)
+		return nil, err
 	}
 
 	var configs []integration.Config
@@ -173,7 +244,7 @@ func (h *PrometheusHTTPSDConfigProvider) Collect(_ context.Context) ([]integrati
 				port = ""
 			}
 
-			config, buildErr := h.buildConfig(host, port, tags)
+			config, buildErr := e.buildConfig(host, port, tags)
 			if buildErr != nil {
 				log.Warnf("http_sd: failed to build config for target %s: %v", target, buildErr)
 				continue
@@ -181,18 +252,16 @@ func (h *PrometheusHTTPSDConfigProvider) Collect(_ context.Context) ([]integrati
 			configs = append(configs, config)
 		}
 	}
-
-	log.Infof("http_sd: collected %d configs from %s", len(configs), h.url)
 	return configs, nil
 }
 
-func (h *PrometheusHTTPSDConfigProvider) fetchTargets() ([]httpSDTargetGroup, error) {
-	req, err := http.NewRequest(http.MethodGet, h.url, nil)
+func (e *httpSDEntry) fetchTargets() ([]httpSDTargetGroup, error) {
+	req, err := http.NewRequest(http.MethodGet, e.url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request: %v", err)
 	}
 
-	resp, err := h.client.Do(req)
+	resp, err := e.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %v", err)
 	}
@@ -211,14 +280,14 @@ func (h *PrometheusHTTPSDConfigProvider) fetchTargets() ([]httpSDTargetGroup, er
 	return targetGroups, nil
 }
 
-func (h *PrometheusHTTPSDConfigProvider) buildConfig(host, port string, tags []string) (integration.Config, error) {
-	initConfigBytes, err := yaml.Marshal(h.checkTemplate.InitConfig)
+func (e *httpSDEntry) buildConfig(host, port string, tags []string) (integration.Config, error) {
+	initConfigBytes, err := yaml.Marshal(e.checkTemplate.InitConfig)
 	if err != nil {
 		return integration.Config{}, fmt.Errorf("cannot marshal init_config: %v", err)
 	}
 
 	// Apply template substitution on the first instance template
-	instanceTemplate := h.checkTemplate.Instances[0]
+	instanceTemplate := e.checkTemplate.Instances[0]
 	instance := make(map[string]interface{}, len(instanceTemplate))
 	for k, v := range instanceTemplate {
 		instance[k] = substituteTemplateVars(v, host, port)
@@ -239,11 +308,11 @@ func (h *PrometheusHTTPSDConfigProvider) buildConfig(host, port string, tags []s
 	}
 
 	return integration.Config{
-		Name:         h.checkTemplate.Name,
+		Name:         e.checkTemplate.Name,
 		InitConfig:   integration.Data(initConfigBytes),
 		Instances:    []integration.Data{instanceBytes},
 		ClusterCheck: true,
-		Source:       "prometheus_http_sd:" + h.url,
+		Source:       "prometheus_http_sd:" + e.url,
 		Provider:     names.PrometheusHTTPSDRegisterName,
 	}, nil
 }

--- a/comp/core/autodiscovery/providers/prometheus_http_sd_test.go
+++ b/comp/core/autodiscovery/providers/prometheus_http_sd_test.go
@@ -21,17 +21,33 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 )
 
+type entrySpec struct {
+	url      string
+	template string
+}
+
 func makeTestProvider(t *testing.T, serverURL string, checkTemplate string) *PrometheusHTTPSDConfigProvider {
 	t.Helper()
+	return makeTestProviderWithEntries(t, []entrySpec{{url: serverURL, template: checkTemplate}})
+}
 
-	var tmpl httpSDCheckTemplate
-	require.NoError(t, json.Unmarshal([]byte(checkTemplate), &tmpl))
+func makeTestProviderWithEntries(t *testing.T, specs []entrySpec) *PrometheusHTTPSDConfigProvider {
+	t.Helper()
+
+	entries := make([]*httpSDEntry, len(specs))
+	for i, s := range specs {
+		var tmpl httpSDCheckTemplate
+		require.NoError(t, json.Unmarshal([]byte(s.template), &tmpl))
+		entries[i] = &httpSDEntry{
+			url:           s.url,
+			client:        http.DefaultClient,
+			checkTemplate: tmpl,
+		}
+	}
 
 	return &PrometheusHTTPSDConfigProvider{
-		url:           serverURL,
-		client:        http.DefaultClient,
-		checkTemplate: tmpl,
-		configErrors:  make(map[string]types.ErrorMsgSet),
+		entries:      entries,
+		configErrors: make(map[string]types.ErrorMsgSet),
 	}
 }
 
@@ -114,9 +130,9 @@ func TestCollectServerError(t *testing.T) {
 	assert.Nil(t, configs)
 	assert.Contains(t, err.Error(), "unexpected status 500")
 
-	// Verify config errors are tracked
+	// Verify config errors are tracked under the per-entry key
 	errs := provider.GetConfigErrors()
-	assert.NotEmpty(t, errs["fetch"])
+	assert.NotEmpty(t, errs["fetch:"+server.URL])
 }
 
 func TestLabelsToTags(t *testing.T) {
@@ -309,6 +325,128 @@ func TestCollectDigestStability(t *testing.T) {
 	require.Len(t, configs1, 1)
 	require.Len(t, configs2, 1)
 	assert.Equal(t, configs1[0].Digest(), configs2[0].Digest())
+}
+
+func TestBuildEntriesMultiple(t *testing.T) {
+	entries, err := buildEntries(
+		[]httpSDConfigEntry{
+			{URL: "http://a/sd", CheckTemplate: defaultCheckTemplate()},
+			{URL: "http://b/sd", CheckTemplate: defaultCheckTemplate()},
+		},
+		http.DefaultClient,
+	)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "http://a/sd", entries[0].url)
+	assert.Equal(t, "http://b/sd", entries[1].url)
+}
+
+func TestBuildEntriesEmpty(t *testing.T) {
+	_, err := buildEntries(nil, http.DefaultClient)
+	assert.Error(t, err)
+}
+
+func TestBuildEntriesMissingURL(t *testing.T) {
+	_, err := buildEntries(
+		[]httpSDConfigEntry{{URL: "", CheckTemplate: defaultCheckTemplate()}},
+		http.DefaultClient,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "url")
+}
+
+func TestBuildEntriesMissingTemplate(t *testing.T) {
+	_, err := buildEntries(
+		[]httpSDConfigEntry{{URL: "http://x/sd", CheckTemplate: ""}},
+		http.DefaultClient,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "check_template")
+}
+
+func TestCollectPerEntryErrorIsolation(t *testing.T) {
+	// good server returns one target
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode([]httpSDTargetGroup{
+			{Targets: []string{"healthy:9090"}},
+		})
+	}))
+	defer good.Close()
+
+	// bad server always 500s
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+
+	provider := makeTestProviderWithEntries(t, []entrySpec{
+		{url: good.URL, template: defaultCheckTemplate()},
+		{url: bad.URL, template: defaultCheckTemplate()},
+	})
+
+	configs, err := provider.Collect(context.Background())
+	require.NoError(t, err, "Collect must succeed when at least one entry succeeds")
+	require.Len(t, configs, 1, "only the healthy entry's target should be returned")
+
+	var instance map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(configs[0].Instances[0], &instance))
+	assert.Equal(t, "http://healthy:9090/metrics", instance["openmetrics_endpoint"])
+
+	// failing entry is surfaced via GetConfigErrors under its URL-keyed slot
+	errs := provider.GetConfigErrors()
+	assert.NotEmpty(t, errs["fetch:"+bad.URL])
+	assert.Empty(t, errs["fetch:"+good.URL])
+}
+
+func TestCollectAllEntriesFail(t *testing.T) {
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer bad.Close()
+
+	provider := makeTestProviderWithEntries(t, []entrySpec{
+		{url: bad.URL, template: defaultCheckTemplate()},
+		{url: bad.URL, template: defaultCheckTemplate()},
+	})
+
+	configs, err := provider.Collect(context.Background())
+	assert.Error(t, err)
+	assert.Nil(t, configs)
+	assert.Contains(t, err.Error(), "all 2 endpoint(s) failed")
+}
+
+func TestCollectMergesEntries(t *testing.T) {
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode([]httpSDTargetGroup{
+			{Targets: []string{"a1:9090"}, Labels: map[string]string{"src": "A"}},
+		})
+	}))
+	defer serverA.Close()
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode([]httpSDTargetGroup{
+			{Targets: []string{"b1:9090", "b2:9090"}, Labels: map[string]string{"src": "B"}},
+		})
+	}))
+	defer serverB.Close()
+
+	provider := makeTestProviderWithEntries(t, []entrySpec{
+		{url: serverA.URL, template: defaultCheckTemplate()},
+		{url: serverB.URL, template: defaultCheckTemplate()},
+	})
+
+	configs, err := provider.Collect(context.Background())
+	require.NoError(t, err)
+	require.Len(t, configs, 3)
+
+	endpoints := make([]string, len(configs))
+	for i, cfg := range configs {
+		var instance map[string]interface{}
+		require.NoError(t, yaml.Unmarshal(cfg.Instances[0], &instance))
+		endpoints[i] = instance["openmetrics_endpoint"].(string)
+	}
+	assert.Contains(t, endpoints, "http://a1:9090/metrics")
+	assert.Contains(t, endpoints, "http://b1:9090/metrics")
+	assert.Contains(t, endpoints, "http://b2:9090/metrics")
 }
 
 func TestCollectCustomCheckTemplate(t *testing.T) {

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -51,8 +51,9 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 	// 2) Auto-add file-based kube service and endpoints config providers based on check config files.
 	if flavor.GetFlavor() == flavor.ClusterAgent {
 
-		if pkgconfigsetup.Datadog().GetString("prometheus_http_sd.url") != "" {
-			log.Info("Prometheus HTTP SD URL is configured: Adding the prometheus_http_sd config provider")
+		cfg := pkgconfigsetup.Datadog()
+		if cfg.IsConfigured("prometheus_http_sd.url") || cfg.IsConfigured("prometheus_http_sd.configs") {
+			log.Info("Prometheus HTTP SD is configured: Adding the prometheus_http_sd config provider")
 			detectedProviders = append(detectedProviders, pkgconfigsetup.ConfigurationProviders{Name: "prometheus_http_sd", Polling: true})
 		}
 

--- a/pkg/config/autodiscovery/autodiscovery_test.go
+++ b/pkg/config/autodiscovery/autodiscovery_test.go
@@ -12,7 +12,50 @@ import (
 	"github.com/stretchr/testify/require"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
+
+func TestDiscoverComponentsFromConfigForHTTPSD(t *testing.T) {
+	configmock.SetDefaultConfigType(t, "yaml")
+	flavor.SetTestFlavor(t, flavor.ClusterAgent)
+
+	t.Run("legacy single url triggers provider", func(t *testing.T) {
+		configmock.NewFromYAML(t, `
+prometheus_http_sd:
+  url: http://legacy/sd
+  check_template: '{"name":"openmetrics","init_config":{},"instances":[{}]}'
+`)
+		providers, _ := DiscoverComponentsFromConfig()
+		require.True(t, containsProvider(providers, "prometheus_http_sd"))
+	})
+
+	t.Run("configs list triggers provider", func(t *testing.T) {
+		configmock.NewFromYAML(t, `
+prometheus_http_sd:
+  configs:
+    - url: http://a/sd
+      check_template: '{"name":"openmetrics","init_config":{},"instances":[{}]}'
+`)
+		providers, _ := DiscoverComponentsFromConfig()
+		require.True(t, containsProvider(providers, "prometheus_http_sd"))
+	})
+
+	t.Run("no http_sd config means no provider", func(t *testing.T) {
+		configmock.NewFromYAML(t, ``)
+		providers, _ := DiscoverComponentsFromConfig()
+		require.False(t, containsProvider(providers, "prometheus_http_sd"))
+	})
+}
+
+func containsProvider(providers []pkgconfigsetup.ConfigurationProviders, name string) bool {
+	for _, p := range providers {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
 
 func TestDiscoverComponentsFromConfigForSnmp(t *testing.T) {
 	configmock.SetDefaultConfigType(t, "yaml")

--- a/pkg/config/schema/core_schema.yaml
+++ b/pkg/config/schema/core_schema.yaml
@@ -14857,10 +14857,6 @@ properties:
         node_type: setting
         type: string
         default: ''
-      configs:
-        node_type: setting
-        type: array
-        default: []
       url:
         node_type: setting
         type: string

--- a/pkg/config/schema/core_schema.yaml
+++ b/pkg/config/schema/core_schema.yaml
@@ -14857,6 +14857,10 @@ properties:
         node_type: setting
         type: string
         default: ''
+      configs:
+        node_type: setting
+        type: array
+        default: []
       url:
         node_type: setting
         type: string

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -178,6 +178,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	// Prometheus HTTP Service Discovery
 	config.BindEnvAndSetDefault("prometheus_http_sd.configs", []map[string]interface{}{}) // List of HTTP SD endpoints to poll. Each entry must specify url and check_template.
+	config.ParseEnvJSON("prometheus_http_sd.configs", []map[string]interface{}{})         // DD_PROMETHEUS_HTTP_SD_CONFIGS is a JSON-encoded list-of-objects.
 	config.BindEnvAndSetDefault("prometheus_http_sd.url", "")                             // [DEPRECATED] URL of the Prometheus HTTP SD endpoint. Use prometheus_http_sd.configs instead.
 	config.BindEnvAndSetDefault("prometheus_http_sd.check_template", "")                  // [DEPRECATED] JSON check template applied to each discovered target. Use prometheus_http_sd.configs instead.
 

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -177,8 +177,9 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("prometheus_scrape.version", 1)               // Version of the openmetrics check to be scheduled by the Prometheus auto-discovery
 
 	// Prometheus HTTP Service Discovery
-	config.BindEnvAndSetDefault("prometheus_http_sd.url", "")            // URL of the Prometheus HTTP SD endpoint
-	config.BindEnvAndSetDefault("prometheus_http_sd.check_template", "") // JSON check template applied to each discovered target (e.g. '{"name":"openmetrics","init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:%%port%%/metrics"}]}')
+	config.BindEnvAndSetDefault("prometheus_http_sd.configs", []map[string]interface{}{}) // List of HTTP SD endpoints to poll. Each entry must specify url and check_template.
+	config.BindEnvAndSetDefault("prometheus_http_sd.url", "")                             // [DEPRECATED] URL of the Prometheus HTTP SD endpoint. Use prometheus_http_sd.configs instead.
+	config.BindEnvAndSetDefault("prometheus_http_sd.check_template", "")                  // [DEPRECATED] JSON check template applied to each discovered target. Use prometheus_http_sd.configs instead.
 
 	// Network Devices Monitoring
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.")

--- a/releasenotes-dca/notes/add-http-sd-provider-ad40316d79e886d0.yaml
+++ b/releasenotes-dca/notes/add-http-sd-provider-ad40316d79e886d0.yaml
@@ -1,11 +1,8 @@
 ---
 features:
   - |
-    Add Prometheus HTTP Service Discovery provider for the Cluster Agent. This
-    new autodiscovery config provider polls a Prometheus-compatible HTTP SD
-    endpoint and generates check configurations for each discovered target.
-    Checks are distributed across available cluster check runners or node
-    agents via the existing cluster checks dispatcher. Configure it by adding
-    ``prometheus_http_sd`` to ``extra_config_providers`` and setting
-    ``prometheus_http_sd.url`` and ``prometheus_http_sd.check_template`` in
-    the Cluster Agent configuration.
+    Add a Prometheus HTTP Service Discovery (HTTP SD) provider for the Cluster
+    Agent. The provider polls Prometheus-compatible HTTP SD endpoints and 
+    generates check configurations for each discovered target. Configure
+    endpoints under ``prometheus_http_sd.configs``, each providing its own 
+    ``url`` and ``check_template``.


### PR DESCRIPTION
### What does this PR do?

Lets the Prometheus HTTP SD config provider poll a list of endpoints instead of a single URL. Each entry under the new `prometheus_http_sd.configs` setting supplies its own `url` and `check_template`. Per-endpoint failures are isolated — the rest of the list keeps producing check configs. The legacy `prometheus_http_sd.url` / `prometheus_http_sd.check_template` keys still work as a single implicit entry and are now marked deprecated.

### Motivation

Prometheus's own `http_sd_configs` is a list of endpoints. Our provider only accepted one, so a cluster with multiple service-discovery sources had to pick one or stand up a fan-out service. The released cluster-agent HTTP SD feature hasn't shipped yet, so this consolidates onto the multi-endpoint shape before users adopt the single-URL form.

### Describe how you validated your changes

Unit Tests

- End-to-end on a local kind cluster via `injector-dev`:
  - Legacy env vars → 10 configs collected → 10 cluster checks dispatched (backward compat).
  - New `DD_PROMETHEUS_HTTP_SD_CONFIGS` JSON list with two mock SD servers → 15 configs (10 + 5) → 15 dispatched checks. Per-entry `check_template` honored (different `timeout` per entry), per-entry source URL recorded on each dispatched config.
