### PR TITLE
[APM] Set explicit Content-Type: application/json on /info, /v0.7/config, and /telemetry/proxy handlers

### DIFF
--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -94,6 +94,7 @@ func ConfigHandler(r *api.HTTPReceiver, cf rcclient.ConfigFetcher, cfg *config.A
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.Write(content)
 
 	})

--- a/cmd/trace-agent/config/remote/config_test.go
+++ b/cmd/trace-agent/config/remote/config_test.go
@@ -31,27 +31,30 @@ import (
 
 func TestConfigEndpoint(t *testing.T) {
 	var tcs = []struct {
-		name               string
-		reqBody            string
-		expectedStatusCode int
-		enabled            bool
-		valid              bool
-		response           string
+		name                string
+		reqBody             string
+		expectedStatusCode  int
+		enabled             bool
+		valid               bool
+		response            string
+		expectedContentType string
 	}{
 		{
-			name:               "bad",
-			enabled:            true,
-			expectedStatusCode: http.StatusBadRequest,
-			response:           "unexpected end of JSON input\n",
+			name:                "bad",
+			enabled:             true,
+			expectedStatusCode:  http.StatusBadRequest,
+			response:            "unexpected end of JSON input\n",
+			expectedContentType: "text/plain; charset=utf-8",
 		},
 		{
 			name:    "valid",
 			reqBody: `{"client":{"id":"test_client"}}`,
 
-			enabled:            true,
-			valid:              true,
-			expectedStatusCode: http.StatusOK,
-			response:           `{"targets":"dGVzdA=="}`,
+			enabled:             true,
+			valid:               true,
+			expectedStatusCode:  http.StatusOK,
+			response:            `{"targets":"dGVzdA=="}`,
+			expectedContentType: "application/json",
 		},
 	}
 	for _, tc := range tcs {
@@ -78,6 +81,7 @@ func TestConfigEndpoint(t *testing.T) {
 			assert.Nil(err)
 			assert.Equal(tc.expectedStatusCode, resp.StatusCode)
 			assert.Equal(tc.response, string(body))
+			assert.Equal(tc.expectedContentType, resp.Header.Get("Content-Type"))
 		})
 	}
 }
@@ -164,6 +168,7 @@ func TestUpstreamRequest(t *testing.T) {
 			assert.NoError(err)
 			assert.Equal(200, resp.StatusCode)
 			assert.Equal(`{"targets":"dGVzdA=="}`, string(body))
+			assert.Equal("application/json", resp.Header.Get("Content-Type"))
 		})
 	}
 }

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -240,6 +240,7 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		}
 
 		body := r.cachedInfoResponse.Load().([]byte)
+		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 		w.Write(body) //nolint:errcheck
 	}

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -371,6 +371,7 @@ func TestInfoHandler(t *testing.T) {
 	req := httptest.NewRequest("GET", "/info", nil)
 	req.Header.Add("Datadog-Container-ID", "id1")
 	h.ServeHTTP(rec, req)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 	var m map[string]any
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&m))
 	assert.NoError(t, ensureKeys(expectedKeys, m, ""))

--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -228,6 +228,7 @@ func (r *HTTPReceiver) telemetryForwarderHandler() http.Handler {
 }
 
 func writeEmptyJSON(w http.ResponseWriter, statusCode int) {
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	w.Write([]byte("{}"))
 }

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -258,6 +258,7 @@ func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
 
 	assert.Equal(200, recordedStatusCode(rec))
 	assert.Equal("{}", recordedResponse(t, rec))
+	assert.Equal("application/json", rec.Result().Header.Get("Content-Type")) //nolint:bodyclose
 
 	// because we use number 2,3 both endpoints must be called to produce 5
 	// just counting number of requests could give false results if first endpoint


### PR DESCRIPTION
### What does this PR do?

Sets `Content-Type: application/json` explicitly on the three trace-agent handlers that return JSON bodies via `w.Write` and were missing the header:

