### PR TITLE
[CONTP-1679] feat(Autodiscovery): Add Instrumentation check AD provider  

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,8 @@ linters:
             - "!**/comp/core/autodiscovery/providers/endpointschecks_nop.go"
             - "!**/comp/core/autodiscovery/providers/etcd.go"
             - "!**/comp/core/autodiscovery/providers/etcd_nop.go"
+            - "!**/comp/core/autodiscovery/providers/instrumentationchecks.go"
+            - "!**/comp/core/autodiscovery/providers/instrumentationchecks_nop.go"
             - "!**/comp/core/autodiscovery/providers/kube_endpoints.go"
             - "!**/comp/core/autodiscovery/providers/kube_endpoints_file.go"
             - "!**/comp/core/autodiscovery/providers/kube_endpoints_file_nop.go"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -651,7 +651,15 @@ exports_files(glob(
 # gazelle:exclude pkg/util/kubernetes/clusterinfo
 # gazelle:exclude pkg/util/kubernetes/clustername
 # gazelle:exclude pkg/util/kubernetes/hostinfo
+# TODO(agent-build): re-include the following files once their unmigrated deps are
+#   reachable from Bazel-migrated targets:
+#     - hostname.go      -> pkg/util/kubernetes/apiserver, pkg/util/kubernetes/clustername
+#     - resource.go      -> k8s.io/apimachinery/pkg/api/resource
+#     - resource_test.go -> k8s.io/apimachinery/pkg/api/resource
+# gazelle:exclude pkg/util/kubernetes/hostname.go
 # gazelle:exclude pkg/util/kubernetes/kubelet
+# gazelle:exclude pkg/util/kubernetes/resource.go
+# gazelle:exclude pkg/util/kubernetes/resource_test.go
 # gazelle:exclude pkg/util/tags
 # gazelle:exclude tasks/unit_tests
 # gazelle:exclude test/benchmarks

--- a/comp/core/autodiscovery/configresolver/configresolver.go
+++ b/comp/core/autodiscovery/configresolver/configresolver.go
@@ -142,7 +142,7 @@ func listDataToResolve(config *integration.Config) []dataToResolve {
 
 	if config.IsLogConfig() {
 		p := tmplvar.YAMLParser
-		if config.Provider == names.Container || config.Provider == names.Kubernetes || config.Provider == names.KubeContainer {
+		if config.Provider == names.Container || config.Provider == names.Kubernetes || config.Provider == names.KubeContainer || config.Provider == names.InstrumentationChecks {
 			p = tmplvar.JSONParser
 		}
 		res = append(res, dataToResolve{

--- a/comp/core/autodiscovery/providers/instrumentationchecks.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks.go
@@ -25,7 +25,7 @@ import (
 // for the instrumentation checks feature. It pulls AD configurations derived
 // from DatadogInstrumentation CRs from the cluster agent.
 type InstrumentationChecksConfigProvider struct {
-	dcaClient        clusteragent.DCAClientInterface
+	dcaClient        clusteragent.InstrumentationCheckClient
 	degradedDuration time.Duration
 	heartbeat        time.Time
 	flushedConfigs   bool
@@ -76,6 +76,8 @@ func (c *InstrumentationChecksConfigProvider) Collect(ctx context.Context) ([]in
 			return nil, err
 		}
 
+		// Return nil configs once to signal the scheduler to unschedule
+		// checks that may be based on stale configuration.
 		if !c.flushedConfigs {
 			c.flushedConfigs = true
 			return nil, nil
@@ -85,10 +87,12 @@ func (c *InstrumentationChecksConfigProvider) Collect(ctx context.Context) ([]in
 	}
 
 	log.Debugf("Received %d instrumentation check configurations from the cluster-agent", len(reply.Configs))
-	for _, config := range reply.Configs {
-		config.Provider = names.InstrumentationChecks
+	for i := range reply.Configs {
+		reply.Configs[i].Provider = names.InstrumentationChecks
 	}
 
+	// Reset flush state and update heartbeat so the degraded mode window
+	// restarts from this successful response.
 	c.flushedConfigs = false
 	c.heartbeat = time.Now()
 

--- a/comp/core/autodiscovery/providers/instrumentationchecks.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+
+package providers
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// InstrumentationChecksConfigProvider implements the ConfigProvider interface
+// for the instrumentation checks feature. It pulls AD configurations derived
+// from DatadogInstrumentation CRs from the cluster agent.
+type InstrumentationChecksConfigProvider struct {
+	dcaClient        clusteragent.DCAClientInterface
+	degradedDuration time.Duration
+	heartbeat        time.Time
+	flushedConfigs   bool
+}
+
+// NewInstrumentationChecksConfigProvider returns a new ConfigProvider collecting
+// instrumentation check configurations from the cluster-agent.
+func NewInstrumentationChecksConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (types.ConfigProvider, error) {
+	c := &InstrumentationChecksConfigProvider{
+		degradedDuration: defaultDegradedDeadline,
+	}
+
+	if providerConfig.DegradedDeadlineMinutes > 0 {
+		c.degradedDuration = time.Duration(providerConfig.DegradedDeadlineMinutes) * time.Minute
+	}
+
+	if err := c.initClient(); err != nil {
+		log.Warnf("Cannot get dca client: %v", err)
+	}
+	return c, nil
+}
+
+// String returns a string representation of the InstrumentationChecksConfigProvider
+func (c *InstrumentationChecksConfigProvider) String() string {
+	return names.InstrumentationChecks
+}
+
+// IsUpToDate always returns false so that Collect is called on every poll cycle.
+func (c *InstrumentationChecksConfigProvider) IsUpToDate(_ context.Context) (bool, error) {
+	return false, nil
+}
+
+func (c *InstrumentationChecksConfigProvider) withinDegradedModePeriod() bool {
+	return withinDegradedModePeriod(c.heartbeat, c.degradedDuration)
+}
+
+// Collect retrieves instrumentation check configurations from the cluster-agent.
+func (c *InstrumentationChecksConfigProvider) Collect(ctx context.Context) ([]integration.Config, error) {
+	log.Debugf("Collecting instrumentation check configurations from the cluster-agent")
+	if c.dcaClient == nil {
+		if err := c.initClient(); err != nil {
+			return nil, err
+		}
+	}
+	reply, err := c.dcaClient.GetInstrumentationConfigs(ctx)
+	if err != nil {
+		if (errors.IsRemoteService(err) || errors.IsTimeout(err)) && c.withinDegradedModePeriod() {
+			return nil, err
+		}
+
+		if !c.flushedConfigs {
+			c.flushedConfigs = true
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	log.Debugf("Received %d instrumentation check configurations from the cluster-agent", len(reply.Configs))
+	for _, config := range reply.Configs {
+		config.Provider = names.InstrumentationChecks
+	}
+
+	c.flushedConfigs = false
+	c.heartbeat = time.Now()
+
+	return reply.Configs, nil
+}
+
+func (c *InstrumentationChecksConfigProvider) initClient() error {
+	dcaClient, err := clusteragent.GetClusterAgentClient()
+	if err == nil {
+		c.dcaClient = dcaClient
+	}
+	return err
+}
+
+// GetConfigErrors is not implemented for the InstrumentationChecksConfigProvider
+func (c *InstrumentationChecksConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
+}

--- a/comp/core/autodiscovery/providers/instrumentationchecks_nop.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks_nop.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubelet
+
+package providers
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// NewInstrumentationChecksConfigProvider returns a new ConfigProvider collecting
+// instrumentation check configurations from the cluster-agent.
+var NewInstrumentationChecksConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/instrumentationchecks_test.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks_test.go
@@ -9,7 +9,7 @@ package providers
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -18,8 +18,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
-	types "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
-	"github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 )
 
 // mockInstrumentationClient implements InstrumentationCheckClient.
@@ -33,9 +33,9 @@ func (m *mockInstrumentationClient) GetInstrumentationConfigs(_ context.Context)
 }
 
 func TestInstrumentationChecksCollect(t *testing.T) {
-	remoteErr := errors.NewRemoteServiceError("cluster-agent", "500 Internal Server Error")
-	timeoutErr := errors.NewTimeoutError("cluster-agent", fmt.Errorf("context deadline exceeded"))
-	genericErr := fmt.Errorf("unexpected error")
+	remoteErr := dderrors.NewRemoteServiceError("cluster-agent", "500 Internal Server Error")
+	timeoutErr := dderrors.NewTimeoutError("cluster-agent", errors.New("context deadline exceeded"))
+	genericErr := errors.New("unexpected error")
 
 	tests := []struct {
 		name             string

--- a/comp/core/autodiscovery/providers/instrumentationchecks_test.go
+++ b/comp/core/autodiscovery/providers/instrumentationchecks_test.go
@@ -1,0 +1,177 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+
+package providers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	types "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	"github.com/DataDog/datadog-agent/pkg/errors"
+)
+
+// mockInstrumentationClient implements InstrumentationCheckClient.
+type mockInstrumentationClient struct {
+	configs types.ConfigResponse
+	err     error
+}
+
+func (m *mockInstrumentationClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
+	return m.configs, m.err
+}
+
+func TestInstrumentationChecksCollect(t *testing.T) {
+	remoteErr := errors.NewRemoteServiceError("cluster-agent", "500 Internal Server Error")
+	timeoutErr := errors.NewTimeoutError("cluster-agent", fmt.Errorf("context deadline exceeded"))
+	genericErr := fmt.Errorf("unexpected error")
+
+	tests := []struct {
+		name             string
+		client           *mockInstrumentationClient
+		degradedDuration time.Duration
+		heartbeat        time.Time
+		flushedConfigs   bool
+		wantConfigs      []integration.Config
+		wantErr          bool
+		wantErrVal       error
+		wantFlushed      bool
+		wantHeartbeat    bool // whether heartbeat should be non-zero after Collect
+	}{
+		{
+			name: "success with configs",
+			client: &mockInstrumentationClient{
+				configs: types.ConfigResponse{Configs: []integration.Config{
+					{Name: "check1"},
+					{Name: "check2"},
+				}},
+			},
+			degradedDuration: defaultDegradedDeadline,
+			wantConfigs:      []integration.Config{{Name: "check1"}, {Name: "check2"}},
+			wantFlushed:      false,
+			wantHeartbeat:    true,
+		},
+		{
+			name: "success resets flushedConfigs and updates heartbeat",
+			client: &mockInstrumentationClient{
+				configs: types.ConfigResponse{Configs: []integration.Config{{Name: "check1"}}},
+			},
+			degradedDuration: defaultDegradedDeadline,
+			flushedConfigs:   true,
+			wantConfigs:      []integration.Config{{Name: "check1"}},
+			wantFlushed:      false,
+			wantHeartbeat:    true,
+		},
+		{
+			name:             "empty response still updates heartbeat",
+			client:           &mockInstrumentationClient{configs: types.ConfigResponse{Configs: []integration.Config{}}},
+			degradedDuration: defaultDegradedDeadline,
+			wantConfigs:      []integration.Config{},
+			wantFlushed:      false,
+			wantHeartbeat:    true,
+		},
+		{
+			name:             "remote error within infinite degraded mode returns error",
+			client:           &mockInstrumentationClient{err: remoteErr},
+			degradedDuration: defaultDegradedDeadline, // 0 = infinite degraded mode
+			wantErr:          true,
+			wantErrVal:       remoteErr,
+		},
+		{
+			name:             "timeout error within degraded mode returns error",
+			client:           &mockInstrumentationClient{err: timeoutErr},
+			degradedDuration: 5 * time.Minute,
+			heartbeat:        time.Now(), // recent heartbeat = within window
+			wantErr:          true,
+			wantErrVal:       timeoutErr,
+		},
+		{
+			name:             "remote error outside degraded mode flushes configs on first call",
+			client:           &mockInstrumentationClient{err: remoteErr},
+			degradedDuration: 5 * time.Minute,
+			heartbeat:        time.Now().Add(-10 * time.Minute), // outside window
+			flushedConfigs:   false,
+			wantErr:          false,
+			wantFlushed:      true,
+		},
+		{
+			name:             "remote error outside degraded mode propagates error after flush",
+			client:           &mockInstrumentationClient{err: remoteErr},
+			degradedDuration: 5 * time.Minute,
+			heartbeat:        time.Now().Add(-10 * time.Minute), // outside window
+			flushedConfigs:   true,
+			wantErr:          true,
+			wantErrVal:       remoteErr,
+		},
+		{
+			name:             "non-retriable error flushes on first call",
+			client:           &mockInstrumentationClient{err: genericErr},
+			degradedDuration: defaultDegradedDeadline,
+			flushedConfigs:   false,
+			wantErr:          false,
+			wantFlushed:      true,
+		},
+		{
+			name:             "non-retriable error propagates after flush",
+			client:           &mockInstrumentationClient{err: genericErr},
+			degradedDuration: defaultDegradedDeadline,
+			flushedConfigs:   true,
+			wantErr:          true,
+			wantErrVal:       genericErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &InstrumentationChecksConfigProvider{
+				dcaClient:        tt.client,
+				degradedDuration: tt.degradedDuration,
+				heartbeat:        tt.heartbeat,
+				flushedConfigs:   tt.flushedConfigs,
+			}
+
+			configs, err := provider.Collect(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrVal != nil {
+					assert.Equal(t, tt.wantErrVal, err)
+				}
+				assert.Nil(t, configs)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, configs, len(tt.wantConfigs))
+			for _, cfg := range configs {
+				assert.Equal(t, names.InstrumentationChecks, cfg.Provider)
+			}
+			assert.Equal(t, tt.wantFlushed, provider.flushedConfigs)
+			if tt.wantHeartbeat {
+				assert.False(t, provider.heartbeat.IsZero())
+			}
+		})
+	}
+}
+
+func TestInstrumentationChecksCollectNilClientInitFails(t *testing.T) {
+	provider := &InstrumentationChecksConfigProvider{
+		dcaClient:        nil,
+		degradedDuration: defaultDegradedDeadline,
+	}
+
+	configs, err := provider.Collect(context.Background())
+	assert.Nil(t, configs)
+	assert.Error(t, err)
+}

--- a/comp/core/autodiscovery/providers/names/provider_names.go
+++ b/comp/core/autodiscovery/providers/names/provider_names.go
@@ -63,6 +63,8 @@ const (
 	DOQueryActions = "do-query-actions"
 	// PrometheusHTTPSD discovers check configurations from a Prometheus HTTP Service Discovery endpoint.
 	PrometheusHTTPSD = "prometheus-http-sd"
+	// InstrumentationChecks pulls AD configurations derived from DatadogInstrumentation CRs via the cluster-agent.
+	InstrumentationChecks = "instrumentation-checks"
 )
 
 // Internal Autodiscovery names for the config providers
@@ -70,20 +72,21 @@ const (
 // And they're kept unchanged for backward compatibility
 // as they could be hardcoded in the agent config.
 const (
-	ConsulRegisterName             = "consul"
-	ClusterChecksRegisterName      = "clusterchecks"
-	EndpointsChecksRegisterName    = "endpointschecks"
-	EtcdRegisterName               = "etcd"
-	KubeletRegisterName            = "kubelet"
-	KubeContainerRegisterName      = "kubernetes-container-allinone"
-	KubeServicesRegisterName       = "kube_services"
-	KubeServicesFileRegisterName   = "kube_services_file"
-	KubeEndpointsRegisterName      = "kube_endpoints"
-	KubeEndpointsFileRegisterName  = "kube_endpoints_file"
-	KubeCrdRegisterName            = "kube_crd"
-	PrometheusPodsRegisterName     = "prometheus_pods"
-	PrometheusServicesRegisterName = "prometheus_services"
-	PrometheusHTTPSDRegisterName   = "prometheus_http_sd"
-	RemoteConfigRegisterName       = "remote_config"
-	ZookeeperRegisterName          = "zookeeper"
+	ConsulRegisterName                = "consul"
+	ClusterChecksRegisterName         = "clusterchecks"
+	EndpointsChecksRegisterName       = "endpointschecks"
+	EtcdRegisterName                  = "etcd"
+	KubeletRegisterName               = "kubelet"
+	KubeContainerRegisterName         = "kubernetes-container-allinone"
+	KubeServicesRegisterName          = "kube_services"
+	KubeServicesFileRegisterName      = "kube_services_file"
+	KubeEndpointsRegisterName         = "kube_endpoints"
+	KubeEndpointsFileRegisterName     = "kube_endpoints_file"
+	KubeCrdRegisterName               = "kube_crd"
+	PrometheusPodsRegisterName        = "prometheus_pods"
+	PrometheusServicesRegisterName    = "prometheus_services"
+	PrometheusHTTPSDRegisterName      = "prometheus_http_sd"
+	InstrumentationChecksRegisterName = "instrumentation_checks"
+	RemoteConfigRegisterName          = "remote_config"
+	ZookeeperRegisterName             = "zookeeper"
 )

--- a/comp/core/autodiscovery/providers/providers.go
+++ b/comp/core/autodiscovery/providers/providers.go
@@ -55,6 +55,7 @@ func RegisterProviders(providerCatalog map[string]types.ConfigProviderFactory) {
 	RegisterProvider(names.ConsulRegisterName, NewConsulConfigProvider, providerCatalog)
 	RegisterProviderWithComponents(names.KubeContainer, NewContainerConfigProvider, providerCatalog)
 	RegisterProvider(names.EndpointsChecksRegisterName, NewEndpointsChecksConfigProvider, providerCatalog)
+	RegisterProvider(names.InstrumentationChecksRegisterName, NewInstrumentationChecksConfigProvider, providerCatalog)
 	RegisterProvider(names.EtcdRegisterName, NewEtcdConfigProvider, providerCatalog)
 	RegisterProvider(names.KubeServicesFileRegisterName, NewKubeServiceFileConfigProvider, providerCatalog)
 	RegisterProvider(names.KubeServicesRegisterName, NewKubeServiceConfigProvider, providerCatalog)

--- a/comp/core/workloadfilter/def/types.go
+++ b/comp/core/workloadfilter/def/types.go
@@ -323,13 +323,14 @@ func (p *Pod) ToBytes() ([]byte, error) {
 }
 
 // CreatePod creates a Filterable Pod object.
-func CreatePod(id, name, namespace string, annotations map[string]string) *Pod {
+func CreatePod(id, name, namespace string, annotations map[string]string, rootOwner *core.FilterRootOwner) *Pod {
 	return &Pod{
 		FilterPod: &core.FilterPod{
 			Id:          id,
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: annotations,
+			Rootowner:   rootOwner,
 		},
 	}
 }

--- a/comp/core/workloadfilter/util/workloadmeta/BUILD.bazel
+++ b/comp/core/workloadfilter/util/workloadmeta/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "//comp/core/workloadfilter/def",
         "//comp/core/workloadmeta/def",
         "//pkg/proto/pbgo/core",
-        "@//pkg/util/kubernetes",
+        "//pkg/util/kubernetes",
     ],
 )
 

--- a/comp/core/workloadfilter/util/workloadmeta/BUILD.bazel
+++ b/comp/core/workloadfilter/util/workloadmeta/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "workloadmeta",
@@ -9,5 +9,18 @@ go_library(
         "//comp/core/workloadfilter/def",
         "//comp/core/workloadmeta/def",
         "//pkg/proto/pbgo/core",
+        "@//pkg/util/kubernetes",
+    ],
+)
+
+go_test(
+    name = "workloadmeta_test",
+    srcs = ["create_test.go"],
+    embed = [":workloadmeta"],
+    gotags = ["test"],
+    deps = [
+        "//comp/core/workloadmeta/def",
+        "//pkg/proto/pbgo/core",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -12,6 +12,7 @@ import (
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
 
 // CreateContainer creates a Filterable Container object from a workloadmeta.Container and an owner.
@@ -42,7 +43,33 @@ func CreatePod(pod *workloadmeta.KubernetesPod) *workloadfilter.Pod {
 			Name:        pod.Name,
 			Namespace:   pod.Namespace,
 			Annotations: pod.Annotations,
+			Rootowner:   resolveRootOwner(pod.Owners),
 		},
+	}
+}
+
+// resolveRootOwner determines the root owner of a pod by walking the owner chain.
+// For example, a pod owned by a ReplicaSet resolves to the parent Deployment.
+func resolveRootOwner(owners []workloadmeta.KubernetesPodOwner) *core.FilterRootOwner {
+	if len(owners) == 0 {
+		return nil
+	}
+	owner := owners[0]
+	switch owner.Kind {
+	case kubernetes.ReplicaSetKind:
+		if deployment := kubernetes.ParseDeploymentForReplicaSet(owner.Name); deployment != "" {
+			return &core.FilterRootOwner{Kind: kubernetes.DeploymentKind, Name: deployment}
+		}
+		return &core.FilterRootOwner{Kind: owner.Kind, Name: owner.Name}
+	case kubernetes.JobKind:
+		if cronjob, _ := kubernetes.ParseCronJobForJob(owner.Name); cronjob != "" {
+			return &core.FilterRootOwner{Kind: kubernetes.CronJobKind, Name: cronjob}
+		}
+		return &core.FilterRootOwner{Kind: owner.Kind, Name: owner.Name}
+	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind:
+		return &core.FilterRootOwner{Kind: owner.Kind, Name: owner.Name}
+	default:
+		return &core.FilterRootOwner{Kind: owner.Kind, Name: owner.Name}
 	}
 }
 

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -54,7 +54,15 @@ func resolveRootOwner(owners []workloadmeta.KubernetesPodOwner) *core.FilterRoot
 	if len(owners) == 0 {
 		return nil
 	}
+
 	owner := owners[0]
+	for _, o := range owners {
+		if o.Controller != nil && *o.Controller {
+			owner = o
+			break
+		}
+	}
+
 	switch owner.Kind {
 	case kubernetes.ReplicaSetKind:
 		if deployment := kubernetes.ParseDeploymentForReplicaSet(owner.Name); deployment != "" {

--- a/comp/core/workloadfilter/util/workloadmeta/create_test.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+func TestResolveRootOwner(t *testing.T) {
+	tests := []struct {
+		name     string
+		owners   []workloadmeta.KubernetesPodOwner
+		expected *core.FilterRootOwner
+	}{
+		{
+			name:     "no owners",
+			owners:   nil,
+			expected: nil,
+		},
+		{
+			name:     "ReplicaSet resolves to Deployment",
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8"}},
+			expected: &core.FilterRootOwner{Kind: "Deployment", Name: "my-app"},
+		},
+		{
+			name:     "Job resolves to CronJob",
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Job", Name: "backup-1562319360"}},
+			expected: &core.FilterRootOwner{Kind: "CronJob", Name: "backup"},
+		},
+		{
+			name:     "standalone Job stays as Job",
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Job", Name: "one-off"}},
+			expected: &core.FilterRootOwner{Kind: "Job", Name: "one-off"},
+		},
+		{
+			name:     "Deployment is its own root",
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Deployment", Name: "my-app"}},
+			expected: &core.FilterRootOwner{Kind: "Deployment", Name: "my-app"},
+		},
+		{
+			name:     "DaemonSet is its own root",
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "DaemonSet", Name: "fluentd"}},
+			expected: &core.FilterRootOwner{Kind: "DaemonSet", Name: "fluentd"},
+		},
+		{
+			name:     "StatefulSet is its own root",
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "StatefulSet", Name: "redis"}},
+			expected: &core.FilterRootOwner{Kind: "StatefulSet", Name: "redis"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveRootOwner(tt.owners)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCreatePodWithRootOwner(t *testing.T) {
+	pod := &workloadmeta.KubernetesPod{
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "my-app-6d4f5b7c8-abc12",
+			Namespace: "default",
+		},
+		Owners: []workloadmeta.KubernetesPodOwner{
+			{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8"},
+		},
+	}
+	result := CreatePod(pod)
+	assert.NotNil(t, result.FilterPod.Rootowner)
+	assert.Equal(t, "Deployment", result.FilterPod.Rootowner.Kind)
+	assert.Equal(t, "my-app", result.FilterPod.Rootowner.Name)
+}

--- a/comp/core/workloadfilter/util/workloadmeta/create_test.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 func TestResolveRootOwner(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -27,33 +29,49 @@ func TestResolveRootOwner(t *testing.T) {
 		},
 		{
 			name:     "ReplicaSet resolves to Deployment",
-			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8"}},
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8", Controller: boolPtr(true)}},
 			expected: &core.FilterRootOwner{Kind: "Deployment", Name: "my-app"},
 		},
 		{
 			name:     "Job resolves to CronJob",
-			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Job", Name: "backup-1562319360"}},
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Job", Name: "backup-1562319360", Controller: boolPtr(true)}},
 			expected: &core.FilterRootOwner{Kind: "CronJob", Name: "backup"},
 		},
 		{
 			name:     "standalone Job stays as Job",
-			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Job", Name: "one-off"}},
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Job", Name: "one-off", Controller: boolPtr(true)}},
 			expected: &core.FilterRootOwner{Kind: "Job", Name: "one-off"},
 		},
 		{
 			name:     "Deployment is its own root",
-			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Deployment", Name: "my-app"}},
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Deployment", Name: "my-app", Controller: boolPtr(true)}},
 			expected: &core.FilterRootOwner{Kind: "Deployment", Name: "my-app"},
 		},
 		{
 			name:     "DaemonSet is its own root",
-			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "DaemonSet", Name: "fluentd"}},
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "DaemonSet", Name: "fluentd", Controller: boolPtr(true)}},
 			expected: &core.FilterRootOwner{Kind: "DaemonSet", Name: "fluentd"},
 		},
 		{
 			name:     "StatefulSet is its own root",
-			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "StatefulSet", Name: "redis"}},
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "StatefulSet", Name: "redis", Controller: boolPtr(true)}},
 			expected: &core.FilterRootOwner{Kind: "StatefulSet", Name: "redis"},
+		},
+		{
+			name: "prefers controller owner over non-controller",
+			owners: []workloadmeta.KubernetesPodOwner{
+				{Kind: "Node", Name: "node-1", Controller: boolPtr(false)},
+				{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8", Controller: boolPtr(true)},
+			},
+			expected: &core.FilterRootOwner{Kind: "Deployment", Name: "my-app"},
+		},
+		{
+			name: "no controller marked falls back to first owner",
+			owners: []workloadmeta.KubernetesPodOwner{
+				{Kind: "Node", Name: "node-1", Controller: boolPtr(false)},
+				{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8", Controller: boolPtr(false)},
+			},
+			expected: &core.FilterRootOwner{Kind: "Node", Name: "node-1"},
 		},
 	}
 	for _, tt := range tests {
@@ -71,7 +89,7 @@ func TestCreatePodWithRootOwner(t *testing.T) {
 			Namespace: "default",
 		},
 		Owners: []workloadmeta.KubernetesPodOwner{
-			{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8"},
+			{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8", Controller: boolPtr(true)},
 		},
 	}
 	result := CreatePod(pod)

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -213,6 +213,10 @@ func (f *FakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (t
 	panic("implement me")
 }
 
+func (f *FakeDCAClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
+	panic("implement me")
+}
+
 func (f *FakeDCAClient) GetKubernetesClusterID() (string, error) {
 	panic("implement me")
 }

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -213,10 +213,6 @@ func (f *FakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (t
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
-	panic("implement me")
-}
-
 func (f *FakeDCAClient) GetKubernetesClusterID() (string, error) {
 	panic("implement me")
 }

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -127,6 +127,10 @@ func (f *FakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (t
 	return f.EndpointsCheckConfigs, f.EndpointsCheckConfigsErr
 }
 
+func (f *FakeDCAClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
+	return types.ConfigResponse{}, nil
+}
+
 func (f *FakeDCAClient) GetKubernetesClusterID() (string, error) {
 	return f.ClusterID, f.ClusterIDErr
 }

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -127,10 +127,6 @@ func (f *FakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (t
 	return f.EndpointsCheckConfigs, f.EndpointsCheckConfigsErr
 }
 
-func (f *FakeDCAClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
-	return types.ConfigResponse{}, nil
-}
-
 func (f *FakeDCAClient) GetKubernetesClusterID() (string, error) {
 	return f.ClusterID, f.ClusterIDErr
 }

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -516,7 +516,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	}
 
 	// is the namespace / container targeted by the instrumentation ?
-	if ci.filter.IsExcluded(workloadfilter.CreateContainer("", exec.Container, "", workloadfilter.CreatePod("", "", ns, nil))) {
+	if ci.filter.IsExcluded(workloadfilter.CreateContainer("", exec.Container, "", workloadfilter.CreatePod("", "", ns, nil, nil))) {
 		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsExcludedResourceReason)
 		return false, nil
 	}
@@ -536,7 +536,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	}
 
 	// is the pod targeted by the instrumentation ?
-	if ci.filter.IsExcluded(workloadfilter.CreateContainer("", "", "", workloadfilter.CreatePod("", "", "", pod.Annotations))) {
+	if ci.filter.IsExcluded(workloadfilter.CreateContainer("", "", "", workloadfilter.CreatePod("", "", "", pod.Annotations, nil))) {
 		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsExcludedByAnnotationReason)
 		return false, nil
 	}
@@ -691,7 +691,7 @@ func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns st
 	}
 
 	// is the pod targeted by the instrumentation ?
-	if ci.filter.IsExcluded(workloadfilter.CreateContainer("", "", "", workloadfilter.CreatePod("", "", ns, pod.Annotations))) {
+	if ci.filter.IsExcluded(workloadfilter.CreateContainer("", "", "", workloadfilter.CreatePod("", "", ns, pod.Annotations, nil))) {
 		metrics.CWSPodMutationAttempts.Inc(ci.mode.String(), "false", cwsExcludedResourceReason)
 		return false, nil
 	}

--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig.go
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig.go
@@ -45,7 +45,13 @@ const collectionInterval = 10 * time.Minute
 const kubeletVirtualKind = "KubeletConfiguration"
 const kubeletVirtualAPIVersion = "virtual.datadoghq.com/v1"
 
-var getClusterAgentClient = clusteragent.GetClusterAgentClient
+type nodeUIDClient interface {
+	GetNodeUID(nodeName string) (string, error)
+}
+
+var getClusterAgentClient = func() (nodeUIDClient, error) {
+	return clusteragent.GetClusterAgentClient()
+}
 
 var groupID atomic.Int32
 

--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
@@ -8,7 +8,6 @@
 package kubeletconfig
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -19,8 +18,6 @@ import (
 
 	"github.com/DataDog/agent-payload/v5/process"
 
-	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
-
 	"github.com/DataDog/datadog-agent/comp/core"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
@@ -28,19 +25,14 @@ import (
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	oconfig "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
-	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
-
 	stypes "github.com/DataDog/datadog-agent/pkg/serializer/types"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
-	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 var (
@@ -54,59 +46,11 @@ type fakeSender struct {
 	manifests []process.MessageBody
 }
 
-type fakeDCAClient struct{}
+type fakeNodeUIDClient struct{}
 
-func (f *fakeDCAClient) Version(_ bool) version.Version                    { panic("not used") }
-func (f *fakeDCAClient) ClusterAgentAPIEndpoint() string                   { panic("not used") }
-func (f *fakeDCAClient) GetNodeLabels(_ string) (map[string]string, error) { panic("not used") }
-func (f *fakeDCAClient) GetNodeAnnotations(_ string, _ ...string) (map[string]string, error) {
-	panic("not used")
-}
-
-func (f *fakeDCAClient) GetNodeUID(_ string) (string, error) {
+func (f *fakeNodeUIDClient) GetNodeUID(_ string) (string, error) {
 	return "uid-test-123", nil
 }
-
-func (f *fakeDCAClient) GetNamespaceLabels(_ string) (map[string]string, error) {
-	panic("not used")
-}
-
-func (f *fakeDCAClient) GetNodeInfo(_ string, _ ...string) (*clusteragent.NodeSystemInfo, error) {
-	panic("implement me")
-}
-
-func (f *fakeDCAClient) GetNamespaceMetadata(_ string) (*clusteragent.Metadata, error) {
-	panic("not used")
-}
-
-func (f *fakeDCAClient) GetPodsMetadataForNode(_ string) (apiv1.NamespacesPodsStringsSet, error) {
-	panic("not used")
-}
-
-func (f *fakeDCAClient) GetKubernetesMetadataNames(_, _, _ string) ([]string, error) {
-	panic("not used")
-}
-
-func (f *fakeDCAClient) GetCFAppsMetadataForNode(_ string) (map[string][]string, error) {
-	panic("not used")
-}
-
-func (f *fakeDCAClient) PostClusterCheckStatus(_ context.Context, _ string, _ types.NodeStatus) (types.StatusResponse, error) {
-	panic("not used")
-}
-
-func (f *fakeDCAClient) GetClusterCheckConfigs(_ context.Context, _ string) (types.ConfigResponse, error) {
-	panic("not used")
-}
-
-func (f *fakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (types.ConfigResponse, error) {
-	panic("not used")
-}
-func (f *fakeDCAClient) GetKubernetesClusterID() (string, error) { panic("not used") }
-func (f *fakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLanguageAnnotationRequest) error {
-	panic("not used")
-}
-func (f *fakeDCAClient) SupportsNamespaceMetadataCollection() bool { panic("not used") }
 
 //nolint:revive // TODO(CAPP) Fix revive linter
 func (s *fakeSender) OrchestratorManifest(msgs []stypes.ProcessMessageBody, clusterID string) {
@@ -161,8 +105,8 @@ func (suite *KubeletConfigTestSuite) SetupSuite() {
 		store:    mockStore,
 	}
 
-	getClusterAgentClient = func() (clusteragent.DCAClientInterface, error) {
-		return &fakeDCAClient{}, nil
+	getClusterAgentClient = func() (nodeUIDClient, error) {
+		return &fakeNodeUIDClient{}, nil
 	}
 }
 

--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
@@ -102,6 +102,9 @@ func (f *fakeDCAClient) GetClusterCheckConfigs(_ context.Context, _ string) (typ
 func (f *fakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (types.ConfigResponse, error) {
 	panic("not used")
 }
+func (f *fakeDCAClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
+	panic("not used")
+}
 func (f *fakeDCAClient) GetKubernetesClusterID() (string, error) { panic("not used") }
 func (f *fakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLanguageAnnotationRequest) error {
 	panic("not used")

--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
@@ -102,9 +102,6 @@ func (f *fakeDCAClient) GetClusterCheckConfigs(_ context.Context, _ string) (typ
 func (f *fakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (types.ConfigResponse, error) {
 	panic("not used")
 }
-func (f *fakeDCAClient) GetInstrumentationConfigs(_ context.Context) (types.ConfigResponse, error) {
-	panic("not used")
-}
 func (f *fakeDCAClient) GetKubernetesClusterID() (string, error) { panic("not used") }
 func (f *fakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLanguageAnnotationRequest) error {
 	panic("not used")

--- a/pkg/collector/python/containers.go
+++ b/pkg/collector/python/containers.go
@@ -38,7 +38,7 @@ func IsContainerExcluded(name, image, namespace *C.char) C.int {
 		goNs = C.GoString(namespace)
 	}
 
-	filterablePod := workloadfilter.CreatePod("", "", goNs, nil)
+	filterablePod := workloadfilter.CreatePod("", "", goNs, nil, nil)
 	filterableContainer := workloadfilter.CreateContainer("", goName, goImg, filterablePod)
 
 	if checkContext.IsExcluded(filterableContainer) {

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -36,6 +36,14 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 		log.Infof("Prometheus scraping is enabled: Adding the Prometheus config provider '%s'", prometheusProvider.Name)
 		detectedProviders = append(detectedProviders, prometheusProvider)
 	}
+
+	// Add instrumentation checks provider if `instrumentation_crd_controller.enabled` is true
+	if pkgconfigsetup.Datadog().GetBool("instrumentation_crd_controller.enabled") && flavor.GetFlavor() == flavor.DefaultAgent {
+		instrumentationChecksProvider := pkgconfigsetup.ConfigurationProviders{Name: "instrumentation_checks", Polling: true, PollInterval: "30s"}
+		log.Info("Instrumentation controller is enabled: Adding the instrumentation checks config provider")
+		detectedProviders = append(detectedProviders, instrumentationChecksProvider)
+	}
+
 	// Add database-monitoring aurora listener if the feature is enabled
 	if pkgconfigsetup.Datadog().GetBool("database_monitoring.autodiscovery.aurora.enabled") {
 		detectedListeners = append(detectedListeners, pkgconfigsetup.Listeners{Name: "database-monitoring-aurora"})

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -39,7 +39,7 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 
 	// Add instrumentation checks provider if `instrumentation_crd_controller.enabled` is true
 	if pkgconfigsetup.Datadog().GetBool("instrumentation_crd_controller.enabled") && flavor.GetFlavor() == flavor.DefaultAgent {
-		instrumentationChecksProvider := pkgconfigsetup.ConfigurationProviders{Name: "instrumentation_checks", Polling: true, PollInterval: "30s"}
+		instrumentationChecksProvider := pkgconfigsetup.ConfigurationProviders{Name: "instrumentation_checks", Polling: true}
 		log.Info("Instrumentation controller is enabled: Adding the instrumentation checks config provider")
 		detectedProviders = append(detectedProviders, instrumentationChecksProvider)
 	}

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -207,8 +207,8 @@ func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 	case names.File:
 		// config defined in a file
 		configs, err = logsConfig.ParseYAML(config.LogsConfig)
-	case names.Container, names.Kubernetes, names.KubeContainer, names.ProcessLog:
-		// config attached to a container label or a pod annotation
+	case names.Container, names.Kubernetes, names.KubeContainer, names.ProcessLog, names.InstrumentationChecks:
+		// config attached to a container label, a pod annotation, or an instrumentation check
 		configs, err = logsConfig.ParseJSON(config.LogsConfig)
 	case names.RemoteConfig:
 		if pkgconfigsetup.Datadog().GetBool("remote_configuration.agent_integrations.allow_log_config_scheduling") {

--- a/pkg/proto/datadog/workloadfilter/workloadfilter.proto
+++ b/pkg/proto/datadog/workloadfilter/workloadfilter.proto
@@ -41,6 +41,12 @@ message FilterPod {
   string name = 2;
   string namespace = 3;
   map<string, string> annotations = 4;
+  FilterRootOwner rootowner = 5;
+}
+
+message FilterRootOwner {
+  string kind = 1;
+  string name = 2;
 }
 
 message FilterProcess {

--- a/pkg/proto/pbgo/core/workloadfilter.pb.go
+++ b/pkg/proto/pbgo/core/workloadfilter.pb.go
@@ -372,6 +372,7 @@ type FilterPod struct {
 	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	Namespace     string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	Annotations   map[string]string      `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Rootowner     *FilterRootOwner       `protobuf:"bytes,5,opt,name=rootowner,proto3" json:"rootowner,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -434,6 +435,65 @@ func (x *FilterPod) GetAnnotations() map[string]string {
 	return nil
 }
 
+func (x *FilterPod) GetRootowner() *FilterRootOwner {
+	if x != nil {
+		return x.Rootowner
+	}
+	return nil
+}
+
+type FilterRootOwner struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FilterRootOwner) Reset() {
+	*x = FilterRootOwner{}
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FilterRootOwner) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FilterRootOwner) ProtoMessage() {}
+
+func (x *FilterRootOwner) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FilterRootOwner.ProtoReflect.Descriptor instead.
+func (*FilterRootOwner) Descriptor() ([]byte, []int) {
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *FilterRootOwner) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *FilterRootOwner) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 type FilterProcess struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Name    string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -447,7 +507,7 @@ type FilterProcess struct {
 
 func (x *FilterProcess) Reset() {
 	*x = FilterProcess{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[4]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -459,7 +519,7 @@ func (x *FilterProcess) String() string {
 func (*FilterProcess) ProtoMessage() {}
 
 func (x *FilterProcess) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[4]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -472,7 +532,7 @@ func (x *FilterProcess) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterProcess.ProtoReflect.Descriptor instead.
 func (*FilterProcess) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{4}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *FilterProcess) GetName() string {
@@ -513,7 +573,7 @@ type FilterECSTask struct {
 
 func (x *FilterECSTask) Reset() {
 	*x = FilterECSTask{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -525,7 +585,7 @@ func (x *FilterECSTask) String() string {
 func (*FilterECSTask) ProtoMessage() {}
 
 func (x *FilterECSTask) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -538,7 +598,7 @@ func (x *FilterECSTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterECSTask.ProtoReflect.Descriptor instead.
 func (*FilterECSTask) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{5}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *FilterECSTask) GetId() string {
@@ -566,7 +626,7 @@ type FilterKubeService struct {
 
 func (x *FilterKubeService) Reset() {
 	*x = FilterKubeService{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[6]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -578,7 +638,7 @@ func (x *FilterKubeService) String() string {
 func (*FilterKubeService) ProtoMessage() {}
 
 func (x *FilterKubeService) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[6]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -591,7 +651,7 @@ func (x *FilterKubeService) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterKubeService.ProtoReflect.Descriptor instead.
 func (*FilterKubeService) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{6}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *FilterKubeService) GetName() string {
@@ -626,7 +686,7 @@ type FilterKubeEndpoint struct {
 
 func (x *FilterKubeEndpoint) Reset() {
 	*x = FilterKubeEndpoint{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[7]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -638,7 +698,7 @@ func (x *FilterKubeEndpoint) String() string {
 func (*FilterKubeEndpoint) ProtoMessage() {}
 
 func (x *FilterKubeEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[7]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -651,7 +711,7 @@ func (x *FilterKubeEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterKubeEndpoint.ProtoReflect.Descriptor instead.
 func (*FilterKubeEndpoint) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{7}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *FilterKubeEndpoint) GetName() string {
@@ -684,7 +744,7 @@ type FilterImage struct {
 
 func (x *FilterImage) Reset() {
 	*x = FilterImage{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[8]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -696,7 +756,7 @@ func (x *FilterImage) String() string {
 func (*FilterImage) ProtoMessage() {}
 
 func (x *FilterImage) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[8]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -709,7 +769,7 @@ func (x *FilterImage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterImage.ProtoReflect.Descriptor instead.
 func (*FilterImage) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{8}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *FilterImage) GetReference() string {
@@ -742,15 +802,19 @@ const file_datadog_workloadfilter_workloadfilter_proto_rawDesc = "" +
 	"\x05image\x18\x03 \x01(\v2#.datadog.workloadfilter.FilterImageR\x05image\x125\n" +
 	"\x03pod\x18\x04 \x01(\v2!.datadog.workloadfilter.FilterPodH\x00R\x03pod\x12B\n" +
 	"\becs_task\x18\x05 \x01(\v2%.datadog.workloadfilter.FilterECSTaskH\x00R\aecsTaskB\a\n" +
-	"\x05owner\"\xe3\x01\n" +
+	"\x05owner\"\xaa\x02\n" +
 	"\tFilterPod\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12T\n" +
-	"\vannotations\x18\x04 \x03(\v22.datadog.workloadfilter.FilterPod.AnnotationsEntryR\vannotations\x1a>\n" +
+	"\vannotations\x18\x04 \x03(\v22.datadog.workloadfilter.FilterPod.AnnotationsEntryR\vannotations\x12E\n" +
+	"\trootowner\x18\x05 \x01(\v2'.datadog.workloadfilter.FilterRootOwnerR\trootowner\x1a>\n" +
 	"\x10AnnotationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"l\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"9\n" +
+	"\x0fFilterRootOwner\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"l\n" +
 	"\rFilterProcess\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\acmdline\x18\x02 \x01(\tR\acmdline\x12\x12\n" +
@@ -793,40 +857,42 @@ func file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_workloadfilter_workloadfilter_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_datadog_workloadfilter_workloadfilter_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_datadog_workloadfilter_workloadfilter_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_datadog_workloadfilter_workloadfilter_proto_goTypes = []any{
 	(WorkloadFilterResult)(0),              // 0: datadog.workloadfilter.WorkloadFilterResult
 	(*WorkloadFilterEvaluateRequest)(nil),  // 1: datadog.workloadfilter.WorkloadFilterEvaluateRequest
 	(*WorkloadFilterEvaluateResponse)(nil), // 2: datadog.workloadfilter.WorkloadFilterEvaluateResponse
 	(*FilterContainer)(nil),                // 3: datadog.workloadfilter.FilterContainer
 	(*FilterPod)(nil),                      // 4: datadog.workloadfilter.FilterPod
-	(*FilterProcess)(nil),                  // 5: datadog.workloadfilter.FilterProcess
-	(*FilterECSTask)(nil),                  // 6: datadog.workloadfilter.FilterECSTask
-	(*FilterKubeService)(nil),              // 7: datadog.workloadfilter.FilterKubeService
-	(*FilterKubeEndpoint)(nil),             // 8: datadog.workloadfilter.FilterKubeEndpoint
-	(*FilterImage)(nil),                    // 9: datadog.workloadfilter.FilterImage
-	nil,                                    // 10: datadog.workloadfilter.FilterPod.AnnotationsEntry
-	nil,                                    // 11: datadog.workloadfilter.FilterKubeService.AnnotationsEntry
-	nil,                                    // 12: datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
+	(*FilterRootOwner)(nil),                // 5: datadog.workloadfilter.FilterRootOwner
+	(*FilterProcess)(nil),                  // 6: datadog.workloadfilter.FilterProcess
+	(*FilterECSTask)(nil),                  // 7: datadog.workloadfilter.FilterECSTask
+	(*FilterKubeService)(nil),              // 8: datadog.workloadfilter.FilterKubeService
+	(*FilterKubeEndpoint)(nil),             // 9: datadog.workloadfilter.FilterKubeEndpoint
+	(*FilterImage)(nil),                    // 10: datadog.workloadfilter.FilterImage
+	nil,                                    // 11: datadog.workloadfilter.FilterPod.AnnotationsEntry
+	nil,                                    // 12: datadog.workloadfilter.FilterKubeService.AnnotationsEntry
+	nil,                                    // 13: datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
 }
 var file_datadog_workloadfilter_workloadfilter_proto_depIdxs = []int32{
 	3,  // 0: datadog.workloadfilter.WorkloadFilterEvaluateRequest.container:type_name -> datadog.workloadfilter.FilterContainer
 	4,  // 1: datadog.workloadfilter.WorkloadFilterEvaluateRequest.pod:type_name -> datadog.workloadfilter.FilterPod
-	5,  // 2: datadog.workloadfilter.WorkloadFilterEvaluateRequest.process:type_name -> datadog.workloadfilter.FilterProcess
-	7,  // 3: datadog.workloadfilter.WorkloadFilterEvaluateRequest.kube_service:type_name -> datadog.workloadfilter.FilterKubeService
-	8,  // 4: datadog.workloadfilter.WorkloadFilterEvaluateRequest.kube_endpoint:type_name -> datadog.workloadfilter.FilterKubeEndpoint
+	6,  // 2: datadog.workloadfilter.WorkloadFilterEvaluateRequest.process:type_name -> datadog.workloadfilter.FilterProcess
+	8,  // 3: datadog.workloadfilter.WorkloadFilterEvaluateRequest.kube_service:type_name -> datadog.workloadfilter.FilterKubeService
+	9,  // 4: datadog.workloadfilter.WorkloadFilterEvaluateRequest.kube_endpoint:type_name -> datadog.workloadfilter.FilterKubeEndpoint
 	0,  // 5: datadog.workloadfilter.WorkloadFilterEvaluateResponse.result:type_name -> datadog.workloadfilter.WorkloadFilterResult
-	9,  // 6: datadog.workloadfilter.FilterContainer.image:type_name -> datadog.workloadfilter.FilterImage
+	10, // 6: datadog.workloadfilter.FilterContainer.image:type_name -> datadog.workloadfilter.FilterImage
 	4,  // 7: datadog.workloadfilter.FilterContainer.pod:type_name -> datadog.workloadfilter.FilterPod
-	6,  // 8: datadog.workloadfilter.FilterContainer.ecs_task:type_name -> datadog.workloadfilter.FilterECSTask
-	10, // 9: datadog.workloadfilter.FilterPod.annotations:type_name -> datadog.workloadfilter.FilterPod.AnnotationsEntry
-	11, // 10: datadog.workloadfilter.FilterKubeService.annotations:type_name -> datadog.workloadfilter.FilterKubeService.AnnotationsEntry
-	12, // 11: datadog.workloadfilter.FilterKubeEndpoint.annotations:type_name -> datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	7,  // 8: datadog.workloadfilter.FilterContainer.ecs_task:type_name -> datadog.workloadfilter.FilterECSTask
+	11, // 9: datadog.workloadfilter.FilterPod.annotations:type_name -> datadog.workloadfilter.FilterPod.AnnotationsEntry
+	5,  // 10: datadog.workloadfilter.FilterPod.rootowner:type_name -> datadog.workloadfilter.FilterRootOwner
+	12, // 11: datadog.workloadfilter.FilterKubeService.annotations:type_name -> datadog.workloadfilter.FilterKubeService.AnnotationsEntry
+	13, // 12: datadog.workloadfilter.FilterKubeEndpoint.annotations:type_name -> datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_datadog_workloadfilter_workloadfilter_proto_init() }
@@ -851,7 +917,7 @@ func file_datadog_workloadfilter_workloadfilter_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_workloadfilter_workloadfilter_proto_rawDesc), len(file_datadog_workloadfilter_workloadfilter_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -427,7 +427,7 @@ func (a *APIServer) start(ctx context.Context) {
 				SendCustomEventKillAction(a.probe, msg.tags, msg.actionReports)
 				if a.containerFilter != nil {
 					containerName, imageName, podNamespace := utils.GetContainerFilterTags(msg.tags)
-					if a.containerFilter.IsExcluded(workloadfilter.CreateContainer("", containerName, imageName, workloadfilter.CreatePod("", "", podNamespace, nil))) {
+					if a.containerFilter.IsExcluded(workloadfilter.CreateContainer("", containerName, imageName, workloadfilter.CreatePod("", "", podNamespace, nil, nil))) {
 						// similar return value as if we had sent the message
 						return true
 					}

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -401,7 +401,7 @@ func (m *Manager) onWorkloadSelectorResolvedEvent(workload *tags.Workload) {
 	}
 
 	containerName, imageName, podNamespace := utils.GetContainerFilterTags(workload.Tags)
-	if m.containerFilters != nil && m.containerFilters.IsExcluded(workloadfilter.CreateContainer("", containerName, imageName, workloadfilter.CreatePod("", "", podNamespace, nil))) {
+	if m.containerFilters != nil && m.containerFilters.IsExcluded(workloadfilter.CreateContainer("", containerName, imageName, workloadfilter.CreatePod("", "", podNamespace, nil, nil))) {
 		return
 	}
 

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -86,7 +86,6 @@ type DCAClientInterface interface {
 	PostClusterCheckStatus(ctx context.Context, nodeName string, status types.NodeStatus) (types.StatusResponse, error)
 	GetClusterCheckConfigs(ctx context.Context, nodeName string) (types.ConfigResponse, error)
 	GetEndpointsCheckConfigs(ctx context.Context, nodeName string) (types.ConfigResponse, error)
-	GetInstrumentationConfigs(ctx context.Context) (types.ConfigResponse, error)
 	GetKubernetesClusterID() (string, error)
 
 	PostLanguageMetadata(ctx context.Context, data *pbgo.ParentLanguageAnnotationRequest) error
@@ -114,7 +113,7 @@ func resetGlobalClusterAgentClient() {
 }
 
 // GetClusterAgentClient returns or init the DCAClient
-func GetClusterAgentClient() (DCAClientInterface, error) {
+func GetClusterAgentClient() (*DCAClient, error) {
 	if globalClusterAgentClient == nil {
 		globalClusterAgentClient = &DCAClient{}
 		globalClusterAgentClient.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -86,6 +86,7 @@ type DCAClientInterface interface {
 	PostClusterCheckStatus(ctx context.Context, nodeName string, status types.NodeStatus) (types.StatusResponse, error)
 	GetClusterCheckConfigs(ctx context.Context, nodeName string) (types.ConfigResponse, error)
 	GetEndpointsCheckConfigs(ctx context.Context, nodeName string) (types.ConfigResponse, error)
+	GetInstrumentationConfigs(ctx context.Context) (types.ConfigResponse, error)
 	GetKubernetesClusterID() (string, error)
 
 	PostLanguageMetadata(ctx context.Context, data *pbgo.ParentLanguageAnnotationRequest) error

--- a/pkg/util/clusteragent/clusterchecks_test.go
+++ b/pkg/util/clusteragent/clusterchecks_test.go
@@ -124,7 +124,7 @@ func (suite *clusterAgentSuite) TestClusterChecksRedirect() {
 	suite.config.SetWithoutSource("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
 	ca, err := GetClusterAgentClient()
 	require.NoError(suite.T(), err)
-	ca.(*DCAClient).initLeaderClient()
+	ca.initLeaderClient()
 
 	// checking version on init
 	assert.NotNil(suite.T(), follower.PopRequest(), "request did not go through follower")

--- a/pkg/util/clusteragent/instrumentationchecks.go
+++ b/pkg/util/clusteragent/instrumentationchecks.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package clusteragent
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+)
+
+const (
+	dcaInstrumentationConfigsPath = "api/v1/instrumentation/configs"
+)
+
+// GetInstrumentationConfigs is called by the instrumentation checks config provider
+// to retrieve AD configurations derived from DatadogInstrumentation CRs.
+func (c *DCAClient) GetInstrumentationConfigs(ctx context.Context) (types.ConfigResponse, error) {
+	var configs types.ConfigResponse
+	err := c.doJSONQuery(ctx, dcaInstrumentationConfigsPath, "GET", nil, &configs, false)
+	return configs, err
+}

--- a/pkg/util/clusteragent/instrumentationchecks.go
+++ b/pkg/util/clusteragent/instrumentationchecks.go
@@ -15,6 +15,12 @@ const (
 	dcaInstrumentationConfigsPath = "api/v1/instrumentation/configs"
 )
 
+// InstrumentationCheckClient is the interface used by the instrumentation
+// checks config provider to retrieve AD configurations from the cluster agent.
+type InstrumentationCheckClient interface {
+	GetInstrumentationConfigs(ctx context.Context) (types.ConfigResponse, error)
+}
+
 // GetInstrumentationConfigs is called by the instrumentation checks config provider
 // to retrieve AD configurations derived from DatadogInstrumentation CRs.
 func (c *DCAClient) GetInstrumentationConfigs(ctx context.Context) (types.ConfigResponse, error) {

--- a/pkg/util/kubernetes/BUILD.bazel
+++ b/pkg/util/kubernetes/BUILD.bazel
@@ -1,2 +1,27 @@
-# gazelle:ignore
-# Stub: parent has .go files; only pkg/util/kubernetes/apiserver/common/namespace is migrated.
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "kubernetes",
+    srcs = [
+        "auth.go",
+        "const.go",
+        "doc.go",
+        "helpers.go",
+        "hostname_stub.go",
+        "tags.go",
+        "time.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/kubernetes",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "kubernetes_test",
+    srcs = [
+        "helpers_test.go",
+        "tags_test.go",
+    ],
+    embed = [":kubernetes"],
+    gotags = ["test"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/pkg/util/kubernetes/hostinfo/node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/node_labels.go
@@ -20,7 +20,7 @@ type NodeInfo struct {
 	// client use to get NodeName from the "/pods" kubelet api.
 	client kubelet.KubeUtilInterface
 	// getClusterAgentFunc get Cluster-Agent client to get Node Labels with the Cluster-Agent api.
-	getClusterAgentFunc func() (clusteragent.DCAClientInterface, error)
+	getClusterAgentFunc func() (*clusteragent.DCAClient, error)
 	// apiserverNodeLabelsFunc get Node Labels from the API server directly
 	apiserverNodeLabelsFunc func(ctx context.Context, nodeName string) (map[string]string, error)
 }

--- a/releasenotes/notes/instrumentation-check-ad-provider-d1ab5c97e20e9f78.yaml
+++ b/releasenotes/notes/instrumentation-check-ad-provider-d1ab5c97e20e9f78.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Enable ``instrumentation_crd_controller.enabled`` and a new autodiscovery provider
+    will schedule checks derived from ``DatadogInstrumentation`` custom resources
+    deployed in the Kubernetes cluster.


### PR DESCRIPTION
### What does this PR do?

The change adds full support for DatadogInstrumentation (DDI) backed checks with the addition of an 'instrumentation-check' AD provider.

Just apply a DDI with the check configuration of your choice and watch as all node agents in the cluster being scheduling checks for the targeted workload.
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogInstrumentation
metadata:
  name: redis-instrumentation
  namespace: cache
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: redis
  config:
    checks:
      - integration: redisdb
        containerImage:
          - redis
        initConfig: {}
        instances:
          - host: "%%host%%"
            port: "%%port%%"
            password: "ENC[k8s_secret@%%kube_namespace%%/redis-secret/password]"
            tags:
              - service:redis
        logs:
          - source: "redis"
            service: "redis"
```

Supported targets are resolved using a new 'rootowner' field in the the `workloadfilter.Pod` filterable type and can be resolved using CEL with `container.pod.rootowner.kind` / `container.pod.rootowner.name`. A pod's root owner is resolved using `resolveRootOwner()` which supports: ReplicaSet, Job, CronJob, Deployment, DaemonSet and StatefulSet as the resolved root owner.

### Motivation

Customers have asked for ways to configure checks, similar to prometheus PodMonitors. With the introduction of the `DatadogInstrumentation` CRD, the cluster agent can now watch for new CRs specifying `config.checks` to then disseminate to node agents using an `instrumentation-check` AD provider.

### Describe how you validated your changes

1. Wrote unit tests for the instrumentation checks provider (`instrumentationchecks_test.go`)

#### Manual QA

1. Enable `instrumentation_crd_controller.enabled` on both cluster and node agents.
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  features:
    logCollection:
      enabled: true
      containerCollectAll: false
  global:
    clusterName: "mathewe-instrumentation"
    checksTagCardinality: "high"
    kubelet:
      tlsVerify: false
    secretBackend:
      command: "/readsecret_multiple_providers.sh"
  override:
    clusterAgent:
      env:
        - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
          value: "true"
    nodeAgent:
      env:
        - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
          value: "true"
        - name: DD_IGNORE_AUTOCONF
          value: "redisdb"
```

2. Apply your DatadogInstrumentation CR with a check config.
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogInstrumentation
metadata:
  name: redis-instrumentation
  namespace: cache
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: redis
  config:
    checks:
      - integration: redisdb
        containerImage:
          - redis
        initConfig: {}
        instances:
          - host: "%%host%%"
            port: "%%port%%"
            password: "ENC[k8s_secret@%%kube_namespace%%/redis-secret/password]"
            tags:
              - service:redis
        logs:
          - source: "redis"
            service: "redis"
```

3. Check for scheduled check with provider 'instrumentation-check' using `agent configcheck`. (it may take 30s for checks to populate)


### Additional Notes