- `/info` — [`pkg/trace/api/info.go:243`](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/info.go#L243) — adds the header next to the existing `Content-Length` set.
- `/v0.7/config` — [`cmd/trace-agent/config/remote/config.go:97`](https://github.com/DataDog/datadog-agent/blob/main/cmd/trace-agent/config/remote/config.go#L97) — adds the header just before `w.Write(content)` on the success path.
- `/telemetry/proxy/*` — [`pkg/trace/api/telemetry.go writeEmptyJSON`](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/telemetry.go#L230) — adds the header before `w.Write([]byte("{}"))`.

The `http.Error` path in `/v0.7/config` (line 94) is intentionally not touched — `http.Error` already sets `text/plain` for the error body, which is correct for that path.

### Motivation

These handlers currently rely on Go's `net/http` body-sniffing (`http.DetectContentType`), which returns `text/plain; charset=utf-8` for typical JSON-looking text. A wire capture from `datadog/agent:latest` v7.78.3 against `/info` confirms this:

```
"Content-Type", "text/plain; charset=utf-8"
"Transfer-Encoding", "chunked"
```

The three JSON-returning trace-agent endpoints that **already** set `Content-Type: application/json` explicitly — service-rates on `/v0.4/traces` via [`httpRateByService`](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/responses.go#L113) and the timeout path at [`api.go:871,985`](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/api.go#L871) — show the desired pattern. This change brings the other three in line.

Clients that rely on `Content-Type` to decide whether to parse the body as JSON (e.g. a tracer that wants to distinguish a real JSON response from a stray HTML error page from an upstream proxy) currently cannot tell these endpoints apart from plain-text responses. A dd-trace-rb change attempting exactly that kind of stricter validation surfaced the issue: [DataDog/dd-trace-rb#5758](https://github.com/DataDog/dd-trace-rb/pull/5758).

### Audit scope

Every non-test handler file under `pkg/trace/api/` and `cmd/trace-agent/` was reviewed. Findings:

| Handler / helper | Wrote JSON without Content-Type? | Action |
|---|---|---|
| `pkg/trace/api/info.go` (`/info`) | Yes | Fixed (this PR) |
| `cmd/trace-agent/config/remote/config.go` (`/v0.7/config`) | Yes (success path) | Fixed (this PR) |
| `pkg/trace/api/telemetry.go` (`writeEmptyJSON` for `/telemetry/proxy/*`) | Yes | Fixed (this PR) |
| `pkg/trace/api/responses.go` (`httpRateByService` for `/v0.4/traces`) | No — already sets `application/json` | — |
| `pkg/trace/api/api.go` (trace timeout path) | No — already sets `application/json` | — |
| `pkg/trace/api/responses.go` (`httpOK` writes `"OK\n"`) | N/A — plain-text body | — |
| `pkg/trace/api/profiles.go` (`writeError`) | N/A — writes `err.Error()` text | — |
| Reverse-proxy handlers (profiles, evp_proxy, openlineage, pipeline_stats, symdb, tracer_flare, debugger) | N/A — pass through upstream `Content-Type` via `httputil.ReverseProxy` | — |
| `pkg/trace/api/debug_server.go` (pprof / expvar / block-rate) | N/A — pprof/expvar handlers set their own `Content-Type`; the block-rate response is human-readable text | — |

### Describe how you validated your changes

- Added `Content-Type` assertions to the existing handler tests:
  - `pkg/trace/api/info_test.go` — `TestInfoHandler` now asserts `application/json` alongside the container-tags-hash header.
  - `cmd/trace-agent/config/remote/config_test.go` — `TestConfigEndpoint` now carries `expectedContentType` per case (`text/plain; charset=utf-8` for the `http.Error` path, `application/json` for the success path); `TestUpstreamRequest` asserts `application/json` on the success path.
  - `pkg/trace/api/telemetry_test.go` — `TestTelemetryProxyMultipleEndpoints` now asserts the response `Content-Type` alongside the existing body check.
- `gofmt -l` on all six touched files: clean.
- CI on this draft PR will run the full `dda inv test` suite for the changed packages.

### Additional Notes

Backward compatibility: the response body bytes are unchanged. Any client that was parsing the body as JSON (which all current clients must do, since the body is JSON) continues to work unmodified. Clients that also check `Content-Type` now receive a header consistent with the body.
